### PR TITLE
Allow notifications to accept a title, body, and CTA

### DIFF
--- a/packages/forma-36-react-components/.size-limit
+++ b/packages/forma-36-react-components/.size-limit
@@ -3,7 +3,7 @@
       "path": "dist/index.js",
       "name": "gzipped js",
       "gzip": false,
-      "limit": "302 KB",
+      "limit": "310 KB",
       "ignore": [
         "react",
         "react-dom"

--- a/packages/forma-36-react-components/src/components/Notification/Notification.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Notification/Notification.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 import { button, text, number, boolean, select } from '@storybook/addon-knobs';
 
 import Button from '../Button';
@@ -86,6 +87,25 @@ storiesOf('Components|Notification', module)
           >
             show notification with the same id
           </Button>
+          <Button
+            style={{ marginLeft: 20 }}
+            buttonType="positive"
+            onClick={() =>
+              Notification.success(
+                `${text('text', 'Hello world')} ${getUniqueNumber()}`,
+                {
+                  duration: number('duration', 6000),
+                  title: text('title', 'Example title'),
+                  cta: {
+                    label: text('cta.label', 'Example label'),
+                    textLinkProps: { onClick: action('onClick') },
+                  },
+                },
+              )
+            }
+          >
+            show notification with title and CTA
+          </Button>
         </div>
       );
     },
@@ -97,9 +117,11 @@ storiesOf('Components|Notification', module)
       <div>
         <NotificationItem
           hasCloseButton={boolean('hasCloseButton', true)}
+          title={text('title', 'Notification title')}
           intent={select('intent', ['success', 'error', 'warning'], 'success')}
+          cta={{ label: text('cta.label', 'Notification CTA') }}
         >
-          {text('text', 'Text for the notification')}
+          {text('body', 'Body for the notification')}
         </NotificationItem>
       </div>
     ),

--- a/packages/forma-36-react-components/src/components/Notification/NotificationItem.css
+++ b/packages/forma-36-react-components/src/components/Notification/NotificationItem.css
@@ -15,7 +15,6 @@
   cursor: default;
   font-family: var(--font-stack-primary);
   font-size: var(--font-size-m);
-  font-weight: var(--font-weight-medium);
   line-height: var(--line-height-default);
 }
 
@@ -46,10 +45,15 @@
   margin-right: var(--spacing-s);
 }
 
+.NotificationItem__title {
+  font-weight: var(--font-weight-medium);
+}
+
 .NotificationItem__dismiss {
   background: transparent;
   border: none;
   cursor: pointer;
   outline: none;
   pointer-events: all;
+  align-self: flex-start;
 }

--- a/packages/forma-36-react-components/src/components/Notification/NotificationItem.test.tsx
+++ b/packages/forma-36-react-components/src/components/Notification/NotificationItem.test.tsx
@@ -13,6 +13,27 @@ it('renders the component', () => {
   expect(output).toMatchSnapshot();
 });
 
