### PR TITLE
fix(select): specify element type for event handlers

### DIFF
--- a/packages/forma-36-react-components/src/components/Select/Select.tsx
+++ b/packages/forma-36-react-components/src/components/Select/Select.tsx
@@ -15,9 +15,9 @@ export interface SelectProps {
   hasError?: boolean;
   value?: string;
   isDisabled?: boolean;
-  onChange?: ChangeEventHandler;
-  onBlur?: FocusEventHandler;
-  onFocus?: FocusEventHandler;
+  onChange?: ChangeEventHandler<HTMLSelectElement>;
+  onBlur?: FocusEventHandler<HTMLSelectElement>;
+  onFocus?: FocusEventHandler<HTMLSelectElement>;
   width?: 'auto' | 'small' | 'medium' | 'large' | 'full';
   testId?: string;
   className?: string;


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

Specify element type of change, blur and focus event handlers as `HTMLSelectElement`.

This currently throws an error in TypeScript because `Property 'value' does not exist on type 'EventTarget & Element'.`:
```jsx
<Select
  value={value}
  onChange={(e) => {
    console.log(e.target.value);
  }
>
  <Option />
</Select>
```
At the moment you have to write the following to not get the error:
```jsx
<Select
  value={value}
  onChange={(e: ChangeEvent<HTMLSelectElement>) => {
    console.log(e.target.value);
  }
>
  <Option />
</Select>
```
With this PR you don't have to explicitly type the parameter of the `onChange` method.

This problem probably exists for other components as well.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
