### PR TITLE
improvement(dropdown): container width not re-calcutating

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
@@ -38,7 +38,6 @@ export interface AnchorDimensionsAndPositonType {
 
 export interface DropdownState {
   isOpen: boolean;
-  containerWidth?: number;
   position: positionType;
   anchorDimensionsAndPositon?: AnchorDimensionsAndPositonType;
 }
@@ -57,7 +56,6 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
 
   state = {
     isOpen: this.props.isOpen,
-    containerWidth: undefined,
     position: this.props.position,
     anchorDimensionsAndPositon: {
       top: 0,
@@ -75,12 +73,6 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
     }
     this.setAnchorDimensions();
     this.bindEventListeners();
-
-    if (this.props.isFullWidth && this.dropdownAnchor) {
-      this.setState({
-        containerWidth: this.dropdownAnchor.getBoundingClientRect().width - 2, // subtract the border
-      });
-    }
   }
 
   setAnchorDimensions = () => {
@@ -179,6 +171,8 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
     } = this.props;
 
     const classNames = cn(styles['Dropdown'], className);
+    const width =
+      isFullWidth && this.state.anchorDimensionsAndPositon.width - 2; // subtract the border
 
     return submenuToggleLabel ? (
       <DropdownListItem
@@ -197,7 +191,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
           <DropdownContainer
             anchorDimensionsAndPositon={this.state.anchorDimensionsAndPositon}
             position={this.props.position}
-            width={this.state.containerWidth}
+            width={width}
             className={dropdownContainerClassName}
             getRef={getContainerRef}
             dropdownAnchor={this.dropdownAnchor}
@@ -230,7 +224,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
             className={dropdownContainerClassName}
             getRef={getContainerRef}
             submenu={false}
-            width={this.state.containerWidth}
+            width={width}
             dropdownAnchor={this.dropdownAnchor}
             isAutoalignmentEnabled={isAutoalignmentEnabled}
             anchorDimensionsAndPositon={this.state.anchorDimensionsAndPositon}

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -20,7 +20,7 @@ export type DropdownContainerProps = {
   position: positionType;
   getRef?: (ref: HTMLElement | null) => void;
   submenu?: boolean;
-  width?: number;
+  width?: number | false;
   isAutoalignmentEnabled?: boolean;
 } & typeof defaultProps;
 


### PR DESCRIPTION
Drop dependency to `containerWidth` state variable from `isFullWidth` prop and reuse `anchorDimensions` since they're keeping better track of the container's width.

# Purpose of PR
Dropdown container width calculation isn't triggering when using `isFullWidth` prop from a client component (e.g Autocomplete)