### PR TITLE
build(forma-36-fcss): Moved postcss from deps to devDeps

### DIFF
--- a/packages/forma-36-fcss/package.json
+++ b/packages/forma-36-fcss/package.json
@@ -9,13 +9,13 @@
     "dist"
   ],
   "devDependencies": {
-    "node-sass": "^4.10.0"
-  },
-  "dependencies": {
-    "@contentful/forma-36-tokens": "^0.2.0",
+    "node-sass": "^4.10.0",
     "postcss": "^7.0.6",
     "postcss-calc": "^7.0.1",
     "postcss-css-variables": "^0.11.0"
+  },
+  "dependencies": {
+    "@contentful/forma-36-tokens": "^0.2.0"
   },
   "scripts": {
     "develop": "node-sass --watch scss/styles.scss -o dist --output-style",

--- a/packages/forma-36-react-components/yarn.lock
+++ b/packages/forma-36-react-components/yarn.lock
@@ -1258,11 +1258,6 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@contentful/forma-36-tokens@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@contentful/forma-36-tokens/-/forma-36-tokens-0.2.0.tgz#c4a1062e7acc2ae0ae5699e7c8606d5b5047a1c5"
-  integrity sha512-6vshI8mlnEuVx6lJ0Yw7Jzeh5YEhlCfxWZiLXg5pbiDmi9JtPAwllWii9ocrKLelIAPwB/gvNQAAzm6uSy/Vug==
-
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"


### PR DESCRIPTION
# Purpose of PR

`postcss` is a developer dependency for `forma-36-fcss` package and it shouldn't be installed when `forma-36-fcss` is used in the app

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
