### PR TITLE
fix(ModalLauncher): make argument of on close optional

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 
 interface ModalLauncherComponentRendererProps<T = any> {
   isShown: boolean;
-  onClose: (result: T) => void;
+  onClose: (result?: T) => void;
 }
 
 interface ModalLauncherOpenOptions {
@@ -52,7 +52,7 @@ function open<T = any>(
       ReactDOM.render(componentRenderer({ onClose, isShown }), getRoot());
     }
 
-    async function onClose(arg: T) {
+    async function onClose(arg?: T) {
       currentConfig = {
         ...currentConfig,
         isShown: false,


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

Makes the argument of on close optional

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
