### PR TITLE
Fix TextInput with CopyButton margins/padding

### DIFF
--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.css
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.css
@@ -16,7 +16,8 @@
   color: var(--color-text-mid);
   font-family: var(--font-stack-primary);
   font-size: var(--font-size-m);
-  padding: calc(1rem * (11 / var(--rem-base)));
+  padding: calc(1rem * (10.5 / var(--rem-base)));
+  margin: 0;
   width: 100%;
 
   &::-webkit-input-placeholder {


### PR DESCRIPTION
This PR fixes the spacing for the TextInput with a CopyButton on Safari, so that the copy button is flush with the input field. It also fixes the padding in general, as it seems it was slightly off on Chrome as well.

## Before

### Chrome
![screen shot 2019-01-23 at 13 30 37](https://user-images.githubusercontent.com/4960056/51606789-29584080-1f13-11e9-98d2-3f54784f5c2f.png)

### Safari
![screen shot 2019-01-23 at 13 30 00](https://user-images.githubusercontent.com/4960056/51606791-29584080-1f13-11e9-9d8c-022e507caa81.png)


## After

### Chrome
![screen shot 2019-01-23 at 11 48 36](https://user-images.githubusercontent.com/4960056/51606685-e4cca500-1f12-11e9-8c38-4067ff2199c7.png)

### Safari
![screen shot 2019-01-23 at 11 48 29](https://user-images.githubusercontent.com/4960056/51606686-e5653b80-1f12-11e9-9b49-50aad92470cb.png)
