### PR TITLE
feat(CardActions): Add isDisabled property

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
@@ -163,6 +163,7 @@ exports[`renders the component with actions 1`] = `
             "onClick": [Function],
           }
         }
+        isDisabled={false}
         testId="cf-ui-card-actions"
       >
         <DropdownList

--- a/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { text } from '@storybook/addon-knobs';
+import { text, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import CardActions from './CardActions';
@@ -12,7 +12,10 @@ storiesOf('Components|Card/CardActions', module)
     propTypes: CardActions['__docgenInfo'],
   })
   .add('default', () => (
-    <CardActions className={text('className', '')}>
+    <CardActions
+      className={text('className', '')}
+      isDisabled={boolean('isDisabled', false)}
+    >
       <DropdownList>
         <DropdownListItem onClick={action('Edit onClick')}>
           Edit
@@ -27,7 +30,10 @@ storiesOf('Components|Card/CardActions', module)
     </CardActions>
   ))
   .add('with multiple lists', () => (
-    <CardActions className={text('className', '')}>
+    <CardActions
+      className={text('className', '')}
+      isDisabled={boolean('isDisabled', false)}
+    >
       <DropdownList>
         <DropdownListItem onClick={action('Edit onClick')}>
           Edit

--- a/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.test.tsx
@@ -19,6 +19,18 @@ it('renders the component using a single dropdown list', () => {
   expect(output).toMatchSnapshot();
 });
 
+it('renders the component as disabled', () => {
+  const output = shallow(
+    <CardActions isDisabled>
+      <DropdownList>
+        <DropdownListItem onClick={() => {}}>Edit</DropdownListItem>
+      </DropdownList>
+    </CardActions>,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
 it('renders the component using a multiple dropdown lists', () => {
   const output = shallow(
     <CardActions>

--- a/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
@@ -13,9 +13,12 @@ export type CardActionsPropTypes = {
    */
   iconButtonProps?: Partial<IconButtonProps>;
   /**
-   * The DropdownList elements used to render an actions dropdown for the component
+   * A boolean used to disable the actions
    */
   isDisabled?: boolean;
+  /**
+   * The DropdownList elements used to render an actions dropdown for the component
+   */
   children:
     | React.ReactElement<DropdownList>
     | React.ReactElement<DropdownList>[];

--- a/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
@@ -15,6 +15,7 @@ export type CardActionsPropTypes = {
   /**
    * The DropdownList elements used to render an actions dropdown for the component
    */
+  isDisabled?: boolean;
   children:
     | React.ReactElement<DropdownList>
     | React.ReactElement<DropdownList>[];
@@ -26,6 +27,7 @@ export interface CardActionsState {
 
 const defaultProps = {
   testId: 'cf-ui-card-actions',
+  isDisabled: false,
 };
 
 export class CardActions extends Component<
@@ -52,6 +54,7 @@ export class CardActions extends Component<
       children,
       testId,
       iconButtonProps,
+      isDisabled,
       ...otherProps
     } = this.props;
 
@@ -69,6 +72,7 @@ export class CardActions extends Component<
           <IconButton
             iconProps={{ icon: 'MoreHorizontal' }}
             buttonType="secondary"
+            disabled={isDisabled}
             label="Actions"
             {...iconButtonProps}
             onClick={event => {

--- a/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
@@ -1,5 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders the component as disabled 1`] = `
+<Dropdown
+  getContainerRef={[Function]}
+  isOpen={false}
+  onClose={[Function]}
+  position="bottom-right"
+  testId="cf-ui-dropdown"
+  toggleElement={
+    <IconButton
+      buttonType="secondary"
+      disabled={true}
+      iconProps={
+        Object {
+          "icon": "MoreHorizontal",
+        }
+      }
+      label="Actions"
+      onClick={[Function]}
+      testId="cf-ui-icon-button"
+      withDropdown={false}
+    />
+  }
+>
+  <DropdownList
+    key=".0/.$.0/.$.0"
+    onClick={[Function]}
+    testId="cf-ui-dropdown-list"
+  >
+    <DropdownListItem
+      isActive={false}
+      isDisabled={false}
+      isTitle={false}
+      onClick={[Function]}
+      testId="cf-ui-dropdown-list-item"
+    >
+      Edit
+    </DropdownListItem>
+  </DropdownList>
+</Dropdown>
+`;
+
 exports[`renders the component using a multiple dropdown lists 1`] = `
 <Dropdown
   getContainerRef={[Function]}

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
@@ -347,6 +347,7 @@ exports[`renders the component with dropdownListElements 1`] = `
             "onClick": [Function],
           }
         }
+        isDisabled={false}
         testId="cf-ui-card-actions"
       >
         <DropdownList

--- a/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
@@ -80,6 +80,7 @@ exports[`renders the component with a dropdown 1`] = `
         "onClick": [Function],
       }
     }
+    isDisabled={false}
     testId="cf-ui-card-actions"
   >
     <DropdownList

--- a/packages/forma-36-react-components/src/components/EntityList/EntityList/__snapshots__/EntityList.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityList/__snapshots__/EntityList.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`renders the component with EntityListItems as children 1`] = `
     contentType="My content type"
     description="Description 1"
     entityType="entry"
