### PR TITLE
chore: add .code-workspace to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 .vscode/
 .idea/
 *.log
+*.code-workspace


### PR DESCRIPTION
Hey!

I've been using workspaces in VS Code to have some different configurations to IDE depending on the project I'm working on. I don't know if other people use this as well, so this PR adds the workspace config file to gitignore

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
