### PR TITLE
fix: type type maxHeight

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownList/DropdownList.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownList/DropdownList.tsx
@@ -8,7 +8,7 @@ export type DropdownListProps = {
   className?: string;
   testId?: string;
   border?: 'top' | 'bottom';
-  maxHeight?: number;
+  maxHeight?: 'initial' | 'inherit' | string | number;
   styles?: object;
 } & typeof defaultProps;
 

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownList/DropdownList.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownList/DropdownList.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import cn from 'classnames';
 import cssStyles from './DropdownList.css';
+import * as CSS from 'csstype';
 
 export type DropdownListProps = {
   children: React.ReactNode;
@@ -8,7 +9,7 @@ export type DropdownListProps = {
   className?: string;
   testId?: string;
   border?: 'top' | 'bottom';
-  maxHeight?: 'initial' | 'inherit' | string | number;
+  maxHeight?: number | CSS.MaxHeightProperty<string>;
   styles?: object;
 } & typeof defaultProps;
 


### PR DESCRIPTION
# Purpose of PR
Removes this warning:
```
Warning: Failed prop type: Invalid prop `maxHeight` of type `string` supplied to `DropdownList`, expected `number`.
```

Prop `maxHeight` is currently defined as optional `number` but is used as css property.


<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->



<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
