### PR TITLE
SVG Icon and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<img src="./forma-icon.png" width="150">
-
-# Forma 36 - The Contentful Design System
+<h1><img src="./forma-icon.svg" height="28" style="vertical-align: baseline"> Forma 36 - The Contentful Design System</h1>
 
 ![build status](https://travis-ci.com/contentful/forma-36.svg?token=9ZgfZHVDFAy8E7oFpbGM&branch=master)
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1><img src="./forma-icon.svg" height="28" style="vertical-align: baseline"> Forma 36 - The Contentful Design System</h1>
+<h1><img src="./forma-icon.svg" height="24"> Forma 36 - The Contentful Design System</h1>
 
 ![build status](https://travis-ci.com/contentful/forma-36.svg?token=9ZgfZHVDFAy8E7oFpbGM&branch=master)
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)

--- a/forma-icon.svg
+++ b/forma-icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024">
+  <path fill="#3c80cf" d="M0-0h1024v1024H0z"/>
+  <g fill="#fff">
+    <circle cx="304" cy="304" r="60"/>
+    <circle cx="512" cy="304" r="60"/>
+    <circle cx="720" cy="304" r="60"/>
+    <circle cx="304" cy="512" r="60"/>
+    <circle cx="512" cy="512" r="60"/>
+    <circle cx="304" cy="720" r="60"/>
+  </g>
+</svg>


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR adds a SVG version of the forma 36 icon, solely derived from the PNG version.
Also the README headline will be adjusted to incorporate a resized icon within the h1 headline.

Currently the icon size is adjusted to meet the styling of the h1 text on GitHub (renders well in Chrome and Firefox on a Mac, but ymmv):
![Screenshot 2019-07-24 13 29 09](https://user-images.githubusercontent.com/446613/61790250-07cf0780-ae17-11e9-88bf-baa80d91b2db.png)


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
