### PR TITLE
style(modal): fix zen mode for Modal component

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/Modal/Modal.css
+++ b/packages/forma-36-react-components/src/components/Modal/Modal/Modal.css
@@ -67,6 +67,11 @@
   outline: none;
 }
 
+.Modal__wrap--zen {
+  width: 100%;
+  height: 100%;
+}
+
 .Modal__wrap--after-open .Modal {
   transform: scale(1);
   opacity: 1;
@@ -108,5 +113,6 @@
   max-width: none;
   max-height: none;
   margin: 0;
-  height: 100vh;
+  height: 100%;
+  width: 100%;
 }

--- a/packages/forma-36-react-components/src/components/Modal/Modal/Modal.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/Modal/Modal.tsx
@@ -132,7 +132,7 @@ export class Modal extends Component<ModalProps> {
         shouldCloseOnOverlayClick={this.props.shouldCloseOnOverlayClick}
         portalClassName={styles.Modal__portal}
         className={{
-          base: styles.Modal__wrap,
+          base: cn(styles.Modal__wrap, { [styles['Modal__wrap--zen']]: this.props.size === 'zen' }),
           afterOpen: styles['Modal__wrap--after-open'],
           beforeClose: styles['Modal__wrap--before-close'],
         }}


### PR DESCRIPTION
Fixed zen mode for Modal component - to avoid breaking the layout with "Show scrollbars: always" setting in OS

# Purpose of PR

When additional scroll-bars would be shown, zen-mode would be broken, this fixes the issue and Modal with zen mode displays correctly with all OS settings.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
