### PR TITLE
Implement animation in the Accordion component

### DIFF
--- a/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.css
+++ b/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.css
@@ -2,20 +2,16 @@
 @import 'settings/transitions';
 
 .AccordionPanel {
-  display: none;
   box-sizing: border-box;
   overflow: hidden;
   padding: 0 var(--spacing-m);
-  padding-bottom: 0;
   height: 0;
   transition: height var(--transition-duration-default)
       var(--transition-easing-default),
-    padding-bottom var(--transition-duration-default)
-      var(--transition-easing-default);
+    padding var(--transition-duration-default) var(--transition-easing-default);
 }
 
 .AccordionPanel--expanded {
-  display: block;
   padding: var(--spacing-xs) var(--spacing-m) var(--spacing-m);
   height: auto;
 }

--- a/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.css
+++ b/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.css
@@ -1,4 +1,5 @@
 @import 'settings/dimensions';
+@import 'settings/transitions';
 
 .AccordionPanel {
   display: none;
@@ -7,6 +8,10 @@
   padding: 0 var(--spacing-m);
   padding-bottom: 0;
   height: 0;
+  transition: height var(--transition-duration-default)
+      var(--transition-easing-default),
+    padding-bottom var(--transition-duration-default)
+      var(--transition-easing-default);
 }
 
 .AccordionPanel--expanded {

--- a/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.css
+++ b/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.css
@@ -5,6 +5,7 @@
   box-sizing: border-box;
   overflow: hidden;
   padding: 0 var(--spacing-m);
+  padding-bottom: 0;
   height: 0;
 }
 

--- a/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
+++ b/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useLayoutEffect, useRef } from 'react';
 import cn from 'classnames';
 import tokens from '@contentful/forma-36-tokens';
 
@@ -24,45 +24,28 @@ export const AccordionPanel: FC<AccordionPanelProps> = ({
   isExpanded,
   ariaId,
 }: AccordionPanelProps) => {
-  const panelEl = React.useRef<HTMLDivElement>(null);
-  const [animate, setAnimate] = React.useState(false);
+  const panelEl = useRef<HTMLDivElement>(null);
 
-  React.useEffect(() => {
-    setAnimate(true);
-  }, []);
-
-  React.useLayoutEffect(() => {
+  useLayoutEffect(() => {
     const { current } = panelEl;
 
-    if (animate && current) {
+    if (current) {
+      const finalHeight = `calc((${current.scrollHeight / 16} * 1rem) + ${
+        tokens.spacingM
+      })`;
+
       if (isExpanded) {
-        current.animate(
-          [
-            { height: '0px', paddingBottom: '0px' },
-            {
-              height: `${current.scrollHeight}px`,
-              paddingBottom: tokens.spacingM,
-            },
-          ],
-          {
-            duration: 300,
-            easing: tokens.transitionEasingDefault,
-          },
-        );
+        requestAnimationFrame(function() {
+          current.style.height = '0px';
+
+          requestAnimationFrame(function() {
+            current.style.height = finalHeight;
+          });
+        });
       } else {
-        current.animate(
-          [
-            {
-              height: `${current.scrollHeight}px`,
-              paddingBottom: tokens.spacingM,
-            },
-            { height: '0px', paddingBottom: '0px' },
-          ],
-          {
-            duration: 300,
-            easing: tokens.transitionEasingDefault,
-          },
-        );
+        requestAnimationFrame(function() {
+          current.style.height = '0px';
+        });
       }
     }
   }, [isExpanded]);

--- a/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
+++ b/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import cn from 'classnames';
+import tokens from '@contentful/forma-36-tokens';
 
 import styles from './AccordionPanel.css';
 
@@ -23,6 +24,49 @@ export const AccordionPanel: FC<AccordionPanelProps> = ({
   isExpanded,
   ariaId,
 }: AccordionPanelProps) => {
+  const panelEl = React.useRef<HTMLDivElement>(null);
+  const [animate, setAnimate] = React.useState(false);
+
+  React.useEffect(() => {
+    setAnimate(true);
+  }, []);
+
+  React.useLayoutEffect(() => {
+    const { current } = panelEl;
+
+    if (animate && current) {
+      if (isExpanded) {
+        current.animate(
+          [
+            { height: '0px', paddingBottom: '0px' },
+            {
+              height: `${current.scrollHeight}px`,
+              paddingBottom: tokens.spacingM,
+            },
+          ],
+          {
+            duration: 300,
+            easing: tokens.transitionEasingDefault,
+          },
+        );
+      } else {
+        current.animate(
+          [
+            {
+              height: `${current.scrollHeight}px`,
+              paddingBottom: tokens.spacingM,
+            },
+            { height: '0px', paddingBottom: '0px' },
+          ],
+          {
+            duration: 300,
+            easing: tokens.transitionEasingDefault,
+          },
+        );
+      }
+    }
+  }, [isExpanded]);
+
   return (
     <div
       id={`accordion-panel--${ariaId}`}
@@ -31,6 +75,7 @@ export const AccordionPanel: FC<AccordionPanelProps> = ({
       className={cn(styles.AccordionPanel, {
         [styles['AccordionPanel--expanded']]: isExpanded,
       })}
+      ref={panelEl}
     >
       {children}
     </div>

--- a/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
+++ b/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
@@ -30,9 +30,10 @@ export const AccordionPanel: FC<AccordionPanelProps> = ({
     const { current } = panelEl;
 
     if (current) {
-      const finalHeight = `calc((${current.scrollHeight / 16} * 1rem) + ${
-        tokens.spacingM
-      })`;
+      // height + padding-top + padding-bottom of the accordion’s panel final state
+      // we need this math because the height will depend on the accordion’s content
+      const panelHeight = `${current.scrollHeight / 16}rem`; // converting height pixels into rem
+      const finalHeight = `calc(${panelHeight} + ${tokens.spacingXs} + ${tokens.spacingM})`;
 
       if (isExpanded) {
         requestAnimationFrame(function() {
@@ -55,6 +56,7 @@ export const AccordionPanel: FC<AccordionPanelProps> = ({
       id={`accordion-panel--${ariaId}`}
       role="region"
       aria-labelledby={`accordion--${ariaId}`}
+      aria-hidden={!isExpanded}
       className={cn(styles.AccordionPanel, {
         [styles['AccordionPanel--expanded']]: isExpanded,
       })}


### PR DESCRIPTION
# Purpose of PR

This PR adds animation to the Accordion component currently in review at PR #531 

There are actually two implementations hahaha
In the first commit I used WAAPI, but look at the support for it:
![Screenshot 2020-08-03 at 16 18 29](https://user-images.githubusercontent.com/6597467/89192868-722b9380-d5a5-11ea-8b37-d6a0c29ba07e.png)

(Also, I think enzyme or jest do not understand `.animate()`)


So I replaced with requestAnimationFrame magic
![Screenshot 2020-08-03 at 16 18 05](https://user-images.githubusercontent.com/6597467/89192973-97200680-d5a5-11ea-9991-9e08aaa151b8.png)

I followed some ideas from [CSS-Tricks](https://css-tricks.com/using-css-transitions-auto-dimensions/) on how to animate `height: auto`
We need it to be auto because the content of the accordion varies

It would be nice if we can make a component (or a custom Hook) out of the animations to make it modular, but I wanted to check with you first. WDYT?

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
