### PR TITLE
chore(CI): fix failing publishes because of commitlint fails

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -2,4 +2,4 @@
 #
 # publish a new version depending on conventional commits
 
-yarn lerna publish --conventional-commits --github-release --yes 
+yarn lerna publish --conventional-commits --github-release --yes --no-verify

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "license": "MIT",
   "private": true,
   "devDependencies": {
-    "@commitlint/cli": "^7.6.1",
-    "@commitlint/config-conventional": "^7.6.0",
+    "@commitlint/cli": "7.6.1",
+    "@commitlint/config-conventional": "7.6.0",
     "commitizen": "^3.1.1",
     "husky": "^2.3.0",
     "lerna": "^3.14.0",


### PR DESCRIPTION
This PR fixes failing CI because of commitlint 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