+it('renders the component with a title and a body', () => {
+  const output = shallow(
+    <NotificationItem title="Notification title" intent="success">
+      This is the body text.
+    </NotificationItem>,
+  );
+  expect(output).toMatchSnapshot();
+});
+
+it('renders the component with a cta', () => {
+  const output = shallow(
+    <NotificationItem
+      cta={{ label: 'This is some label text' }}
+      intent="warning"
+    >
+      This is the body text.
+    </NotificationItem>,
+  );
+  expect(output).toMatchSnapshot();
+});
+
 it('renders the component with "error" intent', () => {
   const output = shallow(
     <NotificationItem onClose={() => {}} intent="error">
@@ -21,7 +42,7 @@ it('renders the component with "error" intent', () => {
   );
 
   expect(output).toMatchSnapshot();
-})
+});
 
 it('renders the component with "warning" intent', () => {
   const output = shallow(
@@ -31,8 +52,7 @@ it('renders the component with "warning" intent', () => {
   );
 
   expect(output).toMatchSnapshot();
-})
-
+});
 
 it(`has no a11y issues`, async () => {
   const output = mount(

--- a/packages/forma-36-react-components/src/components/Notification/NotificationItem.tsx
+++ b/packages/forma-36-react-components/src/components/Notification/NotificationItem.tsx
@@ -2,10 +2,16 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import IconButton from '../IconButton';
 import Icon from '../Icon';
+import TextLink, { TextLinkProps } from '../TextLink';
 
 import styles from './NotificationItem.css';
 
 export type NotificationIntent = 'success' | 'error' | 'warning';
+
+export interface NotificationCtaProps {
+  label: string;
+  textLinkProps: Partial<TextLinkProps>;
+}
 
 export interface NotificationItemProps {
   intent: NotificationIntent;
@@ -13,6 +19,8 @@ export interface NotificationItemProps {
   onClose?: Function;
   testId?: string;
   children: React.ReactNode;
+  title?: string;
+  cta?: Partial<NotificationCtaProps>;
 }
 
 const defaultProps = {
@@ -26,8 +34,37 @@ export class NotificationItem extends Component<
 > {
   static defaultProps = defaultProps;
 
+  renderTitle() {
+    const { title, children } = this.props;
+
+    return (
+      <div className={styles.NotificationItem__title}>
+        {title ? title : children}
+      </div>
+    );
+  }
+
+  renderBody() {
+    const { title, children } = this.props;
+
+    return <div>{title && children}</div>;
+  }
+
+  renderCta() {
+    const { cta } = this.props;
+
+    if (cta && cta.label)
+      return (
+        <div>
+          <TextLink {...cta.textLinkProps} linkType="white">
+            {cta.label}
+          </TextLink>
+        </div>
+      );
+  }
+
   render() {
-    const { children, testId, intent, onClose, hasCloseButton } = this.props;
+    const { testId, intent, onClose, hasCloseButton } = this.props;
 
     const classes = classNames(styles.NotificationItem, {
       [styles[`NotificationItem--${intent}`]]: true,
@@ -47,7 +84,11 @@ export class NotificationItem extends Component<
             color="white"
           />
         </div>
-        <div className={styles.NotificationItem__text}>{children}</div>
+        <div className={styles.NotificationItem__text}>
+          {this.renderTitle()}
+          {this.renderBody()}
+          {this.renderCta()}
+        </div>
         {hasCloseButton && (
           <IconButton
             buttonType="white"

--- a/packages/forma-36-react-components/src/components/Notification/NotificationsManager.tsx
+++ b/packages/forma-36-react-components/src/components/Notification/NotificationsManager.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
-import { NotificationIntent } from './NotificationItem';
+import { NotificationIntent, NotificationCtaProps } from './NotificationItem';
 import NotificationItemContainer from './NotificationItemContainer';
 
 import styles from './NotificationsManager.css';
@@ -22,6 +22,8 @@ export interface Notification {
   canClose: boolean;
   isShown: boolean;
   intent: NotificationIntent;
+  title?: string;
+  cta?: Partial<NotificationCtaProps>;
 }
 
 export type ShowAction<T> = (
@@ -31,6 +33,8 @@ export type ShowAction<T> = (
     id?: string;
     duration?: number;
     canClose?: boolean;
+    title?: string;
+    cta?: Partial<NotificationCtaProps>;
   },
 ) => T;
 
@@ -141,6 +145,8 @@ export class NotificationsManager extends PureComponent<
       canClose,
       isShown: true,
       intent,
+      title: settings && settings.title,
+      cta: settings && settings.cta,
     };
 
     const alreadyThere = this.state.items.find(
@@ -185,6 +191,8 @@ export class NotificationsManager extends PureComponent<
               hasCloseButton={item.canClose}
               onClose={item.close}
               isShown={item.isShown}
+              title={item.title}
+              cta={item.cta}
             >
               {item.text}
             </NotificationItemContainer>

--- a/packages/forma-36-react-components/src/components/Notification/__snapshots__/NotificationItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Notification/__snapshots__/NotificationItem.test.tsx.snap
@@ -27,7 +27,12 @@ exports[`renders the component 1`] = `
   <div
     className="NotificationItem__text"
   >
-    Notification text
+    <div
+      className="NotificationItem__title"
+    >
+      Notification text
+    </div>
+    <div />
   </div>
   <IconButton
     buttonType="white"
@@ -73,7 +78,12 @@ exports[`renders the component with "error" intent 1`] = `
   <div
     className="NotificationItem__text"
   >
-    Notification text
+    <div
+      className="NotificationItem__title"
+    >
+      Notification text
+    </div>
+    <div />
   </div>
   <IconButton
     buttonType="white"
@@ -119,7 +129,126 @@ exports[`renders the component with "warning" intent 1`] = `
   <div
     className="NotificationItem__text"
   >
-    Notification text
+    <div
+      className="NotificationItem__title"
+    >
+      Notification text
+    </div>
+    <div />
+  </div>
+  <IconButton
+    buttonType="white"
+    className="NotificationItem__dismiss"
+    disabled={false}
+    iconProps={
+      Object {
+        "icon": "Close",
+      }
+    }
+    label="Dismiss"
+    onClick={[Function]}
+    testId="cf-ui-notification-close"
+    withDropdown={false}
+  />
+</div>
+`;
+
+exports[`renders the component with a cta 1`] = `
+<div
+  aria-live="assertive"
+  className="NotificationItem NotificationItem--warning"
+  data-intent="warning"
+  data-test-id="cf-ui-notification"
+  role="alert"
+>
+  <div
+    className="NotificationItem__intent"
+  >
+    warning
+  </div>
+  <div
+    aria-hidden="true"
+    className="NotificationItem__icon"
+  >
+    <Icon
+      color="white"
+      icon="Warning"
+      size="small"
+      testId="cf-ui-icon"
+    />
+  </div>
+  <div
+    className="NotificationItem__text"
+  >
+    <div
+      className="NotificationItem__title"
+    >
+      This is the body text.
+    </div>
+    <div />
+    <div>
+      <TextLink
+        disabled={false}
+        iconPosition="left"
+        linkType="white"
+        testId="cf-ui-text-link"
+      >
+        This is some label text
+      </TextLink>
+    </div>
+  </div>
+  <IconButton
+    buttonType="white"
+    className="NotificationItem__dismiss"
+    disabled={false}
+    iconProps={
+      Object {
+        "icon": "Close",
+      }
+    }
+    label="Dismiss"
+    onClick={[Function]}
+    testId="cf-ui-notification-close"
+    withDropdown={false}
+  />
+</div>
+`;
+
+exports[`renders the component with a title and a body 1`] = `
+<div
+  aria-live="polite"
+  className="NotificationItem NotificationItem--success"
+  data-intent="success"
+  data-test-id="cf-ui-notification"
+  role="alert"
+>
+  <div
+    className="NotificationItem__intent"
+  >
+    success
+  </div>
+  <div
+    aria-hidden="true"
+    className="NotificationItem__icon"
+  >
+    <Icon
+      color="white"
+      icon="CheckCircle"
+      size="small"
+      testId="cf-ui-icon"
+    />
+  </div>
+  <div
+    className="NotificationItem__text"
+  >
+    <div
+      className="NotificationItem__title"
+    >
+      Notification title
+    </div>
+    <div>
+      This is the body text.
+    </div>
   </div>
   <IconButton
     buttonType="white"

--- a/packages/forma-36-react-components/src/components/Notification/index.tsx
+++ b/packages/forma-36-react-components/src/components/Notification/index.tsx
@@ -11,7 +11,7 @@ import NotificationManager, {
   Notification as NotificationType,
   Position,
 } from './NotificationsManager';
-import { NotificationIntent } from './NotificationItem';
+import { NotificationIntent, NotificationCtaProps } from './NotificationItem';
 
 export interface NotificationsAPI {
   success: ShowAction<Notification>;
@@ -57,6 +57,8 @@ const show = (intent: NotificationIntent) => (
     duration?: number;
     canClose?: boolean;
     id?: string;
+    title?: string;
+    cta?: Partial<NotificationCtaProps>;
   },
 ) => {
   if (internalAPI.show) {
@@ -73,6 +75,8 @@ type ExternalShowAction<T> = (
     duration?: number;
     canClose?: boolean;
     id?: string;
+    title?: string;
+    cta?: Partial<NotificationCtaProps>;
   },
 ) => T;
 

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.css
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.css
@@ -61,6 +61,17 @@
   color: var(--color-text-light);
 }
 
+.TextLink--white,
+.TextLink--white:link {
+  color: var(--color-white);
+
+  &:hover,
+  &:focus {
+    color: var(--color-white);
+    opacity: 0.75;
+  }
+}
+
 .TextLink--disabled,
 .TextLink--disabled:link {
   opacity: 0.5;
@@ -107,6 +118,14 @@
     }
 
     color: var(--color-text-light);
+  }
+
+  &.TextLink--white:hover {
+    & .TextLink__icon {
+      fill: var(--color-white);
+    }
+
+    color: var(--color-white);
   }
 }
 

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.md
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.md
@@ -13,6 +13,7 @@ There are a number of variations of TextLink styles, here is a guide for when to
 - **Negative** - Used for destructive actions - when something can't be undone. For example, deleting entities.
 - **Secondary** - For actions that should be emphasized less than the default primary style.
 - **Muted** - For actions that should be emphasized less than the secondary style.
+- **White** - For actions appearing on a dark background.
 
 ## Best practices
 

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.stories.tsx
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.stories.tsx
@@ -25,6 +25,7 @@ storiesOf('Components|TextLink', module)
             Negative: 'negative',
             Secondary: 'secondary',
             Muted: 'muted',
+            White: 'white',
           },
           'primary',
         )}

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.test.tsx
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.test.tsx
@@ -46,6 +46,12 @@ it('renders as a "muted" link type', () => {
   expect(output).toMatchSnapshot();
 });
 
+it('renders as a "white" link type', () => {
+  const output = shallow(<TextLink linkType="white">Text Link</TextLink>);
+
+  expect(output).toMatchSnapshot();
+});
+
 it('calls an onClick function', () => {
   const onClickFunc = jest.fn();
   const output = shallow(<TextLink onClick={onClickFunc}>Text Link</TextLink>);

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.tsx
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.tsx
@@ -10,7 +10,8 @@ export type TextLinkType =
   | 'positive'
   | 'negative'
   | 'secondary'
-  | 'muted';
+  | 'muted'
+  | 'white';
 
 type IconPositionType = 'right' | 'left';
 

--- a/packages/forma-36-react-components/src/components/TextLink/__snapshots__/TextLink.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/TextLink/__snapshots__/TextLink.test.tsx.snap
@@ -144,6 +144,19 @@ exports[`renders as a "secondary" link type 1`] = `
 </button>
 `;
 
+exports[`renders as a "white" link type 1`] = `
+<button
+  className="TextLink TextLink--white"
+  data-test-id="cf-ui-text-link"
+  disabled={false}
+  type="button"
+>
+  <TabFocusTrap>
+    Text Link
+  </TabFocusTrap>
+</button>
+`;
+
 exports[`renders as a button 1`] = `
 <button
   className="TextLink TextLink--primary"


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR
This PR will allow notifications to accept a title, body, and CTA 
<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
