### PR TITLE
feat(EntryCard): Add scheduled status icon

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
@@ -30,6 +30,7 @@ storiesOf('Components|Card/EntryCard', module)
           },
           'published',
         )}
+        statusIcon={text('statusIcon', 'Clock')}
         contentType={text('contentType', 'Album')}
         onClick={!boolean('loading', false) ? action('onClick') : undefined}
         dropdownListElements={

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
@@ -8,6 +8,7 @@ import EntryCardSkeleton from './EntryCardSkeleton';
 import CardDragHandle, {
   CardDragHandlePropTypes,
 } from '../CardDragHandle/CardDragHandle';
+import Icon, { IconType } from '../../Icon/Icon';
 
 const styles = require('./EntryCard.css');
 
@@ -34,6 +35,10 @@ export type EntryCardPropTypes = {
    * The publish status of the entry
    */
   status?: EntryCardStatus;
+  /**
+   * An icon for the status of the entry
+   */
+  statusIcon?: string;
   /**
    * The thumbnail of the entry
    */
@@ -171,6 +176,7 @@ export class EntryCard extends Component<EntryCardPropTypes> {
       description,
       contentType,
       status,
+      statusIcon,
       thumbnailElement,
       loading,
       dropdownListElements,
@@ -215,6 +221,13 @@ export class EntryCard extends Component<EntryCardPropTypes> {
                   >
                     {contentType}
                   </div>
+                  {statusIcon && (
+                    <Icon
+                      icon={statusIcon as IconType}
+                      color="muted"
+                      className="f36-margin-right--xs"
+                    />
+                  )}
                   {status && this.renderStatus(status)}
                   {dropdownListElements && (
                     <CardActions


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This adds an icon to EntryCard component that indicates whether or not the entry is scheduled for publish/unpublish/<supported actions>

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
