### PR TITLE
fix(tokens): generate types without quotas

### DIFF
--- a/packages/forma-36-tokens/tools/build.js
+++ b/packages/forma-36-tokens/tools/build.js
@@ -48,8 +48,8 @@ const buildIndexJS = (srcPath, tokens) => {
     `
     Object.defineProperty(exports, "__esModule", {
       value: true
-    }); 
-    
+    });
+
     module.exports = ${JSON.stringify(tokens, null, 2)}
     `,
   );
@@ -69,7 +69,7 @@ function createInterfaceDefinition(tokens) {
     /**
      * ${def.value}
      */
-    "${tokenName}": "${def.type}"`,
+    "${tokenName}": ${def.type}`,
   ).join(',');
 
   return `interface F36Tokens {


### PR DESCRIPTION
# Purpose of PR

Fixes typings for `tokens` package.

`"string"` is not equal to `string`

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
