### PR TITLE
Add ‘warning’ type to Icon props

### DIFF
--- a/packages/forma-36-react-components/src/components/Icon/Icon.test.tsx
+++ b/packages/forma-36-react-components/src/components/Icon/Icon.test.tsx
@@ -65,6 +65,18 @@ it('renders as a "negative" icon', () => {
   expect(output).toMatchSnapshot();
 });
 
+it('renders as a "warning" icon', () => {
+  const output = shallow(
+    <Icon
+      icon={iconName[Object.keys(iconName)[0]]}
+      size="large"
+      color="warning"
+    />,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
 it('renders as a "secondary" icon', () => {
   const output = shallow(
     <Icon

--- a/packages/forma-36-react-components/src/components/Icon/Icon.tsx
+++ b/packages/forma-36-react-components/src/components/Icon/Icon.tsx
@@ -237,6 +237,7 @@ export type IconColorType =
   | 'primary'
   | 'positive'
   | 'negative'
+  | 'warning'
   | 'secondary'
   | 'muted'
   | 'white';

--- a/packages/forma-36-react-components/src/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -66,6 +66,17 @@ exports[`renders as a "secondary" icon 1`] = `
 />
 `;
 
+exports[`renders as a "warning" icon 1`] = `
+<ArrowDown
+  className="Icon Icon--large Icon--warning"
+  data-test-id="cf-ui-icon"
+  height="24"
+  viewBox="0 0 24 24"
+  width="24"
+  xmlns="http://www.w3.org/2000/svg"
+/>
+`;
+
 exports[`renders as a "white" icon 1`] = `
 <ArrowDown
   className="Icon Icon--large Icon--white"


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Adds `warning` as a valid IconColorType to the Icon component to prevent errors in Note component.

Fixes #137 

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
