### PR TITLE
AssetCard - Add small size variant

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.css
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.css
@@ -14,6 +14,18 @@
       var(--transition-easing-default);
 }
 
+.AssetCard--size-small {
+  height: calc(
+    1rem * (196 / var(--font-base-default))
+  ); /* 196 is equal to our 150px small variant plus the height of the card header */
+  min-width: calc(1rem * (150 / var(--font-base-default)));
+}
+
+.AssetCard--size-small .AssetCard__asset {
+  height: calc(1rem * (150 / var(--font-base-default)));
+  width: calc(1rem * (150 / var(--font-base-default)));
+}
+
 .AssetCard--drag-active {
   box-shadow: var(--box-shadow-heavy);
 }
@@ -29,7 +41,7 @@
 }
 
 .AssetCard__header {
-  padding: 0 calc(1rem * (19 / var(--font-base-default)));
+  padding: 0 calc(1rem * (14 / var(--font-base-default)));
   height: calc(1rem * (45 / var(--font-base-default)));
   display: flex;
   align-items: center;

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.stories.tsx
@@ -32,6 +32,14 @@ storiesOf('Components|Card/AssetCard', module)
       title={text('title', 'Image of a cat')}
       withDragHandle={boolean('withDragHandle', false)}
       isDragActive={boolean('isDragActive', false)}
+      size={select(
+        'size',
+        {
+          small: 'small',
+          default: 'default',
+        },
+        'default',
+      )}
     />
   ))
   .add('with custom CardDragHandle', () => (
@@ -53,6 +61,14 @@ storiesOf('Components|Card/AssetCard', module)
       title={text('title', 'Image of a cat')}
       cardDragHandleComponent={<CardDragHandle>Reorder card</CardDragHandle>}
       isDragActive={boolean('isDragActive', false)}
+      size={select(
+        'size',
+        {
+          small: 'small',
+          default: 'default',
+        },
+        'small',
+      )}
     />
   ))
   .add('with dropdownListElements', () => (
@@ -97,5 +113,13 @@ storiesOf('Components|Card/AssetCard', module)
           </DropdownList>
         </React.Fragment>
       }
+      size={select(
+        'size',
+        {
+          small: 'small',
+          default: 'default',
+        },
+        'small',
+      )}
     />
   ));

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.test.tsx
@@ -103,6 +103,18 @@ it('renders the component with a custom drag handle', () => {
   expect(output).toMatchSnapshot();
 });
 
