### PR TITLE
fix: output the correct type for font weights

### DIFF
--- a/packages/forma-36-tokens/tools/build.js
+++ b/packages/forma-36-tokens/tools/build.js
@@ -55,18 +55,12 @@ const buildIndexJS = (srcPath, tokens) => {
   );
 };
 
-const specificTypes = {
-  fontWeightNormal: 'number',
-  fontWeightMedium: 'number',
-  fontWeightDemiBold: 'number'
-}
-
 function createInterfaceDefinition(tokens) {
   const defs = _.mapValues(tokens, (value, key) => {
 
     return {
       value: value,
-      type: specificTypes[key] || 'string',
+      type: typeof value
     };
   });
 

--- a/packages/forma-36-tokens/tools/build.js
+++ b/packages/forma-36-tokens/tools/build.js
@@ -55,11 +55,18 @@ const buildIndexJS = (srcPath, tokens) => {
   );
 };
 
+const specificTypes = {
+  fontWeightNormal: 'number',
+  fontWeightMedium: 'number',
+  fontWeightDemiBold: 'number'
+}
+
 function createInterfaceDefinition(tokens) {
-  const defs = _.mapValues(tokens, value => {
+  const defs = _.mapValues(tokens, (value, key) => {
+
     return {
       value: value,
-      type: 'string',
+      type: specificTypes[key] || 'string',
     };
   });
 

--- a/packages/forma-36-tokens/tools/build.js
+++ b/packages/forma-36-tokens/tools/build.js
@@ -56,7 +56,7 @@ const buildIndexJS = (srcPath, tokens) => {
 };
 
 function createInterfaceDefinition(tokens) {
-  const defs = _.mapValues(tokens, (value, key) => {
+  const defs = _.mapValues(tokens, value => {
 
     return {
       value: value,


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

In previous PR I changed the value of the font weights to a number, but didn't realise I needed to update the build file that creates the type definition. This PR makes it so the outputted types for fontweights are correct. 

I'd appreciate feedback on this approach, as while it currently outputs the correct result - it feels a little big 'magic' to me..

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
