### PR TITLE
fix(IconButton): Added ability to change size. Fixed TS props

### DIFF
--- a/packages/forma-36-react-components/src/components/Icon/Icon.tsx
+++ b/packages/forma-36-react-components/src/components/Icon/Icon.tsx
@@ -269,11 +269,15 @@ export class Icon extends Component<IconProps & typeof defaultProps> {
   render() {
     const { className, icon, size, color, testId, ...otherProps } = this.props;
 
-    const classNames = cn(styles.Icon, className, {
-      [styles[`Icon--${size}`]]: size,
-      [styles[`Icon--${color}`]]: color,
-      [styles['Icon--trimmed']]: icon.toLowerCase().includes('trimmed'),
-    });
+    const classNames = cn(
+      styles.Icon,
+      {
+        [styles[`Icon--${size}`]]: size,
+        [styles[`Icon--${color}`]]: color,
+        [styles['Icon--trimmed']]: icon.toLowerCase().includes('trimmed'),
+      },
+      className,
+    );
 
     const Element = iconComponents[icon];
 

--- a/packages/forma-36-react-components/src/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`renders the component 1`] = `
 
 exports[`renders the component with an additional class name 1`] = `
 <ArrowDown
-  className="Icon my-extra-class Icon--small Icon--primary"
+  className="Icon Icon--small Icon--primary my-extra-class"
   data-test-id="cf-ui-icon"
   height="24"
   viewBox="0 0 24 24"

--- a/packages/forma-36-react-components/src/components/IconButton/IconButton.tsx
+++ b/packages/forma-36-react-components/src/components/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import React, { Component, MouseEventHandler } from 'react';
+import React, { Component } from 'react';
 import cn from 'classnames';
 import Icon from '../Icon';
 import { IconProps } from '../Icon/Icon';
@@ -6,12 +6,11 @@ import TabFocusTrap from '../TabFocusTrap';
 
 const styles = require('./IconButton.css');
 
-export interface IconButtonProps {
+export type IconButtonProps = {
   label: string;
   href?: string;
   iconProps: IconProps;
   disabled?: boolean;
-  onClick?: MouseEventHandler;
   buttonType?:
     | 'primary'
     | 'positive'
@@ -22,7 +21,7 @@ export interface IconButtonProps {
   withDropdown?: boolean;
   className?: string;
   testId?: string;
-}
+} & React.HTMLAttributes<HTMLElement>;
 
 const defaultProps = {
   disabled: false,
@@ -64,7 +63,10 @@ export class IconButton extends Component<
 
     const content = (
       <TabFocusTrap className={styles.IconButton__inner}>
-        <Icon {...iconProps} className={styles.IconButton__icon} />
+        <Icon
+          {...iconProps}
+          className={cn(styles.IconButton__icon, iconProps.className)}
+        />
         <span className={styles.IconButton__label}>{label}</span>
         {withDropdown && (
           <Icon


### PR DESCRIPTION
# Purpose of PR

* Fix TS properties for `IconButton` component.
* Added ability to override IconSize with custom css

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
