### PR TITLE
feat: expose AssetIcon and hide title if it's empty

### DIFF
--- a/packages/forma-36-react-components/src/components/Asset/Asset.tsx
+++ b/packages/forma-36-react-components/src/components/Asset/Asset.tsx
@@ -51,9 +51,13 @@ export class Asset extends Component<AssetProps> {
           alt={title}
         />
       </div>
-      <div className={styles['Asset__title-container']}>
-        <span className={styles['Asset__title-container__title']}>{title}</span>
-      </div>
+      {title && (
+        <div className={styles['Asset__title-container']}>
+          <span className={styles['Asset__title-container__title']}>
+            {title}
+          </span>
+        </div>
+      )}
     </React.Fragment>
   );
 
@@ -63,7 +67,11 @@ export class Asset extends Component<AssetProps> {
         <div className={styles['Asset__illustration-container']}>
           <AssetIcon type={type} />
         </div>
-        <span className={styles['Asset__asset-container__title']}>{title}</span>
+        {title && (
+          <span className={styles['Asset__asset-container__title']}>
+            {title}
+          </span>
+        )}
       </div>
     );
   };

--- a/packages/forma-36-react-components/src/components/Asset/index.ts
+++ b/packages/forma-36-react-components/src/components/Asset/index.ts
@@ -1,2 +1,3 @@
 export * from './Asset';
-export { default } from './Asset';
+export { Asset } from './Asset';
+export { AssetIcon } from './AssetIcon/AssetIcon';

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import cn from 'classnames';
 import Card, { BaseCardProps } from '../Card';
 import CardActions from './../CardActions';
-import Asset from '../../Asset';
+import { Asset } from '../../Asset';
 import { AssetType } from '../../Asset';
 import Tag, { TagType } from '../../Tag';
 import AssetCardSkeleton from './AssetCardSkeleton';

--- a/packages/forma-36-react-components/src/index.ts
+++ b/packages/forma-36-react-components/src/index.ts
@@ -37,7 +37,7 @@ export { TableHead } from './components/Table/TableHead/TableHead';
 export { TableRow } from './components/Table/TableRow/TableRow';
 export { ToggleButton } from './components/ToggleButton/ToggleButton';
 export { AssetCard } from './components/Card/AssetCard/AssetCard';
-export { Asset } from './components/Asset/Asset';
+export { Asset, AssetIcon } from './components/Asset';
 export { Tag } from './components/Tag/Tag';
 export { Heading } from './components/Typography/Heading/Heading';
 export { InViewport } from './components/InViewport/InViewport';


### PR DESCRIPTION
# Purpose of PR

* Exposes `AssetIcon` component that is useful in field-editors code.
* Hides Asset title DOM nodes if asset title is nullable


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
