### PR TITLE
fix: update semantic color mapping

### DIFF
--- a/packages/forma-36-tokens/src/tokens/colors/colors-semantic.js
+++ b/packages/forma-36-tokens/src/tokens/colors/colors-semantic.js
@@ -1,8 +1,8 @@
 const colorsSemantic = {
-  'color-primary': '#1D61AF',
-  'color-positive': '#1D7D58',
-  'color-negative': '#A03343',
-  'color-warning': '#D28004',
+  'color-primary': '#2E75D4',
+  'color-positive': '#16875D',
+  'color-negative': '#BF3045',
+  'color-warning': '#F79B0C',
 };
 
 module.exports = colorsSemantic;


### PR DESCRIPTION
# Purpose of PR

Update semantic color mapping to use `mid` variants

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
