### PR TITLE
fix(TextInput): fix typings for TextInput

### DIFF
--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
@@ -1,12 +1,4 @@
-import React, {
-  Component,
-  RefObject,
-  FocusEvent,
-  KeyboardEvent,
-  ChangeEventHandler,
-  FocusEventHandler,
-  KeyboardEventHandler,
-} from 'react';
+import React, { Component, RefObject, FocusEvent, KeyboardEvent } from 'react';
 import cn from 'classnames';
 import CopyButton from '../CopyButton';
 import styles from './TextInput.css';
@@ -27,23 +19,14 @@ export type TextInputProps = {
   id?: string;
   className?: string;
   withCopyButton?: boolean;
-  placeholder?: string;
-  disabled?: boolean;
   testId?: string;
-  maxLength?: number;
   onCopy?: (value: string) => void;
   value?: string;
   inputRef?: RefObject<HTMLInputElement>;
   error?: boolean;
-  required?: boolean;
-  onChange?: ChangeEventHandler<HTMLInputElement>;
-  onBlur?: FocusEventHandler<HTMLInputElement>;
-  onFocus?: FocusEventHandler<HTMLInputElement>;
-  onKeyPress?: KeyboardEventHandler<HTMLInputElement>;
-  onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
-  onKeyUp?: KeyboardEventHandler<HTMLInputElement>;
   willBlurOnEsc: boolean;
-} & typeof defaultProps;
+} & JSX.IntrinsicElements['input'] &
+  typeof defaultProps;
 
 export interface TextInputState {
   value?: string;


### PR DESCRIPTION
# Purpose of PR

Right now typings for `TextInput` are incorrect. For example, It's not allowed to use `max`, `min` and `step` for an input when the type is `number`.

This PR fixes the issue by whitelisting all possible HTML attributes. 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
