### PR TITLE
fix(CarActions): Prevent default for toggle click

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
@@ -72,6 +72,7 @@ export class CardActions extends Component<
             label="Actions"
             {...iconButtonProps}
             onClick={event => {
+              event.preventDefault();
               this.handleClick(event);
             }}
           />


### PR DESCRIPTION
# Purpose of PR

This PR will add a preventDefault to the toggleButton click of the card actions so if the card is a link it won't follow it on click of the toggle button.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
