### PR TITLE
fix(accordionitem): add handleOpen and handleClose to log when items …

### DIFF
--- a/packages/forma-36-react-components/src/components/Accordion/Accordion.test.tsx
+++ b/packages/forma-36-react-components/src/components/Accordion/Accordion.test.tsx
@@ -49,6 +49,23 @@ it('opens the accordion panel when the header is clicked', () => {
   expect(output.find(accordionId).hasClass(expandedClass)).toBe(true);
 });
 
+it('calls onExpand && onCollapse when an accordion item is expanded and collapsed', () => {
+  const onExpand = jest.fn();
+  const onCollapse = jest.fn();
+  const output = mount(
+    <Accordion>
+      <AccordionItem title="Accordion Title" onExpand={onExpand} onCollapse={onCollapse}>Accordion content</AccordionItem>
+    </Accordion>,
+  );
+
+  output.find('button').simulate('click');
+  expect(onExpand).toBeCalledTimes(1);
+  expect(onCollapse).toBeCalledTimes(0);
+  output.find('button').simulate('click');
+  expect(onExpand).toBeCalledTimes(1);
+  expect(onCollapse).toBeCalledTimes(1);
+});
+
 it('has no a11y issues', async () => {
   const output = mount(
     <Accordion>

--- a/packages/forma-36-react-components/src/components/Accordion/AccordionItem/AccordionItem.tsx
+++ b/packages/forma-36-react-components/src/components/Accordion/AccordionItem/AccordionItem.tsx
@@ -23,6 +23,15 @@ export interface AccordionItemProps {
    * An ID used for testing purposes applied as a data attribute (data-test-id)
    */
   testId?: string;
+  /**
+   * A function to be called when the accordion item is opened
+   */
+  onExpand?: Function;
+  /**
+   * A function to be called when the accordion item is closed
+   */
+  onCollapse?: Function;
+
 }
 
 const defaultProps: AccordionItemProps = {
@@ -35,12 +44,23 @@ export const AccordionItem: FC<AccordionItemProps> = ({
   title,
   titleElement,
   testId,
+  onExpand,
+  onCollapse,
   children,
 }: AccordionItemProps) => {
   const id = useId();
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const onClick = () => setIsExpanded(!isExpanded);
+  const onClick = () => {
+    if (!isExpanded && onExpand) {
+      onExpand()
+    }
+     if (isExpanded && onCollapse) {
+      onCollapse()
+    }
+
+    setIsExpanded(!isExpanded)
+  };
 
   return (
     <li className={styles.AccordionItem} data-test-id={`${testId}-${id}`}>

--- a/packages/forma-36-react-components/yarn.lock
+++ b/packages/forma-36-react-components/yarn.lock
@@ -1562,22 +1562,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@contentful/forma-36-fcss@^0.2.11":
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/@contentful/forma-36-fcss/-/forma-36-fcss-0.2.11.tgz#f4fb3f35371cb080820f67590031eb4d0ca8c639"
-  integrity sha512-5qTgj9I/DOaRaElwVVELezOPo57l2aYcRpPmA9WA8IO0tDBYm1TT/XKFbbRiWdyOhmrr0pv1cpTCrxiN1ZMGIA==
-  dependencies:
-    "@contentful/forma-36-tokens" "^0.9.1"
-
 "@contentful/forma-36-tokens@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@contentful/forma-36-tokens/-/forma-36-tokens-0.2.0.tgz#c4a1062e7acc2ae0ae5699e7c8606d5b5047a1c5"
   integrity sha512-6vshI8mlnEuVx6lJ0Yw7Jzeh5YEhlCfxWZiLXg5pbiDmi9JtPAwllWii9ocrKLelIAPwB/gvNQAAzm6uSy/Vug==
-
-"@contentful/forma-36-tokens@^0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@contentful/forma-36-tokens/-/forma-36-tokens-0.9.1.tgz#e10a68969389621ae8ea564b468a0aa03deea979"
-  integrity sha512-9j1NRsnIzmvSqrTnDShiSExt+n2EXXpqbIZyW/rTEv+NDfhw9SC3ZuFGVnC5Ht3syWayNNJ78Oufk43SfYqCLw==
 
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
# Purpose of PR

Adds handleOpen and handleClose to `AccordionItem.tsx` so that we can log when the accordionItems are opened and closed.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
