### PR TITLE
Fix Asset/Entry/Entity card props

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
@@ -140,6 +140,9 @@ export class AssetCard extends Component<AssetCardProps> {
       isDragActive,
       testId,
       size,
+      cardDragHandleProps,
+      cardDragHandleComponent,
+      withDragHandle,
       ...otherProps
     } = this.props;
 

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
@@ -74,14 +74,6 @@ exports[`renders the component in loading state 1`] = `
 
 exports[`renders the component with a custom drag handle 1`] = `
 <Card
-  cardDragHandleComponent={
-    <CardDragHandle
-      isDragActive={false}
-      testId="cf-ui-card-drag-handle"
-    >
-      Reorder card
-    </CardDragHandle>
-  }
   className="AssetCard AssetCard--size-default my-extra-class"
   padding="none"
   selected={false}
@@ -122,7 +114,6 @@ exports[`renders the component with a drag handle 1`] = `
   selected={false}
   testId="cf-ui-asset-card"
   title="picture of a cat"
-  withDragHandle={true}
 >
   <CardDragHandle
     isDragActive={false}

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
@@ -176,6 +176,9 @@ export class EntryCard extends Component<EntryCardPropTypes> {
       dropdownListElements,
       isDragActive,
       size,
+      cardDragHandleComponent,
+      cardDragHandleProps,
+      withDragHandle,
       ...otherProps
     } = this.props;
 

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
@@ -97,14 +97,6 @@ exports[`renders the component 1`] = `
 
 exports[`renders the component with a custom drag handle 1`] = `
 <Card
-  cardDragHandleComponent={
-    <CardDragHandle
-      isDragActive={false}
-      testId="cf-ui-card-drag-handle"
-    >
-      Reorder card
-    </CardDragHandle>
-  }
   className="EntryCard EntryCard--size-default"
   padding="none"
   selected={false}
@@ -165,7 +157,6 @@ exports[`renders the component with a drag handle 1`] = `
   padding="none"
   selected={false}
   testId="cf-ui-entry-card"
-  withDragHandle={true}
 >
   <CardDragHandle
     isDragActive={false}

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
@@ -194,6 +194,8 @@ export class EntityListItem extends Component<EntityListItemProps> {
       isLoading,
       onClick,
       href,
+      cardDragHandleProps,
+      cardDragHandleComponent,
       ...otherProps
     } = this.props;
 

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
@@ -578,14 +578,6 @@ exports[`renders the component with an additional class name 1`] = `
 
 exports[`renders the component with custom drag handle 1`] = `
 <li
-  cardDragHandleComponent={
-    <CardDragHandle
-      isDragActive={false}
-      testId="cf-ui-card-drag-handle"
-    >
-      Reorder card
-    </CardDragHandle>
-  }
   className="EntityListItem"
   data-test-id="cf-ui-entity-list-item"
 >


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Fixes a bug where if an AssetCard, EntryCard, or EntityListItem component is passed props relating to drag handles, React would throw a warning as these props were passed to the rendered React component or DOM elements via `otherProps`.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
