### PR TITLE
feat(EntityStatusTag): Added Entity Status Tag component

### DIFF
--- a/packages/forma-36-react-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Tag/Tag.stories.tsx
@@ -22,6 +22,17 @@ storiesOf('Components|Tag', module)
         },
         'primary',
       )}
+      entityStatusType={select(
+        'Entity Status Type',
+        {
+          Published: 'published',
+          Archived: 'archived',
+          draft: 'draft',
+          changed: 'changed',
+          'None (default)': undefined,
+        },
+        undefined,
+      )}
       className={text('className', '')}
     >
       {text('Children', 'Published')}

--- a/packages/forma-36-react-components/src/components/Tag/Tag.test.tsx
+++ b/packages/forma-36-react-components/src/components/Tag/Tag.test.tsx
@@ -51,6 +51,30 @@ it('renders a "muted" Tag', () => {
   expect(output).toMatchSnapshot();
 });
 
+it('renders a "published" Tag', () => {
+  const output = shallow(<Tag entityStatusType="published">Published</Tag>);
+
+  expect(output).toMatchSnapshot();
+});
+
+it('renders a "draft" Tag', () => {
+  const output = shallow(<Tag entityStatusType="draft">Draft</Tag>);
+
+  expect(output).toMatchSnapshot();
+});
+
+it('renders a "archived" Tag', () => {
+  const output = shallow(<Tag entityStatusType="archived">Archived</Tag>);
+
+  expect(output).toMatchSnapshot();
+});
+
+it('renders a "changed" Tag', () => {
+  const output = shallow(<Tag entityStatusType="changed">Changed</Tag>);
+
+  expect(output).toMatchSnapshot();
+});
+
 it('has no a11y issues', async () => {
   const output = mount(<Tag>Tag</Tag>).html();
   const results = await axe(output);

--- a/packages/forma-36-react-components/src/components/Tag/Tag.tsx
+++ b/packages/forma-36-react-components/src/components/Tag/Tag.tsx
@@ -11,12 +11,22 @@ export type TagType =
   | 'secondary'
   | 'muted';
 
+type Status = 'published' | 'draft' | 'archived' | 'changed';
+
+const statusTagTypeMap = {
+  published: 'positive',
+  draft: 'warning',
+  archived: 'negative',
+  changed: 'primary',
+};
+
 export type TagProps = {
   tagType?: TagType;
   style?: React.CSSProperties;
   className?: string;
   testId?: string;
   children: React.ReactNode;
+  entityStatusType?: Status;
 } & typeof defaultProps;
 
 const defaultProps = {
@@ -28,10 +38,25 @@ export class Tag extends Component<TagProps> {
   static defaultProps = defaultProps;
 
   render() {
-    const { className, children, tagType, testId, ...otherProps } = this.props;
+    const {
+      className,
+      children,
+      tagType,
+      entityStatusType,
+      testId,
+      ...otherProps
+    } = this.props;
 
     const classNames = cn(styles.Tag, className, {
-      [styles[`Tag--${tagType}`]]: tagType,
+      [styles[
+        `Tag--${
+          entityStatusType
+            ? statusTagTypeMap[entityStatusType as Status]
+            : tagType
+        }`
+      ]]: entityStatusType
+        ? statusTagTypeMap[entityStatusType as Status]
+        : tagType,
     });
 
     return (

--- a/packages/forma-36-react-components/src/components/Tag/__snapshots__/Tag.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Tag/__snapshots__/Tag.test.tsx.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders a "archived" Tag 1`] = `
+<div
+  className="Tag Tag--negative"
+  data-test-id="cf-ui-tag"
+>
+  Archived
+</div>
+`;
+
+exports[`renders a "changed" Tag 1`] = `
+<div
+  className="Tag Tag--primary"
+  data-test-id="cf-ui-tag"
+>
+  Changed
+</div>
+`;
+
+exports[`renders a "draft" Tag 1`] = `
+<div
+  className="Tag Tag--warning"
+  data-test-id="cf-ui-tag"
+>
+  Draft
+</div>
+`;
+
 exports[`renders a "muted" Tag 1`] = `
 <div
   className="Tag Tag--muted"
@@ -33,6 +60,15 @@ exports[`renders a "primary" Tag 1`] = `
   data-test-id="cf-ui-tag"
 >
   Tag
+</div>
+`;
+
+exports[`renders a "published" Tag 1`] = `
+<div
+  className="Tag Tag--positive"
+  data-test-id="cf-ui-tag"
+>
+  Published
 </div>
 `;
 


### PR DESCRIPTION
This PR will add the EntityStatusTag which simplifies color-coding the entity status.
![image](https://user-images.githubusercontent.com/1766274/79569095-4a2c2900-80b7-11ea-8cec-bd40083d1f07.png)
