### PR TITLE
fix(Tooltip): Keep `className` prop in `otherProps`

### DIFF
--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
@@ -228,7 +228,6 @@ export class Tooltip extends Component<TooltipProps, TooltipState> {
 
   render() {
     const {
-      className,
       targetWrapperClassName,
       content,
       onMouseLeave,


### PR DESCRIPTION
Otherwise it won't be added to the `TooltipContainer` and `className` won't have an effect.