### PR TITLE
Stop EntryCard click events firing on CardActions click

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
@@ -1,13 +1,17 @@
 import React, { Component, MouseEvent as ReactMouseEvent } from 'react';
 import Dropdown from '../../Dropdown/Dropdown';
 import DropdownList from '../../Dropdown/DropdownList';
-import IconButton from '../../IconButton';
+import IconButton, { IconButtonProps } from '../../IconButton/IconButton';
 
 export type CardActionsPropTypes = {
   /**
    * Class names to be appended to the className prop of the component
    */
   className?: string;
+  /**
+   * Props to pass down to the IconButton component
+   */
+  iconButtonProps?: Partial<IconButtonProps>;
   /**
    * The DropdownList elements used to render an actions dropdown for the component
    */
@@ -32,8 +36,24 @@ export class CardActions extends Component<
 
   state = { isDropdownOpen: false };
 
+  handleClick = (event: ReactMouseEvent) => {
+    this.setState(prevState => ({
+      isDropdownOpen: !prevState.isDropdownOpen,
+    }));
+
+    if (this.props.iconButtonProps && this.props.iconButtonProps.onClick) {
+      event.stopPropagation();
+    }
+  };
+
   render() {
-    const { className, children, testId, ...otherProps } = this.props;
+    const {
+      className,
+      children,
+      testId,
+      iconButtonProps,
+      ...otherProps
+    } = this.props;
 
     return (
       <Dropdown
@@ -50,10 +70,9 @@ export class CardActions extends Component<
             iconProps={{ icon: 'MoreHorizontal' }}
             buttonType="secondary"
             label="Actions"
-            onClick={() => {
-              this.setState(prevState => ({
-                isDropdownOpen: !prevState.isDropdownOpen,
-              }));
+            {...iconButtonProps}
+            onClick={event => {
+              this.handleClick(event);
             }}
           />
         }
@@ -74,6 +93,7 @@ export class CardActions extends Component<
                       child.props.onClick(e);
                     }
                     this.setState({ isDropdownOpen: false });
+                    e.stopPropagation();
                   },
                 }),
             );

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
@@ -191,7 +191,12 @@ export class EntryCard extends Component<EntryCardPropTypes> {
                   </div>
                   {status && this.renderStatus(status)}
                   {dropdownListElements && (
-                    <CardActions className={styles['EntryCard__actions']}>
+                    <CardActions
+                      className={styles['EntryCard__actions']}
+                      iconButtonProps={{
+                        onClick: e => e.stopPropagation,
+                      }}
+                    >
                       {dropdownListElements}
                     </CardActions>
                   )}

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
@@ -241,6 +241,11 @@ exports[`renders the component with dropdownListElements 1`] = `
       </Tag>
       <CardActions
         className="EntryCard__actions"
+        iconButtonProps={
+          Object {
+            "onClick": [Function],
+          }
+        }
         testId="cf-ui-card-actions"
       >
         <DropdownList


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

There's currently an issue with the EntryCard component - if it has CardActions, when clicking an action the click event on the EntryCard also fires. This PR fixes this issue.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
