### PR TITLE
[WIP] fix(cardactions): close cardactions on blur

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
@@ -80,8 +80,10 @@ export class CardActions extends Component<
             label="Actions"
             {...iconButtonProps}
             onClick={event => {
-              event.preventDefault();
               this.handleClick(event);
+            }}
+            onBlur={() => {
+              this.setState({ isDropdownOpen: false });
             }}
           />
         }
@@ -103,6 +105,12 @@ export class CardActions extends Component<
                     }
                     this.setState({ isDropdownOpen: false });
                     e.stopPropagation();
+                  },
+                  onMouseDown: (e: ReactMouseEvent) => {
+                    e.preventDefault();
+                    if (child.props.onClick) {
+                      child.props.onClick(e);
+                    }
                   },
                 }),
             );

--- a/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`renders the component as disabled 1`] = `
         }
       }
       label="Actions"
+      onBlur={[Function]}
       onClick={[Function]}
       testId="cf-ui-icon-button"
       withDropdown={false}
@@ -27,6 +28,7 @@ exports[`renders the component as disabled 1`] = `
   <DropdownList
     key=".0/.$.0/.$.0"
     onClick={[Function]}
+    onMouseDown={[Function]}
     testId="cf-ui-dropdown-list"
   >
     <DropdownListItem
@@ -60,6 +62,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
         }
       }
       label="Actions"
+      onBlur={[Function]}
       onClick={[Function]}
       testId="cf-ui-icon-button"
       withDropdown={false}
@@ -69,6 +72,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
   <DropdownList
     key=".0/.$.0/.$.0"
     onClick={[Function]}
+    onMouseDown={[Function]}
     testId="cf-ui-dropdown-list"
   >
     <DropdownListItem
@@ -102,6 +106,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
   <DropdownList
     key=".1/.$.0/.$.0"
     onClick={[Function]}
+    onMouseDown={[Function]}
     testId="cf-ui-dropdown-list"
   >
     <DropdownListItem
@@ -153,6 +158,7 @@ exports[`renders the component using a single dropdown list 1`] = `
         }
       }
       label="Actions"
+      onBlur={[Function]}
       onClick={[Function]}
       testId="cf-ui-icon-button"
       withDropdown={false}
@@ -162,6 +168,7 @@ exports[`renders the component using a single dropdown list 1`] = `
   <DropdownList
     key=".0/.$.0/.$.0"
     onClick={[Function]}
+    onMouseDown={[Function]}
     testId="cf-ui-dropdown-list"
   >
     <DropdownListItem
@@ -214,6 +221,7 @@ exports[`renders the component with an additional class name 1`] = `
         }
       }
       label="Actions"
+      onBlur={[Function]}
       onClick={[Function]}
       testId="cf-ui-icon-button"
       withDropdown={false}
@@ -223,6 +231,7 @@ exports[`renders the component with an additional class name 1`] = `
   <DropdownList
     key=".0/.$.0/.$.0"
     onClick={[Function]}
+    onMouseDown={[Function]}
     testId="cf-ui-dropdown-list"
   >
     <DropdownListItem
@@ -274,6 +283,7 @@ exports[`renders the component with published status 1`] = `
         }
       }
       label="Actions"
+      onBlur={[Function]}
       onClick={[Function]}
       testId="cf-ui-icon-button"
       withDropdown={false}
@@ -283,6 +293,7 @@ exports[`renders the component with published status 1`] = `
   <DropdownList
     key=".0/.$.0/.$.0"
     onClick={[Function]}
+    onMouseDown={[Function]}
     testId="cf-ui-dropdown-list"
   >
     <DropdownListItem


### PR DESCRIPTION
## Purpose
Prevent multiple `CardActions` from being simultaneously open when navigating with the keyboard, in other words, tabbing away from an expanded/open `CardActions` should automatically close/collapse it.

### Before
![Screenshot 2020-01-15 at 14 06 56](https://user-images.githubusercontent.com/1368611/72436513-e5ec8700-37a0-11ea-94c8-ad49ef51506a.png)

### After
![Screenshot 2020-01-15 at 14 08 20](https://user-images.githubusercontent.com/1368611/72436529-f3a20c80-37a0-11ea-9a94-c1f59ef63713.png)
## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