+    isActionsDisabled={false}
     testId="cf-ui-entity-list-item"
     title="Entry 1"
   />
@@ -23,6 +24,7 @@ exports[`renders the component with EntityListItems as children 1`] = `
     contentType="My content type"
     description="Description 2"
     entityType="entry"
+    isActionsDisabled={false}
     testId="cf-ui-entity-list-item"
     title="Entry 2"
   />
@@ -30,6 +32,7 @@ exports[`renders the component with EntityListItems as children 1`] = `
     contentType="My content type"
     description="Description 2"
     entityType="entry"
+    isActionsDisabled={false}
     testId="cf-ui-entity-list-item"
     title="Entry 3"
   />

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.stories.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.stories.tsx
@@ -20,6 +20,7 @@ storiesOf('Components|EntityList/EntityListItem', module)
       contentType={text('contentType', 'My content type')}
       thumbnailUrl={text('thumbnailUrl', 'https://placekitten.com/400/400')}
       thumbnailAltText={text('thumbnailAltText', 'My thumbnail text')}
+      isActionsDisabled={boolean('isActionsDisabled', false)}
       entityType={select(
         'entityType',
         {
@@ -68,6 +69,7 @@ storiesOf('Components|EntityList/EntityListItem', module)
       contentType={text('contentType', 'My content type')}
       thumbnailUrl={text('thumbnailUrl', 'https://placekitten.com/400/400')}
       thumbnailAltText={text('thumbnailAltText', 'My thumbnail text')}
+      isActionsDisabled={boolean('isActionsDisabled', false)}
       entityType={select(
         'entityType',
         {

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.test.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.test.tsx
@@ -161,6 +161,20 @@ it('renders the component with an additional class name', () => {
   expect(output).toMatchSnapshot();
 });
 
+it('renders the component with disabled actions', () => {
+  const output = shallow(
+    <EntityListItem
+      title="Title"
+      description="Description"
+      contentType="Content type"
+      className="my-extra-class"
+      isActionsDisabled
+    />,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
 it('has no a11y issues', async () => {
   const output = mount(
     <ul>

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
@@ -89,11 +89,16 @@ export type EntityListItemProps = {
    * An ID used for testing purposes applied as a data attribute (data-test-id)
    */
   testId?: string;
+  /**
+   * A boolean used to disable the CardActions
+   */
+  isActionsDisabled?: boolean;
 } & typeof defaultProps;
 
 const defaultProps = {
   testId: 'cf-ui-entity-list-item',
   entityType: 'entry',
+  isActionsDisabled: false,
 };
 
 export class EntityListItem extends Component<EntityListItemProps> {
@@ -196,6 +201,7 @@ export class EntityListItem extends Component<EntityListItemProps> {
       href,
       cardDragHandleProps,
       cardDragHandleComponent,
+      isActionsDisabled,
       ...otherProps
     } = this.props;
 
@@ -247,6 +253,7 @@ export class EntityListItem extends Component<EntityListItemProps> {
                 {dropdownListElements && (
                   <CardActions
                     className={styles['EntityListItem__actions']}
+                    isDisabled={isActionsDisabled}
                     iconButtonProps={{
                       onClick: e => e.stopPropagation,
                     }}

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
@@ -647,6 +647,60 @@ exports[`renders the component with custom drag handle 1`] = `
 </li>
 `;
 
+exports[`renders the component with disabled actions 1`] = `
+<li
+  className="EntityListItem my-extra-class"
+  data-test-id="cf-ui-entity-list-item"
+>
+  <article
+    className="EntityListItem__inner"
+  >
+    <TabFocusTrap
+      className="EntityListItem__focus-trap"
+    >
+      <figure
+        className="EntityListItem__media"
+      >
+        <Icon
+          color="muted"
+          icon="Entry"
+          size="small"
+          testId="cf-ui-icon"
+        />
+      </figure>
+      <div
+        className="EntityListItem__content"
+      >
+        <div
+          className="EntityListItem__heading"
+        >
+          <h1
+            className="EntityListItem__title"
+          >
+            Title
+          </h1>
+          <div
+            className="EntityListItem__content-type"
+          >
+            (
+            Content type
+            )
+          </div>
+        </div>
+        <p
+          className="EntityListItem__description"
+        >
+          Description
+        </p>
+      </div>
+      <div
+        className="EntityListItem__meta"
+      />
+    </TabFocusTrap>
+  </article>
+</li>
+`;
+
 exports[`renders the component with dropdownListElements 1`] = `
 <li
   className="EntityListItem"

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
@@ -713,6 +713,7 @@ exports[`renders the component with dropdownListElements 1`] = `
               "onClick": [Function],
             }
           }
+          isDisabled={false}
           testId="cf-ui-card-actions"
         >
           <DropdownList


### PR DESCRIPTION
This PR will add the isDisabled property to the Card Actions 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
