### PR TITLE
Remove warnings in Navigation about GatsbyLink

### DIFF
--- a/packages/forma-36-website/src/components/Navigation.js
+++ b/packages/forma-36-website/src/components/Navigation.js
@@ -58,6 +58,7 @@ const styles = {
     position: relative;
     border-radius: 4px;
     padding: ${tokens.spacingXs};
+    cursor: pointer;
   `,
 
   linkIcon: css`
@@ -112,20 +113,23 @@ class MenuListItem extends React.Component {
 
     return (
       <li css={styles.listItem}>
-        <Link
-          css={[
-            item.menuLinks ? styles.linkParent : styles.link,
-            isOpen && styles.linkActive,
-          ]}
-          to={item.link}
-          href={item.link}
-          onClick={!item.link && (event => this.handleToggle(event))}
-        >
-          <span>{item.name}</span>
-          {item.menuLinks && (
+        {!item.link ? (
+          <div
+            css={[styles.linkParent, isOpen && styles.linkActive]}
+            onClick={event => this.handleToggle(event)}
+          >
+            <span>{item.name}</span>
             <Icon css={styles.linkIcon} color="secondary" icon={iconName} />
-          )}
-        </Link>
+          </div>
+        ) : (
+          <Link
+            css={[styles.link, isOpen && styles.linkActive]}
+            to={item.link}
+            href={item.link}
+          >
+            <span>{item.name}</span>
+          </Link>
+        )}
         {item.menuLinks && (isExpanded || isOpen) && (
           <MenuList menuItems={item.menuLinks} currentPath={currentPath} />
         )}
@@ -137,6 +141,7 @@ class MenuListItem extends React.Component {
 class MenuList extends React.Component {
   render() {
     const { menuItems, currentPath } = this.props;
+
     return (
       <ul css={styles.list}>
         {menuItems &&

--- a/packages/forma-36-website/src/components/Navigation.js
+++ b/packages/forma-36-website/src/components/Navigation.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'gatsby';
-/** @jsx jsx */
-import { css, jsx } from '@emotion/core';
+
+import { css } from '@emotion/core';
 import tokens from '@contentful/forma-36-tokens';
 import { Icon } from '@contentful/forma-36-react-components';
 
@@ -81,82 +81,75 @@ const MenuListProps = {
   currentPath: PropTypes.string.isRequired,
 };
 
-class MenuListItem extends React.Component {
-  state = {
-    isExpanded: false,
-  };
+const MenuListItem = ({ item, currentPath }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
 
-  checkOpen = (item, currentPath) => {
+  const checkOpen = (item, currentPath) => {
     if (item.link === currentPath) {
       return true;
     } else if (item.menuLinks) {
-      return item.menuLinks.some(item => this.checkOpen(item, currentPath));
+      return item.menuLinks.some(item => checkOpen(item, currentPath));
     }
 
     return false;
   };
 
-  handleToggle = event => {
+  const handleToggle = event => {
     event.preventDefault();
-
-    this.setState(prevState => {
-      return { isExpanded: !prevState.isExpanded };
-    });
+    setIsExpanded(!isExpanded);
   };
 
-  render() {
-    const { item, currentPath } = this.props;
-    const { isExpanded } = this.state;
-    const isOpen = this.checkOpen(item, currentPath);
-    const iconName =
-      item.menuLinks && (isExpanded || isOpen) ? 'ChevronDown' : 'ChevronRight';
+  const isOpen = checkOpen(item, currentPath);
+  const iconName =
+    item.menuLinks && (isExpanded || isOpen) ? 'ChevronDown' : 'ChevronRight';
 
-    return (
-      <li css={styles.listItem}>
-        {!item.link ? (
-          <div
-            css={[styles.linkParent, isOpen && styles.linkActive]}
-            onClick={event => this.handleToggle(event)}
-          >
-            <span>{item.name}</span>
-            <Icon css={styles.linkIcon} color="secondary" icon={iconName} />
-          </div>
-        ) : (
-          <Link
-            css={[styles.link, isOpen && styles.linkActive]}
-            to={item.link}
-            href={item.link}
-          >
-            <span>{item.name}</span>
-          </Link>
-        )}
-        {item.menuLinks && (isExpanded || isOpen) && (
-          <MenuList menuItems={item.menuLinks} currentPath={currentPath} />
-        )}
-      </li>
-    );
-  }
-}
+  return (
+    <li css={styles.listItem}>
+      {!item.link ? (
+        <div
+          css={[styles.linkParent, isOpen && styles.linkActive]}
+          onClick={handleToggle}
+        >
+          <span>{item.name}</span>
+          <Icon css={styles.linkIcon} color="secondary" icon={iconName} />
+        </div>
+      ) : (
+        <Link
+          css={[styles.link, isOpen && styles.linkActive]}
+          to={item.link}
+          href={item.link}
+        >
+          <span>{item.name}</span>
+        </Link>
+      )}
+      {item.menuLinks && (isExpanded || isOpen) && (
+        <MenuList menuItems={item.menuLinks} currentPath={currentPath} />
+      )}
+    </li>
+  );
+};
 
-class MenuList extends React.Component {
-  render() {
-    const { menuItems, currentPath } = this.props;
+MenuListItem.propTypes = {
+  item: PropTypes.shape({ link: PropTypes.string, name: PropTypes.string })
+    .isRequired,
+  currentPath: PropTypes.string.isRequired,
+};
 
-    return (
-      <ul css={styles.list}>
-        {menuItems &&
-          menuItems.map((item, index) => (
-            <MenuListItem
-              key={index}
-              item={item}
-              menuItems={menuItems}
-              currentPath={currentPath}
-            />
-          ))}
-      </ul>
-    );
-  }
-}
+const MenuList = ({ menuItems, currentPath }) => {
+  return (
+    <ul css={styles.list}>
+      {menuItems &&
+        menuItems.map((item, index) => (
+          <MenuListItem
+            key={index}
+            item={item}
+            menuItems={menuItems}
+            currentPath={currentPath}
+          />
+        ))}
+    </ul>
+  );
+};
 
 MenuList.propTypes = MenuListProps;
 


### PR DESCRIPTION
<img width="941" alt="Screenshot 2020-04-03 at 14 01 39" src="https://user-images.githubusercontent.com/6597467/78361306-7c6a6080-75b8-11ea-8efa-e0fa25213860.png">

# Purpose of PR

While working on the search input I saw that we were getting the warnings above. In this PR I refactored the code in the Navigation component to remove the warnings and also to convert the class components to function components

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
