### PR TITLE
Feat/autocomplete receive query and input element

### DIFF
--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useMemo, useRef } from 'react';
+import React, { useReducer, useMemo, useRef, useEffect } from 'react';
 
 import TextInput from '../TextInput';
 import Dropdown, { DropdownProps } from '../Dropdown';
@@ -24,6 +24,8 @@ export interface AutocompleteProps<T extends {}> {
   onQueryChange: (query: string) => void;
   disabled?: boolean;
   placeholder?: string;
+  toggleElement?: HTMLElement;
+  query?: string;
   name?: string;
   width?: 'small' | 'medium' | 'large' | 'full';
   className?: string;
@@ -94,6 +96,8 @@ export const Autocomplete = <T extends {}>({
   onQueryChange,
   placeholder = 'Search',
   name = 'Search',
+  toggleElement,
+  queryInput,
   width,
   className,
   maxHeight,
@@ -112,6 +116,12 @@ export const Autocomplete = <T extends {}>({
     reducer,
     initialState,
   );
+
+  useEffect(() => {
+    if (queryInput !== query) {
+      updateQuery(queryInput);
+    }
+  });
 
   const toggleList = (isOpen?: boolean): void => {
     dispatch({ type: TOGGLED_LIST, payload: isOpen });
@@ -183,30 +193,34 @@ export const Autocomplete = <T extends {}>({
         dispatch({ type: TOGGLED_LIST });
       }}
       toggleElement={
-        <div className={styles.autocompleteInput}>
-          <TextInput
-            value={query}
-            onChange={e => updateQuery(e.target.value)}
-            onFocus={() => toggleList(true)}
-            onKeyDown={handleKeyDown}
-            disabled={disabled}
-            placeholder={placeholder}
-            width={width}
-            inputRef={inputRef as React.RefObject<HTMLInputElement>}
-            testId="autocomplete.input"
-            type="search"
-            autoComplete="off"
-            aria-label={name}
-          />
-          <IconButton
-            className={styles.inputIconButton}
-            tabIndex={-1}
-            buttonType="muted"
-            iconProps={{ icon: query ? 'Close' : 'ChevronDown' }}
-            onClick={handleInputButtonClick}
-            label={query ? 'Clear' : 'Show list'}
-          />
-        </div>
+        <React.Fragment>
+          {toggleElement || (
+            <div className={styles.autocompleteInput}>
+              <TextInput
+                value={query}
+                onChange={e => updateQuery(e.target.value)}
+                onFocus={() => toggleList(true)}
+                onKeyDown={handleKeyDown}
+                disabled={disabled}
+                placeholder={placeholder}
+                width={width}
+                inputRef={inputRef as React.RefObject<HTMLInputElement>}
+                testId="autocomplete.input"
+                type="search"
+                autoComplete="off"
+                aria-label={name}
+              />
+              <IconButton
+                className={styles.inputIconButton}
+                tabIndex={-1}
+                buttonType="muted"
+                iconProps={{ icon: query ? 'Close' : 'ChevronDown' }}
+                onClick={handleInputButtonClick}
+                label={query ? 'Clear' : 'Show list'}
+              />
+            </div>
+          )}
+        </React.Fragment>
       }
       {...dropdownProps}
     >

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -25,7 +25,7 @@ export interface AutocompleteProps<T extends {}> {
   disabled?: boolean;
   placeholder?: string;
   toggleElement?: HTMLElement;
-  query?: string;
+  queryInput?: string;
   name?: string;
   width?: 'small' | 'medium' | 'large' | 'full';
   className?: string;
@@ -118,7 +118,7 @@ export const Autocomplete = <T extends {}>({
   );
 
   useEffect(() => {
-    if (queryInput !== query) {
+    if (queryInput && queryInput !== query) {
       updateQuery(queryInput);
     }
   });


### PR DESCRIPTION
This PR will allow the Autocomplete to accept a custom input element and a query set through props for more flexibility