### PR TITLE
fix(Asset): Do not attempt to render images with a status of archived

### DIFF
--- a/packages/forma-36-react-components/src/components/Asset/Asset.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Asset/Asset.stories.tsx
@@ -15,4 +15,21 @@ storiesOf('Components|Asset', module)
       title={text('title', 'Image of a cat')}
       type={select('type', types, 'archive')}
     />
+  ))
+  .add('with an image', () => (
+    <Asset
+      className={text('className', '')}
+      src={text('src', 'https://placekitten.com/200/300')}
+      title={text('title', 'Image of a cat')}
+      type={select('type', types, 'image')}
+    />
+  ))
+  .add('with an archived image', () => (
+    <Asset
+      className={text('className', '')}
+      src={text('src', 'https://placekitten.com/200/300')}
+      title={text('title', 'Image of a cat')}
+      type={select('type', types, 'image')}
+      status='archived'
+    />
   ));

--- a/packages/forma-36-react-components/src/components/Asset/Asset.test.tsx
+++ b/packages/forma-36-react-components/src/components/Asset/Asset.test.tsx
@@ -36,6 +36,35 @@ it('renders the component with type pdf', () => {
   expect(output).toMatchSnapshot();
 });
 
+describe('with type=image', () => {
+  it('renders the component as a preview', () => {
+    const output = shallow(
+      <Asset
+        src="https://placekitten.com/200/300"
+        title="Image of a cat"
+        className="extra-class-name"
+        type="image"
+      />,
+    );
+  
+    expect(output.find('img')).toHaveLength(1)
+  })
+
+  it('renders the component as a standard asset with status=archived', () => {
+    const output = shallow(
+      <Asset
+        src="https://placekitten.com/200/300"
+        title="Image of a cat"
+        className="extra-class-name"
+        type="image"
+        status="archived"
+      />,
+    );
+  
+    expect(output.find('img')).toHaveLength(0)
+  })
+})
+
 it('has no a11y issues', async () => {
   const output = mount(
     <Asset src="http://placekitten.com/200/300" title="picture of a cat" />,

--- a/packages/forma-36-react-components/src/components/Asset/Asset.tsx
+++ b/packages/forma-36-react-components/src/components/Asset/Asset.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import cn from 'classnames';
 import Illustration, { IllustrationType } from '../Illustration/Illustration';
+import { AssetState } from '../Card/AssetCard/AssetCard';
 
 const styles = require('./Asset.css');
 
@@ -25,6 +26,7 @@ export type AssetProps = {
   title: string;
   type?: AssetType;
   className?: string;
+  status?: AssetState;
   testId?: string;
 } & typeof defaultProps;
 
@@ -64,13 +66,16 @@ export class Asset extends Component<AssetProps> {
   };
 
   render() {
-    const { className, src, title, type, testId, ...otherProps } = this.props;
+    const { className, src, status, title, type, testId, ...otherProps } = this.props;
 
     const classNames = cn(styles.Asset, className);
 
+    // Archived images will not have a preview available
+    const asImage = type && type === 'image' && (!status || status !== 'archived')
+
     return (
       <div className={classNames} data-test-id={testId} {...otherProps}>
-        {type && type === 'image'
+        {asImage
           ? this.renderImage(src, title)
           : this.renderAsset(type, title)}
       </div>

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
@@ -188,6 +188,7 @@ export class AssetCard extends Component<AssetCardProps> {
                   src={src}
                   title={title}
                   type={type}
+                  status={status}
                 />
               </div>
             </div>

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
@@ -265,6 +265,7 @@ exports[`renders the component with status 1`] = `
       <Asset
         className="AssetCard__asset"
         src="http://placekitten.com/200/300"
+        status="archived"
         testId="cf-ui-asset"
         title="picture of a cat"
         type="image"


### PR DESCRIPTION

<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Check the status as part of rendering an `Asset`.
  * If the status is present and is archived short-circuit to render as an asset
  * Else if the type is an image attempt to render a preview using an `img` tag

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
