### PR TITLE
feat(TextLink): Add proprety to align the Icon left or right

### DIFF
--- a/packages/forma-36-react-components/src/components/InViewport/__snapshots__/InViewport.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/InViewport/__snapshots__/InViewport.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`renders the component 1`] = `
   >
     <TextLink
       disabled={false}
+      iconPosition="left"
       linkType="primary"
       testId="cf-ui-text-link"
     >
@@ -48,6 +49,7 @@ exports[`renders the component with an additional class name 1`] = `
   >
     <TextLink
       disabled={false}
+      iconPosition="left"
       linkType="primary"
       testId="cf-ui-text-link"
     >

--- a/packages/forma-36-react-components/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -150,6 +150,7 @@ exports[`renders the component with a textlink 1`] = `
       className="TextField__label-link"
       disabled={false}
       icon="Lock"
+      iconPosition="left"
       linkType="primary"
       onClick={[Function]}
       testId="cf-ui-text-link"

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.css
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.css
@@ -128,3 +128,8 @@
 .TextLink__icon-wrapper {
   margin-right: 4px;
 }
+
+.TextLink__icon-wrapper--right {
+  margin-left: 4px;
+  order: 2;
+}

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.stories.tsx
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.stories.tsx
@@ -30,6 +30,14 @@ storiesOf('Components|TextLink', module)
         )}
         disabled={boolean('disabled', false)}
         className={text('className', '')}
+        iconPosition={select(
+          'iconPosition',
+          {
+            'left (default)': 'left',
+            right: 'right',
+          },
+          'left',
+        )}
         icon={select('icon', ['', ...Object.keys(iconName)], undefined)}
       >
         {text('children', 'Text Link Label')}

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.test.tsx
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.test.tsx
@@ -111,3 +111,13 @@ it('renders with an icon', () => {
 
   expect(output).toMatchSnapshot();
 });
+
+it('renders with an icon aligned right to the text', () => {
+  const output = shallow(
+    <TextLink iconPosition="right" icon={iconName[Object.keys(iconName)[0]]}>
+      Text Link
+    </TextLink>,
+  );
+
+  expect(output).toMatchSnapshot();
+});

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.tsx
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.tsx
@@ -12,6 +12,8 @@ export type TextLinkType =
   | 'secondary'
   | 'muted';
 
+type IconPositionType = 'right' | 'left';
+
 export type TextLinkProps = {
   children?: React.ReactNode;
   linkType?: TextLinkType;
@@ -22,12 +24,14 @@ export type TextLinkProps = {
   className?: string;
   icon?: IconType;
   text?: string;
+  iconPosition?: IconPositionType;
 } & typeof defaultProps;
 
 const defaultProps = {
   linkType: 'primary',
   testId: 'cf-ui-text-link',
   disabled: false,
+  iconPosition: 'left',
 };
 
 export class TextLink extends Component<TextLinkProps> {
@@ -37,7 +41,13 @@ export class TextLink extends Component<TextLinkProps> {
     if (!icon) return undefined;
 
     return (
-      <div className={styles['TextLink__icon-wrapper']}>
+      <div
+        className={
+          this.props.iconPosition === 'right'
+            ? styles['TextLink__icon-wrapper--right']
+            : styles['TextLink__icon-wrapper']
+        }
+      >
         <Icon icon={icon} color={linkType} className={styles.TextLink__icon} />
       </div>
     );
@@ -54,6 +64,7 @@ export class TextLink extends Component<TextLinkProps> {
       className,
       icon,
       text,
+      iconPosition,
       ...otherProps
     } = this.props;
 

--- a/packages/forma-36-react-components/src/components/TextLink/__snapshots__/TextLink.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/TextLink/__snapshots__/TextLink.test.tsx.snap
@@ -192,3 +192,27 @@ exports[`renders with an icon 1`] = `
   </TabFocusTrap>
 </button>
 `;
+
+exports[`renders with an icon aligned right to the text 1`] = `
+<button
+  className="TextLink TextLink--primary"
+  data-test-id="cf-ui-text-link"
+  disabled={false}
+  type="button"
+>
+  <TabFocusTrap>
+    <div
+      className="TextLink__icon-wrapper--right"
+    >
+      <Icon
+        className="TextLink__icon"
+        color="primary"
+        icon="ArrowDown"
+        size="small"
+        testId="cf-ui-icon"
+      />
+    </div>
+    Text Link
+  </TabFocusTrap>
+</button>
+`;


### PR DESCRIPTION
This PR will add a property iconPosition to the TextLink component which will allow the selection of the Icon left or right from the link text.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
