### PR TITLE
fix(Button): Remove active transition

### DIFF
--- a/packages/forma-36-react-components/src/components/Button/Button.css
+++ b/packages/forma-36-react-components/src/components/Button/Button.css
@@ -91,6 +91,7 @@
   }
 
   &:active:not(.Button--disabled) {
+    transition: none;
     background-image: none;
     background-color: var(--color-blue-dark);
   }
@@ -120,6 +121,7 @@
   }
 
   &:active:not(.Button--disabled) {
+    transition: none;
     background-image: none;
     background-color: var(--color-green-dark);
   }
@@ -149,6 +151,7 @@
   }
 
   &:active:not(.Button--disabled) {
+    transition: none;
     background-image: none;
     background-color: var(--color-red-dark);
   }


### PR DESCRIPTION
This PR will remove the background transition for all active selectors.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
