### PR TITLE
Change Accordion chevron orientation

### DIFF
--- a/packages/forma-36-react-components/src/components/Accordion/Accordion.css
+++ b/packages/forma-36-react-components/src/components/Accordion/Accordion.css
@@ -62,7 +62,7 @@
 
 .AccordionHeader--expanded {
   & .AccordionHeader__icon {
-    transform: rotate(90deg);
+    transform: rotate(180deg);
   }
 }
 

--- a/packages/forma-36-react-components/src/components/Accordion/AccordionHeader/AccordionHeader.tsx
+++ b/packages/forma-36-react-components/src/components/Accordion/AccordionHeader/AccordionHeader.tsx
@@ -55,7 +55,7 @@ export const AccordionHeader: FC<AccordionHeaderProps> = ({
         onClick={handleClick}
       >
         <Icon
-          icon="ChevronRightTrimmed"
+          icon="ChevronDownTrimmed"
           color="secondary"
           className={styles.AccordionHeader__icon}
         />

--- a/packages/forma-36-react-components/tools/.storybook/contentful-theme.js
+++ b/packages/forma-36-react-components/tools/.storybook/contentful-theme.js
@@ -29,10 +29,9 @@ export default create({
   textInverseColor: tokens.colorWhite,
 
   // Toolbar default and active colors
-  barTextColor: tokens.colorText,
+  barTextColor: tokens.colorTextLightest,
   barSelectedColor: tokens.colorPrimary,
   barBg: tokens.colorWhite,
-
   // Form colors
   inputBg: tokens.colorWhite,
   inputBorder: tokens.colorElementMid,


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR makes the chevron in the accordion like this:
![Screenshot 2020-09-11 at 16 54 35](https://user-images.githubusercontent.com/6597467/92941653-f4369400-f450-11ea-964a-9e875aab9fd9.png)
Why?
Check [this research](https://www.nngroup.com/articles/accordion-icons/) made by Nilsen Norman Group



I also made the color of the text in the toolbar lighter

**before**
![Screenshot 2020-09-11 at 16 33 53](https://user-images.githubusercontent.com/6597467/92941904-3a8bf300-f451-11ea-86dd-ebae5193c5f5.png)

**after**
![Screenshot 2020-09-11 at 16 41 37](https://user-images.githubusercontent.com/6597467/92941926-42e42e00-f451-11ea-8c70-96606ddc6b9c.png)



## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
