### PR TITLE
Fix accessibility issues with dropdown

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
@@ -189,7 +189,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
       >
         {toggleElement &&
           React.cloneElement(toggleElement, {
-            'aria-haspopup': 'listbox',
+            'aria-haspopup': 'menu',
             'aria-expanded': this.state.isOpen,
           })}
         {this.state.isOpen && (
@@ -221,7 +221,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
       >
         {toggleElement &&
           React.cloneElement(toggleElement, {
-            'aria-haspopup': 'listbox',
+            'aria-haspopup': 'menu',
             'aria-expanded': this.state.isOpen,
           })}
         {this.state.isOpen && (

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -7,6 +7,8 @@ exports[`renders the component 1`] = `
   position="bottom-left"
 >
   <Button
+    aria-expanded={false}
+    aria-haspopup="menu"
     buttonType="primary"
     disabled={false}
     indicateDropdown={false}
@@ -28,6 +30,8 @@ exports[`renders the component as open 1`] = `
   position="bottom-left"
 >
   <Button
+    aria-expanded={true}
+    aria-haspopup="menu"
     buttonType="primary"
     disabled={false}
     indicateDropdown={false}
@@ -79,6 +83,8 @@ exports[`renders the component with a submenu 1`] = `
   position="bottom-left"
 >
   <Button
+    aria-expanded={true}
+    aria-haspopup="menu"
     buttonType="primary"
     disabled={false}
     indicateDropdown={false}
@@ -148,6 +154,8 @@ exports[`renders the component with an additional class name 1`] = `
   position="bottom-left"
 >
   <Button
+    aria-expanded={false}
+    aria-haspopup="menu"
     buttonType="primary"
     disabled={false}
     indicateDropdown={false}

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownList/DropdownList.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownList/DropdownList.tsx
@@ -37,7 +37,7 @@ export class DropdownList extends Component<DropdownListProps> {
       <ul
         ref={listRef}
         data-test-id={testId}
-        role="listbox"
+        role="menu"
         style={{
           maxHeight: maxHeight || 'auto',
           overflowY: maxHeight ? 'auto' : 'visible',

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownList/__snapshots__/DropdownList.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownList/__snapshots__/DropdownList.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders the component 1`] = `
 <ul
   className="DropdownList"
   data-test-id="cf-ui-dropdown-list"
+  role="menu"
   style={
     Object {
       "maxHeight": "auto",
@@ -26,6 +27,7 @@ exports[`renders the component with a border attribute 1`] = `
 <ul
   className="DropdownList DropdownList--border-top"
   data-test-id="cf-ui-dropdown-list"
+  role="menu"
   style={
     Object {
       "maxHeight": "auto",
@@ -48,6 +50,7 @@ exports[`renders the component with an additional class name 1`] = `
 <ul
   className="DropdownList my-extra-class"
   data-test-id="cf-ui-dropdown-list"
+  role="menu"
   style={
     Object {
       "maxHeight": "auto",

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
@@ -145,7 +145,7 @@ export class DropdownListItem extends Component<DropdownListItemProps> {
         className={classNames}
         data-test-id={testId}
         ref={listItemRef}
-        role="option"
+        role="menuitem"
       >
         {submenuToggleLabel
           ? this.renderSubmenuToggle()

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/__snapshots__/DropdownListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/__snapshots__/DropdownListItem.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`renders the component 1`] = `
 <li
   className="DropdownListItem"
   data-test-id="cf-ui-dropdown-list-item"
+  role="menuitem"
 >
   <span>
     DropdownMenuItem
@@ -15,6 +16,7 @@ exports[`renders the component as active 1`] = `
 <li
   className="DropdownListItem DropdownListItem--active"
   data-test-id="cf-ui-dropdown-list-item"
+  role="menuitem"
 >
   <span>
     entry
@@ -26,6 +28,7 @@ exports[`renders the component as disabled 1`] = `
 <li
   className="DropdownListItem DropdownListItem--disabled"
   data-test-id="cf-ui-dropdown-list-item"
+  role="menuitem"
 >
   <span>
     entry
@@ -37,6 +40,7 @@ exports[`renders the component with a href 1`] = `
 <li
   className="DropdownListItem DropdownListItem__submenu-toggle"
   data-test-id="cf-ui-dropdown-list-item"
+  role="menuitem"
 >
   <a
     className="DropdownListItem__button"
@@ -59,6 +63,7 @@ exports[`renders the component with an additional class name 1`] = `
 <li
   className="DropdownListItem my-extra-class"
   data-test-id="cf-ui-dropdown-list-item"
+  role="menuitem"
 >
   <span
     className="my-extra-class"


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

There are currently a couple of accessibility issues with the dropdown components. This PR fixes them by firstly updating the Jest snapshots, and secondly (and more important for review) - changing the `DropdownList` and `DropdownListItem` role to be `menu` and `menuitem`.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
