### PR TITLE
feat: add modal launcher helper as alpha component

### DIFF
--- a/packages/forma-36-react-components/.size-limit
+++ b/packages/forma-36-react-components/.size-limit
@@ -3,7 +3,7 @@
       "path": "dist/index.js",
       "name": "gzipped js",
       "gzip": false,
-      "limit": "350 KB",
+      "limit": "360 KB",
       "ignore": [
         "react",
         "react-dom"

--- a/packages/forma-36-react-components/src/alpha.ts
+++ b/packages/forma-36-react-components/src/alpha.ts
@@ -5,3 +5,4 @@ export { Flex } from './components/Flex';
 export { NavigationIcon } from './components/NavigationIcon/NavigationIcon';
 export { Accordion } from './components/Accordion/Accordion';
 export { AccordionItem } from './components/Accordion/AccordionItem';
+export { ModalLauncher } from './components/Modal/ModalLauncher/ModalLauncher';

--- a/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.stories.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+
+import ModalLauncher from './ModalLauncher';
+import Button from '../../Button';
+import Modal from '../Modal';
+import Paragraph from '../../Typography/Paragraph';
+
+function DefaultStory() {
+  const [hiddenText, setHiddenText] = useState('');
+
+  return (
+    <React.Fragment>
+      <Button
+        onClick={() => {
+          ModalLauncher.open(({ isShown, onClose }) => (
+            <Modal
+              title="Reveal hidden text"
+              isShown={isShown}
+              onClose={() => onClose(hiddenText)}
+            >
+              {() => (
+                <React.Fragment>
+                  <Modal.Header title="Reveal hidden text" />
+                  <Modal.Content>
+                    Are you want to reveal the hidden text?
+                  </Modal.Content>
+                  <Modal.Controls>
+                    <Button
+                      buttonType="positive"
+                      onClick={() => {
+                        onClose('The text is revealed!');
+                      }}
+                    >
+                      Show text
+                    </Button>
+                    <Button buttonType="muted" onClick={() => onClose('')}>
+                      Hide text
+                    </Button>
+                  </Modal.Controls>
+                </React.Fragment>
+              )}
+            </Modal>
+          )).then(text => {
+            setHiddenText(text);
+          });
+        }}
+      >
+        Trigger ModalLauncher
+      </Button>
+      {hiddenText.length > 0 && <Paragraph>{hiddenText}</Paragraph>}
+    </React.Fragment>
+  );
+}
+
+storiesOf('Components|Modal/ModalLauncher', module)
+  .addParameters({
+    propTypes: ModalLauncher['__docgenInfo'],
+  })
+  .add('default', () => <DefaultStory />);

--- a/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.tsx
@@ -1,0 +1,76 @@
+import ReactDOM from 'react-dom';
+
+type ModalLauncherComponentRendererProps<T = any> = {
+  isShown: boolean;
+  onClose: (result: T) => void;
+};
+
+type ModalLauncherOpenOptions = {
+  modalId?: string;
+  // ms before removing the component from the tree, defaults to 25ms.
+  delay?: number;
+};
+
+function open<T = any>(
+  componentRenderer: (
+    props: ModalLauncherComponentRendererProps<T>,
+  ) => JSX.Element,
+  options: ModalLauncherOpenOptions = {},
+): Promise<T> {
+  options = { delay: 300, ...options };
+
+  // Allow components to specify if they wish to reuse the modal container
+  const rootElId = `modals-root${options.modalId || Date.now()}`;
+  let rootDom: HTMLElement | null = null;
+
+  const getRoot = () => {
+    if (rootDom !== null) {
+      return rootDom;
+    }
+
+    // Reuse the container if we find it
+    rootDom = document.getElementById(rootElId);
+    if (rootDom !== null) {
+      return rootDom;
+    }
+
+    // Otherwise create it
+    rootDom = document.createElement('div');
+    rootDom.setAttribute('id', rootElId);
+    document.body.appendChild(rootDom);
+    return rootDom;
+  };
+
+  return new Promise(resolve => {
+    let currentConfig = { onClose, isShown: true };
+
+    function render({
+      onClose,
+      isShown,
+    }: ModalLauncherComponentRendererProps<T>) {
+      ReactDOM.render(componentRenderer({ onClose, isShown }), getRoot());
+    }
+
+    async function onClose(...args: T[]) {
+      currentConfig = {
+        ...currentConfig,
+        isShown: false,
+      };
+      render(currentConfig);
+      await new Promise(resolveDelay =>
+        setTimeout(resolveDelay, options.delay),
+      );
+      ReactDOM.unmountComponentAtNode(getRoot());
+      getRoot().remove();
+      resolve(...args);
+    }
+
+    render(currentConfig);
+  });
+}
+
+export const ModalLauncher = {
+  open,
+};
+
+export default ModalLauncher;

--- a/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.tsx
@@ -1,15 +1,16 @@
+/* global Promise */
 import ReactDOM from 'react-dom';
 
-type ModalLauncherComponentRendererProps<T = any> = {
+interface ModalLauncherComponentRendererProps<T = any> {
   isShown: boolean;
   onClose: (result: T) => void;
-};
+}
 
-type ModalLauncherOpenOptions = {
+interface ModalLauncherOpenOptions {
   modalId?: string;
   // ms before removing the component from the tree, defaults to 25ms.
   delay?: number;
-};
+}
 
 function open<T = any>(
   componentRenderer: (
@@ -51,7 +52,7 @@ function open<T = any>(
       ReactDOM.render(componentRenderer({ onClose, isShown }), getRoot());
     }
 
-    async function onClose(...args: T[]) {
+    async function onClose(arg: T) {
       currentConfig = {
         ...currentConfig,
         isShown: false,
@@ -62,7 +63,7 @@ function open<T = any>(
       );
       ReactDOM.unmountComponentAtNode(getRoot());
       getRoot().remove();
-      resolve(...args);
+      resolve(arg);
     }
 
     render(currentConfig);

--- a/packages/forma-36-react-components/src/components/Modal/ModalLauncher/index.ts
+++ b/packages/forma-36-react-components/src/components/Modal/ModalLauncher/index.ts
@@ -1,0 +1,2 @@
+export * from './ModalLauncher';
+export { default } from './ModalLauncher';

--- a/packages/forma-36-react-components/src/index.ts
+++ b/packages/forma-36-react-components/src/index.ts
@@ -43,6 +43,7 @@ export { Heading } from './components/Typography/Heading/Heading';
 export { InViewport } from './components/InViewport/InViewport';
 export { Modal } from './components/Modal/Modal';
 export { ModalConfirm } from './components/Modal/ModalConfirm/ModalConfirm';
+export { ModalLauncher } from './components/Modal/ModalLauncher/ModalLauncher';
 export { FieldGroup } from './components/Form/FieldGroup/FieldGroup';
 export { Form } from './components/Form/Form';
 export { Note } from './components/Note/Note';

--- a/packages/forma-36-react-components/src/index.ts
+++ b/packages/forma-36-react-components/src/index.ts
@@ -43,7 +43,6 @@ export { Heading } from './components/Typography/Heading/Heading';
 export { InViewport } from './components/InViewport/InViewport';
 export { Modal } from './components/Modal/Modal';
 export { ModalConfirm } from './components/Modal/ModalConfirm/ModalConfirm';
-export { ModalLauncher } from './components/Modal/ModalLauncher/ModalLauncher';
 export { FieldGroup } from './components/Form/FieldGroup/FieldGroup';
 export { Form } from './components/Form/Form';
 export { Note } from './components/Note/Note';

--- a/packages/forma-36-website/src/pages/components/modal/index.mdx
+++ b/packages/forma-36-website/src/pages/components/modal/index.mdx
@@ -42,6 +42,7 @@ function ModalExample() {
    1. [Modal position](#modal-position)
    2. [Modal sizes](#modal-sizes)
 3. [Writing guidelines](#writing-guidelines)
+4. [Using the modal launcher](#using-the-modal-launcher)
 
 ## Best practices <a name="best-practices" />
 
@@ -165,3 +166,50 @@ function ModalExample() {
 - Avoid “never,” “always” and other absolutes
 - Use contractions when possible
 - Avoid exclamation marks
+
+## Using the modal launcher <a name="using-the-modal-launcher" />
+
+The `ModalLauncher.open` utility can be used to wrap any custom result, based on a user's interaction with a Modal component, in a promise and await it.
+
+```jsx
+function() {
+  const [hiddenText, setHiddenText] = React.useState('');
+
+  return (
+    <React.Fragment>
+      <Button onClick={() => {
+        ModalLauncher.open(({ isShown, onClose }) => (
+          <Modal
+            title="Reveal hidden text"
+            isShown={isShown}
+            onClose={() => onClose(hiddenText)}>
+            {() => (
+              <React.Fragment>
+                <Modal.Header title="Reveal hidden text" />
+                <Modal.Content>
+                  Are you want to reveal the hidden text?
+                </Modal.Content>
+                <Modal.Controls>
+                  <Button buttonType="positive" onClick={() => {
+                    onClose('The text is revealed!');
+                  }}>
+                    Show text
+                  </Button>
+                  <Button buttonType="muted" onClick={() => onClose('')}>
+                    Hide text
+                  </Button>
+                </Modal.Controls>
+              </React.Fragment>
+            )}
+          </Modal>
+        )).then((text) => {
+          setHiddenText(text);
+        })
+      }}>
+        Show Modal with ModalLauncher
+      </Button>
+      {hiddenText.length > 0 && (<Paragraph>{hiddenText}</Paragraph>)}
+    </React.Fragment>
+  )
+}
+```

--- a/packages/forma-36-website/src/pages/components/modal/index.mdx
+++ b/packages/forma-36-website/src/pages/components/modal/index.mdx
@@ -42,7 +42,6 @@ function ModalExample() {
    1. [Modal position](#modal-position)
    2. [Modal sizes](#modal-sizes)
 3. [Writing guidelines](#writing-guidelines)
-4. [Using the modal launcher](#using-the-modal-launcher)
 
 ## Best practices <a name="best-practices" />
 
@@ -166,50 +165,3 @@ function ModalExample() {
 - Avoid “never,” “always” and other absolutes
 - Use contractions when possible
 - Avoid exclamation marks
-
-## Using the modal launcher <a name="using-the-modal-launcher" />
-
-The `ModalLauncher.open` utility can be used to wrap any custom result, based on a user's interaction with a Modal component, in a promise and await it.
-
-```jsx
-function() {
-  const [hiddenText, setHiddenText] = React.useState('');
-
-  return (
-    <React.Fragment>
-      <Button onClick={() => {
-        ModalLauncher.open(({ isShown, onClose }) => (
-          <Modal
-            title="Reveal hidden text"
-            isShown={isShown}
-            onClose={() => onClose(hiddenText)}>
-            {() => (
-              <React.Fragment>
-                <Modal.Header title="Reveal hidden text" />
-                <Modal.Content>
-                  Are you want to reveal the hidden text?
-                </Modal.Content>
-                <Modal.Controls>
-                  <Button buttonType="positive" onClick={() => {
-                    onClose('The text is revealed!');
-                  }}>
-                    Show text
-                  </Button>
-                  <Button buttonType="muted" onClick={() => onClose('')}>
-                    Hide text
-                  </Button>
-                </Modal.Controls>
-              </React.Fragment>
-            )}
-          </Modal>
-        )).then((text) => {
-          setHiddenText(text);
-        })
-      }}>
-        Show Modal with ModalLauncher
-      </Button>
-      {hiddenText.length > 0 && (<Paragraph>{hiddenText}</Paragraph>)}
-    </React.Fragment>
-  )
-}
-```


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

Adds a modal launcher helper with an open method that allows the user to wrap a value that results from a user interaction with a modal window in a promise and await it.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
