### PR TITLE
feat(modal): added zen size

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/Modal/Modal.css
+++ b/packages/forma-36-react-components/src/components/Modal/Modal/Modal.css
@@ -103,3 +103,10 @@
   max-height: none;
   max-width: none;
 }
+
+.Modal.Modal--zen {
+  max-width: none;
+  max-height: none;
+  margin: 0;
+  height: 100vh;
+}

--- a/packages/forma-36-react-components/src/components/Modal/Modal/Modal.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/Modal/Modal.stories.tsx
@@ -36,7 +36,7 @@ function DefaultStory() {
         )}
         size={select(
           'size',
-          ['small', 'medium', 'large', 'fullWidth', '200px', '1500px'],
+          ['small', 'medium', 'large', 'fullWidth', 'zen', '200px', '1500px'],
           Modal.defaultProps.size,
         )}
         position={select(

--- a/packages/forma-36-react-components/src/components/Modal/Modal/Modal.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/Modal/Modal.tsx
@@ -12,6 +12,7 @@ const ModalSizesMapper = {
   small: '400px',
   large: '700px',
   fullWidth: '100vw',
+  zen: '100vw',
 };
 
 export type ModalSizeType =
@@ -19,6 +20,7 @@ export type ModalSizeType =
   | 'medium'
   | 'large'
   | 'fullWidth'
+  | 'zen'
   | string
   | number;
 
@@ -159,6 +161,7 @@ export class Modal extends Component<ModalProps> {
           }}
           className={cn(styles.Modal, this.props.className, {
             [styles['Modal--overflow']]: this.props.allowHeightOverflow,
+            [styles['Modal--zen']]: this.props.size === 'zen',
           })}
         >
           {typeof this.props.children === 'function'


### PR DESCRIPTION
# Purpose of PR

Added ability to open modal in a truly fullscreen mode (`zen` mode).

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
