### PR TITLE
fix(Skeleton): Fix skeleton prop types to allow percentage values

### DIFF
--- a/packages/forma-36-react-components/src/components/Skeleton/SkeletonImage/SkeletonImage.tsx
+++ b/packages/forma-36-react-components/src/components/Skeleton/SkeletonImage/SkeletonImage.tsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 
 export type SkeletonImageProps = {
-  width: number;
-  height: number;
-  radiusX: number;
-  radiusY: number;
-  offsetLeft?: number;
-  offsetTop?: number;
+  width: number | string;
+  height: number | string;
+  radiusX: number | string;
+  radiusY: number | string;
+  offsetLeft?: number | string;
+  offsetTop?: number | string;
   testId?: string;
 } & typeof defaultProps;
 

--- a/packages/forma-36-react-components/src/components/Skeleton/SkeletonText/SkeletonText.tsx
+++ b/packages/forma-36-react-components/src/components/Skeleton/SkeletonText/SkeletonText.tsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 
 export type SkeletonTextProps = {
-  numberOfLines: number;
-  offsetTop: number;
-  offsetLeft: number;
-  lineHeight: number;
-  marginBottom: number;
-  width?: number;
+  numberOfLines: number | string;
+  offsetTop: number | string;
+  offsetLeft: number | string;
+  lineHeight: number | string;
+  marginBottom: number | string;
+  width?: number | string;
 } & typeof defaultProps;
 
 const defaultProps = {


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR
This PR will fix the proptypes of skeleton components to allow percentage values for widths and offsets
<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
