### PR TITLE
fix(Tab): expose event in onSelect callback

### DIFF
--- a/packages/forma-36-react-components/src/components/Tabs/Tab.tsx
+++ b/packages/forma-36-react-components/src/components/Tabs/Tab.tsx
@@ -10,7 +10,7 @@ import styles from './Tabs.css';
 
 export type TabProps = {
   id: string;
-  onSelect?: (id: string) => void;
+  onSelect?: (id: string, e: React.SyntheticEvent) => void;
   selected?: boolean;
   href?: string;
   target?: string;
@@ -32,15 +32,15 @@ const defaultProps = {
 export class Tab extends Component<TabProps> {
   static defaultProps = defaultProps;
 
-  onClick: MouseEventHandler = () => {
+  onClick: MouseEventHandler = e => {
     if (this.props.onSelect && !this.props.disabled) {
-      this.props.onSelect(this.props.id);
+      this.props.onSelect(this.props.id, e);
     }
   };
 
   onKeyPress = (e: KeyboardEvent<HTMLElement>) => {
     if (this.props.onSelect && e.key === 'Enter') {
-      this.props.onSelect(this.props.id);
+      this.props.onSelect(this.props.id, e);
       e.preventDefault();
     }
   };


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Exposes event in Tab.onSelect handler that allows us to do `e.preventDefault()` in application code. This is needed for a proper integration of Tab component and a Link component from `react-router`.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
