### PR TITLE
fix: show image only there's src

### DIFF
--- a/packages/forma-36-react-components/src/components/Asset/Asset.css
+++ b/packages/forma-36-react-components/src/components/Asset/Asset.css
@@ -1,5 +1,6 @@
 @import 'settings/colors';
 @import 'settings/typography';
+@import 'settings/dimensions';
 @import 'settings/transitions';
 
 .Asset {
@@ -62,6 +63,8 @@
     1rem * (35 / var(--font-base-default))
   ); /* 35 value comes from font-size multipled by line height multipled by 2 (for limiting text to 2 lines) */
   word-wrap: break-word;
+  padding-left: var(--spacing-s);
+  padding-right: var(--spacing-s);
 }
 
 .Asset__asset-container {

--- a/packages/forma-36-react-components/src/components/Asset/Asset.css
+++ b/packages/forma-36-react-components/src/components/Asset/Asset.css
@@ -63,8 +63,6 @@
     1rem * (35 / var(--font-base-default))
   ); /* 35 value comes from font-size multipled by line height multipled by 2 (for limiting text to 2 lines) */
   word-wrap: break-word;
-  padding-left: var(--spacing-s);
-  padding-right: var(--spacing-s);
 }
 
 .Asset__asset-container {
@@ -79,6 +77,8 @@
   color: var(--color-text-light);
   font-size: var(--font-size-m);
   font-family: var(--font-stack-primary);
+  padding-left: var(--spacing-s);
+  padding-right: var(--spacing-s);
   max-height: calc(1rem * (40 / var(--font-base-default)));
   overflow: hidden;
   margin-bottom: calc(1rem * calc(20 / var(--font-base-default)));

--- a/packages/forma-36-react-components/src/components/Asset/Asset.tsx
+++ b/packages/forma-36-react-components/src/components/Asset/Asset.tsx
@@ -20,7 +20,7 @@ export const types = {
 };
 
 export function isAssetType(type: string): type is AssetType {
-  return Object.keys(types).includes(type)
+  return Object.keys(types).includes(type);
 }
 
 export type AssetType = keyof typeof types;
@@ -69,18 +69,25 @@ export class Asset extends Component<AssetProps> {
   };
 
   render() {
-    const { className, src, status, title, type, testId, ...otherProps } = this.props;
+    const {
+      className,
+      src,
+      status,
+      title,
+      type,
+      testId,
+      ...otherProps
+    } = this.props;
 
     const classNames = cn(styles.Asset, className);
 
     // Archived images will not have a preview available
-    const asImage = type && type === 'image' && (!status || status !== 'archived')
+    const asImage =
+      type && type === 'image' && (!status || status !== 'archived') && src;
 
     return (
       <div className={classNames} data-test-id={testId} {...otherProps}>
-        {asImage
-          ? this.renderImage(src, title)
-          : this.renderAsset(type, title)}
+        {asImage ? this.renderImage(src, title) : this.renderAsset(type, title)}
       </div>
     );
   }


### PR DESCRIPTION
# Purpose of PR

* `Asset` shouldn't render an image tag if `src` attribute is nullable (for example, an empty string).
* Adds padding to title div, so there not situation like this:

<img width="496" alt="Screenshot 2020-09-21 at 18 37 06" src="https://user-images.githubusercontent.com/3672221/93795293-75540f00-fc39-11ea-8248-e2b4ac60027d.png">



## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
