### PR TITLE
feat(Dropdown): Add isAutoalignmentEnabled prop

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`renders the component as disabled 1`] = `
 <Dropdown
   getContainerRef={[Function]}
+  isAutoalignmentEnabled={true}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"
@@ -44,6 +45,7 @@ exports[`renders the component as disabled 1`] = `
 exports[`renders the component using a multiple dropdown lists 1`] = `
 <Dropdown
   getContainerRef={[Function]}
+  isAutoalignmentEnabled={true}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"
@@ -136,6 +138,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
 exports[`renders the component using a single dropdown list 1`] = `
 <Dropdown
   getContainerRef={[Function]}
+  isAutoalignmentEnabled={true}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"
@@ -196,6 +199,7 @@ exports[`renders the component with an additional class name 1`] = `
 <Dropdown
   className="my-extra-class"
   getContainerRef={[Function]}
+  isAutoalignmentEnabled={true}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"
@@ -255,6 +259,7 @@ exports[`renders the component with an additional class name 1`] = `
 exports[`renders the component with published status 1`] = `
 <Dropdown
   getContainerRef={[Function]}
+  isAutoalignmentEnabled={true}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.stories.tsx
@@ -18,6 +18,7 @@ function DefaultStory() {
       onClose={() => setOpen(false)}
       isFullWidth={boolean('isFullWidth', false)}
       key={Date.now()} // Force Reinit
+      isAutoalignmentEnabled={boolean('isAutoalignmentEnabled', true)}
       position={select(
         'position',
         {

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
@@ -26,6 +26,7 @@ export type DropdownProps = {
   className?: string;
   children: React.ReactNode;
   isFullWidth?: boolean;
+  isAutoalignmentEnabled?: boolean;
 } & typeof defaultProps;
 
 export interface AnchorDimensionsAndPositonType {
@@ -46,6 +47,7 @@ const defaultProps = {
   testId: 'cf-ui-dropdown',
   position: 'bottom-left',
   isOpen: false,
+  isAutoalignmentEnabled: true,
   getContainerRef: () => {},
 };
 
@@ -171,6 +173,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
       dropdownContainerClassName,
       children,
       isOpen,
+      isAutoalignmentEnabled,
       ...otherProps
     } = this.props;
 
@@ -220,6 +223,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
             submenu={false}
             width={this.state.containerWidth}
             dropdownAnchor={this.dropdownAnchor}
+            isAutoalignmentEnabled={isAutoalignmentEnabled}
             anchorDimensionsAndPositon={this.state.anchorDimensionsAndPositon}
             onClose={this.props.onClose}
             openSubmenu={this.openSubmenu}

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`renders the component as open 1`] = `
     }
     dropdownAnchor={null}
     getRef={[Function]}
+    isAutoalignmentEnabled={true}
     openSubmenu={[Function]}
     position="bottom-left"
     submenu={false}
@@ -100,6 +101,7 @@ exports[`renders the component with a submenu 1`] = `
     }
     dropdownAnchor={null}
     getRef={[Function]}
+    isAutoalignmentEnabled={true}
     openSubmenu={[Function]}
     position="bottom-left"
     submenu={false}
@@ -118,6 +120,7 @@ exports[`renders the component with a submenu 1`] = `
       </DropdownListItem>
       <Dropdown
         getContainerRef={[Function]}
+        isAutoalignmentEnabled={true}
         isOpen={true}
         position="bottom-left"
         submenuToggleLabel="Submenu"

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -21,6 +21,7 @@ export type DropdownContainerProps = {
   getRef?: (ref: HTMLElement | null) => void;
   submenu?: boolean;
   width?: number;
+  isAutoalignmentEnabled?: boolean;
 } & typeof defaultProps;
 
 export interface DropdownState {
@@ -35,6 +36,7 @@ const defaultProps = {
   testId: 'cf-ui-dropdown-portal',
   position: 'bottom-left',
   submenu: false,
+  isAutoalignmentEnabled: true,
   getRef: () => {},
 };
 
@@ -90,6 +92,9 @@ class DropdownContainer extends Component<
   };
 
   handleOverflow = (overflowAt: string) => {
+    if (!this.props.isAutoalignmentEnabled) {
+      return;
+    }
     if (overflowAt === this.lastOverflowAt) {
       return;
     }


### PR DESCRIPTION
# Purpose of PR

This PR will add the isAutoalignmentEnabled prop to the Dropdown to manual disable this feature.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
