### PR TITLE
fix(Workbench): set minWidth for sidebars

### DIFF
--- a/packages/forma-36-react-components/src/components/Workbench/Workbench.css
+++ b/packages/forma-36-react-components/src/components/Workbench/Workbench.css
@@ -137,10 +137,12 @@
 
 .Workbench__sidebar--left {
   width: 280px;
+  min-width: 280px;
   border-right: 1px solid var(--color-element-darkest);
 }
 
 .Workbench__sidebar--right {
   width: 360px;
+  min-width: 360px;
   border-left: 1px solid var(--color-element-darkest);
 }


### PR DESCRIPTION
# Purpose of PR

Fix a problem with shrank sidebar width on small screens.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
