### PR TITLE
feat(Modal): Accept non-string titles

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/Modal/Modal.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/Modal/Modal.tsx
@@ -60,7 +60,7 @@ export interface ModalProps {
   /**
       Modal title that is used in header
     */
-  title?: string;
+  title?: React.ReactNode;
   /**
       Size of the modal window
     */

--- a/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.tsx
@@ -19,7 +19,7 @@ export interface ModalConfirmProps {
   /**
       Modal title that is used in header
     */
-  title?: string;
+  title?: React.ReactNode;
   /**
    * Label of the confirm button
    */

--- a/packages/forma-36-react-components/src/components/Modal/ModalHeader/ModalHeader.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalHeader/ModalHeader.tsx
@@ -10,7 +10,7 @@ export interface ModalHeaderProps
     HTMLDivElement
   > {
   onClose?: Function;
-  title: string;
+  title: any;
   testId?: string;
   extraClassNames?: string;
 }


### PR DESCRIPTION
More flexibility, in our case to handle long titles with ellipses, but also e.g. svg in titles.

# Purpose of PR

Allow jsx elements as title of modal dialog.
We need it to shorten long titles with ellipses, but other use cases are imaginable.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required (a string is still a valid title)
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
