### PR TITLE
fix(Pill): Removed draggable attribute from Pill component

### DIFF
--- a/packages/forma-36-react-components/src/components/Pill/Pill.tsx
+++ b/packages/forma-36-react-components/src/components/Pill/Pill.tsx
@@ -40,7 +40,6 @@ export class Pill extends Component<PillProps> {
         className={classNames}
         data-test-id={testId}
         {...otherProps}
-        draggable={!!onDrag}
         onDrag={onDrag}
       >
         {onDrag &&

--- a/packages/forma-36-react-components/src/components/Pill/__snapshots__/Pill.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Pill/__snapshots__/Pill.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`renders the component 1`] = `
 <div
   className="Pill"
   data-test-id="cf-ui-pill"
-  draggable={false}
 >
   <span
     aria-label="test"
@@ -19,7 +18,6 @@ exports[`renders the component with a close button 1`] = `
 <div
   className="Pill my-extra-class"
   data-test-id="cf-ui-pill"
-  draggable={false}
 >
   <span
     aria-label="test"
@@ -49,7 +47,6 @@ exports[`renders the component with a dragging handle 1`] = `
 <div
   className="Pill my-extra-class"
   data-test-id="cf-ui-pill"
-  draggable={true}
   onDrag={[Function]}
 >
   <span
@@ -76,7 +73,6 @@ exports[`renders the component with a test id 1`] = `
 <div
   className="Pill my-extra-class"
   data-test-id="test-id"
-  draggable={false}
 >
   <span
     aria-label="test"
@@ -91,7 +87,6 @@ exports[`renders the component with an additional class name 1`] = `
 <div
   className="Pill my-extra-class"
   data-test-id="cf-ui-pill"
-  draggable={false}
 >
   <span
     aria-label="test"


### PR DESCRIPTION
# Purpose of PR

`draggable=true` confuses browser and third-party drag-n-drop libraries and causes bugs.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
