### PR TITLE
refactor(autocomplete): drop is-hotkey dependency

### DIFF
--- a/packages/forma-36-react-components/package.json
+++ b/packages/forma-36-react-components/package.json
@@ -35,7 +35,6 @@
     "@testing-library/react": "^9.4.0",
     "@types/classnames": "2.2.7",
     "@types/enzyme": "3.9.1",
-    "@types/is-hotkey": "^0.1.1",
     "@types/jest": "^24.0.25",
     "@types/jest-axe": "^3.2.1",
     "@types/react": "16.8.6",
@@ -104,7 +103,6 @@
   "dependencies": {
     "@babel/runtime": "^7.3.4",
     "classnames": "^2.2.6",
-    "is-hotkey": "^0.1.6",
     "prop-types": "^15.7.2",
     "react-animate-height": "^2.0.7",
     "react-copy-to-clipboard": "^5.0.1",

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.test.tsx
@@ -9,6 +9,7 @@ import {
   configure,
 } from '@testing-library/react';
 
+import { KEY_CODE } from './utils';
 import Autocomplete from '../Autocomplete';
 
 interface Item {
@@ -77,7 +78,7 @@ describe('Autocomplete', () => {
     it('shows the dropdown', () => {
       const { getByTestId } = build({});
       const input = getByTestId('autocomplete.input');
-      fireEvent.keyDown(input, { keyCode: 40 });
+      fireEvent.keyDown(input, { keyCode: KEY_CODE.ARROW_DOWN });
       const dropdown = getByTestId('autocomplete.dropdown-list');
       expect(dropdown).toBeVisible();
     });
@@ -89,7 +90,7 @@ describe('Autocomplete', () => {
     beforeEach(() => {
       const { getByTestId } = build({});
       input = getByTestId('autocomplete.input');
-      fireEvent.keyDown(input, { keyCode: 40 });
+      fireEvent.keyDown(input, { keyCode: KEY_CODE.ARROW_DOWN });
       dropdown = getByTestId('autocomplete.dropdown-list');
       options = within(dropdown).getAllByTestId(
         'autocomplete.dropdown-list-item',
@@ -101,7 +102,7 @@ describe('Autocomplete', () => {
     });
 
     it('calls the onChange and onQueryChange callbacks when the selecting an item with the enter key', () => {
-      fireEvent.keyDown(input, { keyCode: 13 }); // select the first item
+      fireEvent.keyDown(input, { keyCode: KEY_CODE.ENTER });
       expect(onChangeFn).toHaveBeenCalledWith(items[0]);
       expect(onQueryChangeFn).toHaveBeenCalledWith('');
     });
@@ -116,7 +117,7 @@ describe('Autocomplete', () => {
     });
 
     it('dismisses the dropdown when selecting with the enter key', () => {
-      fireEvent.keyDown(input, { keyCode: 13 });
+      fireEvent.keyDown(input, { keyCode: KEY_CODE.ENTER });
       const dropdown = within(document as any).queryByTestId(
         'autocomplete.dropdown-list',
       );

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useReducer, useMemo, useRef, FunctionComponent } from 'react';
 import PropTypes from 'prop-types';
-import isHotKey from 'is-hotkey';
 
 import TextInput from '../TextInput';
 import Dropdown, { DropdownProps } from '../Dropdown/Dropdown/Dropdown';
@@ -11,6 +10,7 @@ import SkeletonBodyText from '../Skeleton/SkeletonBodyText';
 import SkeletonContainer from '../Skeleton/SkeletonContainer';
 import IconButton from '../IconButton';
 
+import { KEY_CODE } from './utils';
 import styles from './Autocomplete.css';
 import cn from 'classnames';
 
@@ -129,10 +129,10 @@ export const Autocomplete: FunctionComponent<AutocompleteProps> = ({
   };
 
   const handleKeyDown = (event: any) => {
-    const isEnter = isHotKey('enter', event);
+    const isEnter = event.keyCode === KEY_CODE.ENTER;
     const isTab =
-      isHotKey('tab', event as KeyboardEvent) ||
-      isHotKey('shift+tab', event as KeyboardEvent);
+      event.keyCode === KEY_CODE.TAB ||
+      (event.keyCode === KEY_CODE.TAB && event.shiftKey);
 
     const hasUserSelection = highlightedItemIndex !== null;
     const lastIndex = items.length ? items.length - 1 : 0;
@@ -281,19 +281,18 @@ function OptionSkeleton() {
 }
 
 function getNavigationDirection(event: KeyboardEvent): Direction | null {
-  if (isHotKey('down', event)) {
+  if (event.keyCode === KEY_CODE.ARROW_DOWN) {
     return Direction.DOWN;
   }
 
-  if (isHotKey('up', event)) {
+  if (event.keyCode === KEY_CODE.ARROW_UP) {
     return Direction.UP;
   }
 
   return null;
 }
 
-// Get next navigation index based on current index and
-// navigation direction
+// Get next navigation index based on current index and navigation direction
 function getNewIndex(
   currentIndex: number,
   direction: Direction,

--- a/packages/forma-36-react-components/src/components/Autocomplete/utils.ts
+++ b/packages/forma-36-react-components/src/components/Autocomplete/utils.ts
@@ -1,0 +1,6 @@
+export const KEY_CODE = {
+  ENTER: 13,
+  ARROW_DOWN: 40,
+  ARROW_UP: 38,
+  TAB: 9,
+};

--- a/packages/forma-36-react-components/yarn.lock
+++ b/packages/forma-36-react-components/yarn.lock
@@ -1549,20 +1549,15 @@
     yargs "^11.1.0"
 
 "@contentful/forma-36-fcss@^0.0.34":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@contentful/forma-36-fcss/-/forma-36-fcss-0.0.32.tgz#daba10dc78315741bbdff00c7e35ffb109761be2"
-  integrity sha512-r4xXIue1gZ6qPgeZuNm/FSO9i8HSyycJ42HyOmdR64jipv50lPmH/reejKtmVxYZcGarAhDavCniz/RJAIXWoQ==
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@contentful/forma-36-fcss/-/forma-36-fcss-0.0.34.tgz#afc4514e9b946c67339202ac61df94dc702b3bbe"
+  integrity sha512-AhK2QJn2pQ/MWR8d10H4B6g625MU1rz4lkakkw8/0E0KFpeow53XW2lbN0vTdOXDaNM1TeMOP0F700qFIoeMkA==
   dependencies:
-    "@contentful/forma-36-tokens" "^0.4.5"
+    "@contentful/forma-36-tokens" "^0.5.1"
 
 "@contentful/forma-36-tokens@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@contentful/forma-36-tokens/-/forma-36-tokens-0.2.0.tgz#c4a1062e7acc2ae0ae5699e7c8606d5b5047a1c5"
-
-"@contentful/forma-36-tokens@^0.4.5":
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/@contentful/forma-36-tokens/-/forma-36-tokens-0.4.5.tgz#86880a06178de9ebfb542db983550b7c5ae531d3"
-  integrity sha512-wygRxC9r+Wr4FR4wEp1MVjt+Hx5n1lCux4EOXfva3Au1CXzjcl821ukR8mMaurYM7/3TMrv/olQorySNwGpllg==
 
 "@contentful/forma-36-tokens@^0.5.1":
   version "0.5.1"
@@ -2730,11 +2725,6 @@
   dependencies:
     "@types/through" "*"
     rxjs ">=6.4.0"
-
-"@types/is-hotkey@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@types/is-hotkey/-/is-hotkey-0.1.1.tgz#802e294c2a02f26fbcbe8639c77ef05e38cfdc8c"
-  integrity sha512-QzVKww91fJv/KzARJBS/Im5GS2A8iE64E1HxOed72EmYOvPLG4PBw77QCIUjFl7VwWB3G/SVrxsHedJD/wtn1A==
 
 "@types/istanbul-lib-coverage@*":
   version "2.0.1"
@@ -8973,11 +8963,6 @@ is-glob@^4.0.0, is-glob@^4.0.1:
 is-hexadecimal@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
-
-is-hotkey@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/is-hotkey/-/is-hotkey-0.1.6.tgz#c214b1ccdcbda46fba4ba93d2de64915db737471"
-  integrity sha512-1+hMr0GLPM0M49UDRt9RgE8i+SM29UY4AGRP6sGz6fThOVXqSrEvTMakolhHMcVizJnPNAoMpEmE+Oi1k2NrZQ==
 
 is-installed-globally@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
drop dependency to `is-hotkey`

<!--
# Purpose of PR
Drop `is-hotkey` dependency.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
