### PR TITLE
Prevent text from overflowing EntryCard component

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.css
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.css
@@ -28,6 +28,7 @@
 .EntryCard__wrapper {
   padding: calc(1rem * (14 / var(--font-base-default)));
   flex: 1 1 0;
+  overflow: auto;
 }
 
 .EntryCard--drag-active {


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Prevents the contents of an EntryCard from overflowing the EntryCard itself

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
