### PR TITLE
fix(modal): remove overflow scroll from modal overlay

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/Modal/Modal.css
+++ b/packages/forma-36-react-components/src/components/Modal/Modal/Modal.css
@@ -27,6 +27,7 @@
   /* prettier-ignore */
   background-color: var(--color-contrast-dark)bf;
   text-align: center;
+  overflow: hidden;
 }
 
 .Modal__overlay--after-open {


### PR DESCRIPTION
fix width overflow and automatic scrolling after resizing the viewport

# Purpose of PR

The automatic scrolling was happening because of the appearance of an additional scroll after resize. This is a solution I could think of. I'm not sure if it breaks anything, but all scrolling should be inside the Modal content, if I understand it correctly, so it should be OK.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
