### PR TITLE
docs(AlphaNote): Alpha note on home splash added

### DIFF
--- a/packages/forma-36-website/src/components/HomeSplash.js
+++ b/packages/forma-36-website/src/components/HomeSplash.js
@@ -1,9 +1,17 @@
 import React from 'react';
-import { DisplayText, Paragraph } from '@contentful/forma-36-react-components';
+import {
+  DisplayText,
+  Paragraph,
+  Note,
+  TextLink,
+} from '@contentful/forma-36-react-components';
 import tokens from '@contentful/forma-36-tokens';
 import { css } from '@emotion/core';
 
 const styles = {
+  alphaNote: css`
+    margin-bottom: ${tokens.spacingL};
+  `,
   homeSplash: css`
     background: ${tokens.colorContrastLight};
     padding: 8rem 0;
@@ -31,6 +39,13 @@ const HomeSplash = () => (
   <header css={styles.homeSplash}>
     <div css={styles.inner}>
       <div>
+        <Note css={styles.alphaNote} noteType="primary">
+          This documentation is work in progress. Its contents are subject to
+          change. Leave your feedback or get involved{' '}
+          <TextLink href="https://github.com/contentful/forma-36">
+            here.
+          </TextLink>
+        </Note>
         <DisplayText size="large" css={styles.title}>
           Forma 36
         </DisplayText>


### PR DESCRIPTION
This PR will add the an alpha note to the documentation website:

![image](https://user-images.githubusercontent.com/1766274/59351984-e101b980-8d1f-11e9-8dfd-80bf77ebff02.png)

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
