### PR TITLE
fix(Switch): Replace checked prop with defaultChecked

### DIFF
--- a/packages/forma-36-react-components/src/components/Switch/Switch.tsx
+++ b/packages/forma-36-react-components/src/components/Switch/Switch.tsx
@@ -19,7 +19,7 @@ export const Switch: FunctionComponent<SwitchProps> = (props: SwitchProps) => {
         type="checkbox"
         onClick={onToggle}
         onKeyUp={onKeyUp}
-        checked={props.isChecked}
+        defaultChecked={props.isChecked}
         disabled={props.isDisabled}
         className={classNames(styles['Switch'], {
           [styles['Switch--checked']]: props.isChecked,

--- a/packages/forma-36-react-components/src/components/Switch/__snapshots__/Switch.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Switch/__snapshots__/Switch.test.tsx.snap
@@ -28,8 +28,8 @@ exports[`renders the component as checked 1`] = `
   className="Switch__wrapper"
 >
   <input
-    checked={true}
     className="Switch Switch--checked"
+    defaultChecked={true}
     id="testCheckbox"
     onClick={[Function]}
     onKeyUp={[Function]}
@@ -76,8 +76,8 @@ exports[`renders the component as disabled and checked 1`] = `
   className="Switch__wrapper"
 >
   <input
-    checked={true}
     className="Switch Switch--checked Switch--disabled"
+    defaultChecked={true}
     disabled={true}
     id="testCheckbox"
     onClick={[Function]}


### PR DESCRIPTION
# Purpose of PR

Remove the following React warning:
```
You provided a `checked` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`
```

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
