### PR TITLE
feat(entityList): add forwardRef to component

### DIFF
--- a/packages/forma-36-react-components/src/components/EntityList/EntityList.stories.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityList.stories.tsx
@@ -30,4 +30,18 @@ storiesOf('Components|EntityList/EntityList', module)
         status="published"
       />
     </EntityList>
-  ));
+  ))
+  .add('with Ref', () => {
+    const ref = React.createRef<HTMLUListElement>();
+
+    return (
+      <EntityList className={text('className', '')} ref={ref}>
+        <EntityListItem
+          title="Entry 1"
+          description="Description"
+          contentType="My content type"
+          status="published"
+        />
+      </EntityList>
+    );
+  });

--- a/packages/forma-36-react-components/src/components/EntityList/EntityList.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityList.tsx
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
+import React, { forwardRef } from 'react';
 import cn from 'classnames';
 
 import styles from './EntityList.css';
 
-export type EntityListProps = {
+export interface EntityListProps {
   /**
    * Class names to be appended to the className prop of the component
    */
@@ -16,25 +16,28 @@ export type EntityListProps = {
    * An ID used for testing purposes applied as a data attribute (data-test-id)
    */
   testId?: string;
-} & typeof defaultProps;
+}
 
-const defaultProps = {
-  testId: 'cf-ui-entity-list',
-};
-
-export class EntityList extends Component<EntityListProps> {
-  static defaultProps = defaultProps;
-
-  render() {
-    const { className, children, testId, ...otherProps } = this.props;
+export const EntityList = forwardRef<HTMLUListElement, EntityListProps>(
+  (props: EntityListProps, ref) => {
+    const { className, children, testId, ...otherProps } = props;
     const classNames = cn(styles.EntityList, className);
 
     return (
-      <ul {...otherProps} className={classNames} data-test-id={testId}>
+      <ul
+        ref={ref}
+        className={classNames}
+        data-test-id={testId}
+        {...otherProps}
+      >
         {children}
       </ul>
     );
-  }
-}
+  },
+);
+EntityList.displayName = 'EntityList';
+EntityList.defaultProps = {
+  testId: 'cf-ui-entity-list',
+};
 
 export default EntityList;


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This closes #534 

Following the proposal in #534, this PR implements forwardRef to EntityList. It also refactors the component to a functional component

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
