### PR TITLE
fix: return target wrapper when tooltip has no content

### DIFF
--- a/packages/forma-36-react-components/src/components/CopyButton/__snapshots__/CopyButton.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/CopyButton/__snapshots__/CopyButton.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`renders the component 1`] = `
       }
       isVisible={false}
       maxWidth={360}
-      place="bottom"
+      place="auto"
       testId="cf-ui-tooltip"
     >
       <button
@@ -75,7 +75,7 @@ exports[`renders the component with a copy value 1`] = `
       }
       isVisible={false}
       maxWidth={360}
-      place="bottom"
+      place="auto"
       testId="cf-ui-tooltip"
     >
       <button
@@ -128,7 +128,7 @@ exports[`renders the component with an additional class name 1`] = `
       }
       isVisible={false}
       maxWidth={360}
-      place="bottom"
+      place="auto"
       testId="cf-ui-tooltip"
     >
       <button

--- a/packages/forma-36-react-components/src/components/EditorToolbar/EditorToolbarButton/__snapshots__/EditorToolbarButton.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EditorToolbar/EditorToolbarButton/__snapshots__/EditorToolbarButton.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders the component 1`] = `
     containerElement="span"
     isVisible={false}
     maxWidth={360}
-    place="bottom"
+    place="auto"
     testId="cf-ui-tooltip"
   >
     <IconButton
@@ -33,7 +33,7 @@ exports[`renders the component as active 1`] = `
     content="H1"
     isVisible={false}
     maxWidth={360}
-    place="bottom"
+    place="auto"
     testId="cf-ui-tooltip"
   >
     <IconButton
@@ -59,7 +59,7 @@ exports[`renders the component as disabled 1`] = `
     containerElement="span"
     isVisible={false}
     maxWidth={360}
-    place="bottom"
+    place="auto"
     testId="cf-ui-tooltip"
   >
     <IconButton
@@ -87,7 +87,7 @@ exports[`renders the component with a tooltip 1`] = `
     content="H1"
     isVisible={false}
     maxWidth={360}
-    place="bottom"
+    place="auto"
     testId="cf-ui-tooltip"
   >
     <IconButton
@@ -113,7 +113,7 @@ exports[`renders the component with an additional class name 1`] = `
     containerElement="span"
     isVisible={false}
     maxWidth={360}
-    place="bottom"
+    place="auto"
     testId="cf-ui-tooltip"
   >
     <IconButton
@@ -140,7 +140,7 @@ exports[`renders with a dropdown indicator 1`] = `
     content="H1"
     isVisible={false}
     maxWidth={360}
-    place="bottom"
+    place="auto"
     testId="cf-ui-tooltip"
   >
     <IconButton

--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
@@ -94,7 +94,13 @@ export const Tooltip = ({
   testId,
   ...otherProps
 }: TooltipProps) => {
-  if (!content) return <>{children}</>;
+  if (!content) {
+    return (
+      <ContainerElement className={targetWrapperClassName}>
+        {children}
+      </ContainerElement>
+    );
+  }
 
   const [show, setShow] = useState(isVisible);
   const [arrowPosition, setArrowPosition] = useState<ArrowPositionState>(
@@ -207,7 +213,7 @@ Tooltip.defaultProps = {
   isVisible: false,
   maxWidth: 360,
   testId: 'cf-ui-tooltip',
-  place: 'bottom',
+  place: 'auto',
 };
 
 function getArrowPosition(popperPlacement: string) {

--- a/packages/forma-36-react-components/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`does not render the component if no mouseover event on child 1`] = `
   content="Tooltip content"
   isVisible={false}
   maxWidth={360}
-  place="bottom"
+  place="auto"
   testId="cf-ui-tooltip"
 >
   <span
@@ -28,7 +28,7 @@ exports[`renders the component 1`] = `
   content="Tooltip content"
   isVisible={false}
   maxWidth={360}
-  place="bottom"
+  place="auto"
   testId="cf-ui-tooltip"
 >
   <span
@@ -52,7 +52,7 @@ exports[`renders the component as span with a id attribute 1`] = `
   content="Tooltip content"
   isVisible={false}
   maxWidth={360}
-  place="bottom"
+  place="auto"
   testId="cf-ui-tooltip"
 >
   <span
@@ -77,7 +77,7 @@ exports[`renders the component with a id attribute 1`] = `
   id="Tooltip"
   isVisible={false}
   maxWidth={360}
-  place="bottom"
+  place="auto"
   testId="cf-ui-tooltip"
 >
   <span
@@ -125,7 +125,7 @@ exports[`renders the component with a target wrapper classname 1`] = `
   content="Tooltip content"
   isVisible={false}
   maxWidth={360}
-  place="bottom"
+  place="auto"
   targetWrapperClassName="target-wrapper-class-name"
   testId="cf-ui-tooltip"
 >
@@ -152,7 +152,7 @@ exports[`renders the component with an additional class name 1`] = `
   content="Tooltip content"
   isVisible={false}
   maxWidth={360}
-  place="bottom"
+  place="auto"
   testId="cf-ui-tooltip"
 >
   <span


### PR DESCRIPTION
My bad! I thought we could return the children of the tooltip in case the prop `content` was undefined, but some people rely on the `targetWrapperClassName` prop

So this makes us return the target and its container to fix that

I'm also proposing to change the default value of `place` to 'auto', because I  had to change this in user_interface more than once. Initially, I did the default value 'bottom' to preserve the old API, but it is messing up positioning in some cases where the tooltip does not have room to be placed. And 'auto' is always positioning the tooltip the best way

... or maybe we update this to use portals but that's a bigger task that we can do it in another PR 