### PR TITLE
Card Drag Handles

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.css
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.css
@@ -1,18 +1,31 @@
 @import 'settings/colors';
 @import 'settings/typography';
 @import 'settings/transitions';
+@import 'settings/shadows';
 
 .AssetCard {
   height: calc(1rem * (300 / var(--font-base-default)));
-  display: inline-block;
+  display: inline-flex;
   padding: 0px;
   min-width: calc(1rem * (240 / var(--font-base-default)));
+  transition: box-shadow var(--transition-duration-short)
+      var(--transition-easing-default),
+    border-color var(--transition-duration-default)
+      var(--transition-easing-default);
+}
+
+.AssetCard--drag-active {
+  box-shadow: var(--box-shadow-heavy);
 }
 
 .AssetCard__asset {
   height: calc(
     1rem * (254 / var(--font-base-default))
   ); /* 254 Height of the container substracted by the border width of the header */
+}
+
+.AssetCard__wrapper {
+  flex: 1 1 0;
 }
 
 .AssetCard__header {

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.stories.tsx
@@ -29,6 +29,8 @@ storiesOf('Components|Card/AssetCard', module)
       isLoading={boolean('isLoading', false)}
       src={text('src', 'https://placekitten.com/200/300')}
       title={text('title', 'Image of a cat')}
+      withDragHandle={boolean('withDragHandle', false)}
+      isDragActive={boolean('isDragActive', false)}
     />
   ))
   .add('with dropdownListElements', () => (
@@ -48,6 +50,8 @@ storiesOf('Components|Card/AssetCard', module)
       isLoading={boolean('isLoading', false)}
       src={text('src', 'https://placekitten.com/200/300')}
       title={text('title', 'Image of a cat')}
+      withDragHandle={boolean('withDragHandle', false)}
+      isDragActive={boolean('isDragActive', false)}
       dropdownListElements={
         <React.Fragment>
           <DropdownList>

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.test.tsx
@@ -76,6 +76,19 @@ it('renders the component without actions', () => {
   expect(output).toMatchSnapshot();
 });
 
+it('renders the component with a drag handle', () => {
+  const output = shallow(
+    <AssetCard
+      className="my-extra-class"
+      src="http://placekitten.com/200/300"
+      title="picture of a cat"
+      withDragHandle
+    />,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
 it('has no a11y issues', async () => {
   const output = mount(
     <AssetCard src="http://placekitten.com/200/300" title="picture of a cat" />,

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
@@ -5,20 +5,60 @@ import CardActions from './../CardActions';
 import Asset from '../../Asset';
 import { AssetType } from '../../Asset/Asset';
 import Tag, { TagType } from '../../Tag/Tag';
+import Icon from '../../Icon/';
 import AssetCardSkeleton from './AssetCardSkeleton';
+import CardDragHandle, {
+  CardDragHandlePropTypes,
+} from '../CardDragHandle/CardDragHandle';
 const styles = require('./AssetCard.css');
 
 export type AssetState = 'archived' | 'changed' | 'draft' | 'published';
 
 export type AssetCardProps = {
+  /**
+   * The source of the asset (will also render a thumbnail if the AssetCard's type is set to image)
+   */
   src: string;
+  /**
+   * The title of the asset
+   */
   title: string;
+  /**
+   * Class names to be appended to the className prop of the component
+   */
   className?: string;
+  /**
+   * Loading state for the AssetCard - when true will display loading feedback to the user
+   */
   isLoading?: boolean;
+  /**
+   * The DropdownList elements used to render an actions dropdown for the AssetCard
+   */
   dropdownListElements?: React.ReactElement;
+  /**
+   * The publish status of the asset
+   */
   status?: AssetState;
+  /**
+   * An ID used for testing purposes applied as a data attribute (data-test-id)
+   */
   testId?: string;
+  /**
+   * The type of asset being represented
+   */
   type?: AssetType;
+  /**
+   * Renders a drag handle for the component for use in drag and drop contexts
+   */
+  withDragHandle?: boolean;
+  /**
+   * Applies styling for when the component is actively being dragged by the user
+   */
+  isDragActive?: boolean;
+  /**
+   * Props to pass down to the CardDragHandle component
+   */
+  cardDragHandleProps?: Partial<CardDragHandlePropTypes>;
 } & typeof defaultProps;
 
 const defaultProps = {
@@ -70,14 +110,23 @@ export class AssetCard extends Component<AssetCardProps> {
       status,
       isLoading,
       dropdownListElements,
+      withDragHandle,
+      cardDragHandleProps,
+      isDragActive,
       testId,
       ...otherProps
     } = this.props;
 
-    const classNames = cn(styles['AssetCard'], className);
+    const classNames = cn(
+      styles.AssetCard,
+      { [styles['AssetCard--drag-active']]: isDragActive },
+      className,
+    );
+
     return (
       <Card
         className={classNames}
+        padding="none"
         title={title}
         testId={testId}
         {...otherProps}
@@ -85,24 +134,34 @@ export class AssetCard extends Component<AssetCardProps> {
         {isLoading ? (
           <AssetCardSkeleton />
         ) : (
-          <div className={styles['AssetCard__inner-wrapper']}>
-            <div className={styles['AssetCard__header']}>
-              {status && this.renderStatus(status)}
-              {dropdownListElements && (
-                <CardActions className={styles['AssetCard__actions']}>
-                  {dropdownListElements}
-                </CardActions>
-              )}
+          <React.Fragment>
+            {withDragHandle && (
+              <CardDragHandle
+                isDragActive={isDragActive}
+                {...cardDragHandleProps}
+              >
+                Reorder entry
+              </CardDragHandle>
+            )}
+            <div className={styles['AssetCard__wrapper']}>
+              <div className={styles['AssetCard__header']}>
+                {status && this.renderStatus(status)}
+                {dropdownListElements && (
+                  <CardActions className={styles['AssetCard__actions']}>
+                    {dropdownListElements}
+                  </CardActions>
+                )}
+              </div>
+              <div className={styles['AssetCard__content']}>
+                <Asset
+                  className={styles['AssetCard__asset']}
+                  src={src}
+                  title={title}
+                  type={type}
+                />
+              </div>
             </div>
-            <div className={styles['AssetCard__content']}>
-              <Asset
-                className={styles['AssetCard__asset']}
-                src={src}
-                title={title}
-                type={type}
-              />
-            </div>
-          </div>
+          </React.Fragment>
         )}
       </Card>
     );

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`renders the component 1`] = `
 <Card
   className="AssetCard"
-  padding="default"
+  padding="none"
   selected={false}
   testId="cf-ui-asset-card"
   title="picture of a cat"
 >
   <div
-    className="AssetCard__inner-wrapper"
+    className="AssetCard__wrapper"
   >
     <div
       className="AssetCard__header"
@@ -32,7 +32,7 @@ exports[`renders the component 1`] = `
 exports[`renders the component in loading state 1`] = `
 <Card
   className="AssetCard"
-  padding="default"
+  padding="none"
   selected={false}
   testId="cf-ui-asset-card"
   title="picture of a cat"
@@ -41,16 +41,51 @@ exports[`renders the component in loading state 1`] = `
 </Card>
 `;
 
+exports[`renders the component with a drag handle 1`] = `
+<Card
+  className="AssetCard my-extra-class"
+  padding="none"
+  selected={false}
+  testId="cf-ui-asset-card"
+  title="picture of a cat"
+>
+  <CardDragHandle
+    isDragActive={false}
+    testId="cf-ui-card-drag-handle"
+  >
+    Reorder entry
+  </CardDragHandle>
+  <div
+    className="AssetCard__wrapper"
+  >
+    <div
+      className="AssetCard__header"
+    />
+    <div
+      className="AssetCard__content"
+    >
+      <Asset
+        className="AssetCard__asset"
+        src="http://placekitten.com/200/300"
+        testId="cf-ui-asset"
+        title="picture of a cat"
+        type="image"
+      />
+    </div>
+  </div>
+</Card>
+`;
+
 exports[`renders the component with actions 1`] = `
 <Card
   className="AssetCard"
-  padding="default"
+  padding="none"
   selected={false}
   testId="cf-ui-asset-card"
   title="picture of a cat"
 >
   <div
-    className="AssetCard__inner-wrapper"
+    className="AssetCard__wrapper"
   >
     <div
       className="AssetCard__header"
@@ -100,13 +135,13 @@ exports[`renders the component with actions 1`] = `
 exports[`renders the component with an additional class name 1`] = `
 <Card
   className="AssetCard my-extra-class"
-  padding="default"
+  padding="none"
   selected={false}
   testId="cf-ui-asset-card"
   title="picture of a cat"
 >
   <div
-    className="AssetCard__inner-wrapper"
+    className="AssetCard__wrapper"
   >
     <div
       className="AssetCard__header"
@@ -129,13 +164,13 @@ exports[`renders the component with an additional class name 1`] = `
 exports[`renders the component with status 1`] = `
 <Card
   className="AssetCard"
-  padding="default"
+  padding="none"
   selected={false}
   testId="cf-ui-asset-card"
   title="picture of a cat"
 >
   <div
-    className="AssetCard__inner-wrapper"
+    className="AssetCard__wrapper"
   >
     <div
       className="AssetCard__header"
@@ -170,13 +205,13 @@ exports[`renders the component with status 1`] = `
 exports[`renders the component without actions 1`] = `
 <Card
   className="AssetCard"
-  padding="default"
+  padding="none"
   selected={false}
   testId="cf-ui-asset-card"
   title="picture of a cat"
 >
   <div
-    className="AssetCard__inner-wrapper"
+    className="AssetCard__wrapper"
   >
     <div
       className="AssetCard__header"

--- a/packages/forma-36-react-components/src/components/Card/CardDragHandle/CardActions.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardDragHandle/CardActions.stories.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { text, boolean } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+
+import CardDragHandle from './CardDragHandle';
+
+storiesOf('Components|Card/CardDragHandle', module)
+  .addParameters({
+    propTypes: CardDragHandle['__docgenInfo'],
+  })
+  .add('default', () => (
+    <div style={{ height: 100 }}>
+      <CardDragHandle
+        className={text('className', '')}
+        isDragActive={boolean('isDragActive', false)}
+      >
+        {text('children', 'CardDragHandle')}
+      </CardDragHandle>
+    </div>
+  ));

--- a/packages/forma-36-react-components/src/components/Card/CardDragHandle/CardDragHandle.css
+++ b/packages/forma-36-react-components/src/components/Card/CardDragHandle/CardDragHandle.css
@@ -1,0 +1,42 @@
+@import 'settings/colors';
+@import 'settings/transitions';
+@import 'settings/typography';
+
+.CardDragHandle {
+  composes: focus-outline--default from './../../../styles/settings/a11y.css';
+  display: flex;
+  position: relative;
+  width: calc(1rem * (20 / var(--font-base-default)));
+  height: 100%;
+  align-items: center;
+  background-color: var(--color-element-lightest);
+  border: 0;
+  padding: 0;
+  border-right: 1px solid var(--color-element-mid);
+  cursor: grab;
+  transition: background-color var(--transition-duration-default)
+    var(--transition-easing-default);
+}
+
+.CardDragHandle:hover,
+.CardDragHandle:focus {
+  background-color: var(--color-element-light);
+}
+
+.CardDragHandle--drag-active {
+  background-color: var(--color-element-light);
+  cursor: grabbing;
+}
+
+.CardDragHandle__sr-label {
+  composes: sr-only from './../../../styles/settings/helpers.css';
+}
+
+.CardDragHandle__focus-trap {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  align-items: center;
+}

--- a/packages/forma-36-react-components/src/components/Card/CardDragHandle/CardDragHandle.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardDragHandle/CardDragHandle.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { axe } from 'jest-axe';
+import CardDragHandle from './CardDragHandle';
+import DropdownListItem from '../../Dropdown/DropdownListItem';
+import DropdownList from '../../Dropdown/DropdownList';
+
+it('renders the component', () => {
+  const output = shallow(<CardDragHandle>CardDragHandle</CardDragHandle>);
+
+  expect(output).toMatchSnapshot();
+});
+
+it('renders the component with an additional class name', () => {
+  const output = shallow(
+    <CardDragHandle className="my-extra-class">CardDragHandle</CardDragHandle>,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
+it('renders the component with isDragActive prop set to true', () => {
+  const output = shallow(
+    <CardDragHandle isDragActive>CardDragHandle</CardDragHandle>,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
+it('has no a11y issues', async () => {
+  const output = mount(<CardDragHandle>CardDragHandle</CardDragHandle>).html();
+  const results = await axe(output);
+
+  expect(results).toHaveNoViolations();
+});

--- a/packages/forma-36-react-components/src/components/Card/CardDragHandle/CardDragHandle.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardDragHandle/CardDragHandle.tsx
@@ -1,0 +1,62 @@
+import React, { Component } from 'react';
+import cn from 'classnames';
+import Icon from '../../Icon';
+import TabFocusTrap from '../../TabFocusTrap';
+
+const styles = require('./CardDragHandle.css');
+
+export type CardDragHandlePropTypes = {
+  /**
+   * Label rendered as child in CardDragHandle - not visible on screen as
+   * purpose is for screen readers only
+   */
+  children: React.ReactNode;
+  /**
+   * Class names to be appended to the className prop of the component
+   */
+  className?: string;
+  /**
+   * An ID used for testing purposes applied as a data attribute (data-test-id)
+   */
+  testId?: string;
+  /**
+   * Applies styling for when the component is actively being dragged by the user
+   */
+  isDragActive?: boolean;
+} & typeof defaultProps;
+
+const defaultProps = {
+  testId: 'cf-ui-card-drag-handle',
+  isDragActive: false,
+};
+
+export class CardDragHandle extends Component<CardDragHandlePropTypes> {
+  static defaultProps = defaultProps;
+
+  render() {
+    const {
+      className,
+      testId,
+      children,
+      isDragActive,
+      ...otherProps
+    } = this.props;
+
+    const classNames = cn(
+      styles.CardDragHandle,
+      { [styles['CardDragHandle--drag-active']]: isDragActive },
+      className,
+    );
+
+    return (
+      <button className={classNames} data-test-id={testId} {...otherProps}>
+        <TabFocusTrap className={styles['CardDragHandle__focus-trap']}>
+          <Icon icon="Drag" color="muted" />
+          <span className={styles['CardDragHandle__sr-label']}>{children}</span>
+        </TabFocusTrap>
+      </button>
+    );
+  }
+}
+
+export default CardDragHandle;

--- a/packages/forma-36-react-components/src/components/Card/CardDragHandle/__snapshots__/CardDragHandle.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/CardDragHandle/__snapshots__/CardDragHandle.test.tsx.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders the component 1`] = `
+<button
+  className="CardDragHandle"
+  data-test-id="cf-ui-card-drag-handle"
+>
+  <TabFocusTrap
+    className="CardDragHandle__focus-trap"
+  >
+    <Icon
+      color="muted"
+      icon="Drag"
+      size="small"
+      testId="cf-ui-icon"
+    />
+    <span
+      className="CardDragHandle__sr-label"
+    >
+      CardDragHandle
+    </span>
+  </TabFocusTrap>
+</button>
+`;
+
+exports[`renders the component with an additional class name 1`] = `
+<button
+  className="CardDragHandle my-extra-class"
+  data-test-id="cf-ui-card-drag-handle"
+>
+  <TabFocusTrap
+    className="CardDragHandle__focus-trap"
+  >
+    <Icon
+      color="muted"
+      icon="Drag"
+      size="small"
+      testId="cf-ui-icon"
+    />
+    <span
+      className="CardDragHandle__sr-label"
+    >
+      CardDragHandle
+    </span>
+  </TabFocusTrap>
+</button>
+`;
+
+exports[`renders the component with isDragActive prop set to true 1`] = `
+<button
+  className="CardDragHandle CardDragHandle--drag-active"
+  data-test-id="cf-ui-card-drag-handle"
+>
+  <TabFocusTrap
+    className="CardDragHandle__focus-trap"
+  >
+    <Icon
+      color="muted"
+      icon="Drag"
+      size="small"
+      testId="cf-ui-icon"
+    />
+    <span
+      className="CardDragHandle__sr-label"
+    >
+      CardDragHandle
+    </span>
+  </TabFocusTrap>
+</button>
+`;

--- a/packages/forma-36-react-components/src/components/Card/CardDragHandle/index.ts
+++ b/packages/forma-36-react-components/src/components/Card/CardDragHandle/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CardDragHandle';

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.css
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.css
@@ -1,9 +1,10 @@
 @import 'settings/colors';
 @import 'settings/typography';
 @import 'settings/transitions';
+@import 'settings/shadows';
 
 .EntryCard {
-  display: block;
+  display: flex;
   position: relative;
   box-sizing: border-box;
   font-family: var(--font-stack-primary);
@@ -11,6 +12,19 @@
   line-height: var(--line-height-default);
   color: var(--color-text-dark);
   height: calc(1rem * (135 / var(--font-base-default)));
+  transition: box-shadow var(--transition-duration-short)
+      var(--transition-easing-default),
+    border-color var(--transition-duration-default)
+      var(--transition-easing-default);
+}
+
+.EntryCard__wrapper {
+  padding: calc(1rem * (14 / var(--font-base-default)));
+  flex: 1 1 0;
+}
+
+.EntryCard--drag-active {
+  box-shadow: var(--box-shadow-heavy);
 }
 
 .EntryCard--is-loading {

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
@@ -57,6 +57,8 @@ storiesOf('Components|Card/EntryCard', module)
             </DropdownList>
           </React.Fragment>
         }
+        withDragHandle={boolean('withDragHandle', false)}
+        isDragActive={boolean('isDragActive', false)}
         className={text('className', '')}
         loading={boolean('loading', false)}
       />
@@ -101,6 +103,7 @@ storiesOf('Components|Card/EntryCard', module)
             </DropdownListItem>
           </DropdownList>
         }
+        withDragHandle={boolean('withDragHandle', false)}
         loading={boolean('loading', false)}
         className={text('className', '')}
       />

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.test.tsx
@@ -72,6 +72,20 @@ it('renders the component with an additional class name', () => {
   expect(output).toMatchSnapshot();
 });
 
+it('renders the component with a drag handle', () => {
+  const output = shallow(
+    <EntryCard
+      title="My Entry Card"
+      description="This is my Entry Card"
+      status="published"
+      contentType="My Content Type"
+      withDragHandle
+    />,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
 it('has no a11y issues', async () => {
   const output = mount(
     <EntryCard

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
@@ -3,8 +3,12 @@ import cn from 'classnames';
 import truncate from 'truncate';
 import Card from '../Card';
 import CardActions from '../CardActions';
+import CardDragHandle, {
+  CardDragHandlePropTypes,
+} from '../CardDragHandle/CardDragHandle';
 import Tag, { TagType } from '../../Tag/Tag';
 import EntryCardSkeleton from './EntryCardSkeleton';
+import Icon from './../../Icon';
 
 const styles = require('./EntryCard.css');
 
@@ -51,6 +55,18 @@ export type EntryCardPropTypes = {
    * The DropdownList elements used to render an actions dropdown for the EntryCard
    */
   dropdownListElements?: React.ReactElement;
+  /**
+   * Renders a drag handle for the component for use in drag and drop contexts
+   */
+  withDragHandle?: boolean;
+  /**
+   * Applies styling for when the component is actively being dragged by the user
+   */
+  isDragActive?: boolean;
+  /**
+   * Props to pass down to the CardDragHandle component
+   */
+  cardDragHandleProps?: Partial<CardDragHandlePropTypes>;
 } & typeof defaultProps;
 
 const defaultProps = {
@@ -131,46 +147,66 @@ export class EntryCard extends Component<EntryCardPropTypes> {
       thumbnailElement,
       loading,
       dropdownListElements,
+      withDragHandle,
+      isDragActive,
+      cardDragHandleProps,
       ...otherProps
     } = this.props;
 
-    const classNames = cn(styles.EntryCard, className);
+    const classNames = cn(
+      styles.EntryCard,
+      { [styles['EntryCard--drag-active']]: isDragActive },
+      className,
+    );
 
     return (
       <Card
         className={classNames}
         onClick={!loading ? onClick : undefined}
         testId={testId}
+        padding="none"
         {...otherProps}
       >
         {loading ? (
-          <EntryCardSkeleton />
+          <div className={styles.EntryCard__wrapper}>
+            <EntryCardSkeleton />
+          </div>
         ) : (
-          <article className={styles.EntryCard__wrapper}>
-            <React.Fragment>
-              <div className={styles.EntryCard__meta}>
-                <div
-                  className={styles['EntryCard__content-type']}
-                  data-test-id="content-type"
-                >
-                  {contentType}
+          <React.Fragment>
+            {withDragHandle && (
+              <CardDragHandle
+                isDragActive={isDragActive}
+                {...cardDragHandleProps}
+              >
+                Reorder entry
+              </CardDragHandle>
+            )}
+            <article className={styles.EntryCard__wrapper}>
+              <React.Fragment>
+                <div className={styles.EntryCard__meta}>
+                  <div
+                    className={styles['EntryCard__content-type']}
+                    data-test-id="content-type"
+                  >
+                    {contentType}
+                  </div>
+                  {status && this.renderStatus(status)}
+                  {dropdownListElements && (
+                    <CardActions className={styles['EntryCard__actions']}>
+                      {dropdownListElements}
+                    </CardActions>
+                  )}
                 </div>
-                {status && this.renderStatus(status)}
-                {dropdownListElements && (
-                  <CardActions className={styles['EntryCard__actions']}>
-                    {dropdownListElements}
-                  </CardActions>
-                )}
-              </div>
-              <div className={styles.EntryCard__content}>
-                <div className={styles.EntryCard__body}>
-                  {title && this.renderTitle(title)}
-                  {description && this.renderDescription(description)}
+                <div className={styles.EntryCard__content}>
+                  <div className={styles.EntryCard__body}>
+                    {title && this.renderTitle(title)}
+                    {description && this.renderDescription(description)}
+                  </div>
+                  {thumbnailElement && this.renderThumbnail(thumbnailElement)}
                 </div>
-                {thumbnailElement && this.renderThumbnail(thumbnailElement)}
-              </div>
-            </React.Fragment>
-          </article>
+              </React.Fragment>
+            </article>
+          </React.Fragment>
         )}
       </Card>
     );

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders the component 1`] = `
 <Card
   className="EntryCard"
-  padding="default"
+  padding="none"
   selected={false}
   testId="cf-ui-entry-card"
 >
@@ -50,10 +50,66 @@ exports[`renders the component 1`] = `
 </Card>
 `;
 
+exports[`renders the component with a drag handle 1`] = `
+<Card
+  className="EntryCard"
+  padding="none"
+  selected={false}
+  testId="cf-ui-entry-card"
+>
+  <CardDragHandle
+    isDragActive={false}
+    testId="cf-ui-card-drag-handle"
+  >
+    Reorder entry
+  </CardDragHandle>
+  <article
+    className="EntryCard__wrapper"
+  >
+    <div
+      className="EntryCard__meta"
+    >
+      <div
+        className="EntryCard__content-type"
+        data-test-id="content-type"
+      >
+        My Content Type
+      </div>
+      <Tag
+        tagType="positive"
+        testId="cf-ui-tag"
+      >
+        published
+      </Tag>
+    </div>
+    <div
+      className="EntryCard__content"
+    >
+      <div
+        className="EntryCard__body"
+      >
+        <h1
+          className="EntryCard__title"
+          data-test-id="title"
+          title=""
+        >
+          My Entry Card
+        </h1>
+        <p
+          className="EntryCard__description"
+        >
+          This is my Entry Card
+        </p>
+      </div>
+    </div>
+  </article>
+</Card>
+`;
+
 exports[`renders the component with a thumbnail element 1`] = `
 <Card
   className="EntryCard"
-  padding="default"
+  padding="none"
   selected={false}
   testId="cf-ui-entry-card"
 >
@@ -111,7 +167,7 @@ exports[`renders the component with a thumbnail element 1`] = `
 exports[`renders the component with an additional class name 1`] = `
 <Card
   className="EntryCard my-extra-class"
-  padding="default"
+  padding="none"
   selected={false}
   testId="cf-ui-entry-card"
 >
@@ -161,7 +217,7 @@ exports[`renders the component with an additional class name 1`] = `
 exports[`renders the component with dropdownListElements 1`] = `
 <Card
   className="EntryCard"
-  padding="default"
+  padding="none"
   selected={false}
   testId="cf-ui-entry-card"
 >


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR adds a drag handle to the EntryCard and AssetCard components for use in drag and drop contexts

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
