### PR TITLE
Refactor card drag handles

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.stories.tsx
@@ -6,6 +6,7 @@ import { action } from '@storybook/addon-actions';
 import AssetCard from './AssetCard';
 import DropdownList from '../../Dropdown/DropdownList';
 import DropdownListItem from '../../Dropdown/DropdownListItem';
+import CardDragHandle from './../CardDragHandle';
 import { types } from '../../Asset/Asset';
 
 storiesOf('Components|Card/AssetCard', module)
@@ -30,6 +31,27 @@ storiesOf('Components|Card/AssetCard', module)
       src={text('src', 'https://placekitten.com/200/300')}
       title={text('title', 'Image of a cat')}
       withDragHandle={boolean('withDragHandle', false)}
+      isDragActive={boolean('isDragActive', false)}
+    />
+  ))
+  .add('with custom CardDragHandle', () => (
+    <AssetCard
+      className={text('className', '')}
+      status={select(
+        'status',
+        {
+          Draft: 'draft',
+          Changed: 'changed',
+          Published: 'published',
+          Archived: 'archived',
+        },
+        'published',
+      )}
+      type={select('type', types, 'image')}
+      isLoading={boolean('isLoading', false)}
+      src={text('src', 'https://placekitten.com/200/300')}
+      title={text('title', 'Image of a cat')}
+      cardDragHandleComponent={<CardDragHandle>Reorder card</CardDragHandle>}
       isDragActive={boolean('isDragActive', false)}
     />
   ))

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.test.tsx
@@ -4,6 +4,7 @@ import { axe } from 'jest-axe';
 import AssetCard from './AssetCard';
 import DropdownList from '../../Dropdown/DropdownList';
 import DropdownListItem from '../../Dropdown/DropdownListItem';
