### PR TITLE
Fix AssetCard in IE/Edge

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.css
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.css
@@ -37,7 +37,7 @@
 }
 
 .AssetCard__wrapper {
-  flex: 1 1 0;
+  flex: 1 1 auto;
 }
 
 .AssetCard__header {

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.stories.tsx
@@ -67,7 +67,7 @@ storiesOf('Components|Card/AssetCard', module)
           small: 'small',
           default: 'default',
         },
-        'small',
+        'default',
       )}
     />
   ))
@@ -119,7 +119,7 @@ storiesOf('Components|Card/AssetCard', module)
           small: 'small',
           default: 'default',
         },
-        'small',
+        'default',
       )}
     />
   ));


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Without this change there was an issue with the component width in IE11 and Edge. This change fixes that.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
