### PR TITLE
fix(TextInput): Add Date and Time as type

### DIFF
--- a/packages/forma-36-react-components/src/components/TextField/TextField.tsx
+++ b/packages/forma-36-react-components/src/components/TextField/TextField.tsx
@@ -64,7 +64,7 @@ export class TextField extends Component<TextFieldProps, TextFieldState> {
     if (props.value !== state.initialValue) {
       return { ...state, value: props.value, initialValue: props.value };
     }
-    return null;
+    return state;
   }
 
   render() {

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
@@ -11,7 +11,15 @@ import styles from './TextInput.css';
 
 export type TextInputProps = {
   width?: 'small' | 'medium' | 'large' | 'full';
-  type?: 'text' | 'password' | 'email' | 'number' | 'search' | 'url';
+  type?:
+    | 'text'
+    | 'password'
+    | 'email'
+    | 'number'
+    | 'search'
+    | 'url'
+    | 'date'
+    | 'time';
   name?: string;
   id?: string;
   className?: string;


### PR DESCRIPTION
This PR will introduce Date and Time as types for the input component. It also fixes a warning of not returning state on getDerivedStateFromProps.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
