### PR TITLE
Fix text link typescript

### DIFF
--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.tsx
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.tsx
@@ -17,7 +17,9 @@ type IconPositionType = 'right' | 'left';
 export type TextLinkProps = {
   children?: React.ReactNode;
   linkType?: TextLinkType;
-  href?: string;
+  href?: React.AnchorHTMLAttributes<HTMLAnchorElement>['href'];
+  target?: React.AnchorHTMLAttributes<HTMLAnchorElement>['target'];
+  rel?: React.AnchorHTMLAttributes<HTMLInputElement>['rel'];
   disabled?: boolean;
   testId?: string;
   onClick?: MouseEventHandler<HTMLAnchorElement | HTMLButtonElement>;


### PR DESCRIPTION
# Purpose of PR

- [x] Add missing typescript properties for TextLink component.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