+it('renders a small variant of the component', () => {
+  const output = shallow(
+    <AssetCard
+      size="small"
+      src="http://placekitten.com/200/300"
+      title="picture of a cat"
+    />,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
 it('has no a11y issues', async () => {
   const output = mount(
     <AssetCard src="http://placekitten.com/200/300" title="picture of a cat" />,

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
@@ -62,11 +62,16 @@ export type AssetCardProps = {
    * Applies styling for when the component is actively being dragged by the user
    */
   isDragActive?: boolean;
+  /**
+   * Renders a small variant of the card which accommodates a 150x150px image
+   */
+  size?: 'small' | 'default';
 } & typeof defaultProps;
 
 const defaultProps = {
   isLoading: false,
   testId: 'cf-ui-asset-card',
+  size: 'default',
 };
 
 export class AssetCard extends Component<AssetCardProps> {
@@ -134,12 +139,16 @@ export class AssetCard extends Component<AssetCardProps> {
       dropdownListElements,
       isDragActive,
       testId,
+      size,
       ...otherProps
     } = this.props;
 
     const classNames = cn(
       styles.AssetCard,
-      { [styles['AssetCard--drag-active']]: isDragActive },
+      {
+        [styles['AssetCard--drag-active']]: isDragActive,
+        [styles[`AssetCard--size-${size}`]]: size,
+      },
       className,
     );
 
@@ -152,7 +161,7 @@ export class AssetCard extends Component<AssetCardProps> {
         {...otherProps}
       >
         {isLoading ? (
-          <AssetCardSkeleton />
+          <AssetCardSkeleton size={size} />
         ) : (
           <React.Fragment>
             {this.renderCardDragHandle()}

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCardSkeleton.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCardSkeleton.tsx
@@ -3,12 +3,22 @@ import SkeletonContainer from '../../Skeleton/SkeletonContainer';
 import SkeletonBodyText from '../../Skeleton/SkeletonBodyText';
 import SkeletonImage from '../../Skeleton/SkeletonImage';
 
-const AssetCardSkeleton = () => (
-  <SkeletonContainer svgWidth={240} clipId="f36-asset-card-skeleton">
-    <SkeletonImage offsetLeft={85} offsetTop={100} />
+export interface AssetCardSkeletonProps {
+  size?: 'small' | 'default';
+}
+
+const AssetCardSkeleton = (props: AssetCardSkeletonProps) => (
+  <SkeletonContainer
+    svgWidth={props.size === 'small' ? 150 : 240}
+    clipId="f36-asset-card-skeleton"
+  >
+    <SkeletonImage
+      offsetLeft={props.size === 'small' ? 40 : 85}
+      offsetTop={props.size === 'small' ? 50 : 100}
+    />
     <SkeletonBodyText
-      offsetLeft={70}
-      offsetTop={190}
+      offsetLeft={props.size === 'small' ? 25 : 70}
+      offsetTop={props.size === 'small' ? 140 : 190}
       numberOfLines={1}
       width={100}
     />

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
@@ -1,8 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders a small variant of the component 1`] = `
+<Card
+  className="AssetCard AssetCard--size-small"
+  padding="none"
+  selected={false}
+  testId="cf-ui-asset-card"
+  title="picture of a cat"
+>
+  <div
+    className="AssetCard__wrapper"
+  >
+    <div
+      className="AssetCard__header"
+    />
+    <div
+      className="AssetCard__content"
+    >
+      <Asset
+        className="AssetCard__asset"
+        src="http://placekitten.com/200/300"
+        testId="cf-ui-asset"
+        title="picture of a cat"
+        type="image"
+      />
+    </div>
+  </div>
+</Card>
+`;
+
 exports[`renders the component 1`] = `
 <Card
-  className="AssetCard"
+  className="AssetCard AssetCard--size-default"
   padding="none"
   selected={false}
   testId="cf-ui-asset-card"
@@ -31,13 +60,15 @@ exports[`renders the component 1`] = `
 
 exports[`renders the component in loading state 1`] = `
 <Card
-  className="AssetCard"
+  className="AssetCard AssetCard--size-default"
   padding="none"
   selected={false}
   testId="cf-ui-asset-card"
   title="picture of a cat"
 >
-  <AssetCardSkeleton />
+  <AssetCardSkeleton
+    size="default"
+  />
 </Card>
 `;
 
@@ -51,7 +82,7 @@ exports[`renders the component with a custom drag handle 1`] = `
       Reorder card
     </CardDragHandle>
   }
-  className="AssetCard my-extra-class"
+  className="AssetCard AssetCard--size-default my-extra-class"
   padding="none"
   selected={false}
   testId="cf-ui-asset-card"
@@ -86,7 +117,7 @@ exports[`renders the component with a custom drag handle 1`] = `
 
 exports[`renders the component with a drag handle 1`] = `
 <Card
-  className="AssetCard my-extra-class"
+  className="AssetCard AssetCard--size-default my-extra-class"
   padding="none"
   selected={false}
   testId="cf-ui-asset-card"
@@ -122,7 +153,7 @@ exports[`renders the component with a drag handle 1`] = `
 
 exports[`renders the component with actions 1`] = `
 <Card
-  className="AssetCard"
+  className="AssetCard AssetCard--size-default"
   padding="none"
   selected={false}
   testId="cf-ui-asset-card"
@@ -183,7 +214,7 @@ exports[`renders the component with actions 1`] = `
 
 exports[`renders the component with an additional class name 1`] = `
 <Card
-  className="AssetCard my-extra-class"
+  className="AssetCard AssetCard--size-default my-extra-class"
   padding="none"
   selected={false}
   testId="cf-ui-asset-card"
@@ -212,7 +243,7 @@ exports[`renders the component with an additional class name 1`] = `
 
 exports[`renders the component with status 1`] = `
 <Card
-  className="AssetCard"
+  className="AssetCard AssetCard--size-default"
   padding="none"
   selected={false}
   testId="cf-ui-asset-card"
@@ -253,7 +284,7 @@ exports[`renders the component with status 1`] = `
 
 exports[`renders the component without actions 1`] = `
 <Card
-  className="AssetCard"
+  className="AssetCard AssetCard--size-default"
   padding="none"
   selected={false}
   testId="cf-ui-asset-card"


### PR DESCRIPTION
Adds a prop which will render a small variant of the AssetCard component

<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR adds a size prop to the AssetCard, giving it the ability to render a smaller image.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
