### PR TITLE
Add href prop to DropdownItem

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
@@ -35,9 +35,7 @@ storiesOf('Components|Card/EntryCard', module)
           <React.Fragment>
             <DropdownList>
               <DropdownListItem isTitle>Actions</DropdownListItem>
-              <DropdownListItem onClick={action('Edit onClick')}>
-                Edit
-              </DropdownListItem>
+              <DropdownListItem href="#">Edit (with href)</DropdownListItem>
               <DropdownListItem onClick={action('Download onClick')}>
                 Download
               </DropdownListItem>

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.css
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.css
@@ -15,7 +15,7 @@
   margin: 0;
 }
 
-.DropdownListItem__toggle-button:hover {
+.DropdownListItem__button:hover {
   background: var(--color-element-lightest);
 }
 
@@ -23,7 +23,7 @@
   padding: 0px;
 }
 
-.DropdownListItem__toggle-button {
+.DropdownListItem__button {
   composes: focus-outline--default from './../../../styles/settings/a11y.css';
   border: none;
   background: transparent;
@@ -34,9 +34,11 @@
   padding: 0;
   cursor: pointer;
   color: var(--color-text-mid);
+  display: block;
+  text-decoration: none;
 }
 
-.DropdownListItem__toggle-button__inner-wrapper {
+.DropdownListItem__button__inner-wrapper {
   display: block;
   padding: calc(1rem * (7 / var(--font-base-default)))
     calc(1rem * (20 / var(--font-base-default)));
@@ -59,7 +61,7 @@
   background: var(--color-element-light);
 }
 
-.DropdownListItem--active .DropdownListItem__toggle-button:hover {
+.DropdownListItem--active .DropdownListItem__button:hover {
   background: var(--color-element-light);
   cursor: default;
 }

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { text, boolean } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 
 import DropdownListItem from './DropdownListItem';
 
@@ -13,7 +14,19 @@ storiesOf('Components|Dropdown/DropdownListItem', module)
       isDisabled={boolean('isDisabled', false)}
       isActive={boolean('isActive', false)}
       isTitle={boolean('isTitle', false)}
+      href={text('href', '')}
     >
-      {text('Text', 'Menu Entry')}
+      {text('children', 'Menu Entry')}
+    </DropdownListItem>
+  ))
+  .add('with onClick', () => (
+    <DropdownListItem
+      isDisabled={boolean('isDisabled', false)}
+      isActive={boolean('isActive', false)}
+      isTitle={boolean('isTitle', false)}
+      href={text('href', '')}
+      onClick={action('onClick')}
+    >
+      {text('children', 'Menu Entry')}
     </DropdownListItem>
   ));

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.test.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.test.tsx
@@ -10,9 +10,7 @@ it('renders the component', () => {
 
 it('renders the component with an additional class name', () => {
   const output = shallow(
-    <DropdownListItem className="my-extra-class">
-      <DropdownListItem>Entry</DropdownListItem>
-    </DropdownListItem>,
+    <DropdownListItem className="my-extra-class">Entry</DropdownListItem>,
   );
 
   expect(output).toMatchSnapshot();
@@ -50,4 +48,12 @@ it('does not call onClick on a disabled menu item', () => {
   const button = dropDownItem.find('button');
   button.simulate('click');
   expect(mockOnClick).not.toHaveBeenCalled();
+});
+
+it('renders the component with a href', () => {
+  const output = shallow(
+    <DropdownListItem href="#">DropdownListItem with a href</DropdownListItem>,
+  );
+
+  expect(output).toMatchSnapshot();
 });

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
@@ -1,4 +1,9 @@
-import React, { Component, MouseEventHandler, FocusEventHandler } from 'react';
+import React, {
+  Component,
+  MouseEventHandler,
+  FocusEventHandler,
+  MouseEvent as ReactMouseEvent,
+} from 'react';
 import cn from 'classnames';
 import TabFocusTrap from '../../TabFocusTrap/TabFocusTrap';
 import styles from './DropdownListItem.css';
@@ -11,6 +16,7 @@ export type DropdownListItemProps = {
   onClick?: MouseEventHandler;
   onMouseDown?: MouseEventHandler;
   submenuToggleLabel?: string;
+  href?: string;
   onFocus?: FocusEventHandler;
   onLeave?: MouseEventHandler;
   onEnter?: MouseEventHandler;
@@ -35,7 +41,7 @@ export class DropdownListItem extends Component<DropdownListItemProps> {
         <button
           type="button"
           data-test-id="cf-ui-dropdown-submenu-toggle"
-          className={styles['DropdownListItem__toggle-button']}
+          className={styles['DropdownListItem__button']}
           onClick={onClick}
           onMouseEnter={onEnter}
           onFocus={onFocus}
@@ -43,7 +49,7 @@ export class DropdownListItem extends Component<DropdownListItemProps> {
           {...otherProps}
         >
           <TabFocusTrap
-            className={styles['DropdownListItem__toggle-button__inner-wrapper']}
+            className={styles['DropdownListItem__button__inner-wrapper']}
           >
             {this.props.submenuToggleLabel}
           </TabFocusTrap>
@@ -53,32 +59,41 @@ export class DropdownListItem extends Component<DropdownListItemProps> {
     );
   };
 
-  renderListItem = () =>
-    this.props.onClick || this.props.onMouseDown ? (
-      <button
-        type="button"
-        data-test-id="cf-ui-dropdown-list-item-button"
-        className={styles['DropdownListItem__toggle-button']}
-        onClick={e => {
-          if (!this.props.isDisabled && this.props.onClick) {
-            this.props.onClick(e);
-          }
-        }}
-        onMouseDown={e => {
-          if (!this.props.isDisabled && this.props.onMouseDown) {
-            this.props.onMouseDown(e);
-          }
-        }}
-      >
-        <TabFocusTrap
-          className={styles['DropdownListItem__toggle-button__inner-wrapper']}
+  renderListItem = () => {
+    const isClickable =
+      this.props.onClick || this.props.onMouseDown || this.props.href;
+
+    if (isClickable) {
+      const Element = this.props.href ? 'a' : 'button';
+
+      return (
+        <Element
+          type="button"
+          href={this.props.href}
+          data-test-id="cf-ui-dropdown-list-item-button"
+          className={styles['DropdownListItem__button']}
+          onClick={(e: ReactMouseEvent) => {
+            if (!this.props.isDisabled && this.props.onClick) {
+              this.props.onClick(e);
+            }
+          }}
+          onMouseDown={(e: ReactMouseEvent) => {
+            if (!this.props.isDisabled && this.props.onMouseDown) {
+              this.props.onMouseDown(e);
+            }
+          }}
         >
-          {this.props.children}
-        </TabFocusTrap>
-      </button>
-    ) : (
-      this.props.children
-    );
+          <TabFocusTrap
+            className={styles['DropdownListItem__button__inner-wrapper']}
+          >
+            {this.props.children}
+          </TabFocusTrap>
+        </Element>
+      );
+    }
+
+    return this.props.children;
+  };
 
   render() {
     const {
@@ -88,13 +103,14 @@ export class DropdownListItem extends Component<DropdownListItemProps> {
       isActive,
       onClick,
       onMouseDown,
+      href,
       submenuToggleLabel,
       isTitle,
     } = this.props;
 
     const classNames = cn(styles['DropdownListItem'], className, {
       [styles['DropdownListItem__submenu-toggle']]:
-        submenuToggleLabel || onClick || onMouseDown,
+        submenuToggleLabel || onClick || onMouseDown || href,
       [styles['DropdownListItem--disabled']]: isDisabled,
       [styles['DropdownListItem--active']]: isActive,
       [styles['DropdownListItem--title']]: isTitle,

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/__snapshots__/DropdownListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/__snapshots__/DropdownListItem.test.tsx.snap
@@ -27,18 +27,33 @@ exports[`renders the component as disabled 1`] = `
 </li>
 `;
 
+exports[`renders the component with a href 1`] = `
+<li
+  className="DropdownListItem DropdownListItem__submenu-toggle"
+  data-test-id="cf-ui-dropdown-list-item"
+>
+  <a
+    className="DropdownListItem__button"
+    data-test-id="cf-ui-dropdown-list-item-button"
+    href="#"
+    onClick={[Function]}
+    onMouseDown={[Function]}
+    type="button"
+  >
+    <TabFocusTrap
+      className="DropdownListItem__button__inner-wrapper"
+    >
+      DropdownListItem with a href
+    </TabFocusTrap>
+  </a>
+</li>
+`;
+
 exports[`renders the component with an additional class name 1`] = `
 <li
   className="DropdownListItem my-extra-class"
   data-test-id="cf-ui-dropdown-list-item"
 >
-  <DropdownListItem
-    isActive={false}
-    isDisabled={false}
-    isTitle={false}
-    testId="cf-ui-dropdown-list-item"
-  >
-    Entry
-  </DropdownListItem>
+  Entry
 </li>
 `;


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This change adds a `href` prop to the `DropdownItem` component. This adds the ability to render dropdown actions as links, enabling native browser features such as the ability to open items in a new tab/page.

This PR requires #139 to be merged into master first - once this is merged I will rebase.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
