### PR TITLE
Expose Ref for Textarea

### DIFF
--- a/packages/forma-36-react-components/.size-limit
+++ b/packages/forma-36-react-components/.size-limit
@@ -3,7 +3,7 @@
       "path": "dist/index.js",
       "name": "gzipped js",
       "gzip": false,
-      "limit": "280 KB",
+      "limit": "281 KB",
       "ignore": [
         "react",
         "react-dom"

--- a/packages/forma-36-react-components/src/components/Icon/Icon.tsx
+++ b/packages/forma-36-react-components/src/components/Icon/Icon.tsx
@@ -26,6 +26,8 @@ const Code = require('./svg/Code.svg');
 const CodeTrimmed = require('./svg/CodeTrimmed.svg');
 const Copy = require('./svg/Copy.svg');
 const CopyTrimmed = require('./svg/CopyTrimmed.svg');
+const Delete = require('./svg/Delete.svg');
+const DeleteTrimmed = require('./svg/DeleteTrimmed.svg');
 const Download = require('./svg/Download.svg');
 const DownloadTrimmed = require('./svg/DownloadTrimmed.svg');
 const Drag = require('./svg/Drag.svg');
@@ -146,6 +148,8 @@ const iconComponents = {
   CodeTrimmed,
   Copy,
   CopyTrimmed,
+  Delete,
+  DeleteTrimmed,
   Download,
   DownloadTrimmed,
   Drag,

--- a/packages/forma-36-react-components/src/components/Icon/constants.ts
+++ b/packages/forma-36-react-components/src/components/Icon/constants.ts
@@ -25,6 +25,8 @@ export const iconName = {
   CodeTrimmed: 'CodeTrimmed',
   Copy: 'Copy',
   CopyTrimmed: 'CopyTrimmed',
+  Delete: 'Delete',
+  DeleteTrimmed: 'DeleteTrimmed',
   Download: 'Download',
   DownloadTrimmed: 'DownloadTrimmed',
   Drag: 'Drag',

--- a/packages/forma-36-react-components/src/components/Icon/svg/Delete.svg
+++ b/packages/forma-36-react-components/src/components/Icon/svg/Delete.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/><path d="M0 0h24v24H0z" fill="none"/></svg>

--- a/packages/forma-36-react-components/src/components/Icon/svg/DeleteTrimmed.svg
+++ b/packages/forma-36-react-components/src/components/Icon/svg/DeleteTrimmed.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" width="24" viewBox="0 0 14 24" >
+<path d="M1,19c0,1.1,0.9,2,2,2h8c1.1,0,2-0.9,2-2V7H1V19z M14,4h-3.5l-1-1h-5l-1,1H0v2h14V4z"/>
+<path fill="none" d="M-5,0h24v24H-5V0z"/>
+</svg>

--- a/packages/forma-36-react-components/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Textarea/Textarea.stories.tsx
@@ -4,6 +4,7 @@ import { text, boolean, select, number } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import Textarea from './Textarea';
+import Button from './../Button';
 
 storiesOf('Components|TextArea', module)
   .addParameters({
@@ -34,4 +35,42 @@ storiesOf('Components|TextArea', module)
       rows={number('rows', 2)}
       willBlurOnEsc={boolean('willBlurOnEsc', true)}
     />
-  ));
+  ))
+  .add('Controlling focus via ref', () => {
+    const textareaRef = React.createRef<HTMLTextAreaElement>();
+
+    return (
+      <React.Fragment>
+        <Textarea
+          className={text('className', '')}
+          name="someInput"
+          id="someInput"
+          error={boolean('error', false)}
+          maxLength={number('maxLength', 50)}
+          required={boolean('required', false)}
+          width={select(
+            'width',
+            {
+              'Full (default)': 'full',
+              large: 'large',
+              medium: 'medium',
+              small: 'small',
+            },
+            'full',
+          )}
+          onChange={action('onChange')}
+          onBlur={action('onBlur')}
+          disabled={boolean('disabled', false)}
+          value={text('value', '123456')}
+          rows={number('rows', 2)}
+          willBlurOnEsc={boolean('willBlurOnEsc', true)}
+          textareaRef={textareaRef}
+        />
+        <Button
+          onClick={() => (textareaRef.current as HTMLTextAreaElement).focus()}
+        >
+          Focus Textarea with ref
+        </Button>
+      </React.Fragment>
+    );
+  });

--- a/packages/forma-36-react-components/src/components/Textarea/Textarea.tsx
+++ b/packages/forma-36-react-components/src/components/Textarea/Textarea.tsx
@@ -4,6 +4,7 @@ import React, {
   FocusEventHandler,
   ChangeEventHandler,
   KeyboardEventHandler,
+  RefObject,
 } from 'react';
 import cn from 'classnames';
 import styles from './Textarea.css';
@@ -28,6 +29,7 @@ export type TextareaProps = {
   onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement>;
   onKeyUp?: KeyboardEventHandler<HTMLTextAreaElement>;
   willBlurOnEsc: boolean;
+  textareaRef?: RefObject<HTMLTextAreaElement>;
 } & typeof defaultProps;
 
 export interface TextareaState {
@@ -86,6 +88,7 @@ export class Textarea extends Component<TextareaProps, TextareaState> {
       rows,
       id,
       willBlurOnEsc,
+      textareaRef,
       ...otherProps
     } = this.props;
 
@@ -116,6 +119,7 @@ export class Textarea extends Component<TextareaProps, TextareaState> {
           maxLength={maxLength}
           value={disabled ? value : this.state && this.state.value}
           onKeyDown={this.handleKeyDown}
+          ref={textareaRef}
           {...otherProps}
         />
       </div>


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR exposes a ref for the Textarea component so that focus can be controlled programmatically (similar to TextInput), and adds two new icons - Delete and DeleteTrimmed

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
