### PR TITLE
feat(Button): Add warning button type

### DIFF
--- a/packages/forma-36-react-components/src/components/Button/Button.css
+++ b/packages/forma-36-react-components/src/components/Button/Button.css
@@ -166,6 +166,37 @@
   }
 }
 
+.Button--warning {
+  border-color: var(--color-orange-dark);
+  background-image: linear-gradient(
+    to top,
+    var(--color-orange-base),
+    var(--color-orange-light)
+  );
+  background-size: 100% 200%;
+
+  &:hover:not(.Button--disabled),
+  &:focus:not(.Button--disabled) {
+    background-position: 0 100%;
+  }
+
+  &:focus:not(.Button--disabled) {
+    border-color: var(--color-orange-dark);
+    box-shadow: var(--glow-warning);
+  }
+
+  &:active:not(.Button--disabled),
+  &.Button--is-active:not(.Button--disabled) {
+    transition: none;
+    background-image: none;
+    background-color: var(--color-orange-dark);
+  }
+
+  & .Button__label {
+    color: var(--color-element-lightest);
+  }
+}
+
 .Button--disabled {
   opacity: 0.5;
   &:hover {

--- a/packages/forma-36-react-components/src/components/Button/Button.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.stories.tsx
@@ -25,6 +25,7 @@ storiesOf('Components|Button', module)
             positive: 'positive',
             negative: 'negative',
             naked: 'naked',
+            warning: 'warning',
           },
           'muted',
         )}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR will add the "warning" button type to the button component
![image](https://user-images.githubusercontent.com/1766274/69064377-60598e80-0a1e-11ea-9f3c-2e093fe5d094.png)

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
