### PR TITLE
System UI font preparation

### DIFF
--- a/packages/forma-36-react-components/src/components/Button/Button.css
+++ b/packages/forma-36-react-components/src/components/Button/Button.css
@@ -180,7 +180,7 @@
 .Button__label {
   margin: 0 calc(1rem * (4 / var(--font-base-default)));
   color: var(--color-text-mid);
-  line-height: 1.5;
+  line-height: 2;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;

--- a/packages/forma-36-react-components/src/components/CheckboxField/CheckboxField.css
+++ b/packages/forma-36-react-components/src/components/CheckboxField/CheckboxField.css
@@ -19,5 +19,5 @@
 }
 
 .CheckboxField__label--light {
-  font-weight: 300;
+  font-weight: var(--font-weight-normal);
 }

--- a/packages/forma-36-react-components/src/components/ControlledInputField/ControlledInputField.css
+++ b/packages/forma-36-react-components/src/components/ControlledInputField/ControlledInputField.css
@@ -21,5 +21,5 @@
 }
 
 .ControlledInputField__label--light {
-  font-weight: 300;
+  font-weight: var(--font-weight-normal);
 }

--- a/packages/forma-36-tokens/src/tokens/typography/font-stack.js
+++ b/packages/forma-36-tokens/src/tokens/typography/font-stack.js
@@ -1,7 +1,8 @@
 const fontStack = {
   'font-stack-primary':
-    "'Avenir Next W01', -apple-system, BlinkMacSystemTypography, 'Segoe UI', Cantarell, Helvetica, Arial, sans-serif",
-  'font-stack-monospace': "'Menlo', 'Andale mono', monospace",
+    "'Avenir Next W01', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+  'font-stack-monospace':
+    'SFMono-Regular, Consolas, Liberation Mono, Menlo,monospace',
 };
 
 module.exports = fontStack;

--- a/packages/forma-36-tokens/src/tokens/typography/font-weight.js
+++ b/packages/forma-36-tokens/src/tokens/typography/font-weight.js
@@ -1,5 +1,5 @@
 const fontWeight = {
-  'font-weight-normal': '500',
+  'font-weight-normal': '400',
   'font-weight-medium': '600',
   'font-weight-demi-bold': '700',
 };


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR includes some preparations for the deprecation of Avenir in favour of system UI fonts.

**⚠️ This PR does not remove Avenir from the font-stack - this will happen in a follow up PR**

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
