### PR TITLE
fix(EntityListItem): Do not render a thumbnail for archived assets

### DIFF
--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.test.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.test.tsx
@@ -116,6 +116,38 @@ it('renders the component as an asset entityType variant', () => {
   expect(output).toMatchSnapshot();
 });
 
+it('renders the component as an asset thumbnail preview', () => {
+  const output = shallow(
+    <EntityListItem
+      title="Title"
+      description="Description"
+      contentType="Content type"
+      status="published"
+      thumbnailUrl="https://path/to/thumbnail.jpg"
+      thumbnailAltText="Something clever"
+      entityType="asset"
+    />,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
+it('renders the component as an asset entityType icon with an archived status', () => {
+  const output = shallow(
+    <EntityListItem
+      title="Title"
+      description="Description"
+      contentType="Content type"
+      status="archived"
+      thumbnailUrl="https://path/to/thumbnail.jpg"
+      thumbnailAltText="Something clever"
+      entityType="asset"
+    />,
+  );
+
+  expect(output).toMatchSnapshot();
+});
+
 it('renders the component as isLoading', () => {
   const output = shallow(
     <EntityListItem title="Title" description="Description" isLoading />,

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
@@ -212,6 +212,10 @@ export class EntityListItem extends Component<EntityListItemProps> {
 
     const Element = onClick ? 'a' : 'article';
 
+    // archived assets will not be available on the CDN, resulting in a broken image src
+    const isArchived = status === 'archived';
+    const asIcon = isArchived || !thumbnailUrl;
+
     return (
       <li {...otherProps} className={classNames} data-test-id={testId}>
         {this.renderCardDragHandle()}
@@ -227,7 +231,7 @@ export class EntityListItem extends Component<EntityListItemProps> {
           >
             <TabFocusTrap className={styles['EntityListItem__focus-trap']}>
               <figure className={styles['EntityListItem__media']}>
-                {thumbnailUrl ? this.renderThumbnail() : this.renderIcon()}
+                {asIcon ? this.renderIcon() : this.renderThumbnail()}
               </figure>
 
               <div className={styles['EntityListItem__content']}>

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
@@ -158,6 +158,71 @@ exports[`renders the component as an \`a\` element if passed a href prop 1`] = `
 </li>
 `;
 
+exports[`renders the component as an asset entityType icon with an archived status 1`] = `
+<li
+  className="EntityListItem"
+  data-test-id="cf-ui-entity-list-item"
+>
+  <article
+    className="EntityListItem__inner"
+  >
+    <TabFocusTrap
+      className="EntityListItem__focus-trap"
+    >
+      <figure
+        className="EntityListItem__media"
+      >
+        <Icon
+          color="muted"
+          icon="Asset"
+          size="small"
+          testId="cf-ui-icon"
+        />
+      </figure>
+      <div
+        className="EntityListItem__content"
+      >
+        <div
+          className="EntityListItem__heading"
+        >
+          <h1
+            className="EntityListItem__title"
+          >
+            Title
+          </h1>
+          <div
+            className="EntityListItem__content-type"
+          >
+            (
+            Content type
+            )
+          </div>
+        </div>
+        <p
+          className="EntityListItem__description"
+        >
+          Description
+        </p>
+      </div>
+      <div
+        className="EntityListItem__meta"
+      >
+        <div
+          className="EntityListItem__status"
+        >
+          <Tag
+            tagType="negative"
+            testId="cf-ui-tag"
+          >
+            archived
+          </Tag>
+        </div>
+      </div>
+    </TabFocusTrap>
+  </article>
+</li>
+`;
+
 exports[`renders the component as an asset entityType variant 1`] = `
 <li
   className="EntityListItem"
@@ -177,6 +242,70 @@ exports[`renders the component as an asset entityType variant 1`] = `
           icon="Asset"
           size="small"
           testId="cf-ui-icon"
+        />
+      </figure>
+      <div
+        className="EntityListItem__content"
+      >
+        <div
+          className="EntityListItem__heading"
+        >
+          <h1
+            className="EntityListItem__title"
+          >
+            Title
+          </h1>
+          <div
+            className="EntityListItem__content-type"
+          >
+            (
+            Content type
+            )
+          </div>
+        </div>
+        <p
+          className="EntityListItem__description"
+        >
+          Description
+        </p>
+      </div>
+      <div
+        className="EntityListItem__meta"
+      >
+        <div
+          className="EntityListItem__status"
+        >
+          <Tag
+            tagType="positive"
+            testId="cf-ui-tag"
+          >
+            published
+          </Tag>
+        </div>
+      </div>
+    </TabFocusTrap>
+  </article>
+</li>
+`;
+
+exports[`renders the component as an asset thumbnail preview 1`] = `
+<li
+  className="EntityListItem"
+  data-test-id="cf-ui-entity-list-item"
+>
+  <article
+    className="EntityListItem__inner"
+  >
+    <TabFocusTrap
+      className="EntityListItem__focus-trap"
+    >
+      <figure
+        className="EntityListItem__media"
+      >
+        <img
+          alt="Something clever"
+          className="EntityListItem__thumbnail"
+          src="https://path/to/thumbnail.jpg"
         />
       </figure>
       <div


### PR DESCRIPTION
# Purpose of PR

Archived assets will not have a preview image available due to the asset being removed from the CDN. This PR short-circuits the logic in EntityListItem to revert to rendering the icon instead of the thumbnail.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information

## Preview

![image](https://user-images.githubusercontent.com/552364/73073801-6eada600-3eb8-11ea-8f4b-746e8ff0e407.png)
