### PR TITLE
chore(Commitlint): Disable commitlint to recover failed publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "travis-deploy-once": "travis-deploy-once --pro",
     "semantic-release": "lerna exec --concurrency 1 -- npx --no-install semantic-release -e semantic-release-monorepo",
     "postinstall": "lerna bootstrap && lerna run --scope @contentful/forma-36-tokens build && lerna run --scope @contentful/forma-36-fcss build",
-    "commitmsg": "validate-commit-msg",
     "build": "lerna run build",
     "test": "lerna run test",
     "lint": "lerna run lint",
@@ -29,12 +28,5 @@
   },
   "resolutions": {
     "tar": "4.4.8"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "yarn pretty-quick --staged",
-      "pre-push": "yarn lint && yarn type-check && yarn test",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
   }
 }


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR
Disable commitlint to recover failed publishes
<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
