### PR TITLE
fix(EntityListItem): Fix ct overflow

### DIFF
--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.css
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.css
@@ -80,6 +80,7 @@
 }
 
 .EntityListItem__content-type {
+  min-width: var(--spacing-3xl);
   composes: truncate from './../../../styles/settings/helpers.css';
   font-size: var(--font-size-m);
   color: var(--color-text-light);


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR
This PR fixes the overflow of the content type. It'll hide the content type if the title is to long. The title will have a content type tooltip using the title attribute.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
