### PR TITLE
fix: Add missing aria attribute to ToggleButton

### DIFF
--- a/packages/forma-36-react-components/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/forma-36-react-components/src/components/ToggleButton/ToggleButton.tsx
@@ -52,7 +52,7 @@ export class ToggleButton extends Component<ToggleButtonProps> {
       <Card
         extraClassNames={classNames}
         padding="none"
-        selected={this.props.isActive}
+        selected={isActive}
         {...otherProps}
       >
         <button
@@ -61,6 +61,7 @@ export class ToggleButton extends Component<ToggleButtonProps> {
           disabled={isDisabled}
           data-test-id="button"
           onClick={this.handleToggle}
+          aria-pressed={isActive}
         >
           <TabFocusTrap
             extraClassNames={styles['Toggle__button__inner-wrapper']}

--- a/packages/forma-36-react-components/src/components/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/ToggleButton/__snapshots__/ToggleButton.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`renders the component 1`] = `
   testId="cf-ui-toggle-button"
 >
   <button
+    aria-pressed={false}
     className="Toggle__button"
     data-test-id="button"
     disabled={false}
@@ -37,6 +38,7 @@ exports[`renders the component active 1`] = `
   testId="cf-ui-toggle-button"
 >
   <button
+    aria-pressed={true}
     className="Toggle__button"
     data-test-id="button"
     disabled={false}
@@ -65,6 +67,7 @@ exports[`renders the component with an additional class name 1`] = `
   testId="cf-ui-toggle-button"
 >
   <button
+    aria-pressed={false}
     className="Toggle__button"
     data-test-id="button"
     disabled={false}
@@ -93,6 +96,7 @@ exports[`renders the component with icon 1`] = `
   testId="cf-ui-toggle-button"
 >
   <button
+    aria-pressed={false}
     className="Toggle__button"
     data-test-id="button"
     disabled={false}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

The `ToggleButton` component is missing the `aria-pressed` attribute to make it fully accessible to screen readers. This is based on Heydon Pickering's great tutorial on accessible toggle buttons: https://inclusive-components.design/toggle-button/#atruetogglebutton

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
