### PR TITLE
improvement(dropdown): change default box-sizing to border-box

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
@@ -171,8 +171,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
     } = this.props;
 
     const classNames = cn(styles['Dropdown'], className);
-    const width =
-      isFullWidth && this.state.anchorDimensionsAndPositon.width - 2; // subtract the border
+    const width = isFullWidth && this.state.anchorDimensionsAndPositon.width;
 
     return submenuToggleLabel ? (
       <DropdownListItem

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.css
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.css
@@ -5,6 +5,7 @@
 .DropdownContainer {
   background: var(--color-white);
   box-shadow: var(--box-shadow-default);
+  box-sizing: border-box;
   border: calc(1rem * (1 / var(--font-base-default))) solid
     var(--color-element-mid);
   list-style: none;

--- a/packages/forma-36-react-components/tools/plop-templates/components/styles.css.hbs
+++ b/packages/forma-36-react-components/tools/plop-templates/components/styles.css.hbs
@@ -4,4 +4,5 @@
 
 .{{pascalCase name}} {
   display: inline-block;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
# Purpose of PR
Forma 36 components default box-sizing should default to border-box. Apply rule to `dropdown` and hint library developers with the plop templates.

