### PR TITLE
fix(EntryListItem): Add target blank if onClick and href is defined

### DIFF
--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
@@ -217,6 +217,7 @@ export class EntityListItem extends Component<EntityListItemProps> {
             onClick={onClick}
             href={href}
             tabIndex={onClick && 0}
+            target={onClick && href ? '_blank' : undefined}
           >
             <TabFocusTrap className={styles['EntityListItem__focus-trap']}>
               <figure className={styles['EntityListItem__media']}>


### PR DESCRIPTION
If onClick and href is defined we still want to provide right click open in new tab.