### PR TITLE
Chore(website): remove eslintrc and  ignore react-components/dist

### DIFF
--- a/packages/forma-36-website/.eslintignore
+++ b/packages/forma-36-website/.eslintignore
@@ -1,1 +1,1 @@
-../forma-36-react-components/dist/esm/index.js
+../forma-36-react-components/dist

--- a/packages/forma-36-website/.eslintrc
+++ b/packages/forma-36-website/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "@typescript-eslint/no-explicit-any": "off"
-  }
-}


### PR DESCRIPTION
# Purpose of PR

Previously we ignored the files in `/dist/esm` but maybe it's not enough and we are still getting the error @burakukula posted in #493 

So this PR ignores all `/dist`

I'm not 100% sure if this is correct tough 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
