### PR TITLE
fix(TextField): Update character count on value set through props

### DIFF
--- a/packages/forma-36-react-components/src/components/TextField/TextField.tsx
+++ b/packages/forma-36-react-components/src/components/TextField/TextField.tsx
@@ -34,6 +34,7 @@ export type TextFieldProps = {
 
 export interface TextFieldState {
   value?: string;
+  initialValue?: string;
 }
 
 const defaultProps = {
@@ -46,7 +47,7 @@ const defaultProps = {
 export class TextField extends Component<TextFieldProps, TextFieldState> {
   static defaultProps = defaultProps;
 
-  state = { value: this.props.value || '' };
+  state = { value: this.props.value || '', initialValue: this.props.value };
 
   // Store a copy of the value in state.
   // This is used by this component when the `countCharacters`
@@ -55,6 +56,15 @@ export class TextField extends Component<TextFieldProps, TextFieldState> {
     this.setState({ value: (evt.target as HTMLInputElement).value });
     if (this.props.onChange) this.props.onChange(evt);
   };
+
+  static getDerivedStateFromProps(
+    props: TextFieldProps,
+    state: TextFieldState,
+  ) {
+    if (props.value !== state.initialValue) {
+      return { ...state, value: props.value, initialValue: props.value };
+    }
+  }
 
   render() {
     const {


### PR DESCRIPTION
This PR will fix the issue of the character count not beeing updated when the value is set through props.
Related Issue: https://github.com/contentful/forma-36/issues/143

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
