### PR TITLE
chore(gatsby-config.js): Remove promotional bar

### DIFF
--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -1,10 +1,9 @@
 module.exports = {
   siteMetadata: {
     title: 'Forma 36 - The Contentful Design System',
-    // Uncomment the lines below to display a promotional bar at the very top of the website
-    // promoText: 'Join the Berlin Design Systems Community Q&A on November 28th',
-    // promoLink: 'https://www.meetup.com/berlin-design-systems/events/266289217/',
-    // promoLinkText: 'Sign up on Meetup',
+    promoText: '',
+    promoLink: '',
+    promoLinkText: '',
     menuLinks: [
       {
         name: 'Foundation',

--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -1,9 +1,10 @@
 module.exports = {
   siteMetadata: {
     title: 'Forma 36 - The Contentful Design System',
-    promoText: 'Join the Berlin Design Systems Community Q&A on November 28th',
-    promoLink: 'https://www.meetup.com/berlin-design-systems/events/266289217/',
-    promoLinkText: 'Sign up on Meetup',
+    // Uncomment the lines below to display a promotional bar at the very top of the website
+    // promoText: 'Join the Berlin Design Systems Community Q&A on November 28th',
+    // promoLink: 'https://www.meetup.com/berlin-design-systems/events/266289217/',
+    // promoLinkText: 'Sign up on Meetup',
     menuLinks: [
       {
         name: 'Foundation',


### PR DESCRIPTION
# Purpose of PR

This PR removes the irrelevant promotional bar from the documentation website. ~I chose to comment the relevant code instead of removing it in order to make it more discoverable. Ideally it should be added to the readme as well. Let me know if you disagree with this approach.~
I added the properties back as empty strings to fix failing tests, thanks @m10l for the hint.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
