### PR TITLE
docs: add asset page

### DIFF
--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -116,6 +116,10 @@ module.exports = {
         link: '',
         menuLinks: [
           {
+            name: 'Asset',
+            link: '/components/asset/',
+          },
+          {
             name: 'Button',
             link: '/components/button/',
           },

--- a/packages/forma-36-website/src/pages/components/asset/index.mdx
+++ b/packages/forma-36-website/src/pages/components/asset/index.mdx
@@ -1,0 +1,113 @@
+---
+title: 'Asset'
+type: 'component'
+status: 'stable'
+github: 'https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components/src/components/Asset'
+storybook: 'https://f36-storybook.contentful.com/?path=/story/components-asset--default'
+---
+
+Detailed documentation will be provided soon. For now, please have a look into the storybook for implementation details.
+
+```jsx
+<React.Fragment>
+  <Asset src="https://placekitten.com/200/300" title="Image of a cat" />
+</React.Fragment>
+```
+
+## Variations
+
+### Archive
+
+```jsx
+<React.Fragment>
+  <Asset src="my_archive.zip" title="My Archive" type="archive" />
+</React.Fragment>
+```
+
+### Audio
+
+```jsx
+<React.Fragment>
+  <Asset src="my_audio.mp3" title="My Audio" type="audio" />
+</React.Fragment>
+```
+
+### Code
+
+```jsx
+<React.Fragment>
+  <Asset src="my_code.js" title="My Code" type="code" />
+</React.Fragment>
+```
+
+### Image
+
+```jsx
+<React.Fragment>
+  <Asset
+    src="https://placekitten.com/200/300"
+    title="Image of a cat"
+    type="image"
+  />
+</React.Fragment>
+```
+
+### Markup
+
+```jsx
+<React.Fragment>
+  <Asset src="my_markup.md" title="My Markup" type="markup" />
+</React.Fragment>
+```
+
+### PDF
+
+```jsx
+<React.Fragment>
+  <Asset src="my_pdf.pdf" title="My PDF" type="pdf" />
+</React.Fragment>
+```
+
+### Plaintext
+
+```jsx
+<React.Fragment>
+  <Asset src="my_text.txt" title="My Plaintext" type="plaintext" />
+</React.Fragment>
+```
+
+### Presentation
+
+```jsx
+<React.Fragment>
+  <Asset
+    src="my_presentation.ppt"
+    title="My Presentation"
+    type="presentation"
+  />
+</React.Fragment>
+```
+
+### Richtext
+
+```jsx
+<React.Fragment>
+  <Asset src="my_text.txt" title="My Richtext" type="richtext" />
+</React.Fragment>
+```
+
+### Spreadsheet
+
+```jsx
+<React.Fragment>
+  <Asset src="my_spreadsheet.xlx" title="My Spreadsheet" type="spreadsheet" />
+</React.Fragment>
+```
+
+### Video
+
+```jsx
+<React.Fragment>
+  <Asset src="my_video.mpeg" title="My Video" type="video" />
+</React.Fragment>
+```


### PR DESCRIPTION

![Screenshot 2020-06-02 at 14 13 16](https://user-images.githubusercontent.com/6597467/83892260-aeca4280-a74e-11ea-8447-919761f99927.png)

# Purpose of PR

This PR is adding basic documentation for the Asset component

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information

