### PR TITLE
fix(TextLink): Allow wrapping of right aligned Icon

### DIFF
--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.css
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.css
@@ -9,7 +9,7 @@
 
 .TextLink,
 .TextLink:link {
-  display: inline-flex;
+  display: inline;
   align-items: center;
   box-sizing: border-box;
   border: 0;
@@ -126,10 +126,11 @@
 }
 
 .TextLink__icon-wrapper {
+  display: inline;
   margin-right: 4px;
 }
 
 .TextLink__icon-wrapper--right {
+  display: inline;
   margin-left: 4px;
-  order: 2;
 }

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.tsx
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.tsx
@@ -75,8 +75,9 @@ export class TextLink extends Component<TextLinkProps> {
 
     const content = (
       <TabFocusTrap>
-        {icon && this.renderIcon(icon, linkType)}
+        {icon && iconPosition === 'left' && this.renderIcon(icon, linkType)}
         {text || children}
+        {icon && iconPosition === 'right' && this.renderIcon(icon, linkType)}
       </TabFocusTrap>
     );
 

--- a/packages/forma-36-react-components/src/components/TextLink/__snapshots__/TextLink.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/TextLink/__snapshots__/TextLink.test.tsx.snap
@@ -201,6 +201,7 @@ exports[`renders with an icon aligned right to the text 1`] = `
   type="button"
 >
   <TabFocusTrap>
+    Text Link
     <div
       className="TextLink__icon-wrapper--right"
     >
@@ -212,7 +213,6 @@ exports[`renders with an icon aligned right to the text 1`] = `
         testId="cf-ui-icon"
       />
     </div>
-    Text Link
   </TabFocusTrap>
 </button>
 `;


### PR DESCRIPTION
This PR will fix a small issue with the right aligned TextLink Icon. It'll now wrap if the text is too long.
## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
