### PR TITLE
fix(modal component): fix Modal window centering

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/Modal/Modal.css
+++ b/packages/forma-36-react-components/src/components/Modal/Modal/Modal.css
@@ -14,6 +14,8 @@
 */
 
 .Modal__overlay {
+  display: flex;
+  flex-wrap: wrap;
   top: 0;
   right: 0;
   bottom: 0;
@@ -41,8 +43,9 @@
   Overlay if modal is centered
 */
 
-.Modal__overlay--centered .Modal__wrap {
-  vertical-align: middle;
+.Modal__overlay--centered {
+  align-items: center;
+  justify-content: center;
 }
 
 /*


### PR DESCRIPTION
# Purpose of PR

Use 'display: flex' for centering Modal window position

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
