### PR TITLE
fix: use FieldGroup classname property

### DIFF
--- a/packages/forma-36-react-components/src/components/Form/FieldGroup/FieldGroup.tsx
+++ b/packages/forma-36-react-components/src/components/Form/FieldGroup/FieldGroup.tsx
@@ -22,7 +22,7 @@ export class FieldGroup extends Component<FieldGroupProps> {
   render() {
     const { className, children, row, testId, ...otherProps } = this.props;
 
-    const classNames = cn(styles.FieldGroup, styles.className, {
+    const classNames = cn(styles.FieldGroup, className, {
       [styles['FieldGroup--row']]: row,
     });
 

--- a/packages/forma-36-react-components/src/components/Form/FieldGroup/__snapshots__/FieldGroup.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Form/FieldGroup/__snapshots__/FieldGroup.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`renders the component 1`] = `
 <div
-  className="FieldGroup className"
+  className="FieldGroup"
   data-test-id="cf-ui-field-group"
 >
   <div
@@ -38,7 +38,7 @@ exports[`renders the component 1`] = `
 
 exports[`renders the component children in a row 1`] = `
 <div
-  className="FieldGroup className FieldGroup--row"
+  className="FieldGroup my-extra-class FieldGroup--row"
   data-test-id="cf-ui-field-group"
 >
   <div
@@ -74,7 +74,7 @@ exports[`renders the component children in a row 1`] = `
 
 exports[`renders the component with an additional class name 1`] = `
 <div
-  className="FieldGroup className"
+  className="FieldGroup my-extra-class"
   data-test-id="cf-ui-field-group"
 >
   <div


### PR DESCRIPTION
# Purpose of PR

Fixes `FieldGroup` which wasn't using a passed `className`.
