### PR TITLE
feat(EntryCard): Allow status icon to be a string or node for more flexibility

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
@@ -9,6 +9,7 @@ import CardDragHandle, {
   CardDragHandlePropTypes,
 } from '../CardDragHandle/CardDragHandle';
 import Icon, { IconType } from '../../Icon/Icon';
+import Tooltip from '../../Tooltip';
 
 const styles = require('./EntryCard.css');
 
@@ -38,7 +39,7 @@ export type EntryCardPropTypes = {
   /**
    * An icon for the status of the entry
    */
-  statusIcon?: string;
+  statusIcon?: string | React.ReactNode;
   /**
    * The thumbnail of the entry
    */
@@ -221,12 +222,14 @@ export class EntryCard extends Component<EntryCardPropTypes> {
                   >
                     {contentType}
                   </div>
-                  {statusIcon && (
+                  {statusIcon && typeof statusIcon === 'string' ? (
                     <Icon
                       icon={statusIcon as IconType}
                       color="muted"
                       className="f36-margin-right--xs"
                     />
+                  ) : (
+                    statusIcon
                   )}
                   {status && this.renderStatus(status)}
                   {dropdownListElements && (


### PR DESCRIPTION
Allow status icon to be a string or node for more flexibility (e.g: Icon wrapped in Tooltip)

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
