### PR TITLE
fix(Workbench): Align header icon with title

### DIFF
--- a/packages/forma-36-react-components/src/components/Workbench/Workbench.css
+++ b/packages/forma-36-react-components/src/components/Workbench/Workbench.css
@@ -56,6 +56,7 @@
 
 .Workbench__header-icon {
   margin-right: var(--spacing-m);
+  display: flex;
 }
 
 .Workbench__header-title {


### PR DESCRIPTION
Without flexbox, the icon container doesn't properly adapt to it's child dimensions.
There might be alternative solutions

![icon-alignment](https://user-images.githubusercontent.com/40791319/61727772-33e57c80-ad74-11e9-9fb1-dc83437e4bd4.gif)

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
