### PR TITLE
EntryCard - Give explicit text colour to description

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.css
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.css
@@ -74,6 +74,7 @@
   word-break: break-word;
   text-overflow: ellipsis;
   overflow: hidden;
+  color: var(--color-text-dark);
 }
 
 .EntryCard__description {
@@ -82,6 +83,7 @@
   word-break: break-word;
   white-space: initial;
   font-size: var(--font-size-l);
+  color: var(--color-text-dark);
 }
 
 .EntryCard__thumbnail {


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Fixes a bug where if an EntryCard is displayed within an `a` tag, the description text inherits the text colour from that tag if it has been styled with a `:link` pseudo-class in CSS.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
