### PR TITLE
Remove flex box from ModalControls

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/ModalControls/ModalControls.css
+++ b/packages/forma-36-react-components/src/components/Modal/ModalControls/ModalControls.css
@@ -1,10 +1,6 @@
-@import 'settings/colors';
 @import 'settings/typography';
-@import 'settings/transitions';
 
 .ModalControls {
-  display: flex;
-  align-items: center;
   padding: calc(1rem * (30 / var(--rem-base)));
   padding-top: 0;
 }


### PR DESCRIPTION
Flexbox doesn't appear to be needed for ModalControls. The addition of it causes issues when a Modal features long content and the browser's viewport is small - the modal content overlaps the modal controls.