### PR TITLE
feat(EmptyState): Update prop type

### DIFF
--- a/packages/forma-36-react-components/src/components/EmptyState/EmptyState.tsx
+++ b/packages/forma-36-react-components/src/components/EmptyState/EmptyState.tsx
@@ -37,7 +37,7 @@ export type EmptyStateProps = {
 } & typeof defaultProps;
 
 interface TextElementProps {
-  text: string;
+  text: React.ReactNode;
   elementType?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
 }
 


### PR DESCRIPTION
# Purpose of PR
 Update headingProps and desctiptionProps to support ReactNode type for text prop, so it's possible to pass down JSX elements.  

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
