### PR TITLE
fix(SkeletonText): Allow string as proptype for percentage values

### DIFF
--- a/packages/forma-36-react-components/src/components/Skeleton/SkeletonImage/SkeletonImage.tsx
+++ b/packages/forma-36-react-components/src/components/Skeleton/SkeletonImage/SkeletonImage.tsx
@@ -1,12 +1,14 @@
 import React, { Component } from 'react';
 
+type stringOrNumber = string | number;
+
 export type SkeletonImageProps = {
-  width: number;
-  height: number;
-  radiusX: number;
-  radiusY: number;
-  offsetLeft?: number;
-  offsetTop?: number;
+  width: stringOrNumber;
+  height: stringOrNumber;
+  radiusX: stringOrNumber;
+  radiusY: stringOrNumber;
+  offsetLeft?: stringOrNumber;
+  offsetTop?: stringOrNumber;
   testId?: string;
 } & typeof defaultProps;
 

--- a/packages/forma-36-react-components/src/components/Skeleton/SkeletonText/SkeletonText.tsx
+++ b/packages/forma-36-react-components/src/components/Skeleton/SkeletonText/SkeletonText.tsx
@@ -1,12 +1,14 @@
 import React, { Component } from 'react';
 
+type stringOrNumber = string | number;
+
 export type SkeletonTextProps = {
   numberOfLines: number;
-  offsetTop: number;
-  offsetLeft: number;
-  lineHeight: number;
-  marginBottom: number;
-  width?: number;
+  offsetTop: stringOrNumber;
+  offsetLeft: stringOrNumber;
+  lineHeight: stringOrNumber;
+  marginBottom: stringOrNumber;
+  width?: stringOrNumber;
 } & typeof defaultProps;
 
 const defaultProps = {


### PR DESCRIPTION
This PR will add string as proptype of widths and other spacing props so we don't get warnings for percentage values.