### PR TITLE
chore: added back button to Workbench components

### DIFF
--- a/packages/forma-36-react-components/src/components/IconButton/IconButton.tsx
+++ b/packages/forma-36-react-components/src/components/IconButton/IconButton.tsx
@@ -64,8 +64,7 @@ export class IconButton extends Component<
 
     const content = (
       <TabFocusTrap className={styles.IconButton__inner}>
-        <Icon icon={iconProps.icon} className={styles.IconButton__icon} />
-
+        <Icon {...iconProps} className={styles.IconButton__icon} />
         <span className={styles.IconButton__label}>{label}</span>
         {withDropdown && (
           <Icon

--- a/packages/forma-36-react-components/src/components/Workbench/Workbench.css
+++ b/packages/forma-36-react-components/src/components/Workbench/Workbench.css
@@ -33,12 +33,36 @@
   box-shadow: var(--box-shadow-default);
 }
 
+.Workbench__header-back {
+  margin: calc(-1 * var(--spacing-l));
+  margin-right: var(--spacing-m);
+  border-right: 1px solid var(--color-element-light);
+}
+
+.Workbench__header-back-button {
+  margin: 0;
+  width: 50px;
+  height: 69px;
+}
+
+.Workbench .Workbench__header-back-button svg {
+  fill: var(--color-element-dark);
+}
+
+.Workbench .Workbench__header-back-button:hover svg,
+.Workbench .Workbench__header-back-button:focus svg {
+  fill: var(--color-element-darkest);
+}
+
 .Workbench__header-icon {
   margin-right: var(--spacing-m);
 }
 
 .Workbench__header-title {
   flex-grow: 1;
+  display: flex;
+  align-items: center;
+  flex-direction: row;
 }
 
 .Workbench__header-actions {

--- a/packages/forma-36-react-components/src/components/Workbench/Workbench.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Workbench/Workbench.stories.tsx
@@ -118,4 +118,27 @@ storiesOf('(alpha)|Workbench', module)
         </div>
       </Workbench.Sidebar>
     </Workbench>
+  ))
+  .add('with back button', () => (
+    <Workbench className={text('className', '')} testId={text('testId')}>
+      <Workbench.Header
+        onBack={() => {}}
+        title={'Page title'}
+        icon={<Icon icon="ArrowDown" />}
+        actions={<Button buttonType="muted">Click</Button>}
+      />
+      <Workbench.Content
+        type={select(
+          'Workbench.Content -> type',
+          ['default', 'text', 'full'],
+          'default',
+        )}
+      >
+        <div
+          style={{ height: '2000px', backgroundColor: tokens.colorBlueBase }}
+        >
+          Workbench
+        </div>
+      </Workbench.Content>
+    </Workbench>
   ));

--- a/packages/forma-36-react-components/src/components/Workbench/Workbench.tsx
+++ b/packages/forma-36-react-components/src/components/Workbench/Workbench.tsx
@@ -1,13 +1,15 @@
 import React, { Component } from 'react';
 import cn from 'classnames';
 import Heading from '../Typography/Heading';
+import IconButton from '../IconButton';
 
 const styles = require('./Workbench.css');
 
 interface WorkbenchHeaderProps {
-  title?: string;
+  title?: React.ReactElement | string;
   icon?: React.ReactElement;
   actions?: React.ReactElement;
+  onBack?: Function;
   className?: string;
   testId?: string;
 }
@@ -18,17 +20,40 @@ export function WorkbenchHeader(props: WorkbenchHeaderProps) {
       className={cn(styles['Workbench__header'], props.className)}
       data-test-id={props.testId}
     >
+      {props.onBack ? (
+        <div className={styles['Workbench__header-back']}>
+          <IconButton
+            onClick={() => {
+              if (typeof props.onBack === 'function') {
+                props.onBack();
+              }
+            }}
+            testId="workbench-back-btn"
+            className={styles['Workbench__header-back-button']}
+            label="Back"
+            buttonType="muted"
+            iconProps={{
+              size: 'large',
+              icon: 'ChevronLeft',
+            }}
+          />
+        </div>
+      ) : null}
       {props.icon ? (
         <div className={styles['Workbench__header-icon']}>{props.icon}</div>
       ) : null}
-      {props.title ? (
-        <Heading
+      {props.title && (
+        <div
+          data-test-id="workbench-title"
           className={styles['Workbench__header-title']}
-          testId="workbench-title"
         >
-          {props.title}
-        </Heading>
-      ) : null}
+          {typeof props.title === 'string' ? (
+            <Heading>{props.title}</Heading>
+          ) : (
+            props.title
+          )}
+        </div>
+      )}
       {props.actions ? (
         <div className={styles['Workbench__header-actions']}>
           {props.actions}


### PR DESCRIPTION
# Purpose of PR

Add `BackButton` to Workbench components and more flexible `title` property.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
