### PR TITLE
docs(Forma 36 Components): Changed the title from UI Component Librar…

### DIFF
--- a/packages/forma-36-react-components/tools/.storybook/config.js
+++ b/packages/forma-36-react-components/tools/.storybook/config.js
@@ -13,7 +13,7 @@ setDefaults({
 });
 
 setOptions({
-  name: 'UI Component Library',
+  name: 'Forma 36 Components',
   url: '#',
   hierarchyRootSeparator: /\|/,
   sidebarAnimations: false,


### PR DESCRIPTION
This PR will change the storybook title from UI Component Library to Forma 36 Components. Forma 36 React Components is to long and will break the title

![image](https://user-images.githubusercontent.com/1766274/49230224-73c7b000-f3ef-11e8-9461-d59fb7947ed6.png)
