### PR TITLE
feat(DropDown): Add dropdownContainerClassName

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`renders the component using a multiple dropdown lists 1`] = `
 <Dropdown
+  getContainerRef={[Function]}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"
@@ -93,6 +94,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
 
 exports[`renders the component using a single dropdown list 1`] = `
 <Dropdown
+  getContainerRef={[Function]}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"
@@ -152,6 +154,7 @@ exports[`renders the component using a single dropdown list 1`] = `
 exports[`renders the component with an additional class name 1`] = `
 <Dropdown
   className="my-extra-class"
+  getContainerRef={[Function]}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"
@@ -210,6 +213,7 @@ exports[`renders the component with an additional class name 1`] = `
 
 exports[`renders the component with published status 1`] = `
 <Dropdown
+  getContainerRef={[Function]}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
@@ -22,7 +22,6 @@ export type DropdownProps = {
   onClose?: Function;
   testId?: string;
   getContainerRef?: (ref: HTMLElement | null) => void;
-  dropdownContainerClassName?: string;
   className?: string;
   children: React.ReactNode;
 } & typeof defaultProps;
@@ -160,7 +159,6 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
       getContainerRef,
       children,
       isOpen,
-      dropdownContainerClassName,
       ...otherProps
     } = this.props;
 
@@ -179,7 +177,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
           <DropdownContainer
             anchorDimensionsAndPositon={this.state.anchorDimensionsAndPositon}
             position={this.props.position}
-            className={dropdownContainerClassName}
+            className={`${className}__container`}
             getRef={getContainerRef}
             dropdownAnchor={this.dropdownAnchor}
             onClose={this.props.onClose}
