### PR TITLE
fix(Form): Use forma tokens for spacing configuration

### DIFF
--- a/packages/forma-36-react-components/src/components/Form/Form/Form.css
+++ b/packages/forma-36-react-components/src/components/Form/Form/Form.css
@@ -1,4 +1,5 @@
 @import 'settings/typography';
+@import 'settings/dimensions';
 
 .Form {
   display: block;
@@ -9,9 +10,9 @@
 }
 
 .Form__item--default {
-  margin-bottom: calc(1rem * (40 / var(--font-base-default)));
+  margin-bottom: var(--spacing-l);
 }
 
 .Form__item--condensed {
-  margin-bottom: calc(1rem * (28 / var(--font-base-default)));
+  margin-bottom: var(--spacing-m);
 }


### PR DESCRIPTION
This PR changes the values of the spacing setting to the following:

default: spacing-l
condensed: spacing-m

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