+import CardDragHandle from './../CardDragHandle';
 
 it('renders the component', () => {
   const output = shallow(
@@ -83,6 +84,19 @@ it('renders the component with a drag handle', () => {
       src="http://placekitten.com/200/300"
       title="picture of a cat"
       withDragHandle
+    />,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
+it('renders the component with a custom drag handle', () => {
+  const output = shallow(
+    <AssetCard
+      className="my-extra-class"
+      src="http://placekitten.com/200/300"
+      title="picture of a cat"
+      cardDragHandleComponent={<CardDragHandle>Reorder card</CardDragHandle>}
     />,
   );
 

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
@@ -47,17 +47,21 @@ export type AssetCardProps = {
    */
   type?: AssetType;
   /**
-   * Renders a drag handle for the component for use in drag and drop contexts
+   * Prop to pass a custom CardDragHandle component to for use in drag and drop contexts
+   */
+  cardDragHandleComponent?: React.ReactNode;
+  /**
+   * Renders a default drag handle for the component for use in drag and drop contexts
    */
   withDragHandle?: boolean;
+  /**
+   * Props to pass down to the default CardDragHandle component (does not work with cardDragHandleComponent prop)
+   */
+  cardDragHandleProps?: Partial<CardDragHandlePropTypes>;
   /**
    * Applies styling for when the component is actively being dragged by the user
    */
   isDragActive?: boolean;
-  /**
-   * Props to pass down to the CardDragHandle component
-   */
-  cardDragHandleProps?: Partial<CardDragHandlePropTypes>;
 } & typeof defaultProps;
 
 const defaultProps = {
@@ -100,6 +104,25 @@ export class AssetCard extends Component<AssetCardProps> {
     );
   };
 
+  renderCardDragHandle() {
+    const {
+      cardDragHandleComponent,
+      isDragActive,
+      cardDragHandleProps,
+      withDragHandle,
+    } = this.props;
+
+    if (cardDragHandleComponent) {
+      return cardDragHandleComponent;
+    } else if (withDragHandle) {
+      return (
+        <CardDragHandle isDragActive={isDragActive} {...cardDragHandleProps}>
+          Reorder entry
+        </CardDragHandle>
+      );
+    }
+  }
+
   render() {
     const {
       className,
@@ -109,8 +132,6 @@ export class AssetCard extends Component<AssetCardProps> {
       status,
       isLoading,
       dropdownListElements,
-      withDragHandle,
-      cardDragHandleProps,
       isDragActive,
       testId,
       ...otherProps
@@ -134,14 +155,7 @@ export class AssetCard extends Component<AssetCardProps> {
           <AssetCardSkeleton />
         ) : (
           <React.Fragment>
-            {withDragHandle && (
-              <CardDragHandle
-                isDragActive={isDragActive}
-                {...cardDragHandleProps}
-              >
-                Reorder entry
-              </CardDragHandle>
-            )}
+            {this.renderCardDragHandle()}
             <div className={styles['AssetCard__wrapper']}>
               <div className={styles['AssetCard__header']}>
                 {status && this.renderStatus(status)}

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
@@ -41,6 +41,49 @@ exports[`renders the component in loading state 1`] = `
 </Card>
 `;
 
+exports[`renders the component with a custom drag handle 1`] = `
+<Card
+  cardDragHandleComponent={
+    <CardDragHandle
+      isDragActive={false}
+      testId="cf-ui-card-drag-handle"
+    >
+      Reorder card
+    </CardDragHandle>
+  }
+  className="AssetCard my-extra-class"
+  padding="none"
+  selected={false}
+  testId="cf-ui-asset-card"
+  title="picture of a cat"
+>
+  <CardDragHandle
+    isDragActive={false}
+    testId="cf-ui-card-drag-handle"
+  >
+    Reorder card
+  </CardDragHandle>
+  <div
+    className="AssetCard__wrapper"
+  >
+    <div
+      className="AssetCard__header"
+    />
+    <div
+      className="AssetCard__content"
+    >
+      <Asset
+        className="AssetCard__asset"
+        src="http://placekitten.com/200/300"
+        testId="cf-ui-asset"
+        title="picture of a cat"
+        type="image"
+      />
+    </div>
+  </div>
+</Card>
+`;
+
 exports[`renders the component with a drag handle 1`] = `
 <Card
   className="AssetCard my-extra-class"
@@ -48,6 +91,7 @@ exports[`renders the component with a drag handle 1`] = `
   selected={false}
   testId="cf-ui-asset-card"
   title="picture of a cat"
+  withDragHandle={true}
 >
   <CardDragHandle
     isDragActive={false}

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
@@ -4,6 +4,7 @@ import { text, select, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import EntryCard from './EntryCard';
+import CardDragHandle from './../CardDragHandle';
 import DropdownList from '../../Dropdown/DropdownList';
 import DropdownListItem from '../../Dropdown/DropdownListItem';
 
@@ -72,6 +73,67 @@ storiesOf('Components|Card/EntryCard', module)
       />
     </div>
   ))
+  .add('with custom CardDragHandle', () => (
+    <div>
+      <EntryCard
+        title={text('title', 'Closer')}
+        description={text(
+          'description',
+          'Closer is the second and final studio album by English rock band Joy Division. It was released on 18 July 1980 on Factory Records, following the May 1980 suicide of lead singer Ian Curtis. The album was produced by Martin Hannett.',
+        )}
+        status={select(
+          'status',
+          {
+            Draft: 'draft',
+            Changed: 'changed',
+            Published: 'published',
+            Archived: 'archived',
+          },
+          'published',
+        )}
+        contentType={text('contentType', 'Album')}
+        onClick={!boolean('loading', false) ? action('onClick') : undefined}
+        cardDragHandleComponent={<CardDragHandle>Reorder card</CardDragHandle>}
+        dropdownListElements={
+          <React.Fragment>
+            <DropdownList>
+              <DropdownListItem isTitle>Actions</DropdownListItem>
+              <DropdownListItem href="#">Edit (with href)</DropdownListItem>
+              <DropdownListItem onClick={action('Download onClick')}>
+                Download
+              </DropdownListItem>
+              <DropdownListItem onClick={action('Remove onClick')}>
+                Remove
+              </DropdownListItem>
+            </DropdownList>
+            <DropdownList>
+              <DropdownListItem isTitle>Actions</DropdownListItem>
+              <DropdownListItem onClick={action('Edit onClick')}>
+                Edit
+              </DropdownListItem>
+              <DropdownListItem onClick={action('Download onClick')}>
+                Download
+              </DropdownListItem>
+              <DropdownListItem onClick={action('Remove onClick')}>
+                Remove
+              </DropdownListItem>
+            </DropdownList>
+          </React.Fragment>
+        }
+        isDragActive={boolean('isDragActive', false)}
+        className={text('className', '')}
+        loading={boolean('loading', false)}
+        size={select(
+          'size',
+          {
+            default: 'default',
+            small: 'small',
+          },
+          'default',
+        )}
+      />
+    </div>
+  ))
   .add('with thumbnailElement', () => (
     <div>
       <EntryCard
@@ -98,6 +160,8 @@ storiesOf('Components|Card/EntryCard', module)
           />
         }
         onClick={!boolean('loading', false) ? action('onClick') : undefined}
+        withDragHandle={boolean('withDragHandle', false)}
+        isDragActive={boolean('isDragActive', false)}
         dropdownListElements={
           <DropdownList>
             <DropdownListItem onClick={action('Edit onClick')}>
@@ -111,7 +175,6 @@ storiesOf('Components|Card/EntryCard', module)
             </DropdownListItem>
           </DropdownList>
         }
-        withDragHandle={boolean('withDragHandle', false)}
         loading={boolean('loading', false)}
         className={text('className', '')}
       />

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.test.tsx
@@ -4,6 +4,7 @@ import { axe } from 'jest-axe';
 import EntryCard from './EntryCard';
 import DropdownList from '../../Dropdown/DropdownList';
 import DropdownListItem from '../../Dropdown/DropdownListItem';
+import CardDragHandle from './../CardDragHandle';
 
 it('renders the component', () => {
   const output = shallow(
@@ -80,6 +81,20 @@ it('renders the component with a drag handle', () => {
       status="published"
       contentType="My Content Type"
       withDragHandle
+    />,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
+it('renders the component with a custom drag handle', () => {
+  const output = shallow(
+    <EntryCard
+      title="My Entry Card"
+      description="This is my Entry Card"
+      status="published"
+      contentType="My Content Type"
+      cardDragHandleComponent={<CardDragHandle>Reorder card</CardDragHandle>}
     />,
   );
 

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
@@ -3,11 +3,11 @@ import cn from 'classnames';
 import truncate from 'truncate';
 import Card from '../Card';
 import CardActions from '../CardActions';
+import Tag, { TagType } from '../../Tag/Tag';
+import EntryCardSkeleton from './EntryCardSkeleton';
 import CardDragHandle, {
   CardDragHandlePropTypes,
 } from '../CardDragHandle/CardDragHandle';
-import Tag, { TagType } from '../../Tag/Tag';
-import EntryCardSkeleton from './EntryCardSkeleton';
 
 const styles = require('./EntryCard.css');
 
@@ -55,17 +55,21 @@ export type EntryCardPropTypes = {
    */
   dropdownListElements?: React.ReactElement;
   /**
-   * Renders a drag handle for the component for use in drag and drop contexts
+   * Prop to pass a custom CardDragHandle component to for use in drag and drop contexts
+   */
+  cardDragHandleComponent?: React.ReactNode;
+  /**
+   * Renders a default drag handle for the component for use in drag and drop contexts
    */
   withDragHandle?: boolean;
+  /**
+   * Props to pass down to the default CardDragHandle component (does not work with cardDragHandleComponent prop)
+   */
+  cardDragHandleProps?: Partial<CardDragHandlePropTypes>;
   /**
    * Applies styling for when the component is actively being dragged by the user
    */
   isDragActive?: boolean;
-  /**
-   * Props to pass down to the CardDragHandle component
-   */
-  cardDragHandleProps?: Partial<CardDragHandlePropTypes>;
   /**
    * Changes the height of the component. When small will also ensure thumbnail and description aren't rendered
    */
@@ -139,6 +143,25 @@ export class EntryCard extends Component<EntryCardPropTypes> {
     return <Tag tagType={type}>{label}</Tag>;
   };
 
+  renderCardDragHandle() {
+    const {
+      cardDragHandleComponent,
+      isDragActive,
+      cardDragHandleProps,
+      withDragHandle,
+    } = this.props;
+
+    if (cardDragHandleComponent) {
+      return cardDragHandleComponent;
+    } else if (withDragHandle) {
+      return (
+        <CardDragHandle isDragActive={isDragActive} {...cardDragHandleProps}>
+          Reorder entry
+        </CardDragHandle>
+      );
+    }
+  }
+
   render() {
     const {
       className,
@@ -151,9 +174,7 @@ export class EntryCard extends Component<EntryCardPropTypes> {
       thumbnailElement,
       loading,
       dropdownListElements,
-      withDragHandle,
       isDragActive,
-      cardDragHandleProps,
       size,
       ...otherProps
     } = this.props;
@@ -181,14 +202,7 @@ export class EntryCard extends Component<EntryCardPropTypes> {
           </div>
         ) : (
           <React.Fragment>
-            {withDragHandle && (
-              <CardDragHandle
-                isDragActive={isDragActive}
-                {...cardDragHandleProps}
-              >
-                Reorder entry
-              </CardDragHandle>
-            )}
+            {this.renderCardDragHandle()}
             <article className={styles.EntryCard__wrapper}>
               <React.Fragment>
                 <div className={styles.EntryCard__meta}>

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
@@ -95,12 +95,77 @@ exports[`renders the component 1`] = `
 </Card>
 `;
 
+exports[`renders the component with a custom drag handle 1`] = `
+<Card
+  cardDragHandleComponent={
+    <CardDragHandle
+      isDragActive={false}
+      testId="cf-ui-card-drag-handle"
+    >
+      Reorder card
+    </CardDragHandle>
+  }
+  className="EntryCard EntryCard--size-default"
+  padding="none"
+  selected={false}
+  testId="cf-ui-entry-card"
+>
+  <CardDragHandle
+    isDragActive={false}
+    testId="cf-ui-card-drag-handle"
+  >
+    Reorder card
+  </CardDragHandle>
+  <article
+    className="EntryCard__wrapper"
+  >
+    <div
+      className="EntryCard__meta"
+    >
+      <div
+        className="EntryCard__content-type"
+        data-test-id="content-type"
+      >
+        My Content Type
+      </div>
+      <Tag
+        tagType="positive"
+        testId="cf-ui-tag"
+      >
+        published
+      </Tag>
+    </div>
+    <div
+      className="EntryCard__content"
+    >
+      <div
+        className="EntryCard__body"
+      >
+        <h1
+          className="EntryCard__title"
+          data-test-id="title"
+          title=""
+        >
+          My Entry Card
+        </h1>
+        <p
+          className="EntryCard__description"
+        >
+          This is my Entry Card
+        </p>
+      </div>
+    </div>
+  </article>
+</Card>
+`;
+
 exports[`renders the component with a drag handle 1`] = `
 <Card
   className="EntryCard EntryCard--size-default"
   padding="none"
   selected={false}
   testId="cf-ui-entry-card"
+  withDragHandle={true}
 >
   <CardDragHandle
     isDragActive={false}

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.stories.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.stories.tsx
@@ -6,6 +6,7 @@ import { action } from '@storybook/addon-actions';
 import EntityListItem from './EntityListItem';
 import DropdownList from '../../Dropdown/DropdownList';
 import DropdownListItem from '../../Dropdown/DropdownListItem';
+import CardDragHandle from './../../Card/CardDragHandle';
 
 storiesOf('Components|EntityList/EntityListItem', module)
   .addParameters({
@@ -53,6 +54,54 @@ storiesOf('Components|EntityList/EntityListItem', module)
         </DropdownList>
       }
       withDragHandle={boolean('withDragHandle', false)}
+      isDragActive={boolean('isDragActive', false)}
+      isLoading={boolean('isLoading', false)}
+      onClick={action('EntityListItem onClick')}
+      href={text('href', '')}
+    />
+  ))
+  .add('with custom CardDragHandle', () => (
+    <EntityListItem
+      className={text('className', '')}
+      title={text('title', 'My title')}
+      description={text('description', 'My description')}
+      contentType={text('contentType', 'My content type')}
+      thumbnailUrl={text('thumbnailUrl', 'https://placekitten.com/400/400')}
+      thumbnailAltText={text('thumbnailAltText', 'My thumbnail text')}
+      entityType={select(
+        'entityType',
+        {
+          asset: 'asset',
+          entry: 'entry',
+        },
+        'entry',
+      )}
+      status={select(
+        'status',
+        {
+          archived: 'archived',
+          changed: 'changed',
+          draft: 'draft',
+          published: 'published',
+          default: null,
+        },
+        'published',
+      )}
+      dropdownListElements={
+        <DropdownList>
+          <DropdownListItem isTitle>Actions</DropdownListItem>
+          <DropdownListItem onClick={action('Edit onClick')}>
+            Edit
+          </DropdownListItem>
+          <DropdownListItem onClick={action('Download onClick')}>
+            Download
+          </DropdownListItem>
+          <DropdownListItem onClick={action('Remove onClick')}>
+            Remove
+          </DropdownListItem>
+        </DropdownList>
+      }
+      cardDragHandleComponent={<CardDragHandle>Reorder card</CardDragHandle>}
       isDragActive={boolean('isDragActive', false)}
       isLoading={boolean('isLoading', false)}
       onClick={action('EntityListItem onClick')}

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.test.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.test.tsx
@@ -4,6 +4,7 @@ import { axe } from 'jest-axe';
 import EntityListItem from './EntityListItem';
 import DropdownList from '../../Dropdown/DropdownList';
 import DropdownListItem from '../../Dropdown/DropdownListItem';
+import CardDragHandle from './../../Card/CardDragHandle';
 
 it('renders the component', () => {
   const output = shallow(
@@ -59,7 +60,21 @@ it('renders the component with dropdownListElements', () => {
   expect(output).toMatchSnapshot();
 });
 
-it('renders the component with drag handle', () => {
+it('renders the component with custom drag handle', () => {
+  const output = shallow(
+    <EntityListItem
+      title="Title"
+      description="Description"
+      contentType="Content type"
+      status="published"
+      cardDragHandleComponent={<CardDragHandle>Reorder card</CardDragHandle>}
+    />,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
+it('renders the component with a drag handle', () => {
   const output = shallow(
     <EntityListItem
       title="Title"
@@ -73,14 +88,13 @@ it('renders the component with drag handle', () => {
   expect(output).toMatchSnapshot();
 });
 
-it('renders the component with an active drag handle', () => {
+it('renders the component with active drag state', () => {
   const output = shallow(
     <EntityListItem
       title="Title"
       description="Description"
       contentType="Content type"
       status="published"
-      withDragHandle
       isDragActive
     />,
   );

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
@@ -4,13 +4,13 @@ import cn from 'classnames';
 import Tag, { TagType } from '../../Tag/Tag';
 import Icon from '../../Icon/Icon';
 import CardActions from '../../Card/CardActions/CardActions';
-import CardDragHandle, {
-  CardDragHandlePropTypes,
-} from '../../Card/CardDragHandle/CardDragHandle';
 import SkeletonBodyText from '../../Skeleton/SkeletonBodyText';
 import SkeletonImage from '../../Skeleton/SkeletonImage';
 import SkeletonContainer from '../../Skeleton/SkeletonContainer';
 import TabFocusTrap from '../../TabFocusTrap';
+import CardDragHandle, {
+  CardDragHandlePropTypes,
+} from '../../Card/CardDragHandle/CardDragHandle';
 
 const styles = require('./EntityListItem.css');
 
@@ -58,7 +58,11 @@ export type EntityListItemProps = {
    */
   isDragActive?: boolean;
   /**
-   * Props to pass down to the CardDragHandle component
+   * Prop to pass a custom CardDragHandle component to for use in drag and drop contexts
+   */
+  cardDragHandleComponent?: React.ReactNode;
+  /**
+   * Props to pass down to the default CardDragHandle component (does not work with cardDragHandleComponent prop)
    */
   cardDragHandleProps?: Partial<CardDragHandlePropTypes>;
   /**
@@ -154,6 +158,25 @@ export class EntityListItem extends Component<EntityListItemProps> {
     );
   }
 
+  renderCardDragHandle() {
+    const {
+      cardDragHandleComponent,
+      isDragActive,
+      cardDragHandleProps,
+      withDragHandle,
+    } = this.props;
+
+    if (cardDragHandleComponent) {
+      return cardDragHandleComponent;
+    } else if (withDragHandle) {
+      return (
+        <CardDragHandle isDragActive={isDragActive} {...cardDragHandleProps}>
+          Reorder entry
+        </CardDragHandle>
+      );
+    }
+  }
+
   render() {
     const {
       className,
@@ -168,7 +191,6 @@ export class EntityListItem extends Component<EntityListItemProps> {
       dropdownListElements,
       withDragHandle,
       isDragActive,
-      cardDragHandleProps,
       isLoading,
       onClick,
       href,
@@ -184,11 +206,7 @@ export class EntityListItem extends Component<EntityListItemProps> {
 
     return (
       <li {...otherProps} className={classNames} data-test-id={testId}>
-        {withDragHandle && (
-          <CardDragHandle isDragActive={isDragActive} {...cardDragHandleProps}>
-            Reorder entry
-          </CardDragHandle>
-        )}
+        {this.renderCardDragHandle()}
         {isLoading ? (
           this.renderLoadingCard()
         ) : (

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
@@ -321,6 +321,77 @@ exports[`renders the component with a description 1`] = `
 </li>
 `;
 
+exports[`renders the component with a drag handle 1`] = `
+<li
+  className="EntityListItem"
+  data-test-id="cf-ui-entity-list-item"
+>
+  <CardDragHandle
+    isDragActive={false}
+    testId="cf-ui-card-drag-handle"
+  >
+    Reorder entry
+  </CardDragHandle>
+  <article
+    className="EntityListItem__inner"
+  >
+    <TabFocusTrap
+      className="EntityListItem__focus-trap"
+    >
+      <figure
+        className="EntityListItem__media"
+      >
+        <Icon
+          color="muted"
+          icon="Entry"
+          size="small"
+          testId="cf-ui-icon"
+        />
+      </figure>
+      <div
+        className="EntityListItem__content"
+      >
+        <div
+          className="EntityListItem__heading"
+        >
+          <h1
+            className="EntityListItem__title"
+          >
+            Title
+          </h1>
+          <div
+            className="EntityListItem__content-type"
+          >
+            (
+            Content type
+            )
+          </div>
+        </div>
+        <p
+          className="EntityListItem__description"
+        >
+          Description
+        </p>
+      </div>
+      <div
+        className="EntityListItem__meta"
+      >
+        <div
+          className="EntityListItem__status"
+        >
+          <Tag
+            tagType="positive"
+            testId="cf-ui-tag"
+          >
+            published
+          </Tag>
+        </div>
+      </div>
+    </TabFocusTrap>
+  </article>
+</li>
+`;
+
 exports[`renders the component with a status 1`] = `
 <li
   className="EntityListItem"
@@ -386,17 +457,11 @@ exports[`renders the component with a status 1`] = `
 </li>
 `;
 
-exports[`renders the component with an active drag handle 1`] = `
+exports[`renders the component with active drag state 1`] = `
 <li
   className="EntityListItem EntityListItem--drag-active"
   data-test-id="cf-ui-entity-list-item"
 >
-  <CardDragHandle
-    isDragActive={true}
-    testId="cf-ui-card-drag-handle"
-  >
-    Reorder entry
-  </CardDragHandle>
   <article
     className="EntityListItem__inner"
   >
@@ -511,8 +576,16 @@ exports[`renders the component with an additional class name 1`] = `
 </li>
 `;
 
-exports[`renders the component with drag handle 1`] = `
+exports[`renders the component with custom drag handle 1`] = `
 <li
+  cardDragHandleComponent={
+    <CardDragHandle
+      isDragActive={false}
+      testId="cf-ui-card-drag-handle"
+    >
+      Reorder card
+    </CardDragHandle>
+  }
   className="EntityListItem"
   data-test-id="cf-ui-entity-list-item"
 >
@@ -520,7 +593,7 @@ exports[`renders the component with drag handle 1`] = `
     isDragActive={false}
     testId="cf-ui-card-drag-handle"
   >
-    Reorder entry
+    Reorder card
   </CardDragHandle>
   <article
     className="EntityListItem__inner"


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR introduces a breaking change: the `withDragHandle` prop is now deprecated. To render a drag handle on a component you must pass a CardDragHandle via the `cardDragHandleComponent` prop. This change is necessary for integrating drag and drop libraries such as `react-sortable-hoc` (https://github.com/clauderic/react-sortable-hoc/blob/master/examples/drag-handle.js#L10) - it'll allow the user to pass a HOC drag and drop handle.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
