### PR TITLE
Add size prop to EntryCard component

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.css
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.css
@@ -11,11 +11,18 @@
   font-size: var(--font-size-m);
   line-height: var(--line-height-default);
   color: var(--color-text-dark);
-  height: calc(1rem * (135 / var(--font-base-default)));
   transition: box-shadow var(--transition-duration-short)
       var(--transition-easing-default),
     border-color var(--transition-duration-default)
       var(--transition-easing-default);
+}
+
+.EntryCard--size-default {
+  height: calc(1rem * (135 / var(--font-base-default)));
+}
+
+.EntryCard--size-small {
+  height: calc(1rem * (84 / var(--font-base-default)));
 }
 
 .EntryCard__wrapper {

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
@@ -61,6 +61,14 @@ storiesOf('Components|Card/EntryCard', module)
         isDragActive={boolean('isDragActive', false)}
         className={text('className', '')}
         loading={boolean('loading', false)}
+        size={select(
+          'size',
+          {
+            default: 'default',
+            small: 'small',
+          },
+          'default',
+        )}
       />
     </div>
   ))

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.test.tsx
@@ -86,6 +86,20 @@ it('renders the component with a drag handle', () => {
   expect(output).toMatchSnapshot();
 });
 
+it('renders a small sized variant of the component', () => {
+  const output = shallow(
+    <EntryCard
+      title="My Entry Card"
+      description="This is my Entry Card"
+      status="published"
+      contentType="My Content Type"
+      size="small"
+    />,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
 it('has no a11y issues', async () => {
   const output = mount(
     <EntryCard

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
@@ -66,11 +66,16 @@ export type EntryCardPropTypes = {
    * Props to pass down to the CardDragHandle component
    */
   cardDragHandleProps?: Partial<CardDragHandlePropTypes>;
+  /**
+   * Changes the height of the component. When small will also ensure thumbnail and description aren't rendered
+   */
+  size: 'default' | 'small';
 } & typeof defaultProps;
 
 const defaultProps = {
   title: 'Untitled',
   testId: 'cf-ui-entry-card',
+  size: 'default',
 };
 
 export class EntryCard extends Component<EntryCardPropTypes> {
@@ -149,12 +154,16 @@ export class EntryCard extends Component<EntryCardPropTypes> {
       withDragHandle,
       isDragActive,
       cardDragHandleProps,
+      size,
       ...otherProps
     } = this.props;
 
     const classNames = cn(
       styles.EntryCard,
-      { [styles['EntryCard--drag-active']]: isDragActive },
+      {
+        [styles['EntryCard--drag-active']]: isDragActive,
+        [styles[`EntryCard--size-${size}`]]: size,
+      },
       className,
     );
 
@@ -204,9 +213,13 @@ export class EntryCard extends Component<EntryCardPropTypes> {
                 <div className={styles.EntryCard__content}>
                   <div className={styles.EntryCard__body}>
                     {title && this.renderTitle(title)}
-                    {description && this.renderDescription(description)}
+                    {description &&
+                      size === 'default' &&
+                      this.renderDescription(description)}
                   </div>
-                  {thumbnailElement && this.renderThumbnail(thumbnailElement)}
+                  {thumbnailElement &&
+                    size === 'default' &&
+                    this.renderThumbnail(thumbnailElement)}
                 </div>
               </React.Fragment>
             </article>

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
@@ -1,8 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders a small sized variant of the component 1`] = `
+<Card
+  className="EntryCard EntryCard--size-small"
+  padding="none"
+  selected={false}
+  testId="cf-ui-entry-card"
+>
+  <article
+    className="EntryCard__wrapper"
+  >
+    <div
+      className="EntryCard__meta"
+    >
+      <div
+        className="EntryCard__content-type"
+        data-test-id="content-type"
+      >
+        My Content Type
+      </div>
+      <Tag
+        tagType="positive"
+        testId="cf-ui-tag"
+      >
+        published
+      </Tag>
+    </div>
+    <div
+      className="EntryCard__content"
+    >
+      <div
+        className="EntryCard__body"
+      >
+        <h1
+          className="EntryCard__title"
+          data-test-id="title"
+          title=""
+        >
+          My Entry Card
+        </h1>
+      </div>
+    </div>
+  </article>
+</Card>
+`;
+
 exports[`renders the component 1`] = `
 <Card
-  className="EntryCard"
+  className="EntryCard EntryCard--size-default"
   padding="none"
   selected={false}
   testId="cf-ui-entry-card"
@@ -52,7 +97,7 @@ exports[`renders the component 1`] = `
 
 exports[`renders the component with a drag handle 1`] = `
 <Card
-  className="EntryCard"
+  className="EntryCard EntryCard--size-default"
   padding="none"
   selected={false}
   testId="cf-ui-entry-card"
@@ -108,7 +153,7 @@ exports[`renders the component with a drag handle 1`] = `
 
 exports[`renders the component with a thumbnail element 1`] = `
 <Card
-  className="EntryCard"
+  className="EntryCard EntryCard--size-default"
   padding="none"
   selected={false}
   testId="cf-ui-entry-card"
@@ -166,7 +211,7 @@ exports[`renders the component with a thumbnail element 1`] = `
 
 exports[`renders the component with an additional class name 1`] = `
 <Card
-  className="EntryCard my-extra-class"
+  className="EntryCard EntryCard--size-default my-extra-class"
   padding="none"
   selected={false}
   testId="cf-ui-entry-card"
@@ -216,7 +261,7 @@ exports[`renders the component with an additional class name 1`] = `
 
 exports[`renders the component with dropdownListElements 1`] = `
 <Card
-  className="EntryCard"
+  className="EntryCard EntryCard--size-default"
   padding="none"
   selected={false}
   testId="cf-ui-entry-card"


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR adds a size prop to the EntryCard component for purposes of rendering more compact entry cards.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
