### PR TITLE
fix(DropdownContainer): Pass dropdown test id down to dropdownContainer

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.tsx
@@ -172,6 +172,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
 
     const classNames = cn(styles['Dropdown'], className);
     const width = isFullWidth && this.state.anchorDimensionsAndPositon.width;
+    const containerTestId = testId ? `${testId}-container` : testId;
 
     return submenuToggleLabel ? (
       <DropdownListItem
@@ -224,6 +225,7 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
             getRef={getContainerRef}
             submenu={false}
             width={width}
+            testId={containerTestId}
             dropdownAnchor={this.dropdownAnchor}
             isAutoalignmentEnabled={isAutoalignmentEnabled}
             anchorDimensionsAndPositon={this.state.anchorDimensionsAndPositon}

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`renders the component as open 1`] = `
     openSubmenu={[Function]}
     position="bottom-left"
     submenu={false}
-    testId="cf-ui-dropdown-portal"
+    testId="cf-ui-dropdown-container"
   >
     <DropdownList
       testId="cf-ui-dropdown-list"
@@ -111,7 +111,7 @@ exports[`renders the component with a submenu 1`] = `
     openSubmenu={[Function]}
     position="bottom-left"
     submenu={false}
-    testId="cf-ui-dropdown-portal"
+    testId="cf-ui-dropdown-container"
   >
     <DropdownList
       testId="cf-ui-dropdown-list"

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -82,8 +82,8 @@ class DropdownContainer extends Component<
     if (
       this.dropdown &&
       !this.dropdown.contains(e.target as Node) &&
-      (this.props.dropdownAnchor &&
-        !this.props.dropdownAnchor.contains(e.target as Node))
+      this.props.dropdownAnchor &&
+      !this.props.dropdownAnchor.contains(e.target as Node)
     ) {
       if (this.props.onClose) {
         this.props.onClose();
@@ -178,7 +178,7 @@ class DropdownContainer extends Component<
     );
 
   render() {
-    const { submenu, className, width } = this.props;
+    const { submenu, className, width, testId } = this.props;
 
     const classNames = cn(
       className,
@@ -191,6 +191,7 @@ class DropdownContainer extends Component<
         ref={ref => {
           this.dropdown = ref;
         }}
+        data-test-id={testId}
         style={{
           ...(width ? { width: `${width}px` } : {}),
           ...(!submenu && this.calculatePosition()),

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/__snapshots__/DropdownContainer.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/__snapshots__/DropdownContainer.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`has no a11y issues 1`] = `
 >
   <div
     className="DropdownContainer"
+    data-test-id="cf-ui-dropdown-portal"
     onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -36,6 +37,7 @@ exports[`renders the component 1`] = `
 >
   <div
     className="DropdownContainer"
+    data-test-id="cf-ui-dropdown-portal"
     onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -63,6 +65,7 @@ exports[`renders the component 1`] = `
 exports[`renders the component as a submenu 1`] = `
 <div
   className="extraClassName DropdownContainer DropdownContainer__submenu DropdownContainer__container-position--bottom-left"
+  data-test-id="cf-ui-dropdown-portal"
   onFocus={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
@@ -87,6 +90,7 @@ exports[`renders the component with an additional class name 1`] = `
 >
   <div
     className="extraClassName DropdownContainer"
+    data-test-id="cf-ui-dropdown-portal"
     onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}


### PR DESCRIPTION
Pass the test id, given to dropdown, down to dropdownContainer

First of all, dropdownContainer's testId prop was defined, but never used
Secondly, it was unable to identify which dropdownList relates to which dropdown if there were multiple on the page.