### PR TITLE
fix(AssetCard): Close dropdown after onClick

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
@@ -52,7 +52,25 @@ export class AssetCard extends Component<AssetCardPropTypes, AssetCardState> {
         </button>
       }
     >
-      {dropdownListElements}
+      {dropdownListElements.props.children &&
+        React.Children.map(dropdownListElements.props.children, listItem => {
+          return React.cloneElement(listItem, {
+            children: listItem.props.children.map(item => {
+              if (!item || !item.props.onClick) {
+                return item;
+              }
+              return React.cloneElement(item, {
+                onClick: e => {
+                  if (item.props.onClick) {
+                    item.props.onClick(e);
+                  }
+
+                  this.setState({ isOpen: false });
+                },
+              });
+            }),
+          });
+        })}
     </Dropdown>
   );
 

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
@@ -76,33 +76,32 @@ exports[`renders the component with actions 1`] = `
           </button>
         }
       >
-        <span>
-          <DropdownList
-            testId="cf-ui-dropdown-list"
+        <DropdownList
+          key=".0"
+          testId="cf-ui-dropdown-list"
+        >
+          <DropdownListItem
+            isActive={false}
+            isDisabled={false}
+            isTitle={true}
+            onEnter={[Function]}
+            onLeave={[Function]}
+            testId="cf-ui-dropdown-list-item"
           >
-            <DropdownListItem
-              isActive={false}
-              isDisabled={false}
-              isTitle={true}
-              onEnter={[Function]}
-              onLeave={[Function]}
-              testId="cf-ui-dropdown-list-item"
-            >
-              Actions
-            </DropdownListItem>
-            <DropdownListItem
-              isActive={false}
-              isDisabled={false}
-              isTitle={false}
-              onClick={[Function]}
-              onEnter={[Function]}
-              onLeave={[Function]}
-              testId="cf-ui-dropdown-list-item"
-            >
-              Edit
-            </DropdownListItem>
-          </DropdownList>
-        </span>
+            Actions
+          </DropdownListItem>
+          <DropdownListItem
+            isActive={false}
+            isDisabled={false}
+            isTitle={false}
+            onClick={[Function]}
+            onEnter={[Function]}
+            onLeave={[Function]}
+            testId="cf-ui-dropdown-list-item"
+          >
+            Edit
+          </DropdownListItem>
+        </DropdownList>
       </Dropdown>
     </div>
     <div


### PR DESCRIPTION
To prevent ghost dropdowns floating over the slide in editor we should close the dropdown of the asset card after onClick has been dispatched.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
