### PR TITLE
feat(Button): Add isActive prop for active state

### DIFF
--- a/packages/forma-36-react-components/src/components/Button/Button.css
+++ b/packages/forma-36-react-components/src/components/Button/Button.css
@@ -49,7 +49,8 @@
     background-color: var(--color-element-mid);
   }
 
-  &:active:not(.Button--disabled) {
+  &:active:not(.Button--disabled),
+  &.Button--is-active:not(.Button--disabled) {
     transition: none;
     background-color: var(--color-element-dark);
   }
@@ -64,7 +65,8 @@
     background-color: var(--color-element-light);
   }
 
-  &:active:not(.Button--disabled) {
+  &:active:not(.Button--disabled),
+  &.Button--is-active:not(.Button--disabled) {
     transition: none;
     background-color: var(--color-element-mid);
   }
@@ -90,7 +92,8 @@
     box-shadow: var(--glow-primary);
   }
 
-  &:active:not(.Button--disabled) {
+  &:active:not(.Button--disabled),
+  &.Button--is-active:not(.Button--disabled) {
     transition: none;
     background-image: none;
     background-color: var(--color-blue-dark);
@@ -120,7 +123,8 @@
     box-shadow: var(--glow-positive);
   }
 
-  &:active:not(.Button--disabled) {
+  &:active:not(.Button--disabled),
+  &.Button--is-active:not(.Button--disabled) {
     transition: none;
     background-image: none;
     background-color: var(--color-green-dark);
@@ -150,7 +154,8 @@
     box-shadow: var(--glow-negative);
   }
 
-  &:active:not(.Button--disabled) {
+  &:active:not(.Button--disabled),
+  &.Button--is-active:not(.Button--disabled) {
     transition: none;
     background-image: none;
     background-color: var(--color-red-dark);

--- a/packages/forma-36-react-components/src/components/Button/Button.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.stories.tsx
@@ -36,6 +36,7 @@ storiesOf('Components|Button', module)
         onClick={action('onClick')}
         onBlur={action('onBlur')}
         href={text('href', '')}
+        isActive={boolean('isActive', false)}
       >
         {text('Text', 'Embed entry')}
       </Button>

--- a/packages/forma-36-react-components/src/components/Button/Button.test.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.test.tsx
@@ -95,3 +95,9 @@ it('renders the button as link', () => {
 
   expect(output).toMatchSnapshot();
 });
+
+it('renders the button as active', () => {
+  const output = shallow(<Button isActive>Active button</Button>);
+
+  expect(output).toMatchSnapshot();
+});

--- a/packages/forma-36-react-components/src/components/Button/Button.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.tsx
@@ -30,6 +30,7 @@ export type ButtonProps = {
   style?: CSSProperties;
   className?: string;
   children?: React.ReactNode;
+  isActive?: boolean;
 } & typeof defaultProps;
 
 const defaultProps = {
@@ -61,6 +62,7 @@ export class Button extends Component<ButtonProps> {
       indicateDropdown,
       href,
       type,
+      isActive,
       ...otherProps
     } = this.props;
 
@@ -72,6 +74,7 @@ export class Button extends Component<ButtonProps> {
         [styles['Button--disabled']]: disabled,
         [styles[`Button--${size}`]]: size,
         [styles['Button--full-width']]: isFullWidth,
+        [styles['Button--is-active']]: isActive,
       },
     );
 

--- a/packages/forma-36-react-components/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders the button as active 1`] = `
+<button
+  className="Button Button--primary Button--is-active"
+  data-test-id="cf-ui-button"
+  disabled={false}
+  onBlur={[Function]}
+  onClick={[Function]}
+  type="button"
+>
+  <TabFocusTrap
+    className="Button__inner-wrapper"
+  >
+    <span
+      className="Button__label"
+    >
+      Active button
+    </span>
+    <CSSTransition
+      classNames={
+        Object {
+          "enter": "Button--spinner--enter",
+          "enterActive": "Button--spinner-active",
+          "exit": "Button--spinner--exit",
+          "exitActive": "Button--spinner-exit-active",
+        }
+      }
+      in={false}
+      mountOnEnter={true}
+      timeout={1000}
+      unmountOnExit={true}
+    >
+      <Spinner
+        className="Button__spinner"
+        color="white"
+        size="small"
+        testId="cf-ui-spinner"
+      />
+    </CSSTransition>
+  </TabFocusTrap>
+</button>
+`;
+
 exports[`renders the button as link 1`] = `
 <a
   className="Button Button--primary"


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR adds an isActive prop for programmatically setting active state rather than just relying on the CSS `:active` pseudoclass. Thanks @Silhoue for flagging!

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
