### PR TITLE
Fix broken spacing in Form caused by nullable children

### DIFF
--- a/packages/forma-36-react-components/src/components/Form/Form/Form.tsx
+++ b/packages/forma-36-react-components/src/components/Form/Form/Form.tsx
@@ -9,7 +9,7 @@ export type FormProps = {
   testId?: string;
   style?: React.CSSProperties;
   className?: string;
-  children: React.ReactNode;
+  children: React.ReactChild | React.ReactNodeArray;
 } & typeof defaultProps;
 
 const defaultProps = {
@@ -51,9 +51,12 @@ export class Form extends Component<FormProps> {
         onSubmit={this.handleSubmit}
         {...otherProps}
       >
-        {React.Children.map(children, child => (
-          <div className={formItemClassNames}>{child}</div>
-        ))}
+        {React.Children.map(children, child => {
+          if (child) {
+            return <div className={formItemClassNames}>{child}</div>;
+          }
+          return null;
+        })}
       </form>
     );
   }

--- a/packages/forma-36-react-components/src/components/TextField/TextField.tsx
+++ b/packages/forma-36-react-components/src/components/TextField/TextField.tsx
@@ -64,6 +64,7 @@ export class TextField extends Component<TextFieldProps, TextFieldState> {
     if (props.value !== state.initialValue) {
       return { ...state, value: props.value, initialValue: props.value };
     }
+    return null;
   }
 
   render() {


### PR DESCRIPTION
# Purpose of PR

*  Filter out nullable children in Form component, so the following code doesn't cause weird empty spacing:

```
<Form>
   {null}
  <TextField />
  <TextField />
</Form>
```

* Fixed warning about incorrect usage of getDerivedStateFromProps

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
