### PR TITLE
fix(Autocomplete): Support for full width

### DIFF
--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.css
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.css
@@ -1,5 +1,9 @@
 @import 'settings/dimensions';
 
+.autocompleteDropdown {
+  display: block;
+}
+
 .autocompleteInput {
   display: flex;
 }
@@ -13,7 +17,6 @@
 }
 
 .inputIconButton {
-  position: absolute;
-  top: calc(50% - var(--spacing-xs));
-  right: var(--spacing-xs);
+  position: relative;
+  margin-left: calc(-1 * var(--spacing-xl));
 }

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { boolean, number, object, text } from '@storybook/addon-knobs';
+import { boolean, number, object, text, select } from '@storybook/addon-knobs';
 
 import Autocomplete from './Autocomplete';
 
@@ -38,7 +38,16 @@ const AutocompleteDefaultStory = ({ items }: { items: Item[] }) => {
         'Choose from spaces in your organization',
       )}
       isLoading={boolean('isLoading', false)}
-      width="large"
+      width={select(
+        'width',
+        {
+          'Full (default)': 'full',
+          large: 'large',
+          medium: 'medium',
+          small: 'small',
+        },
+        'full',
+      )}
       disabled={boolean('disabled', false)}
       emptyListMessage={text(
         'emptyListMessage',

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -11,6 +11,7 @@ import SkeletonContainer from '../Skeleton/SkeletonContainer';
 import IconButton from '../IconButton';
 
 import styles from './Autocomplete.css';
+import cn from 'classnames';
 
 const TOGGLED_LIST = 'TOGGLED_LIST';
 const NAVIGATED_ITEMS = 'NAVIGATED_ITEMS';
@@ -166,9 +167,11 @@ export const Autocomplete: FunctionComponent<AutocompleteProps> = ({
     [children, items],
   );
 
+  const dropdownClassNames = cn(styles.autocompleteDropdown, className);
+
   return (
     <Dropdown
-      className={className}
+      className={dropdownClassNames}
       isOpen={isOpen}
       onClose={() => {
         willClearQueryOnClose && updateQuery('');


### PR DESCRIPTION

# Purpose of PR

Support the `width="full"` option in the Autocomplete component. It is currently not working.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
