### PR TITLE
Fix clipping Tooltips in Safari

### DIFF
--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.css
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.css
@@ -29,7 +29,7 @@
   border-radius: calc(1rem * (4 / var(--rem-base)));
   z-index: 99;
   user-select: none;
-  width: max-content;
+  width: auto;
 }
 
 .Tooltip--hidden {


### PR DESCRIPTION
This PR will fix clipping Tooltip content in Safari.