### PR TITLE
fix(Dropdown): Dont reposition if no resoulution available

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -111,14 +111,17 @@ class DropdownContainer extends Component<
       },
     };
     const currentPosition = this.state.position;
-    this.setState(
-      {
-        position: resolutions[overflowAt][currentPosition],
-      },
-      () => {
-        this.lastOverflowAt = overflowAt;
-      },
-    );
+    const resolution = resolutions[overflowAt][currentPosition];
+    if (resolution) {
+      this.setState(
+        {
+          position: resolution,
+        },
+        () => {
+          this.lastOverflowAt = overflowAt;
+        },
+      );
+    }
   };
 
   calculatePosition = () => {


### PR DESCRIPTION
This PR will fix a bug of dropdown repositioning when no resolution is defined.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
