### PR TITLE
chore(Dropdown): add a11y attributes to dropdown components

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownList/DropdownList.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownList/DropdownList.tsx
@@ -34,6 +34,7 @@ export class DropdownList extends Component<DropdownListProps> {
     return (
       <ul
         data-test-id={testId}
+        role="listbox"
         style={{
           maxHeight: maxHeight || 'auto',
           overflowY: maxHeight ? 'auto' : 'visible',

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownList/__snapshots__/DropdownList.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownList/__snapshots__/DropdownList.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders the component 1`] = `
 <ul
   className="DropdownList"
   data-test-id="cf-ui-dropdown-list"
+  role="listbox"
   style={
     Object {
       "maxHeight": "auto",
@@ -26,6 +27,7 @@ exports[`renders the component with a border attribute 1`] = `
 <ul
   className="DropdownList DropdownList--border-top"
   data-test-id="cf-ui-dropdown-list"
+  role="listbox"
   style={
     Object {
       "maxHeight": "auto",
@@ -48,6 +50,7 @@ exports[`renders the component with an additional class name 1`] = `
 <ul
   className="DropdownList my-extra-class"
   data-test-id="cf-ui-dropdown-list"
+  role="listbox"
   style={
     Object {
       "maxHeight": "auto",

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
@@ -129,7 +129,7 @@ export class DropdownListItem extends Component<DropdownListItemProps> {
     });
 
     return (
-      <li className={classNames} data-test-id={testId}>
+      <li className={classNames} data-test-id={testId} aria-selected={isActive} role="option">
         {submenuToggleLabel
           ? this.renderSubmenuToggle()
           : this.renderListItem()}

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/__snapshots__/DropdownListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/__snapshots__/DropdownListItem.test.tsx.snap
@@ -2,8 +2,10 @@
 
 exports[`renders the component 1`] = `
 <li
+  aria-selected={false}
   className="DropdownListItem"
   data-test-id="cf-ui-dropdown-list-item"
+  role="option"
 >
   <span>
     DropdownMenuItem
@@ -13,8 +15,10 @@ exports[`renders the component 1`] = `
 
 exports[`renders the component as active 1`] = `
 <li
+  aria-selected={true}
   className="DropdownListItem DropdownListItem--active"
   data-test-id="cf-ui-dropdown-list-item"
+  role="option"
 >
   <span>
     entry
@@ -24,8 +28,10 @@ exports[`renders the component as active 1`] = `
 
 exports[`renders the component as disabled 1`] = `
 <li
+  aria-selected={false}
   className="DropdownListItem DropdownListItem--disabled"
   data-test-id="cf-ui-dropdown-list-item"
+  role="option"
 >
   <span>
     entry
@@ -35,8 +41,10 @@ exports[`renders the component as disabled 1`] = `
 
 exports[`renders the component with a href 1`] = `
 <li
+  aria-selected={false}
   className="DropdownListItem DropdownListItem__submenu-toggle"
   data-test-id="cf-ui-dropdown-list-item"
+  role="option"
 >
   <a
     className="DropdownListItem__button"
@@ -57,8 +65,10 @@ exports[`renders the component with a href 1`] = `
 
 exports[`renders the component with an additional class name 1`] = `
 <li
+  aria-selected={false}
   className="DropdownListItem my-extra-class"
   data-test-id="cf-ui-dropdown-list-item"
+  role="option"
 >
   <span
     className="my-extra-class"


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Adds a couple of wai-aria attributes to Dropdown sub components.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
