### PR TITLE
Add willBlurOnEsc to more inputs

### DIFF
--- a/packages/forma-36-react-components/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Checkbox/Checkbox.stories.tsx
@@ -19,5 +19,6 @@ storiesOf('Components|Checkbox', module)
       required={boolean('required', false)}
       name={text('name', 'some-name')}
       onChange={action('onChange')}
+      willBlurOnEsc={boolean('willBlurOnEsc', true)}
     />
   ));

--- a/packages/forma-36-react-components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/forma-36-react-components/src/components/Checkbox/Checkbox.tsx
@@ -1,17 +1,26 @@
-import React, { FunctionComponent } from 'react';
+import React, { Component } from 'react';
 import ControlledInput, {
   ControlledInputPropTypes,
 } from '../ControlledInput/ControlledInput';
 
-export const Checkbox: FunctionComponent<ControlledInputPropTypes> = props => (
-  <ControlledInput type="checkbox" {...props} />
-);
+export type CheckboxProps = ControlledInputPropTypes & typeof defaultProps;
 
-Checkbox.defaultProps = {
+const defaultProps = {
   required: false,
   disabled: false,
   type: 'checkbox',
   testId: 'ctf-ui-checkbox',
+  willBlurOnEsc: true,
 };
+
+export class Checkbox extends Component<CheckboxProps> {
+  static defaultProps = defaultProps;
+
+  render() {
+    return <ControlledInput {...this.props} />;
+  }
+}
+
+Checkbox.defaultProps = defaultProps;
 
 export default Checkbox;

--- a/packages/forma-36-react-components/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`renders the component 1`] = `
   required={false}
   testId="ctf-ui-checkbox"
   type="checkbox"
+  willBlurOnEsc={true}
 />
 `;
 
@@ -18,5 +19,6 @@ exports[`renders the component with an additional class name 1`] = `
   required={false}
   testId="ctf-ui-checkbox"
   type="checkbox"
+  willBlurOnEsc={true}
 />
 `;

--- a/packages/forma-36-react-components/src/components/ControlledInput/ControlledInput.tsx
+++ b/packages/forma-36-react-components/src/components/ControlledInput/ControlledInput.tsx
@@ -1,4 +1,10 @@
-import React, { Component, EventHandler, ChangeEvent, FocusEvent } from 'react';
+import React, {
+  Component,
+  EventHandler,
+  ChangeEvent,
+  FocusEvent,
+  KeyboardEvent,
+} from 'react';
 import cn from 'classnames';
 
 const styles = require('./ControlledInput.css');
