### PR TITLE
feat(Tokens): Add ZIndex tokens

### DIFF
--- a/packages/forma-36-react-components/.size-limit
+++ b/packages/forma-36-react-components/.size-limit
@@ -12,7 +12,7 @@
     {
       "path": "dist/styles.css",
       "name": "gzipped css",
-      "limit": "65 KB",
+      "limit": "66 KB",
       "gzip": false
     }
   ]

--- a/packages/forma-36-react-components/src/components/Button/Button.css
+++ b/packages/forma-36-react-components/src/components/Button/Button.css
@@ -207,7 +207,7 @@
 .Button__inner-wrapper {
   display: flex;
   height: 100%;
-  z-index: 1;
+  z-index: var(--z-index-default);
   padding: 0 calc(1rem * (14 / var(--font-base-default)));
   align-items: center;
   justify-content: center;

--- a/packages/forma-36-react-components/src/components/Card/InlineEntryCard/InlineEntryCard.css
+++ b/packages/forma-36-react-components/src/components/Card/InlineEntryCard/InlineEntryCard.css
@@ -23,7 +23,7 @@
   width: 100%;
   height: 100%;
   background: var(--color-white);
-  z-index: 1;
+  z-index: var(--z-index-default);
   left: 0px;
   display: flex;
   align-items: center;

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.css
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.css
@@ -11,7 +11,7 @@
   padding: 0;
   margin: 0;
   position: fixed;
-  z-index: 99;
+  z-index: var(--z-index-dropdown);
 }
 
 .DropdownContainer > div {

--- a/packages/forma-36-react-components/src/components/Modal/Modal/Modal.css
+++ b/packages/forma-36-react-components/src/components/Modal/Modal/Modal.css
@@ -3,6 +3,7 @@
 @import 'settings/typography';
 @import 'settings/transitions';
 @import 'settings/shadows';
+@import 'settings/z-index';
 
 .Modal__portal {
   display: block;
@@ -17,7 +18,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 1000;
+  z-index: var(--z-index-modal);
   opacity: 0;
   transition: opacity var(--transition-duration-default)
     var(--transition-easing-default);
@@ -57,7 +58,7 @@
 */
 
 .Modal__wrap {
-  z-index: 1001;
+  z-index: var(--z-index-modal-content);
   position: relative;
   padding: 0;
   display: inline-block;

--- a/packages/forma-36-react-components/src/components/Notification/NotificationsManager.css
+++ b/packages/forma-36-react-components/src/components/Notification/NotificationsManager.css
@@ -6,7 +6,7 @@
   left: 0;
   right: 0;
   position: fixed;
-  z-index: 9999;
+  z-index: var(--z-index-notification);
   pointer-events: none;
 }
 

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.css
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.css
@@ -33,7 +33,7 @@
 }
 
 .TextInput__input:focus {
-  z-index: 1;
+  z-index: var(--z-index-default);
 }
 
 .TextInput--small {
@@ -79,6 +79,6 @@
   }
 
   &:focus-within {
-    z-index: 1;
+    z-index: var(--z-index-default);
   }
 }

--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.css
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.css
@@ -28,7 +28,7 @@
   padding: calc(1rem * (8 / var(--font-base-default)))
     calc(1rem * (10 / var(--font-base-default)));
   border-radius: calc(1rem * (4 / var(--font-base-default)));
-  z-index: 99;
+  z-index: var(--z-index-tooltip);
   user-select: none;
   width: auto;
   word-wrap: break-word;
@@ -37,7 +37,7 @@
 .Tooltip--hidden {
   visibility: hidden;
   pointer-events: none;
-  z-index: -1;
+  z-index: var(--z-index-negative);
 }
 
 .Tooltip--place-bottom,

--- a/packages/forma-36-react-components/src/components/Workbench/Workbench.css
+++ b/packages/forma-36-react-components/src/components/Workbench/Workbench.css
@@ -13,7 +13,7 @@
   right: 0;
   left: 0;
   bottom: 0;
-  z-index: 0;
+  z-index: var(--z-index-workbench);
   overflow-x: hidden;
 }
 
@@ -22,7 +22,7 @@
   position: relative;
   width: 100%;
   background-color: var(--color-element-lightest);
-  z-index: 6;
+  z-index: var(--z-index-workbench-header);
   height: 70px;
   display: flex;
   flex-direction: row;

--- a/packages/forma-36-react-components/src/styles/settings/z-index.css
+++ b/packages/forma-36-react-components/src/styles/settings/z-index.css
@@ -1,0 +1,1 @@
+@import '@contentful/forma-36-tokens/dist/css/z-index.css';

--- a/packages/forma-36-tokens/src/tokens/z-index.js
+++ b/packages/forma-36-tokens/src/tokens/z-index.js
@@ -1,0 +1,13 @@
+const zIndex = {
+  'z-index-negative': '-1',
+  'z-index-workbench': '0',
+  'z-index-default': '1',
+  'z-index-workbench-header': '10',
+  'z-index-modal': '100',
+  'z-index-modal-content': '101',
+  'z-index-dropdown': '1000',
+  'z-index-tooltip': '10000',
+  'z-index-notification': '100000',
+};
+
+module.exports = zIndex;


### PR DESCRIPTION
# Purpose of PR

This PR will add ZIndex tokens to Forma 36. It should also fix the inability to use tooltips in modals.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
