### PR TITLE
Fix styles tree shaking in webpack 4

### DIFF
--- a/packages/forma-36-react-components/package.json
+++ b/packages/forma-36-react-components/package.json
@@ -12,7 +12,7 @@
     "index.d.ts",
     "dist"
   ],
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",

--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.js
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.js
@@ -5,8 +5,6 @@ import cn from 'classnames';
 import InViewport from '../InViewport';
 import styles from './Tooltip.css';
 
-const tooltipRoot = document.body;
-
 const TooltipContainer = ({
   children,
   setRef,
@@ -82,7 +80,7 @@ export class Tooltip extends React.Component {
   };
 
   componentDidMount() {
-    tooltipRoot.appendChild(this.portalTarget);
+    document.body.appendChild(this.portalTarget);
   }
 
   componentDidUpdate(prevProps) {
@@ -92,7 +90,7 @@ export class Tooltip extends React.Component {
   }
 
   componentWillUnmount() {
-    tooltipRoot.removeChild(this.portalTarget);
+    document.body.tooltipRoot.removeChild(this.portalTarget);
   }
 
   setPlace = place => {

--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.js
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.js
@@ -90,7 +90,7 @@ export class Tooltip extends React.Component {
   }
 
   componentWillUnmount() {
-    document.body.tooltipRoot.removeChild(this.portalTarget);
+    document.body.removeChild(this.portalTarget);
   }
 
   setPlace = place => {

--- a/packages/forma-36-website/src/components/Layout.js
+++ b/packages/forma-36-website/src/components/Layout.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { StaticQuery, graphql } from 'gatsby';
+import Container from './Container';
 import '@contentful/forma-36-react-components/dist/styles.css';
 import '@contentful/forma-36-fcss/dist/styles.css';
-import Container from './Container';
 import './Layout.css';
 
 const Layout = ({ children }) => (

--- a/packages/forma-36-website/src/pages/404.js
+++ b/packages/forma-36-website/src/pages/404.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import DisplayText from '@contentful/forma-36-react-components/dist/components/Typography/DisplayText';
-import Card from '@contentful/forma-36-react-components/dist/components/Card/Card';
+import { DisplayText, Card } from '@contentful/forma-36-react-components';
 import Layout from '../components/Layout';
 
 const NotFoundPage = () => (

--- a/packages/forma-36-website/src/pages/index.js
+++ b/packages/forma-36-website/src/pages/index.js
@@ -1,10 +1,12 @@
 import React from 'react';
-import DisplayText from '@contentful/forma-36-react-components/dist/components/Typography/DisplayText';
-import Subheading from '@contentful/forma-36-react-components/dist/components/Typography/Subheading';
-import Paragraph from '@contentful/forma-36-react-components/dist/components/Typography/Paragraph';
-import Button from '@contentful/forma-36-react-components/dist/components/Button/Button';
-import TextLink from '@contentful/forma-36-react-components/dist/components/TextLink/TextLink';
-import Card from '@contentful/forma-36-react-components/dist/components/Card/Card';
+import {
+  DisplayText,
+  Subheading,
+  Paragraph,
+  Button,
+  TextLink,
+  Card,
+} from '@contentful/forma-36-react-components';
 import Logo from '../components/Logo';
 import Imprint from '../components/Imprint';
 


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

* Fixes problem with SSR in Tooltip component which caused a build fail of Gatsby website.
* Fixes problem with `"sideEffects": false` which caused Webpack 4 to cut styles from the build in production mode

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
