### PR TITLE
Fix TextLinks in Notes

### DIFF
--- a/packages/forma-36-react-components/src/components/Note/Note.css
+++ b/packages/forma-36-react-components/src/components/Note/Note.css
@@ -21,7 +21,7 @@
   border: 1px solid var(--color-ice-dark);
 }
 .Note--primary a {
-  color: var(--color-primary);
+  color: var(--color-primary) !important;
 }
 
 .Note--negative {
@@ -29,7 +29,7 @@
   border: 1px solid var(--color-coral-dark);
 }
 .Note--negative a {
-  color: var(--color-negative);
+  color: var(--color-negative) !important;
 }
 
 .Note--positive {
@@ -37,7 +37,7 @@
   border: 1px solid var(--color-mint-dark);
 }
 .Note--positive a {
-  color: var(--color-positive);
+  color: var(--color-positive) !important;
 }
 
 .Note--warning {
@@ -46,7 +46,7 @@
 }
 
 .Note--warning a {
-  color: var(--color-warning);
+  color: var(--color-warning) !important;
 }
 
 .Note__title {

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.css
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.css
@@ -51,6 +51,11 @@
   color: var(--color-red-base);
 }
 
+.TextLink--warning,
+.TextLink--warning:link {
+  color: var(--color-warning);
+}
+
 .TextLink--secondary,
 .TextLink--secondary:link {
   color: var(--color-text-mid);
@@ -91,6 +96,14 @@
     }
 
     color: var(--color-red-base);
+  }
+
+  &.TextLink--warning:hover {
+    & .TextLink__icon {
+      fill: var(--color-warning);
+    }
+
+    color: var(--color-warning);
   }
 
   &.TextLink--secondary:hover {

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.stories.tsx
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.stories.tsx
@@ -23,6 +23,7 @@ storiesOf('Components|TextLink', module)
             'Primary (default)': 'primary',
             Positive: 'positive',
             Negative: 'negative',
+            Warning: 'warning',
             Secondary: 'secondary',
             Muted: 'muted',
           },

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.test.tsx
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.test.tsx
@@ -28,6 +28,12 @@ it('renders as a "positive" link type', () => {
   expect(output).toMatchSnapshot();
 });
 
+it('renders as a "warning" link type', () => {
+  const output = shallow(<TextLink linkType="warning">Text Link</TextLink>);
+
+  expect(output).toMatchSnapshot();
+});
+
 it('renders as a "negative" link type', () => {
   const output = shallow(<TextLink linkType="negative">Text Link</TextLink>);
 

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.tsx
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.tsx
@@ -9,6 +9,7 @@ export type TextLinkType =
   | 'primary'
   | 'positive'
   | 'negative'
+  | 'warning'
   | 'secondary'
   | 'muted';
 

--- a/packages/forma-36-react-components/src/components/TextLink/__snapshots__/TextLink.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/TextLink/__snapshots__/TextLink.test.tsx.snap
@@ -144,6 +144,19 @@ exports[`renders as a "secondary" link type 1`] = `
 </button>
 `;
 
+exports[`renders as a "warning" link type 1`] = `
+<button
+  className="TextLink TextLink--warning"
+  data-test-id="cf-ui-text-link"
+  disabled={false}
+  type="button"
+>
+  <TabFocusTrap>
+    Text Link
+  </TabFocusTrap>
+</button>
+`;
+
 exports[`renders as a button 1`] = `
 <button
   className="TextLink TextLink--primary"

--- a/packages/forma-36-website/src/pages/components/text-link/index.mdx
+++ b/packages/forma-36-website/src/pages/components/text-link/index.mdx
@@ -28,6 +28,7 @@ The TextLink component can be configured in a number of different ways. Here is 
 <React.Fragment>
   <TextLink linkType="primary">Primary</TextLink>
   <TextLink linkType="positive">Positive</TextLink>
+  <TextLink linkType="warning">Warning</TextLink>
   <TextLink linkType="negative">Negative</TextLink>
   <TextLink linkType="muted">Muted</TextLink>
   <TextLink linkType="secondary">Secondary</TextLink>
@@ -38,7 +39,8 @@ The TextLink component can be configured in a number of different ways. Here is 
 | :------------ | :--------------------------------------------------------------- |
 | **Primary**   | The default styling for TextLinks.                               |
 | **Positive**  | For actions with positive results, such as creating a new entity |
-| **Negative**  | For actions has a negative results, such as deleting an entity   |
+| **Warning**   | For actions that users should take some caution over making      |
+| **Negative**  | For actions with negative results, such as deleting an entity    |
 | **Secondary** | Used for actions with less emphasis                              |
 | **Muted**     | Used for actions with least amount of emphasis                   |
 
@@ -51,6 +53,9 @@ The TextLink component can be configured in a number of different ways. Here is 
   </TextLink>
   <TextLink linkType="positive" icon="ExternalLink">
     Positive
+  </TextLink>
+  <TextLink linkType="warning" icon="ExternalLink">
+    Warning
   </TextLink>
   <TextLink linkType="negative" icon="ExternalLink">
     Negative


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR does two things:

1. Ensures that `TextLinks` are rendered using the appropriate intent. Occasionally there are instances where the CSS from the `Note` component is not overriding links properly. This should prevent that from happening, however, perhaps we don't want to do this change in general.
2. Adds a warning `linkType` to the `TextLink` component

I'd like to suggest removing the intent-based styling for TextLinks and instead use `secondary` TextLinks so that there is adequate contrast for TextLinks - please discuss in the comments!

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