@@ -204,7 +202,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
         {toggleElement}
         {this.state.isOpen && (
           <DropdownContainer
-            className={dropdownContainerClassName}
+            className={`${className}__container`}
             getRef={getContainerRef}
             submenu={false}
             dropdownAnchor={this.dropdownAnchor}

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
@@ -21,6 +21,7 @@ export type DropdownProps = {
   isOpen: boolean;
   onClose?: Function;
   testId?: string;
+  dropdownContainerClassName?: string;
   getContainerRef?: (ref: HTMLElement | null) => void;
   className?: string;
   children: React.ReactNode;
@@ -157,6 +158,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
       testId,
       submenuToggleLabel,
       getContainerRef,
+      dropdownContainerClassName,
       children,
       isOpen,
       ...otherProps
@@ -177,7 +179,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
           <DropdownContainer
             anchorDimensionsAndPositon={this.state.anchorDimensionsAndPositon}
             position={this.props.position}
-            className={`${className}__container`}
+            className={dropdownContainerClassName}
             getRef={getContainerRef}
             dropdownAnchor={this.dropdownAnchor}
             onClose={this.props.onClose}
@@ -202,7 +204,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
         {toggleElement}
         {this.state.isOpen && (
           <DropdownContainer
-            className={`${className}__container`}
+            className={dropdownContainerClassName}
             getRef={getContainerRef}
             submenu={false}
             dropdownAnchor={this.dropdownAnchor}

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
@@ -21,6 +21,7 @@ export type DropdownProps = {
   isOpen: boolean;
   onClose?: Function;
   testId?: string;
+  getContainerRef?: (ref: HTMLElement | null) => void;
   dropdownContainerClassName?: string;
   className?: string;
   children: React.ReactNode;
@@ -43,6 +44,7 @@ const defaultProps = {
   testId: 'cf-ui-dropdown',
   position: 'bottom-left',
   isOpen: false,
+  getContainerRef: () => {},
 };
 
 export class Dropdown extends Component<DropdownProps, DropdownState> {
@@ -155,6 +157,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
       toggleElement,
       testId,
       submenuToggleLabel,
+      getContainerRef,
       children,
       isOpen,
       dropdownContainerClassName,
@@ -176,6 +179,8 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
           <DropdownContainer
             anchorDimensionsAndPositon={this.state.anchorDimensionsAndPositon}
             position={this.props.position}
+            className={dropdownContainerClassName}
+            getRef={getContainerRef}
             dropdownAnchor={this.dropdownAnchor}
             onClose={this.props.onClose}
             openSubmenu={this.openSubmenu}
@@ -200,6 +205,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
         {this.state.isOpen && (
           <DropdownContainer
             className={dropdownContainerClassName}
+            getRef={getContainerRef}
             submenu={false}
             dropdownAnchor={this.dropdownAnchor}
             anchorDimensionsAndPositon={this.state.anchorDimensionsAndPositon}

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
@@ -21,6 +21,7 @@ export type DropdownProps = {
   isOpen: boolean;
   onClose?: Function;
   testId?: string;
+  dropdownContainerClassName?: string;
   className?: string;
   children: React.ReactNode;
 } & typeof defaultProps;
@@ -156,6 +157,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
       submenuToggleLabel,
       children,
       isOpen,
+      dropdownContainerClassName,
       ...otherProps
     } = this.props;
 
@@ -197,6 +199,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
         {toggleElement}
         {this.state.isOpen && (
           <DropdownContainer
+            className={dropdownContainerClassName}
             submenu={false}
             dropdownAnchor={this.dropdownAnchor}
             anchorDimensionsAndPositon={this.state.anchorDimensionsAndPositon}

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`renders the component as open 1`] = `
         "width": 0,
       }
     }
-    className="undefined__container"
     dropdownAnchor={null}
     getRef={[Function]}
     openSubmenu={[Function]}
@@ -99,7 +98,6 @@ exports[`renders the component with a submenu 1`] = `
         "width": 0,
       }
     }
-    className="undefined__container"
     dropdownAnchor={null}
     getRef={[Function]}
     openSubmenu={[Function]}

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -48,6 +48,7 @@ exports[`renders the component as open 1`] = `
         "width": 0,
       }
     }
+    className="undefined__container"
     dropdownAnchor={null}
     getRef={[Function]}
     openSubmenu={[Function]}
@@ -98,6 +99,7 @@ exports[`renders the component with a submenu 1`] = `
         "width": 0,
       }
     }
+    className="undefined__container"
     dropdownAnchor={null}
     getRef={[Function]}
     openSubmenu={[Function]}

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -49,6 +49,7 @@ exports[`renders the component as open 1`] = `
       }
     }
     dropdownAnchor={null}
+    getRef={[Function]}
     openSubmenu={[Function]}
     position="bottom-left"
     submenu={false}
@@ -98,6 +99,7 @@ exports[`renders the component with a submenu 1`] = `
       }
     }
     dropdownAnchor={null}
+    getRef={[Function]}
     openSubmenu={[Function]}
     position="bottom-left"
     submenu={false}
@@ -115,6 +117,7 @@ exports[`renders the component with a submenu 1`] = `
         entry
       </DropdownListItem>
       <Dropdown
+        getContainerRef={[Function]}
         isOpen={true}
         position="bottom-left"
         submenuToggleLabel="Submenu"

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -169,9 +169,10 @@ class DropdownContainer extends Component<
     );
 
   render() {
-    const { submenu } = this.props;
+    const { submenu, className } = this.props;
 
     const classNames = cn(
+      className,
       styles['DropdownContainer'],
       submenu ? this.getSubmenuClassNames() : '',
     );

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -18,6 +18,7 @@ export type DropdownContainerProps = {
   openSubmenu?: (value: boolean) => void;
   anchorDimensionsAndPositon?: AnchorDimensionsAndPositonType;
   position: positionType;
+  getRef?: (ref: HTMLElement | null) => void;
   submenu?: boolean;
 } & typeof defaultProps;
 
@@ -33,6 +34,7 @@ const defaultProps = {
   testId: 'cf-ui-dropdown-portal',
   position: 'bottom-left',
   submenu: false,
+  getRef: () => {},
 };
 
 class DropdownContainer extends Component<
@@ -65,6 +67,7 @@ class DropdownContainer extends Component<
       });
     }
     document.addEventListener('mousedown', this.trackOutsideClick, true);
+    this.props.getRef(this.dropdown);
   }
 
   componentWillUnmount() {

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/__snapshots__/DropdownContainer.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/__snapshots__/DropdownContainer.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`renders the component 1`] = `
 
 exports[`renders the component as a submenu 1`] = `
 <div
-  className="DropdownContainer DropdownContainer__submenu DropdownContainer__container-position--bottom-left"
+  className="extraClassName DropdownContainer DropdownContainer__submenu DropdownContainer__container-position--bottom-left"
   onFocus={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
@@ -86,7 +86,7 @@ exports[`renders the component with an additional class name 1`] = `
   containerInfo={<div />}
 >
   <div
-    className="DropdownContainer"
+    className="extraClassName DropdownContainer"
     onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}


### PR DESCRIPTION
This PR will add `dropdownContainerClassName` prop to the dropdown for more flexibility overwriting portal container styles. (e.g override zIndex when used in modals)