### PR TITLE
fix(cardactions): close cardactions on blur

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
@@ -79,9 +79,14 @@ export class CardActions extends Component<
             disabled={isDisabled}
             label="Actions"
             {...iconButtonProps}
-            onClick={event => {
+            onMouseDown={event => {
               event.preventDefault();
+            }}
+            onClick={event => {
               this.handleClick(event);
+            }}
+            onBlur={() => {
+              this.setState({ isDropdownOpen: false });
             }}
           />
         }

--- a/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
@@ -18,7 +18,9 @@ exports[`renders the component as disabled 1`] = `
         }
       }
       label="Actions"
+      onBlur={[Function]}
       onClick={[Function]}
+      onMouseDown={[Function]}
       testId="cf-ui-icon-button"
       withDropdown={false}
     />
@@ -60,7 +62,9 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
         }
       }
       label="Actions"
+      onBlur={[Function]}
       onClick={[Function]}
+      onMouseDown={[Function]}
       testId="cf-ui-icon-button"
       withDropdown={false}
     />
@@ -153,7 +157,9 @@ exports[`renders the component using a single dropdown list 1`] = `
         }
       }
       label="Actions"
+      onBlur={[Function]}
       onClick={[Function]}
+      onMouseDown={[Function]}
       testId="cf-ui-icon-button"
       withDropdown={false}
     />
@@ -214,7 +220,9 @@ exports[`renders the component with an additional class name 1`] = `
         }
       }
       label="Actions"
+      onBlur={[Function]}
       onClick={[Function]}
+      onMouseDown={[Function]}
       testId="cf-ui-icon-button"
       withDropdown={false}
     />
@@ -274,7 +282,9 @@ exports[`renders the component with published status 1`] = `
         }
       }
       label="Actions"
+      onBlur={[Function]}
       onClick={[Function]}
+      onMouseDown={[Function]}
       testId="cf-ui-icon-button"
       withDropdown={false}
     />


### PR DESCRIPTION
## Purpose
Prevent multiple `CardActions` from being simultaneously open when navigating through the keyboard

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
