### PR TITLE
fix(Dropdown): Position DropdownContainer when list of options reduces

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -144,7 +144,7 @@ class DropdownContainer extends Component<
         };
       case 'top-left':
         return {
-          top: anchorDimensionsAndPositon.top - dropdownDimensions.height,
+          bottom: window.innerHeight - anchorDimensionsAndPositon.top,
           left: anchorDimensionsAndPositon.left,
         };
       case 'bottom-right':
@@ -157,7 +157,7 @@ class DropdownContainer extends Component<
         };
       case 'top-right':
         return {
-          top: anchorDimensionsAndPositon.top - dropdownDimensions.height,
+          bottom: window.innerHeight - anchorDimensionsAndPositon.top,
           left:
             anchorDimensionsAndPositon.left -
             (dropdownDimensions.width - anchorDimensionsAndPositon.width),


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

With the introduction of the Autocomplete component, the list of options in a dropdown can change depending on the search/filter. This caused an issue where, when positioned at the top of the anchor, the list would not be positioned correctly after a filter is applied.

![Screenshot 2019-07-22 at 16 15 53](https://user-images.githubusercontent.com/36824/61640465-adf70200-ac9d-11e9-9e20-9cae562a1d6f.png)
_List in its default state_

---

![Screenshot 2019-07-22 at 16 27 34](https://user-images.githubusercontent.com/36824/61640525-c6671c80-ac9d-11e9-910c-ef50ade46414.png)
_List after a filter is applied, before the fix_

---

![Screenshot 2019-07-22 at 16 14 48](https://user-images.githubusercontent.com/36824/61640554-d54dcf00-ac9d-11e9-8a2c-faa368aa12ac.png)
_After the fix_

---

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
