### PR TITLE
fix(cards): fix missing href ts definition

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
@@ -66,6 +66,8 @@ export type AssetCardProps = {
    * Renders a small variant of the card which accommodates a 150x150px image
    */
   size?: 'small' | 'default';
+
+  href?: string;
 } & typeof defaultProps;
 
 const defaultProps = {
@@ -143,6 +145,7 @@ export class AssetCard extends Component<AssetCardProps> {
       cardDragHandleProps,
       cardDragHandleComponent,
       withDragHandle,
+      href,
       ...otherProps
     } = this.props;
 
@@ -161,6 +164,7 @@ export class AssetCard extends Component<AssetCardProps> {
         padding="none"
         title={title}
         testId={testId}
+        href={href}
         {...otherProps}
       >
         {isLoading ? (

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
@@ -79,6 +79,8 @@ export type EntryCardPropTypes = {
    * Changes the height of the component. When small will also ensure thumbnail and description aren't rendered
    */
   size: 'default' | 'small';
+
+  href?: string;
 } & typeof defaultProps;
 
 const defaultProps = {
@@ -185,6 +187,7 @@ export class EntryCard extends Component<EntryCardPropTypes> {
       cardDragHandleComponent,
       cardDragHandleProps,
       withDragHandle,
+      href,
       ...otherProps
     } = this.props;
 
@@ -202,6 +205,7 @@ export class EntryCard extends Component<EntryCardPropTypes> {
         className={classNames}
         onClick={!loading ? onClick : undefined}
         testId={testId}
+        href={href}
         padding="none"
         {...otherProps}
       >

--- a/packages/forma-36-react-components/src/components/Card/InlineEntryCard/InlineEntryCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/InlineEntryCard/InlineEntryCard.tsx
@@ -32,6 +32,7 @@ export type InlineEntryCardPropTypes = {
    * An ID used for testing purposes applied as a data attribute (data-test-id)
    */
   testId?: string;
+  href?: string;
   /**
    * Child nodes to be rendered in the component
    */
@@ -54,6 +55,7 @@ export class InlineEntryCard extends Component<InlineEntryCardPropTypes> {
       testId,
       isLoading,
       status,
+      href,
       ...otherProps
     } = this.props;
 
@@ -71,6 +73,7 @@ export class InlineEntryCard extends Component<InlineEntryCardPropTypes> {
       <Card
         selected={isSelected}
         className={classNames}
+        href={href}
         {...otherProps}
         data-test-id={testId}
       >


### PR DESCRIPTION
# Purpose of PR

Fix TS definitions and make it clear that href can be passed.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
