### PR TITLE
docs: Update hyperlink to UI Kit

### DIFF
--- a/packages/forma-36-website/src/pages/resources/index.mdx
+++ b/packages/forma-36-website/src/pages/resources/index.mdx
@@ -5,7 +5,7 @@ subpages:
     {
       title: 'UI Kit',
       desc: 'A Sketch component library for Forma 36',
-      path: 'https://sketch.cloud/s/dDdL3',
+      path: 'https://www.dropbox.com/s/gfup7tvfbcuinz0/F36%20UI%20Kit.sketch?dl=1',
       icon: 'sketch',
     },
     {


### PR DESCRIPTION
# Purpose of PR

This change allows people to get the F36 UI Kit directly from Dropbox.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
