### PR TITLE
feat(tag): add deleted variant to entityStatusType

### DIFF
--- a/packages/forma-36-react-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Tag/Tag.stories.tsx
@@ -30,6 +30,7 @@ storiesOf('Components/Tag', module)
           Archived: 'archived',
           draft: 'draft',
           changed: 'changed',
+          deleted: 'deleted',
           'None (default)': undefined,
         },
         undefined,

--- a/packages/forma-36-react-components/src/components/Tag/Tag.test.tsx
+++ b/packages/forma-36-react-components/src/components/Tag/Tag.test.tsx
@@ -75,6 +75,12 @@ it('renders a "changed" Tag', () => {
   expect(output).toMatchSnapshot();
 });
 
+it('renders a "deleted" Tag', () => {
+  const output = shallow(<Tag entityStatusType="deleted">Deleted</Tag>);
+
+  expect(output).toMatchSnapshot();
+});
+
 it('has no a11y issues', async () => {
   const output = mount(<Tag>Tag</Tag>).html();
   const results = await axe(output);

--- a/packages/forma-36-react-components/src/components/Tag/Tag.tsx
+++ b/packages/forma-36-react-components/src/components/Tag/Tag.tsx
@@ -11,13 +11,14 @@ export type TagType =
   | 'secondary'
   | 'muted';
 
-type Status = 'published' | 'draft' | 'archived' | 'changed';
+type Status = 'published' | 'draft' | 'archived' | 'changed' | 'deleted';
 
 const statusTagTypeMap = {
   published: 'positive',
   draft: 'warning',
   archived: 'negative',
   changed: 'primary',
+  deleted: 'negative',
 };
 
 export type TagProps = {

--- a/packages/forma-36-react-components/src/components/Tag/__snapshots__/Tag.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Tag/__snapshots__/Tag.test.tsx.snap
@@ -18,6 +18,15 @@ exports[`renders a "changed" Tag 1`] = `
 </div>
 `;
 
+exports[`renders a "deleted" Tag 1`] = `
+<div
+  className="Tag Tag--negative"
+  data-test-id="cf-ui-tag"
+>
+  Deleted
+</div>
+`;
+
 exports[`renders a "draft" Tag 1`] = `
 <div
   className="Tag Tag--warning"

--- a/packages/forma-36-react-components/yarn.lock
+++ b/packages/forma-36-react-components/yarn.lock
@@ -1502,22 +1502,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@contentful/forma-36-fcss@^0.2.7":
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/@contentful/forma-36-fcss/-/forma-36-fcss-0.2.7.tgz#2d2067d9163ff34e8ea551aa9fa2de7ed24abfd3"
-  integrity sha512-ni88X2ZYyNglGnrh8XDb8AxM2Km8yf5mvHFzVF4k4dusLBSbcjd1AJcXXnN4lisHwHGxGeroqZNosgYdxI/Sng==
-  dependencies:
-    "@contentful/forma-36-tokens" "^0.8.0"
-
 "@contentful/forma-36-tokens@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@contentful/forma-36-tokens/-/forma-36-tokens-0.2.0.tgz#c4a1062e7acc2ae0ae5699e7c8606d5b5047a1c5"
   integrity sha512-6vshI8mlnEuVx6lJ0Yw7Jzeh5YEhlCfxWZiLXg5pbiDmi9JtPAwllWii9ocrKLelIAPwB/gvNQAAzm6uSy/Vug==
-
-"@contentful/forma-36-tokens@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@contentful/forma-36-tokens/-/forma-36-tokens-0.8.0.tgz#0c8ff7435bd771a2bd3422d68d1e46f742421c0f"
-  integrity sha512-+/DxXhXZ7Tb0sdN1s2KoDD71ffw0WENeGizLtLH/GZC/hAv7+jFtUzaWC6Ty7HGDZD0AryTBBq4PiCUwlS89PA==
 
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
# Purpose of PR

Add 'deleted' status to `entityStatusType` prop on `Tag` component

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
