### PR TITLE
fix(Tabs): Add withDivider property

### DIFF
--- a/packages/forma-36-react-components/src/components/Tabs/Tabs.css
+++ b/packages/forma-36-react-components/src/components/Tabs/Tabs.css
@@ -30,6 +30,10 @@
   margin-right: 0;
 }
 
+.Tabs__with-divider {
+  box-shadow: inset 0 -3px 0px 0px var(--color-element-mid);
+}
+
 .Tab__selected {
   font-weight: var(--font-weight-medium);
 }

--- a/packages/forma-36-react-components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Tabs/Tabs.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { text } from '@storybook/addon-knobs';
+import { text, boolean } from '@storybook/addon-knobs';
 
 import Tabs from './Tabs';
 import Tab from './Tab';
@@ -12,7 +12,10 @@ function DefaultStory() {
 
   return (
     <div>
-      <Tabs className={text('className', '')}>
+      <Tabs
+        className={text('className', '')}
+        withDivider={boolean('withDivider', false)}
+      >
         <Tab
           id="first"
           selected={selected === 'first'}
@@ -60,7 +63,11 @@ function DefaultStory() {
 function AsNavigationStory() {
   const [selected, setSelected] = useState('first');
   return (
-    <Tabs role="navigation" className={text('className', '')}>
+    <Tabs
+      role="navigation"
+      className={text('className', '')}
+      withDivider={boolean('withDivider', false)}
+    >
       <Tab
         id="first"
         href="https://contentful.com"

--- a/packages/forma-36-react-components/src/components/Tabs/Tabs.tsx
+++ b/packages/forma-36-react-components/src/components/Tabs/Tabs.tsx
@@ -7,6 +7,7 @@ export type TabsProps = {
   role?: 'navigation' | 'tablist';
   style?: CSSProperties;
   className?: string;
+  withDivider?: boolean;
   children?: React.ReactNode;
   testId?: string;
 } & typeof defaultProps;
@@ -14,15 +15,27 @@ export type TabsProps = {
 const defaultProps = {
   testId: 'cf-ui-tabs',
   role: 'tablist',
+  withDivider: false,
 };
 
 export class Tabs extends Component<TabsProps> {
   static defaultProps = defaultProps;
 
   render() {
-    const { className, children, testId, role, style } = this.props;
+    const {
+      className,
+      children,
+      testId,
+      role,
+      withDivider,
+      style,
+    } = this.props;
 
-    const classNames = cn(styles.Tabs, className);
+    const classNames = cn(
+      styles.Tabs,
+      { [styles['Tabs__with-divider']]: withDivider },
+      className,
+    );
 
     const elementProps = {
       'data-test-id': testId,

--- a/packages/forma-36-react-components/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -5,6 +5,7 @@ Array [
   <Tabs
     role="tablist"
     testId="cf-ui-tabs"
+    withDivider={false}
   >
     <div
       className="Tabs"
@@ -117,6 +118,7 @@ exports[`renders the component with role=navigation and an additional class name
   className="my-extra-class"
   role="navigation"
   testId="cf-ui-tabs"
+  withDivider={false}
 >
   <nav
     className="Tabs my-extra-class"


### PR DESCRIPTION
This PR adds a withDivider property to the Tabs component. if this is true a border will be shown underneath the tabs panel. 

![image](https://user-images.githubusercontent.com/1766274/63435334-0816ee80-c427-11e9-8446-8e6c0307b031.png)
