### PR TITLE
refactor(dropdown): skip propagation of none html attributes to the dom

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
@@ -174,6 +174,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
       children,
       isOpen,
       isAutoalignmentEnabled,
+      isFullWidth,
       ...otherProps
     } = this.props;
 

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
@@ -36,7 +36,20 @@ export class DropdownListItem extends Component<DropdownListItemProps> {
   static defaultProps = defaultProps;
 
   renderSubmenuToggle = () => {
-    const { onClick, onEnter, onLeave, onFocus, ...otherProps } = this.props;
+    const {
+      onClick,
+      onEnter,
+      onLeave,
+      onFocus,
+      children,
+      submenuToggleLabel,
+      testId,
+      isDisabled,
+      isActive,
+      isTitle,
+      ...otherProps
+    } = this.props;
+
     return (
       <React.Fragment>
         <button
@@ -52,10 +65,10 @@ export class DropdownListItem extends Component<DropdownListItemProps> {
           <TabFocusTrap
             className={styles['DropdownListItem__button__inner-wrapper']}
           >
-            {this.props.submenuToggleLabel}
+            {submenuToggleLabel}
           </TabFocusTrap>
         </button>
-        {this.props.children}
+        {children}
       </React.Fragment>
     );
   };


### PR DESCRIPTION
Skip propagation of none HTML attributes to the DOM

# Purpose of PR
Get rid of react warnings from passing none HTML attributes to the DOM
