### PR TITLE
fix(ModalConfirm): allow "muted" as a value for the secondaryIntent prop

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.stories.tsx
@@ -26,6 +26,7 @@ function DefaultStory() {
           'negative',
           'positive',
           'primary',
+          'muted',
         ])}
         size={select(
           'size',

--- a/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.tsx
@@ -46,7 +46,7 @@ export type ModalConfirmProps = {
   /**
    * The intent of the ModalConfirm. Used for the secondary Button.
    */
-  secondaryIntent?: 'primary' | 'positive' | 'negative';
+  secondaryIntent?: 'primary' | 'positive' | 'negative' | 'muted';
   /**
       Size of the modal window
     */


### PR DESCRIPTION
# Purpose of PR

Make it possible for a secondary button to have "muted" color schema w/out any prop-types warnings 