### PR TITLE
feat(Modal): Allow height overflow as default

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/Modal/Modal.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/Modal/Modal.tsx
@@ -90,7 +90,7 @@ const defaultProps = {
   testId: 'cf-ui-modal',
   topOffset: '50px',
   size: 'medium',
-  allowHeightOverflow: false,
+  allowHeightOverflow: true,
 };
 
 export class Modal extends Component<ModalProps> {

--- a/packages/forma-36-react-components/src/components/Modal/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Modal/Modal/__snapshots__/Modal.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`can be controlled 1`] = `
   }
 >
   <div
-    className="Modal"
+    className="Modal Modal--overflow"
     data-test-id="cf-ui-modal"
     style={
       Object {
@@ -99,7 +99,7 @@ exports[`can override header and content properties 1`] = `
   }
 >
   <div
-    className="Modal"
+    className="Modal Modal--overflow"
     data-test-id="cf-ui-modal"
     style={
       Object {
@@ -158,7 +158,7 @@ exports[`renders the component 1`] = `
   }
 >
   <div
-    className="Modal"
+    className="Modal Modal--overflow"
     data-test-id="cf-ui-modal"
     style={
       Object {
@@ -214,7 +214,7 @@ exports[`renders the component without title 1`] = `
   }
 >
   <div
-    className="Modal"
+    className="Modal Modal--overflow"
     data-test-id="cf-ui-modal"
     style={
       Object {


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR
This PR will set the default of allowHeightOverflow to true since it's commonly configured this way. It's a small change but breaking so this PR target is next and will kick off F36 4.0
Related Issue: https://github.com/contentful/forma-36/issues/305
<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
