### PR TITLE
fix(DropdownContainer): Recalculate dropdown position

### DIFF
--- a/packages/forma-36-react-components/.size-limit
+++ b/packages/forma-36-react-components/.size-limit
@@ -3,7 +3,7 @@
       "path": "dist/index.js",
       "name": "gzipped js",
       "gzip": false,
-      "limit": "289 KB",
+      "limit": "290 KB",
       "ignore": [
         "react",
         "react-dom"

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown/Dropdown.stories.tsx
@@ -117,6 +117,58 @@ function ScrollableStory() {
   );
 }
 
+function DynamicContentStory() {
+  const messages = ['Loading...', 'This is my other piece of text'];
+  const [isOpen, setOpen] = useState(false);
+  const [text, setText] = useState(messages[0]);
+
+  const onClose = () => {
+    setOpen(false);
+    setText(messages[0]);
+  };
+
+  const onClick = () => {
+    if (isOpen) {
+      return onClose();
+    }
+
+    setTimeout(() => setText(messages[1]), 500);
+    setOpen(true);
+  };
+
+  return (
+    <Dropdown
+      isOpen={isOpen}
+      onClose={onClose}
+      isAutoalignmentEnabled={boolean('isAutoalignmentEnabled', true)}
+      position={select(
+        'position',
+        {
+          'bottom-left': 'bottom-left',
+          'bottom-right': 'bottom-right',
+          'top-left': 'top-left',
+          'top-right': 'top-right',
+        },
+        'bottom-right',
+      )}
+      toggleElement={
+        <Button
+          size="small"
+          buttonType="muted"
+          onClick={onClick}
+          indicateDropdown
+        >
+          Choose more options and settings
+        </Button>
+      }
+    >
+      <DropdownList>
+        <DropdownListItem>{text}</DropdownListItem>
+      </DropdownList>
+    </Dropdown>
+  );
+}
+
 storiesOf('Components|Dropdown', module)
   .addParameters({
     propTypes: [
@@ -126,4 +178,5 @@ storiesOf('Components|Dropdown', module)
     ],
   })
   .add('default', () => <DefaultStory />)
-  .add('scrollable', () => <ScrollableStory />);
+  .add('scrollable', () => <ScrollableStory />)
+  .add('dynamic', () => <DynamicContentStory />);

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -73,6 +73,29 @@ class DropdownContainer extends Component<
     this.props.getRef(this.dropdown);
   }
 
+  componentDidUpdate(
+    prevProps: DropdownContainerProps,
+    prevState: DropdownState,
+  ) {
+    if (!this.dropdown) {
+      return;
+    }
+
+    const dropdownRect = this.dropdown.getBoundingClientRect();
+
+    if (
+      dropdownRect.width !== prevState.dropdownDimensions.width ||
+      dropdownRect.height !== prevState.dropdownDimensions.height
+    ) {
+      this.setState({
+        dropdownDimensions: {
+          width: dropdownRect.width,
+          height: dropdownRect.height,
+        },
+      });
+    }
+  }
+
   componentWillUnmount() {
     document.body.removeChild(this.portalTarget);
     document.removeEventListener('mousedown', this.trackOutsideClick, true);


### PR DESCRIPTION
# Purpose of PR

Check if the size of the dropdown list dimensions have changed and, if so, re-calculate the offset

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
