### PR TITLE
fix(asset): handle overflow in asset title

### DIFF
--- a/packages/forma-36-react-components/src/components/Asset/Asset.css
+++ b/packages/forma-36-react-components/src/components/Asset/Asset.css
@@ -80,7 +80,10 @@
   padding-left: var(--spacing-s);
   padding-right: var(--spacing-s);
   max-height: calc(1rem * (40 / var(--font-base-default)));
+  max-width: 100%;
+  white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
   margin-bottom: calc(1rem * calc(20 / var(--font-base-default)));
 }
 


### PR DESCRIPTION
# Purpose of PR

Fix issue with longer titles of an asset as seen here: 
![image](https://user-images.githubusercontent.com/863612/94686083-964bec80-032a-11eb-87dc-39c254ea9a72.png)
