### PR TITLE
Make Safari's TextInput always look like a text input

### DIFF
--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.css
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.css
@@ -21,6 +21,8 @@
   margin: 0;
   width: 100%;
 
+  -webkit-appearance: textfield;
+
   &::-webkit-input-placeholder {
     color: var(--color-ice-dark);
   }


### PR DESCRIPTION
# Purpose of PR

This PR adds `-webkit-appearance: textfield` to the `TextInput.css` file. 

Currently in Safari, if the type attribute is set to `search`, the input field looks a lot smaller and unstyled, due to Safari setting the appearance to `searchfield`. To override this, I've explicitly set the appearance to `textfield`.

### Before

![image](https://user-images.githubusercontent.com/4960056/67263148-3c1f9600-f4e2-11e9-955f-2f9087c8601f.png)

### After

![image](https://user-images.githubusercontent.com/4960056/67263167-4b064880-f4e2-11e9-9bb3-86e155f58411.png)


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
