### PR TITLE
Improve display of logo on F36 docs site

### DIFF
--- a/packages/forma-36-website/src/components/Masthead.js
+++ b/packages/forma-36-website/src/components/Masthead.js
@@ -13,6 +13,7 @@ const styles = {
     padding: ${tokens.spacing3Xl} 0;
     background-image: url(${bg});
     background-size: 30px;
+    background-position: center top;
   `,
   content: css`
     width: 28rem;
@@ -33,8 +34,8 @@ const Logo = () => (
   <svg
     x="0px"
     y="0px"
-    width="64px"
-    height="64px"
+    width="80px"
+    height="80px"
     viewBox="0 0 90 90"
     enable-background="new 0 0 90 90"
     css={styles.logo}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Tidy up the display of the F36 logo on the documentation website. Previously the logo wasn't aligned with the dotted background image on the homepage banner. This PR makes sure that it's aligned at any viewport width.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
