### PR TITLE
fix(Tooltip): Use position fixed for positioning of Tooltip

### DIFF
--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.css
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.css
@@ -12,7 +12,7 @@
 }
 
 .Tooltip {
-  position: absolute;
+  position: fixed;
   margin: calc(1rem * (10 / var(--font-base-default))) 0px;
   display: inline-block;
   background: var(--color-contrast-mid);

--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.stories.js
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.stories.js
@@ -30,7 +30,7 @@ storiesOf('Components|Tooltip', module)
           )}
           id="tip1"
           targetWrapperClassName={text('Wrapper class name', 'target-wrapper')}
-          content={text('Tooltip Text', "Hi I'm a Tooltip")}
+          content={text('Tooltip Text', 'Hi I am a Tooltip')}
         >
           <TextLink>Hover me</TextLink>
         </Tooltip>


### PR DESCRIPTION
Position absolute can be influenced by the parent positioning

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
