### PR TITLE
Fix/remove dom refs from constructor for ssr

### DIFF
--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
@@ -115,7 +115,10 @@ export class Tooltip extends Component<TooltipProps, TooltipState> {
   }
 
   setPlace = (place: TooltipPlace) => {
-    this.place = place;
+    if (this.state.isVisible) {
+      this.place = place;
+      this.forceUpdate();
+    }
   };
 
   calculatePosition = () => {

--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
@@ -59,6 +59,11 @@ export type TooltipProps = {
   onBlur?: Function;
 } & typeof defaultProps;
 
+interface TooltipState {
+  isVisible?: boolean;
+  portalTarget?: Node;
+}
+
 const defaultProps = {
   containerElement: 'span',
   isVisible: false,
@@ -67,7 +72,7 @@ const defaultProps = {
   maxWidth: 360,
 };
 
-export class Tooltip extends Component<TooltipProps> {
+export class Tooltip extends Component<TooltipProps, TooltipState> {
   static defaultProps = defaultProps;
 
   portalTarget: HTMLDivElement | null = null;
@@ -75,20 +80,26 @@ export class Tooltip extends Component<TooltipProps> {
   containerDomNode: HTMLSpanElement | null = null;
   tooltipDomNode: HTMLDivElement | null = null;
 
-  constructor(props: TooltipProps) {
-    super(props);
-    this.portalTarget = document.createElement('div');
-    this.place = props.place;
-  }
-
-  state = {
+  state: Partial<TooltipState> = {
     isVisible: this.props.isVisible,
   };
 
+  constructor(props: TooltipProps) {
+    super(props);
+    this.place = props.place;
+  }
+
   componentDidMount() {
-    if (this.portalTarget) {
-      document.body.appendChild(this.portalTarget);
-    }
+    this.setState(
+      {
+        portalTarget: window.document.createElement('div'),
+      },
+      () => {
+        if (this.state.portalTarget) {
+          window.document.body.appendChild(this.state.portalTarget);
+        }
+      },
+    );
   }
 
   componentDidUpdate(prevProps: TooltipProps) {
@@ -98,8 +109,8 @@ export class Tooltip extends Component<TooltipProps> {
   }
 
   componentWillUnmount() {
-    if (this.portalTarget) {
-      document.body.removeChild(this.portalTarget);
+    if (this.state.portalTarget) {
+      window.document.body.removeChild(this.state.portalTarget);
     }
   }
 
@@ -156,6 +167,9 @@ export class Tooltip extends Component<TooltipProps> {
   };
 
   renderTooltip = (content: React.ReactNode) => {
+    if (!this.state.portalTarget) {
+      return null;
+    }
     const placeClass = `Tooltip--place-${this.place}`;
     const classNames = cn(
       styles['Tooltip'],
@@ -198,7 +212,7 @@ export class Tooltip extends Component<TooltipProps> {
       </div>
     );
 
-    return ReactDOM.createPortal(tooltip, this.portalTarget as Element);
+    return ReactDOM.createPortal(tooltip, this.state.portalTarget as Element);
   };
 
   render() {


### PR DESCRIPTION
# Purpose of PR

Remove all dom references from the constructor the enable SSR (Gatsby won't build). As a bonus it fixes annoying repositioning quirks when the tooltip overflows and is invisible.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