@@ -17,6 +23,7 @@ export interface ControlledInputPropTypes {
   type?: 'checkbox' | 'radio';
   className?: string;
   testId?: string;
+  willBlurOnEsc: boolean;
 }
 
 const defaultProps = {
@@ -24,12 +31,21 @@ const defaultProps = {
   required: false,
   disabled: false,
   type: 'checkbox',
+  willBlurOnEsc: true,
 };
 
 export class ControlledInput extends Component<
   ControlledInputPropTypes & typeof defaultProps
 > {
   static defaultProps = defaultProps;
+
+  handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    const ESC = 27;
+
+    if (e.keyCode === ESC && this.props.willBlurOnEsc) {
+      e.currentTarget.blur();
+    }
+  };
 
   render() {
     const {
@@ -46,6 +62,7 @@ export class ControlledInput extends Component<
       value,
       type,
       labelText,
+      willBlurOnEsc,
       ...otherProps
     } = this.props;
 
@@ -80,6 +97,7 @@ export class ControlledInput extends Component<
         id={id}
         required={required}
         disabled={disabled}
+        onKeyDown={this.handleKeyDown}
         {...otherProps}
       />
     );

--- a/packages/forma-36-react-components/src/components/ControlledInput/__snapshots__/ControlledInput.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/ControlledInput/__snapshots__/ControlledInput.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`renders the component with a value 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
   required={false}
   type="checkbox"
   value="someValue"
@@ -26,6 +27,7 @@ exports[`renders the component with all required props 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
   required={false}
   type="checkbox"
 />
@@ -41,6 +43,7 @@ exports[`renders the component with an additional class name 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
   required={false}
   type="checkbox"
 />
@@ -57,6 +60,7 @@ exports[`renders the component with as checked 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
   required={false}
   type="checkbox"
 />
@@ -72,6 +76,7 @@ exports[`renders the component with disabled prop 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
   required={false}
   type="checkbox"
 />
@@ -87,6 +92,7 @@ exports[`renders the component with required prop 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
+  onKeyDown={[Function]}
   required={true}
   type="checkbox"
 />

--- a/packages/forma-36-react-components/src/components/ControlledInputField/__snapshots__/ControlledInputField.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/ControlledInputField/__snapshots__/ControlledInputField.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`renders the component 1`] = `
     required={false}
     testId="cf-ui-controlled-input"
     type="checkbox"
+    willBlurOnEsc={true}
   />
   <div
     className="Checkbox__label-wrapper"
@@ -45,6 +46,7 @@ exports[`renders the component as checked 1`] = `
     required={false}
     testId="cf-ui-controlled-input"
     type="checkbox"
+    willBlurOnEsc={true}
   />
   <div
     className="Checkbox__label-wrapper"
@@ -76,6 +78,7 @@ exports[`renders the component as required 1`] = `
     required={true}
     testId="cf-ui-controlled-input"
     type="checkbox"
+    willBlurOnEsc={true}
   />
   <div
     className="Checkbox__label-wrapper"
@@ -107,6 +110,7 @@ exports[`renders the component in a disabled state 1`] = `
     required={false}
     testId="cf-ui-controlled-input"
     type="checkbox"
+    willBlurOnEsc={true}
   />
   <div
     className="Checkbox__label-wrapper"
@@ -138,6 +142,7 @@ exports[`renders the component with a help text 1`] = `
     required={false}
     testId="cf-ui-controlled-input"
     type="checkbox"
+    willBlurOnEsc={true}
   />
   <div
     className="Checkbox__label-wrapper"
@@ -175,6 +180,7 @@ exports[`renders the component with a light label variation 1`] = `
     required={false}
     testId="cf-ui-controlled-input"
     type="checkbox"
+    willBlurOnEsc={true}
   />
   <div
     className="Checkbox__label-wrapper"
@@ -212,6 +218,7 @@ exports[`renders the component with a validation message 1`] = `
     required={false}
     testId="cf-ui-controlled-input"
     type="checkbox"
+    willBlurOnEsc={true}
   />
   <div
     className="Checkbox__label-wrapper"
@@ -250,6 +257,7 @@ exports[`renders the component with a value 1`] = `
     testId="cf-ui-controlled-input"
     type="checkbox"
     value="someValue"
+    willBlurOnEsc={true}
   />
   <div
     className="Checkbox__label-wrapper"
@@ -281,6 +289,7 @@ exports[`renders the component with an additional class name 1`] = `
     required={false}
     testId="cf-ui-controlled-input"
     type="checkbox"
+    willBlurOnEsc={true}
   />
   <div
     className="Checkbox__label-wrapper"

--- a/packages/forma-36-react-components/src/components/RadioButton/RadioButton.stories.tsx
+++ b/packages/forma-36-react-components/src/components/RadioButton/RadioButton.stories.tsx
@@ -17,5 +17,6 @@ storiesOf('Components|RadioButton', module)
       disabled={boolean('Disabled', false)}
       required={boolean('Required', false)}
       name={text('Name', 'some-name')}
+      willBlurOnEsc={boolean('willBlurOnEsc', true)}
     />
   ));

--- a/packages/forma-36-react-components/src/components/RadioButton/RadioButton.tsx
+++ b/packages/forma-36-react-components/src/components/RadioButton/RadioButton.tsx
@@ -8,14 +8,16 @@ export type RadioButtonProps = ControlledInputPropTypes & typeof defaultProps;
 const defaultProps = {
   required: false,
   disabled: false,
+  type: 'radio',
   testId: 'cf-ui-radio-button',
+  willBlurOnEsc: true,
 };
 
 export class RadioButton extends Component<RadioButtonProps> {
   static defaultProps = defaultProps;
 
   render() {
-    return <ControlledInput {...this.props} type="radio" />;
+    return <ControlledInput {...this.props} />;
   }
 }
 

--- a/packages/forma-36-react-components/src/components/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`renders the component 1`] = `
   required={false}
   testId="cf-ui-radio-button"
   type="radio"
+  willBlurOnEsc={true}
 />
 `;
 
@@ -18,5 +19,6 @@ exports[`renders the component with an additional class name 1`] = `
   required={false}
   testId="cf-ui-radio-button"
   type="radio"
+  willBlurOnEsc={true}
 />
 `;

--- a/packages/forma-36-react-components/src/components/Select/Select/Select.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Select/Select/Select.stories.tsx
@@ -31,6 +31,7 @@ storiesOf('Components|Select', module)
         },
         'full',
       )}
+      willBlurOnEsc={boolean('willBlurOnEsc', true)}
     >
       <Option value="optionOne">Option 1</Option>
       <Option value="optionTwo">Long Option 2</Option>

--- a/packages/forma-36-react-components/src/components/Select/Select/Select.tsx
+++ b/packages/forma-36-react-components/src/components/Select/Select/Select.tsx
@@ -1,4 +1,9 @@
-import React, { Component, ChangeEventHandler, FocusEventHandler } from 'react';
+import React, {
+  Component,
+  ChangeEventHandler,
+  FocusEventHandler,
+  KeyboardEvent,
+} from 'react';
 import cn from 'classnames';
 import Icon from '../../Icon/Icon';
 import styles from './Select.css';
@@ -17,6 +22,7 @@ export type SelectProps = {
   testId?: string;
   className?: string;
   children: React.ReactNode;
+  willBlurOnEsc: boolean;
 } & typeof defaultProps;
 
 export interface SelectState {
@@ -29,6 +35,7 @@ const defaultProps = {
   hasError: false,
   isDisabled: false,
   width: 'full',
+  willBlurOnEsc: true,
 };
 
 export class Select extends Component<SelectProps, SelectState> {
@@ -46,6 +53,14 @@ export class Select extends Component<SelectProps, SelectState> {
     }
   }
 
+  handleKeyDown = (e: KeyboardEvent<HTMLSelectElement>) => {
+    const ESC = 27;
+
+    if (e.keyCode === ESC && this.props.willBlurOnEsc) {
+      e.currentTarget.blur();
+    }
+  };
+
   render() {
     const {
       id,
@@ -60,6 +75,7 @@ export class Select extends Component<SelectProps, SelectState> {
       onFocus,
       isDisabled,
       hasError,
+      willBlurOnEsc,
       ...otherProps
     } = this.props;
 
@@ -98,6 +114,7 @@ export class Select extends Component<SelectProps, SelectState> {
             }
           }}
           onBlur={onBlur}
+          onKeyDown={this.handleKeyDown}
           {...otherProps}
         >
           {children}

--- a/packages/forma-36-react-components/src/components/Select/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Select/Select/__snapshots__/Select.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`renders the component 1`] = `
     id="optionSelect"
     name="optionSelect"
     onChange={[Function]}
+    onKeyDown={[Function]}
     required={false}
   >
     <Option
@@ -43,6 +44,7 @@ exports[`renders the component as required 1`] = `
     id="optionSelect"
     name="optionSelect"
     onChange={[Function]}
+    onKeyDown={[Function]}
     required={true}
   >
     <Option
@@ -74,6 +76,7 @@ exports[`renders the component in disabled state 1`] = `
     id="optionSelect"
     name="optionSelect"
     onChange={[Function]}
+    onKeyDown={[Function]}
     required={false}
   >
     <Option
@@ -105,6 +108,7 @@ exports[`renders the component with a value 1`] = `
     id="optionSelect"
     name="optionSelect"
     onChange={[Function]}
+    onKeyDown={[Function]}
     required={false}
     value="value1"
   >
@@ -137,6 +141,7 @@ exports[`renders the component with an extra class name 1`] = `
     id="optionSelect"
     name="optionSelect"
     onChange={[Function]}
+    onKeyDown={[Function]}
     required={false}
   >
     <Option
@@ -168,6 +173,7 @@ exports[`renders the component with error 1`] = `
     id="optionSelect"
     name="optionSelect"
     onChange={[Function]}
+    onKeyDown={[Function]}
     required={false}
   >
     <Option

--- a/packages/forma-36-react-components/src/components/SelectField/__snapshots__/SelectField.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/SelectField/__snapshots__/SelectField.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`renders the component 1`] = `
     required={false}
     testId="cf-ui-select"
     width="full"
+    willBlurOnEsc={true}
   >
     <Option
       testId="cf-ui-select-option"
@@ -63,6 +64,7 @@ exports[`renders the component as disabled 1`] = `
     required={false}
     testId="cf-ui-select"
     width="full"
+    willBlurOnEsc={true}
   >
     <Option
       testId="cf-ui-select-option"
@@ -100,6 +102,7 @@ exports[`renders the component as required 1`] = `
     required={false}
     testId="cf-ui-select"
     width="full"
+    willBlurOnEsc={true}
   >
     <Option
       testId="cf-ui-select-option"
@@ -137,6 +140,7 @@ exports[`renders the component with a help text 1`] = `
     required={false}
     testId="cf-ui-select"
     width="full"
+    willBlurOnEsc={true}
   >
     <Option
       testId="cf-ui-select-option"
@@ -184,6 +188,7 @@ exports[`renders the component with a validation message 1`] = `
     required={false}
     testId="cf-ui-select"
     width="full"
+    willBlurOnEsc={true}
   >
     <Option
       testId="cf-ui-select-option"
@@ -228,6 +233,7 @@ exports[`renders the component with a value 1`] = `
     testId="cf-ui-select"
     value="optionOne"
     width="full"
+    willBlurOnEsc={true}
   >
     <Option
       testId="cf-ui-select-option"


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR adds a `willBlurOnEsc` prop to checkboxes, radio buttons, and select inputs.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
