### PR TITLE
fix(EmptyState): Added customImageElement prop

### DIFF
--- a/packages/forma-36-react-components/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/forma-36-react-components/src/components/EmptyState/EmptyState.stories.tsx
@@ -38,6 +38,17 @@ storiesOf('Components|EmptyState', module)
       }}
     />
   ))
+  .add('with custom image element', () => (
+    <EmptyState
+      className={text('className', '')}
+      headingProps={{ text: 'Heading' }}
+      customImageElement={<img src={imageUrl} alt="" />}
+      descriptionProps={{
+        text:
+          'This is a descriptionProps for the empty state. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vulputate, sem a porttitor porttitor, velit nulla lacinia dolor, sit amet interdum ligula lectus hendrerit sem. Aliquam ultricies viverra tincidunt.',
+      }}
+    />
+  ))
   .add('with children', () => (
     <EmptyState
       className={text('className', '')}

--- a/packages/forma-36-react-components/src/components/EmptyState/EmptyState.test.tsx
+++ b/packages/forma-36-react-components/src/components/EmptyState/EmptyState.test.tsx
@@ -57,3 +57,18 @@ it('renders component with image', () => {
 
   expect(output).toMatchSnapshot();
 });
+
+it('renders component with custom image element', () => {
+  const output = mount(
+    <EmptyState
+      headingProps={{ text: 'Heading' }}
+      customImageElement={<img src={'/url'} alt="" />}
+      descriptionProps={{
+        text:
+          'This is a description for the empty state. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vulputate, sem a porttitor porttitor, velit nulla lacinia dolor, sit amet interdum ligula lectus hendrerit sem. Aliquam ultricies viverra tincidunt.',
+      }}
+    />,
+  );
+
+  expect(output).toMatchSnapshot();
+});

--- a/packages/forma-36-react-components/src/components/EmptyState/EmptyState.tsx
+++ b/packages/forma-36-react-components/src/components/EmptyState/EmptyState.tsx
@@ -23,6 +23,10 @@ export type EmptyStateProps = {
    */
   imageProps?: ImageProps;
   /**
+   * As alternative,
+   */
+  customImageElement?: JSX.Element;
+  /**
    * Heading text and semantic element type
    */
   headingProps: TextElementProps;
@@ -74,6 +78,7 @@ export class EmptyState extends Component<EmptyStateProps> {
       className,
       children,
       testId,
+      customImageElement,
       imageProps,
       headingProps,
       descriptionProps,
@@ -84,22 +89,24 @@ export class EmptyState extends Component<EmptyStateProps> {
     return (
       <div {...otherProps} className={classNames} data-test-id={testId}>
         <div className={styles['EmptyState_container']}>
-          {imageProps && (
-            <div
-              style={{
-                backgroundImage: `url(${imageProps.url})`,
-                width: imageProps.width,
-                height: imageProps.height,
-              }}
-              className={cn(
-                imageProps.className,
-                styles['EmptyState_element'],
-                styles['EmptyState_illustration'],
-              )}
-              aria-label={imageProps.description}
-              role="img"
-            />
-          )}
+          <div className={styles['EmptyState_element']}>
+            {customImageElement
+              ? customImageElement
+              : imageProps && (
+                  <img
+                    src={imageProps.url}
+                    alt={imageProps.description}
+                    className={cn(
+                      imageProps.className,
+                      styles['EmptyState_illustration'],
+                    )}
+                    style={{
+                      height: imageProps.height,
+                      width: imageProps.width,
+                    }}
+                  />
+                )}
+          </div>
           <Heading
             element={headingProps.elementType ? headingProps.elementType : 'h1'}
             className={styles['EmptyState_element']}

--- a/packages/forma-36-react-components/src/components/EmptyState/__snapshots__/EmptyState.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EmptyState/__snapshots__/EmptyState.test.tsx.snap
@@ -1,5 +1,69 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders component with custom image element 1`] = `
+<EmptyState
+  customImageElement={
+    <img
+      alt=""
+      src="/url"
+    />
+  }
+  descriptionProps={
+    Object {
+      "text": "This is a description for the empty state. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vulputate, sem a porttitor porttitor, velit nulla lacinia dolor, sit amet interdum ligula lectus hendrerit sem. Aliquam ultricies viverra tincidunt.",
+    }
+  }
+  headingProps={
+    Object {
+      "text": "Heading",
+    }
+  }
+  testId="cf-ui-empty-state"
+>
+  <div
+    className="EmptyState"
+    data-test-id="cf-ui-empty-state"
+  >
+    <div
+      className="EmptyState_container"
+    >
+      <div
+        className="EmptyState_element"
+      >
+        <img
+          alt=""
+          src="/url"
+        />
+      </div>
+      <Heading
+        className="EmptyState_element"
+        element="h1"
+        testId="cf-ui-heading"
+      >
+        <h1
+          className="Heading EmptyState_element"
+          data-test-id="cf-ui-heading"
+        >
+          Heading
+        </h1>
+      </Heading>
+      <Paragraph
+        className="EmptyState_paragraph EmptyState_element"
+        element="p"
+        testId="cf-ui-paragraph"
+      >
+        <p
+          className="Paragraph EmptyState_paragraph EmptyState_element"
+          data-test-id="cf-ui-paragraph"
+        >
+          This is a description for the empty state. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vulputate, sem a porttitor porttitor, velit nulla lacinia dolor, sit amet interdum ligula lectus hendrerit sem. Aliquam ultricies viverra tincidunt.
+        </p>
+      </Paragraph>
+    </div>
+  </div>
+</EmptyState>
+`;
+
 exports[`renders component with image 1`] = `
 <EmptyState
   descriptionProps={
@@ -30,17 +94,20 @@ exports[`renders component with image 1`] = `
       className="EmptyState_container"
     >
       <div
-        aria-label="Image description"
-        className="EmptyState_element EmptyState_illustration"
-        role="img"
-        style={
-          Object {
-            "backgroundImage": "url(url)",
-            "height": "250px",
-            "width": "340px",
+        className="EmptyState_element"
+      >
+        <img
+          alt="Image description"
+          className="EmptyState_illustration"
+          src="url"
+          style={
+            Object {
+              "height": "250px",
+              "width": "340px",
+            }
           }
-        }
-      />
+        />
+      </div>
       <Heading
         className="EmptyState_element"
         element="h1"
@@ -78,6 +145,9 @@ exports[`renders the component 1`] = `
   <div
     className="EmptyState_container"
   >
+    <div
+      className="EmptyState_element"
+    />
     <Heading
       className="EmptyState_element"
       element="h1"
@@ -104,6 +174,9 @@ exports[`renders the component with an additional class name 1`] = `
   <div
     className="EmptyState_container"
   >
+    <div
+      className="EmptyState_element"
+    />
     <Heading
       className="EmptyState_element"
       element="h1"


### PR DESCRIPTION
# Purpose of PR

To provide an opportunity to use SVG or any custom element as the illustration, the customImageElement prop was added.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
