### PR TITLE
fix(tooltip): return children if no content provided and add z-index

### DIFF
--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
@@ -41,7 +41,7 @@ export interface TooltipProps {
   /**
    * It sets a max-width for the Tooltip
    */
-  maxWidth?: CSS.MaxWidthProperty<string>;
+  maxWidth?: number | CSS.MaxWidthProperty<string>;
   /**
    * Function that will be called when target gets blurred
    */
@@ -144,7 +144,7 @@ export const Tooltip = ({
   };
 
   const contentMaxWidth =
-    maxWidth && Number.isNaN(maxWidth) ? `${maxWidth}px` : maxWidth;
+    typeof maxWidth === 'string' ? maxWidth : `${maxWidth}px`;
 
   const contentStyles: CSSProperties = {
     zIndex: tokens.zIndexTooltip,

--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
@@ -4,12 +4,15 @@ import React, {
   useRef,
   MouseEvent,
   FocusEvent,
+  CSSProperties,
 } from 'react';
 import { usePopper } from 'react-popper';
 import { Placement } from '@popperjs/core';
+import * as CSS from 'csstype';
 import cn from 'classnames';
 
 import styles from './Tooltip.css';
+import tokens from '@contentful/forma-36-tokens';
 
 export type TooltipPlace = Placement;
 
@@ -25,8 +28,7 @@ export interface TooltipProps {
   /**
    * HTML element used to wrap the target of the Tooltip
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  containerElement?: any;
+  containerElement?: React.ElementType;
   /**
    * Content of the Tooltip
    */
@@ -39,7 +41,7 @@ export interface TooltipProps {
   /**
    * It sets a max-width for the Tooltip
    */
-  maxWidth?: number | string;
+  maxWidth?: CSS.MaxWidthProperty<string>;
   /**
    * Function that will be called when target gets blurred
    */
@@ -78,7 +80,7 @@ interface ArrowPositionState {
 export const Tooltip = ({
   children,
   className,
-  containerElement: ContainerElement,
+  containerElement: ContainerElement = 'span',
   content,
   id,
   isVisible,
@@ -92,6 +94,8 @@ export const Tooltip = ({
   testId,
   ...otherProps
 }: TooltipProps) => {
+  if (!content) return <>{children}</>;
+
   const [show, setShow] = useState(isVisible);
   const [arrowPosition, setArrowPosition] = useState<ArrowPositionState>(
     getArrowPosition('bottom'),
@@ -139,11 +143,14 @@ export const Tooltip = ({
     transform: 'rotate(45deg)',
   };
 
-  const widthStyle = maxWidth
-    ? {
-        maxWidth: typeof maxWidth === 'string' ? maxWidth : `${maxWidth}px`,
-      }
-    : {};
+  const contentMaxWidth =
+    maxWidth && Number.isNaN(maxWidth) ? `${maxWidth}px` : maxWidth;
+
+  const contentStyles: CSSProperties = {
+    zIndex: tokens.zIndexTooltip,
+    maxWidth: contentMaxWidth,
+    ...popperStyles.popper,
+  };
 
   return (
     <>
@@ -177,7 +184,7 @@ export const Tooltip = ({
           ref={popperRef}
           aria-hidden={show ? 'true' : 'false'}
           role="tooltip"
-          style={{ ...popperStyles.popper, ...widthStyle }}
+          style={contentStyles}
           className={cn(styles.Tooltip, className, {
             [styles['Tooltip--hidden']]: !show,
           })}

--- a/packages/forma-36-tokens/src/tokens/z-index.js
+++ b/packages/forma-36-tokens/src/tokens/z-index.js
@@ -1,13 +1,13 @@
 const zIndex = {
-  'z-index-negative': '-1',
-  'z-index-workbench': '0',
-  'z-index-default': '1',
-  'z-index-workbench-header': '10',
-  'z-index-modal': '100',
-  'z-index-modal-content': '101',
-  'z-index-dropdown': '1000',
-  'z-index-tooltip': '10000',
-  'z-index-notification': '100000',
+  'z-index-negative': -1,
+  'z-index-workbench': 0,
+  'z-index-default': 1,
+  'z-index-workbench-header': 10,
+  'z-index-modal': 100,
+  'z-index-modal-content': 101,
+  'z-index-dropdown': 1000,
+  'z-index-tooltip': 10000,
+  'z-index-notification': 100000,
 };
 
 module.exports = zIndex;


### PR DESCRIPTION
# Purpose of PR

- Add tooltip `z-index` value from tokens
- Change tokens `z-index` values to `number` instead of `string` to generate the correct type

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
