### PR TITLE
feat(entity-list-item): add withThumbnail prop

### DIFF
--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.stories.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.stories.tsx
@@ -21,6 +21,7 @@ storiesOf('Components|EntityList/EntityListItem', module)
       thumbnailUrl={text('thumbnailUrl', 'https://placekitten.com/400/400')}
       thumbnailAltText={text('thumbnailAltText', 'My thumbnail text')}
       isActionsDisabled={boolean('isActionsDisabled', false)}
+      withThumbnail={boolean('withThumbnail', true)}
       entityType={select(
         'entityType',
         {
@@ -70,6 +71,7 @@ storiesOf('Components|EntityList/EntityListItem', module)
       thumbnailUrl={text('thumbnailUrl', 'https://placekitten.com/400/400')}
       thumbnailAltText={text('thumbnailAltText', 'My thumbnail text')}
       isActionsDisabled={boolean('isActionsDisabled', false)}
+      withThumbnail={boolean('withThumbnail', true)}
       entityType={select(
         'entityType',
         {

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
@@ -38,6 +38,10 @@ export type EntityListItemProps = {
    */
   status?: 'archived' | 'changed' | 'draft' | 'published';
   /**
+   * A boolean used to render the Thumbnail or not
+   */
+  withThumbnail?: boolean;
+  /**
    * The URL of the entity's preview thumbnail. Use 46px x 46px images for best results
    */
   thumbnailUrl?: string;
@@ -100,6 +104,7 @@ export type EntityListItemProps = {
 const defaultProps = {
   testId: 'cf-ui-entity-list-item',
   entityType: 'entry',
+  withThumbnail: true,
   isActionsDisabled: false,
 };
 
@@ -195,6 +200,7 @@ export class EntityListItem extends Component<EntityListItemProps> {
       description,
       contentType,
       entityType,
+      withThumbnail,
       thumbnailUrl,
       thumbnailAltText,
       status,
@@ -235,9 +241,11 @@ export class EntityListItem extends Component<EntityListItemProps> {
             target={onClick && href ? '_blank' : undefined}
           >
             <TabFocusTrap className={styles['EntityListItem__focus-trap']}>
-              <figure className={styles['EntityListItem__media']}>
-                {asIcon ? this.renderIcon() : this.renderThumbnail()}
-              </figure>
+              {withThumbnail && (
+                <figure className={styles['EntityListItem__media']}>
+                  {asIcon ? this.renderIcon() : this.renderThumbnail()}
+                </figure>
+              )}
 
               <div className={styles['EntityListItem__content']}>
                 <div className={styles['EntityListItem__heading']}>

--- a/packages/forma-36-react-components/src/components/EntityList/__snapshots__/EntityList.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EntityList/__snapshots__/EntityList.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`renders the component with EntityListItems as children 1`] = `
     isActionsDisabled={false}
     testId="cf-ui-entity-list-item"
     title="Entry 1"
+    withThumbnail={true}
   />
   <EntityListItem
     contentType="My content type"
@@ -27,6 +28,7 @@ exports[`renders the component with EntityListItems as children 1`] = `
     isActionsDisabled={false}
     testId="cf-ui-entity-list-item"
     title="Entry 2"
+    withThumbnail={true}
   />
   <EntityListItem
     contentType="My content type"
@@ -35,6 +37,7 @@ exports[`renders the component with EntityListItems as children 1`] = `
     isActionsDisabled={false}
     testId="cf-ui-entity-list-item"
     title="Entry 3"
+    withThumbnail={true}
   />
 </ul>
 `;


### PR DESCRIPTION
# Purpose of PR

Closes #535 

Adds `withThumbnail` prop to control whether or not the Thumbnail should render

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information