### PR TITLE
docs(readme.md): add link to Contentful community Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ contribute to a package, see the README of the corresponding package.
 - [Johannes Bugiel](https://github.com/wichniowski)
 - [Mike Mitchell](https://github.com/m10l)
 
-You can also reach out using the Contentful community Slack. We've setup a channel [#forma36](https://contentful-community.slack.com/messages/CFXGTMB98) in which we announce latest changes and updates.
+You can also reach out using the [Contentful community Slack](https://www.contentful.com/slack/). We've setup a channel [#forma36](https://contentful-community.slack.com/messages/CFXGTMB98) in which we announce latest changes and updates.
 
 ### You found a bug or want to propose a feature?
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ contribute to a package, see the README of the corresponding package.
 
 ## Reach out to us
 
+You can reach out to us using the [Contentful community Slack](https://www.contentful.com/slack/). We've setup a channel [#forma36](https://contentful-community.slack.com/messages/CFXGTMB98) in which we announce latest changes and updates.
+
 ### Maintainers
 
 - [Johannes Bugiel](https://github.com/wichniowski)
 - [Mike Mitchell](https://github.com/m10l)
-
-You can also reach out using the [Contentful community Slack](https://www.contentful.com/slack/). We've setup a channel [#forma36](https://contentful-community.slack.com/messages/CFXGTMB98) in which we announce latest changes and updates.
 
 ### You found a bug or want to propose a feature?
 


### PR DESCRIPTION
# Purpose of PR

I've added a link to the Contentful community Slack where it is referenced in the README to avoid
newcomers having to guess where to find that and save them a google.

View the markdown here: https://github.com/jacquesporveau/forma-36/tree/jacquesporveau/update-readme#reach-out-to-us

## Also

Hey 👋 

I am new here. Trying to get some experience working on UI design libraries. I'll write some real code soon.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
