### PR TITLE
fix(CI): reset github remote origin

### DIFF
--- a/bin/before-deploy
+++ b/bin/before-deploy
@@ -4,5 +4,6 @@
 
 git config --global user.email ${GITHUB_EMAIL}
 git config --global user.name ${GITHUB_USER}
+git remote set-url origin "https://${GITHUB_TOKEN}@github.com/contentful/forma-36.git" > /dev/null 2>&1
 git checkout master
 echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc 2> /dev/null


### PR DESCRIPTION
# Purpose of PR

This PR should fix authentication with Github in CI

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
