### PR TITLE
Stop CardActions events propagating to AssetCard and InlineEntryCard

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
@@ -146,7 +146,12 @@ export class AssetCard extends Component<AssetCardProps> {
               <div className={styles['AssetCard__header']}>
                 {status && this.renderStatus(status)}
                 {dropdownListElements && (
-                  <CardActions className={styles['AssetCard__actions']}>
+                  <CardActions
+                    className={styles['AssetCard__actions']}
+                    iconButtonProps={{
+                      onClick: e => e.stopPropagation,
+                    }}
+                  >
                     {dropdownListElements}
                   </CardActions>
                 )}

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
@@ -92,6 +92,11 @@ exports[`renders the component with actions 1`] = `
     >
       <CardActions
         className="AssetCard__actions"
+        iconButtonProps={
+          Object {
+            "onClick": [Function],
+          }
+        }
         testId="cf-ui-card-actions"
       >
         <DropdownList

--- a/packages/forma-36-react-components/src/components/Card/InlineEntryCard/InlineEntryCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/InlineEntryCard/InlineEntryCard.tsx
@@ -95,7 +95,12 @@ export class InlineEntryCard extends Component<InlineEntryCardPropTypes> {
           {isLoading ? 'Loading' : children}
         </span>
         {dropdownListElements && (
-          <CardActions className={styles['InlineEntryCard__actions']}>
+          <CardActions
+            className={styles['InlineEntryCard__actions']}
+            iconButtonProps={{
+              onClick: e => e.stopPropagation,
+            }}
+          >
             {dropdownListElements}
           </CardActions>
         )}

--- a/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
@@ -75,6 +75,11 @@ exports[`renders the component with a dropdown 1`] = `
   </span>
   <CardActions
     className="InlineEntryCard__actions"
+    iconButtonProps={
+      Object {
+        "onClick": [Function],
+      }
+    }
     testId="cf-ui-card-actions"
   >
     <DropdownList


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR will stop CardActions events propagating to AssetCards and InlineEntryCards

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
