### PR TITLE
fix: change font-weight to number

### DIFF
--- a/packages/forma-36-tokens/src/tokens/typography/font-weight.js
+++ b/packages/forma-36-tokens/src/tokens/typography/font-weight.js
@@ -1,7 +1,7 @@
 const fontWeight = {
-  'font-weight-normal': '400',
-  'font-weight-medium': '600',
-  'font-weight-demi-bold': '700',
+  'font-weight-normal': 400,
+  'font-weight-medium': 600,
+  'font-weight-demi-bold': 700,
 };
 
 module.exports = fontWeight;


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR
This is to fix type errors when using these tokens with emotion
which expects font-weight to be a number


<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
