### PR TITLE
Use propTypes addon in component stories Plop template

### DIFF
--- a/packages/forma-36-react-components/tools/plop-templates/components/stories.tsx.hbs
+++ b/packages/forma-36-react-components/tools/plop-templates/components/stories.tsx.hbs
@@ -5,8 +5,12 @@ import { text } from '@storybook/addon-knobs';
 import {{pascalCase name}} from './{{pascalCase name}}';
 import notes from './{{pascalCase name}}.md';
 
-storiesOf('Components|{{pascalCase name}}', module).add('default', () => (
-  <{{pascalCase name}} extraClassNames={text('Extra Class Names', '')}>
-    {{{pascalCase name}}}
-  </{{pascalCase name}}>
-));
+storiesOf('Components|{{pascalCase name}}', module)
+  .addParameters({
+    propTypes: {{pascalCase name}}['__docgenInfo'],
+  })
+  .add('default', () => (
+    <{{pascalCase name}} extraClassNames={text('Extra Class Names', '')}>
+      {{{pascalCase name}}}
+    </{{pascalCase name}}>
+  ));


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR updates the component stories Plop template to use the new propTypes addon.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
