### PR TITLE
fix(autocomplete): prevent chrome autocomplete

### DIFF
--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -187,8 +187,8 @@ export const Autocomplete: FunctionComponent<AutocompleteProps> = ({
             inputRef={inputRef}
             testId="autocomplete.input"
             type="search"
-            name={name}
             autoComplete="off"
+            aria-label={name}
           />
           <IconButton
             className={styles.inputIconButton}


### PR DESCRIPTION
# Purpose of PR
Prevent chrome from autocompleting Forma 36 Autocomplete

# TODO
We could consider adding `aria-label` to the TextInput component directly
