### PR TITLE
fix(ModalWindow): Remove unsetting of max width when allowHeightOverflow is set

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/Modal/Modal.css
+++ b/packages/forma-36-react-components/src/components/Modal/Modal/Modal.css
@@ -101,7 +101,6 @@
 .Modal.Modal--overflow {
   overflow: auto;
   max-height: none;
-  max-width: none;
 }
 
 .Modal.Modal--zen {


### PR DESCRIPTION
# Purpose of PR

Fixes a bug with the `allowHeightOverflow` prop. 

By default, the modal window set a max-width prop which allows the user to set any arbitrary width but the modal will then nicely resize horizontally as the user resizes their browser window.

The `allowHeightOverflow` removes this max-width setting (alongside the max-height), which essentially allows the modal window to overflow both in width and height. 

This would have made sense, if the prop was `allowOverflow` as opposed to `allowHeightOverflow` where the expected behavior should be that the window will overflow only vertically.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
