### PR TITLE
Add option for modal title wrapping

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/Modal/Modal.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/Modal/Modal.tsx
@@ -69,6 +69,11 @@ export interface ModalProps {
    * Are modals highter that viewerport allowed
    */
   allowHeightOverflow?: boolean;
+
+  /**
+      To disable word-wrapping of the modal title
+    */
+  isNotWrapped?: boolean;
   extraClassNames?: string;
   testId?: string;
 
@@ -102,7 +107,11 @@ export class Modal extends Component<ModalProps> {
     return (
       <React.Fragment>
         {this.props.title && (
-          <ModalHeader title={this.props.title} onClose={this.props.onClose} />
+          <ModalHeader
+            title={this.props.title}
+            onClose={this.props.onClose}
+            isNotWrapped={this.props.isNotWrapped}
+          />
         )}
         <ModalContent>{this.props.children}</ModalContent>
       </React.Fragment>

--- a/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.tsx
@@ -52,6 +52,10 @@ export interface ModalConfirmProps {
    * When true, the confirm button is set to loading.
    */
   isConfirmLoading?: boolean;
+  /**
+      To disable word-wrapping of the modal title
+    */
+  isNotWrapped?: boolean;
   testId?: string;
   confirmTestId?: string;
   cancelTestId?: string;
@@ -92,6 +96,7 @@ export class ModalConfirm extends Component<ModalConfirmProps> {
       isConfirmLoading,
       confirmTestId,
       cancelTestId,
+      isNotWrapped,
     } = this.props;
 
     return (
@@ -105,7 +110,7 @@ export class ModalConfirm extends Component<ModalConfirmProps> {
       >
         {() => (
           <div>
-            <Modal.Header title={title} />
+            <Modal.Header title={title} isNotWrapped={isNotWrapped} />
             <Modal.Content>{children}</Modal.Content>
             <Modal.Controls>
               <Button

--- a/packages/forma-36-react-components/src/components/Modal/ModalHeader/ModalHeader.css
+++ b/packages/forma-36-react-components/src/components/Modal/ModalHeader/ModalHeader.css
@@ -21,4 +21,10 @@
   font-family: var(--font-stack-primary);
   font-size: 1rem;
   line-height: var(--line-height-default);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ModalHeader__title--is-not-wrapped {
+  white-space: nowrap;
 }

--- a/packages/forma-36-react-components/src/components/Modal/ModalHeader/ModalHeader.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalHeader/ModalHeader.tsx
@@ -13,6 +13,7 @@ export interface ModalHeaderProps
   title: string;
   testId?: string;
   extraClassNames?: string;
+  isNotWrapped?: boolean;
 }
 
 export class ModalHeader extends Component<ModalHeaderProps> {
@@ -21,14 +22,26 @@ export class ModalHeader extends Component<ModalHeaderProps> {
   };
 
   render() {
-    const { onClose, title, testId, extraClassNames, ...rest } = this.props;
+    const {
+      onClose,
+      title,
+      testId,
+      isNotWrapped,
+      extraClassNames,
+      ...rest
+    } = this.props;
+
+    const titleClassNames = cn(styles.ModalHeader__title, {
+      [styles['ModalHeader__title--is-not-wrapped']]: isNotWrapped,
+    });
+
     return (
       <div
         {...rest}
         className={cn(styles.ModalHeader, extraClassNames)}
         data-test-id={testId}
       >
-        <h1 className={styles.ModalHeader__title}>{title}</h1>
+        <h1 className={titleClassNames}>{title}</h1>
         {onClose && (
           <IconButton
             iconProps={{ icon: 'Close' }}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

This PR adds the option to disable word wrapping for the Modal title. It also automatically truncates long words to prevent them from breaking outside the title container.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] Tests are added/updated/not required
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
