### PR TITLE
fix: radio button example

### DIFF
--- a/packages/forma-36-website/src/pages/components/radio-button/index.mdx
+++ b/packages/forma-36-website/src/pages/components/radio-button/index.mdx
@@ -5,15 +5,16 @@ status: 'stable'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components/src/components/RadioButton'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-radiobutton--default'
 ---
+
 Detailed documentation will be provided soon. For now, please have a look into the storybook for implementation details.
 
 ```jsx
 <>
   <RadioButtonField
-    labelText='Radio button label'
+    labelText="Radio button label"
     helpText="This is a helptext"
     name="someOption"
-    checked="true"
+    checked={true}
     value="yes"
     id="termsCheckbox"
   />


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

There is an issue in the current radio button example:

- `checked` is a boolean and not a string
- we should be consistent with the quotes in jsx

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
