### PR TITLE
fix(ExtendDependency): Bump version to 3.0.2

### DIFF
--- a/packages/forma-36-react-components/package.json
+++ b/packages/forma-36-react-components/package.json
@@ -163,7 +163,8 @@
   },
   "resolutions": {
     "url-parse": "1.4.4",
-    "merge": "1.2.1"
+    "merge": "1.2.1",
+    "extend": "3.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/forma-36-react-components/yarn.lock
+++ b/packages/forma-36-react-components/yarn.lock
@@ -5617,9 +5617,10 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+extend@3.0.2, extend@^3.0.0, extend@~3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 external-editor@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
This PR will force Extend version 3.0.2 to prevent a vulnerability

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
