### PR TITLE
fix(Docs): Removed mention of blueprints

### DIFF
--- a/packages/forma-36-react-components/tools/.storybook/docs/General/General.md
+++ b/packages/forma-36-react-components/tools/.storybook/docs/General/General.md
@@ -15,7 +15,3 @@ Design tokens are the granular values we use when designing and implementing UI.
 ## Components
 
 React components available for immediate use.
-
-## Blueprints
-
-Components we have identified but are not yet available within the component library. These serve as design notes to those wanting to add components to the component library.


### PR DESCRIPTION
# Purpose of PR

This PR will remove the mention of blueprints in the documentation

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
