### PR TITLE
fix: More concise fonts fallback list

### DIFF
--- a/packages/forma-36-tokens/src/tokens/typography/font-stack.js
+++ b/packages/forma-36-tokens/src/tokens/typography/font-stack.js
@@ -1,5 +1,6 @@
 const fontStack = {
-  'font-stack-primary': "'Avenir Next W01', '-apple-system', 'BlinkMacSystemTypography', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'sans-serif'",
+  'font-stack-primary':
+    "'Avenir Next W01', -apple-system, BlinkMacSystemTypography, 'Segoe UI', Cantarell, Helvetica, Arial, sans-serif",
   'font-stack-monospace': "'Menlo', 'Andale mono', monospace",
 };
 


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

https://github.com/contentful/forma-36/pull/128 improved situation on MacOS but made it worse for Ubuntu users. This PR limits fonts fallback list to fonts that look acceptable on all OS.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
