### PR TITLE
Fix broken rendering of token values

### DIFF
--- a/packages/forma-36-website/src/pages/foundation/box-shadows/index.mdx
+++ b/packages/forma-36-website/src/pages/foundation/box-shadows/index.mdx
@@ -36,7 +36,7 @@ Box shadows are used to give depth to the user interface.
         <TableRow key={token}>
           <TableCell>{token}</TableCell>
           <TableCell>
-            <code>{value}</code>
+            <pre>{value}</pre>
           </TableCell>
           <TableCell>
             <Card>Box Shadow</Card>
@@ -67,7 +67,7 @@ Button component.
         <TableRow key={token}>
           <TableCell>{token}</TableCell>
           <TableCell>
-            <code>{value}</code>
+            <pre>{value}</pre>
           </TableCell>
           <TableCell>
             <Card style={{ boxShadow: value }}>Box Shadow</Card>

--- a/packages/forma-36-website/src/pages/foundation/spacing/index.mdx
+++ b/packages/forma-36-website/src/pages/foundation/spacing/index.mdx
@@ -29,10 +29,10 @@ import {
             <strong>{token}</strong>
           </TableCell>
           <TableCell style={{ verticalAlign: 'middle' }}>
-            <code>{valuePx}px</code>
+            <pre>{valuePx}px</pre>
           </TableCell>
           <TableCell style={{ verticalAlign: 'middle' }}>
-            <code>{value}</code>
+            <pre>{value}</pre>
           </TableCell>
           <TableCell style={{ verticalAlign: 'middle' }}>
             <div

--- a/packages/forma-36-website/src/pages/foundation/transitions/index.mdx
+++ b/packages/forma-36-website/src/pages/foundation/transitions/index.mdx
@@ -35,10 +35,10 @@ import {
         <TableRow key={token}>
           <TableCell>{token}</TableCell>
           <TableCell>
-            <code>--{token}</code>
+            <pre>--{token}</pre>
           </TableCell>
           <TableCell>
-            <code>{value}</code>
+            <pre>{value}</pre>
           </TableCell>
           <TableCell>
             <Slider>
@@ -69,10 +69,10 @@ import {
         <TableRow key={token}>
           <TableCell>{token}</TableCell>
           <TableCell>
-            <code>--{token}</code>
+            <pre>--{token}</pre>
           </TableCell>
           <TableCell>
-            <code>{value}</code>
+            <pre>{value}</pre>
           </TableCell>
           <TableCell>
             <Slider>

--- a/packages/forma-36-website/src/pages/foundation/typography/index.mdx
+++ b/packages/forma-36-website/src/pages/foundation/typography/index.mdx
@@ -40,10 +40,10 @@ Our font base is used in combination with the REM font sizes below
             <span style={{ fontSize: value }}>{token}</span>
           </TableCell>
           <TableCell>
-            <code>--{token}</code>
+            <pre>--{token}</pre>
           </TableCell>
           <TableCell>
-            <code>{value}</code>
+            <pre>{value}</pre>
           </TableCell>
         </TableRow>
       );
@@ -72,13 +72,13 @@ Our font base is used in combination with the REM font sizes below
             <span style={{ fontSize: value }}>{token}</span>
           </TableCell>
           <TableCell>
-            <code>--{token}</code>
+            <pre>--{token}</pre>
           </TableCell>
           <TableCell>
-            <code>{value}</code>
+            <pre>{value}</pre>
           </TableCell>
           <TableCell>
-            <code>{valuePx}px</code>
+            <pre>{valuePx}px</pre>
           </TableCell>
         </TableRow>
       );
@@ -105,10 +105,10 @@ Our font base is used in combination with the REM font sizes below
             <span style={{ fontWeight: value }}>{token}</span>
           </TableCell>
           <TableCell>
-            <code>--{token}</code>
+            <pre>--{token}</pre>
           </TableCell>
           <TableCell>
-            <code>{value}</code>
+            <pre>{value}</pre>
           </TableCell>
         </TableRow>
       );
@@ -141,10 +141,10 @@ Our font base is used in combination with the REM font sizes below
             </div>
           </TableCell>
           <TableCell>
-            <code>--{token}</code>
+            <pre>--{token}</pre>
           </TableCell>
           <TableCell>
-            <code>{value}</code>
+            <pre>{value}</pre>
           </TableCell>
         </TableRow>
       );
@@ -177,10 +177,10 @@ Our font base is used in combination with the REM font sizes below
             </div>
           </TableCell>
           <TableCell>
-            <code>--{token}</code>
+            <pre>--{token}</pre>
           </TableCell>
           <TableCell>
-            <code>{value}</code>
+            <pre>{value}</pre>
           </TableCell>
         </TableRow>
       );
@@ -209,10 +209,10 @@ Our font base is used in combination with the REM font sizes below
             <div style={{ letterSpacing: value }}>Contentful</div>
           </TableCell>
           <TableCell>
-            <code>--{token}</code>
+            <pre>--{token}</pre>
           </TableCell>
           <TableCell>
-            <code>{value}</code>
+            <pre>{value}</pre>
           </TableCell>
         </TableRow>
       );


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

After upgrading `gatsby-plugin-mdx` the foundation pages are attempting to render the code source component when we display values for our tokens. This doesn't work so well… This PR changes the foundation docs to use the `pre` tag rather than `code`, resulting in values being displayed as expected. 

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
