### PR TITLE
feat(dropdown): use Popper.js for a proper positioning

### DIFF
--- a/packages/components/forma-36-react-timepicker/jest.config.js
+++ b/packages/components/forma-36-react-timepicker/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  moduleNameMapper: {
+    '^react($|/.+)': '<rootDir>/node_modules/react$1',
+  },
+};

--- a/packages/components/forma-36-react-timepicker/package.json
+++ b/packages/components/forma-36-react-timepicker/package.json
@@ -40,8 +40,8 @@
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.9.3",
     "husky": "^3.0.9",
-    "react": "16.10.2",
-    "react-dom": "16.10.2",
+    "react": "^16.8.3",
+    "react-dom": "^16.8.3",
     "tsdx": "^0.11.0",
     "tslib": "^1.10.0",
     "typescript": "^3.6.4"

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
@@ -169,15 +169,15 @@ exports[`renders the component with actions 1`] = `
         <DropdownList
           testId="cf-ui-dropdown-list"
         >
-          <DropdownListItem
+          <ForwardRef
             isActive={false}
             isDisabled={false}
             isTitle={true}
             testId="cf-ui-dropdown-list-item"
           >
             Actions
-          </DropdownListItem>
-          <DropdownListItem
+          </ForwardRef>
+          <ForwardRef
             isActive={false}
             isDisabled={false}
             isTitle={false}
@@ -185,7 +185,7 @@ exports[`renders the component with actions 1`] = `
             testId="cf-ui-dropdown-list-item"
           >
             Edit
-          </DropdownListItem>
+          </ForwardRef>
         </DropdownList>
       </CardActions>
     </div>

--- a/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
@@ -20,8 +20,8 @@ export interface CardActionsPropTypes {
    * The DropdownList elements used to render an actions dropdown for the component
    */
   children:
-    | React.ReactElement<DropdownList>
-    | React.ReactElement<DropdownList>[];
+    | React.ReactElement<typeof DropdownList>
+    | React.ReactElement<typeof DropdownList>[];
   /**
    * An ID used for testing purposes applied as a data attribute (data-test-id)
    */
@@ -73,7 +73,6 @@ export class CardActions extends Component<
           });
         }}
         position="bottom-right"
-        isAutoalignmentEnabled={false}
         className={className}
         isOpen={this.state.isDropdownOpen}
         testId={testId}

--- a/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders the component as disabled 1`] = `
 <Dropdown
   getContainerRef={[Function]}
-  isAutoalignmentEnabled={false}
+  isAutoalignmentEnabled={true}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"
@@ -29,7 +29,7 @@ exports[`renders the component as disabled 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <DropdownListItem
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -37,7 +37,7 @@ exports[`renders the component as disabled 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </DropdownListItem>
+    </ForwardRef>
   </DropdownList>
 </Dropdown>
 `;
@@ -45,7 +45,7 @@ exports[`renders the component as disabled 1`] = `
 exports[`renders the component using a multiple dropdown lists 1`] = `
 <Dropdown
   getContainerRef={[Function]}
-  isAutoalignmentEnabled={false}
+  isAutoalignmentEnabled={true}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"
@@ -71,7 +71,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <DropdownListItem
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -79,8 +79,8 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </DropdownListItem>
-    <DropdownListItem
+    </ForwardRef>
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -88,8 +88,8 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </DropdownListItem>
-    <DropdownListItem
+    </ForwardRef>
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -97,14 +97,14 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </DropdownListItem>
+    </ForwardRef>
   </DropdownList>
   <DropdownList
     key=".1/.$.0/.$.0"
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <DropdownListItem
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -112,8 +112,8 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </DropdownListItem>
-    <DropdownListItem
+    </ForwardRef>
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -121,8 +121,8 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </DropdownListItem>
-    <DropdownListItem
+    </ForwardRef>
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -130,7 +130,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </DropdownListItem>
+    </ForwardRef>
   </DropdownList>
 </Dropdown>
 `;
@@ -138,7 +138,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
 exports[`renders the component using a single dropdown list 1`] = `
 <Dropdown
   getContainerRef={[Function]}
-  isAutoalignmentEnabled={false}
+  isAutoalignmentEnabled={true}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"
@@ -164,7 +164,7 @@ exports[`renders the component using a single dropdown list 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <DropdownListItem
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -172,8 +172,8 @@ exports[`renders the component using a single dropdown list 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </DropdownListItem>
-    <DropdownListItem
+    </ForwardRef>
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -181,8 +181,8 @@ exports[`renders the component using a single dropdown list 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </DropdownListItem>
-    <DropdownListItem
+    </ForwardRef>
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -190,7 +190,7 @@ exports[`renders the component using a single dropdown list 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </DropdownListItem>
+    </ForwardRef>
   </DropdownList>
 </Dropdown>
 `;
@@ -199,7 +199,7 @@ exports[`renders the component with an additional class name 1`] = `
 <Dropdown
   className="my-extra-class"
   getContainerRef={[Function]}
-  isAutoalignmentEnabled={false}
+  isAutoalignmentEnabled={true}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"
@@ -225,7 +225,7 @@ exports[`renders the component with an additional class name 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <DropdownListItem
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -233,8 +233,8 @@ exports[`renders the component with an additional class name 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </DropdownListItem>
-    <DropdownListItem
+    </ForwardRef>
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -242,8 +242,8 @@ exports[`renders the component with an additional class name 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </DropdownListItem>
-    <DropdownListItem
+    </ForwardRef>
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -251,7 +251,7 @@ exports[`renders the component with an additional class name 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </DropdownListItem>
+    </ForwardRef>
   </DropdownList>
 </Dropdown>
 `;
@@ -259,7 +259,7 @@ exports[`renders the component with an additional class name 1`] = `
 exports[`renders the component with published status 1`] = `
 <Dropdown
   getContainerRef={[Function]}
-  isAutoalignmentEnabled={false}
+  isAutoalignmentEnabled={true}
   isOpen={false}
   onClose={[Function]}
   position="bottom-right"
@@ -285,7 +285,7 @@ exports[`renders the component with published status 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <DropdownListItem
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -293,8 +293,8 @@ exports[`renders the component with published status 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </DropdownListItem>
-    <DropdownListItem
+    </ForwardRef>
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -302,8 +302,8 @@ exports[`renders the component with published status 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </DropdownListItem>
-    <DropdownListItem
+    </ForwardRef>
+    <ForwardRef
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -311,7 +311,7 @@ exports[`renders the component with published status 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </DropdownListItem>
+    </ForwardRef>
   </DropdownList>
 </Dropdown>
 `;

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
@@ -353,15 +353,15 @@ exports[`renders the component with dropdownListElements 1`] = `
         <DropdownList
           testId="cf-ui-dropdown-list"
         >
-          <DropdownListItem
+          <ForwardRef
             isActive={false}
             isDisabled={false}
             isTitle={true}
             testId="cf-ui-dropdown-list-item"
           >
             Actions
-          </DropdownListItem>
-          <DropdownListItem
+          </ForwardRef>
+          <ForwardRef
             isActive={false}
             isDisabled={false}
             isTitle={false}
@@ -369,8 +369,8 @@ exports[`renders the component with dropdownListElements 1`] = `
             testId="cf-ui-dropdown-list-item"
           >
             Edit
-          </DropdownListItem>
-          <DropdownListItem
+          </ForwardRef>
+          <ForwardRef
             isActive={false}
             isDisabled={false}
             isTitle={false}
@@ -378,8 +378,8 @@ exports[`renders the component with dropdownListElements 1`] = `
             testId="cf-ui-dropdown-list-item"
           >
             Download
-          </DropdownListItem>
-          <DropdownListItem
+          </ForwardRef>
+          <ForwardRef
             isActive={false}
             isDisabled={false}
             isTitle={false}
@@ -387,7 +387,7 @@ exports[`renders the component with dropdownListElements 1`] = `
             testId="cf-ui-dropdown-list-item"
           >
             Remove
-          </DropdownListItem>
+          </ForwardRef>
         </DropdownList>
       </CardActions>
     </div>

--- a/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`renders the component with a dropdown 1`] = `
     <DropdownList
       testId="cf-ui-dropdown-list"
     >
-      <DropdownListItem
+      <ForwardRef
         isActive={false}
         isDisabled={false}
         isTitle={false}
@@ -95,8 +95,8 @@ exports[`renders the component with a dropdown 1`] = `
         testId="cf-ui-dropdown-list-item"
       >
         Edit
-      </DropdownListItem>
-      <DropdownListItem
+      </ForwardRef>
+      <ForwardRef
         isActive={false}
         isDisabled={false}
         isTitle={false}
@@ -105,7 +105,7 @@ exports[`renders the component with a dropdown 1`] = `
         testId="cf-ui-dropdown-list-item"
       >
         Remove
-      </DropdownListItem>
+      </ForwardRef>
     </DropdownList>
   </CardActions>
 </Card>

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.stories.tsx
@@ -83,6 +83,7 @@ function ScrollableStory() {
     <Dropdown
       isOpen={isOpen}
       onClose={() => setOpen(false)}
+      isAutoalignmentEnabled={boolean('isAutoalignmentEnabled', true)}
       position={select(
         'position',
         {

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
@@ -1,9 +1,30 @@
-import React, { Component } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import cn from 'classnames';
+import { usePopper } from 'react-popper';
+import { Modifier, Placement, State as PopperState } from '@popperjs/core';
+
 import DropdownListItem from './DropdownListItem/DropdownListItem';
 import DropdownContainer from './DropdownContainer';
-import isBrowser from '../../utils/isBrowser';
 import styles from './Dropdown.css';
+
+/**
+ * Popper.js modifier to give the popper element the full width of the reference
+ */
+const sameWidth: Modifier<'sameWidth', {}> = {
+  name: 'sameWidth',
+  enabled: true,
+  phase: 'beforeWrite',
+  requires: ['computeStyles'],
+  fn: ({ state }: { state: PopperState }) => {
+    state.styles.popper.width = `${state.rects.reference.width}px`;
+  },
+  effect: ({ state }: { state: PopperState }) => {
+    const reference = state.elements.reference as HTMLElement;
+    state.elements.popper.style.width = `${reference.offsetWidth}px`;
+
+    return () => {};
+  },
+};
 
 export type positionType =
   | 'top'
@@ -14,231 +35,253 @@ export type positionType =
   | 'top-right'
   | 'top-left';
 
-export interface DropdownProps {
-  toggleElement?: React.ReactElement;
-  submenuToggleLabel?: string;
-  position: positionType;
-  isOpen: boolean;
-  onClose?: Function;
-  testId?: string;
-  dropdownContainerClassName?: string;
-  getContainerRef?: (ref: HTMLElement | null) => void;
-  className?: string;
-  children: React.ReactNode;
-  isFullWidth?: boolean;
-  isAutoalignmentEnabled?: boolean;
-}
+/**
+ * Helper method to map our current Dropdown position props to Popper.js
+ * placements.
+ *
+ * @todo: Maybe we can use the Popper placements in the next breaking change?
+ */
+const mapPositionTypeToPlacement = (position: positionType): Placement => {
+  switch (position) {
+    case 'bottom-left':
+      return 'bottom-start';
 
-export interface AnchorDimensionsAndPositonType {
-  top: number;
-  left: number;
-  width: number;
-  height: number;
-}
+    case 'bottom-right':
+      return 'bottom-end';
 
-export interface DropdownState {
-  isOpen: boolean;
-  position: positionType;
-  anchorDimensionsAndPositon?: AnchorDimensionsAndPositonType;
-}
+    case 'right':
+      return 'right-start';
 
-const defaultProps: Partial<DropdownProps> = {
-  testId: 'cf-ui-dropdown',
-  position: 'bottom-left',
-  isOpen: false,
-  isAutoalignmentEnabled: true,
-  getContainerRef: () => {},
+    case 'left':
+      return 'left-start';
+
+    case 'top-left':
+      return 'top-start';
+
+    case 'top-right':
+      return 'top-end';
+
+    default:
+      return position;
+  }
 };
 
-export class Dropdown extends Component<DropdownProps, DropdownState> {
-  static defaultProps = defaultProps;
-  toggleElementWrapper: HTMLSpanElement | null = null;
-
-  state = {
-    isOpen: this.props.isOpen,
-    position: this.props.position,
-    anchorDimensionsAndPositon: {
-      top: 0,
-      left: 0,
-      height: 0,
-      width: 0,
-    },
-  };
-
-  dropdownAnchor: HTMLDivElement | null = null;
-
-  componentDidMount() {
-    if (!isBrowser) {
-      return;
-    }
-    this.setAnchorDimensions();
-    this.bindEventListeners();
-  }
-
-  setAnchorDimensions = () => {
-    if (this.dropdownAnchor) {
-      const dropdownAnchorRect = this.dropdownAnchor.getBoundingClientRect();
-      this.setState({
-        anchorDimensionsAndPositon: {
-          top: dropdownAnchorRect.top,
-          left: dropdownAnchorRect.left,
-          width: dropdownAnchorRect.width,
-          height: dropdownAnchorRect.height,
-        },
-      });
-    }
-  };
-
-  UNSAFE_componentWillReceiveProps(newProps: DropdownProps) {
-    this.setState({
-      isOpen: newProps.isOpen,
-    });
-  }
-
-  componentDidUpdate(prevProps: DropdownProps) {
-    if (!isBrowser) {
-      return;
-    }
-
-    if (prevProps.isOpen !== this.props.isOpen) {
-      this.setAnchorDimensions();
-    }
-
-    this.bindEventListeners();
-  }
-
-  bindEventListeners = () => {
-    if (this.state.isOpen) {
-      document.addEventListener('keydown', this.handleEscapeKey, true);
-      window.addEventListener('resize', this.setAnchorDimensions, true);
-      document.addEventListener('scroll', this.setAnchorDimensions, true);
-    } else {
-      document.removeEventListener('keydown', this.handleEscapeKey, true);
-      window.removeEventListener('resize', this.setAnchorDimensions, true);
-      document.removeEventListener('scroll', this.setAnchorDimensions, true);
-    }
-  };
-
-  componentWillUnmount() {
-    if (!isBrowser) {
-      return;
-    }
-
-    document.removeEventListener('keydown', this.handleEscapeKey, true);
-    window.removeEventListener('resize', this.setAnchorDimensions, true);
-    document.removeEventListener('scroll', this.setAnchorDimensions, true);
-  }
-
-  openMenu = (isOpen: boolean) => {
-    this.setState({ isOpen });
-  };
-
-  handleEscapeKey = (event: KeyboardEvent) => {
-    const ESCAPE_KEYCODE = 27;
-
-    if (event.keyCode === ESCAPE_KEYCODE) {
-      event.stopPropagation();
-
-      this.setState({
-        isOpen: false,
-      });
-
-      if (this.props.onClose) {
-        this.props.onClose();
-      }
-    }
-  };
-
-  openSubmenu = (isOpen: boolean) => {
-    if (this.props.submenuToggleLabel) {
-      this.openMenu(isOpen);
-    }
-  };
-
-  render() {
-    const {
-      className,
-      toggleElement,
-      testId,
-      submenuToggleLabel,
-      getContainerRef,
-      dropdownContainerClassName,
-      children,
-      isOpen,
-      isAutoalignmentEnabled,
-      isFullWidth,
-      ...otherProps
-    } = this.props;
-
-    const classNames = cn(styles['Dropdown'], className);
-    const width = isFullWidth && this.state.anchorDimensionsAndPositon.width;
-    const containerTestId = testId ? `${testId}-container` : testId;
-
-    return submenuToggleLabel ? (
-      <DropdownListItem
-        testId={testId}
-        submenuToggleLabel={submenuToggleLabel}
-        onEnter={() => this.openMenu(true)}
-        onLeave={() => this.openMenu(false)}
-        {...otherProps}
-      >
-        {toggleElement &&
-          React.cloneElement(toggleElement, {
-            'aria-haspopup': 'menu',
-            'aria-expanded': this.state.isOpen,
-          })}
-        {this.state.isOpen && (
-          <DropdownContainer
-            anchorDimensionsAndPositon={this.state.anchorDimensionsAndPositon}
-            position={this.props.position}
-            width={width}
-            className={dropdownContainerClassName}
-            getRef={getContainerRef}
-            dropdownAnchor={this.dropdownAnchor}
-            onClose={this.props.onClose}
-            openSubmenu={this.openSubmenu}
-            submenu
-          >
-            {this.props.children}
-          </DropdownContainer>
-        )}
-      </DropdownListItem>
-    ) : (
-      <div
-        data-test-id={testId}
-        className={classNames}
-        ref={(ref) => {
-          if (!submenuToggleLabel) {
-            this.dropdownAnchor = ref;
-          }
-        }}
-        {...otherProps}
-      >
-        {toggleElement &&
-          React.cloneElement(toggleElement, {
-            'aria-haspopup': 'menu',
-            'aria-expanded': this.state.isOpen,
-          })}
-        {this.state.isOpen && (
-          <DropdownContainer
-            className={dropdownContainerClassName}
-            getRef={getContainerRef}
-            submenu={false}
-            width={width}
-            testId={containerTestId}
-            dropdownAnchor={this.dropdownAnchor}
-            isAutoalignmentEnabled={isAutoalignmentEnabled}
-            anchorDimensionsAndPositon={this.state.anchorDimensionsAndPositon}
-            onClose={this.props.onClose}
-            openSubmenu={this.openSubmenu}
-            position={this.props.position}
-          >
-            {this.props.children}
-          </DropdownContainer>
-        )}
-      </div>
-    );
-  }
+export interface DropdownProps {
+  /**
+   * Child nodes to be rendered in the component
+   */
+  children: React.ReactNode;
+  /**
+   * Class names to be appended to the className prop of the Dropdown wrapper
+   */
+  className?: string;
+  /**
+   * Class names to be appended to the className prop of the DropdownContainer
+   */
+  dropdownContainerClassName?: string;
+  getContainerRef?: (ref: HTMLElement | null) => void;
+  /**
+   * Boolean to disable automatic positioning of the element to fit the
+   * available viewport. Instead this forces the element to follow the given
+   * or default value of the `position` prop.
+   */
+  isAutoalignmentEnabled?: boolean;
+  /**
+   * Boolean to determine if the Dropdown should take the full width of
+   * the container
+   */
+  isFullWidth?: boolean;
+  /**
+   * Boolean to control whether or not the Dropdown is open
+   */
+  isOpen: boolean;
+  /**
+   * Callback function to run when the Dropdown closes
+   */
+  onClose?: Function;
+  /**
+   * Determines the preferred position of the Dropdown. This position is not
+   * guaranteed, as the Dropdown might be moved to fit the viewport
+   */
+  position: positionType;
+  /**
+   * A text label to use as the toggle element for the submenu
+   */
+  submenuToggleLabel?: string;
+  /**
+   * An ID used for testing purposes applied as a data attribute (data-test-id)
+   */
+  testId?: string;
+  /**
+   * React element to use as the toggle, opening and closing the Dropdown
+   */
+  toggleElement?: React.ReactElement;
 }
+
+export function Dropdown({
+  children,
+  className,
+  dropdownContainerClassName,
+  getContainerRef,
+  isAutoalignmentEnabled,
+  isFullWidth,
+  isOpen: isOpenProp,
+  onClose,
+  position,
+  submenuToggleLabel,
+  testId,
+  toggleElement,
+  ...otherProps
+}: DropdownProps) {
+  const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(
+    null,
+  );
+  const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
+  const [isOpen, setIsOpen] = useState(isOpenProp);
+  const placement = mapPositionTypeToPlacement(position);
+  const { attributes, forceUpdate, styles: popperStyles } = usePopper(
+    referenceElement,
+    popperElement,
+    {
+      placement,
+      modifiers: [
+        isFullWidth ? sameWidth : {},
+        isAutoalignmentEnabled !== undefined
+          ? {
+              name: 'preventOverflow',
+              options: {
+                mainAxis: isAutoalignmentEnabled,
+              },
+            }
+          : {},
+        isAutoalignmentEnabled === false
+          ? {
+              name: 'flip',
+              options: {
+                fallbackPlacements: [],
+              },
+            }
+          : {},
+      ],
+    },
+  );
+  const classNames = cn(styles['Dropdown'], className);
+  const containerTestId = testId ? `${testId}-container` : testId;
+
+  useEffect(() => {
+    setIsOpen(isOpenProp);
+  }, [isOpenProp]);
+
+  useEffect(() => {
+    if (forceUpdate) {
+      forceUpdate();
+    }
+  }, [children]);
+
+  const openSubmenu = (isOpen: boolean) => {
+    if (submenuToggleLabel) {
+      setIsOpen(isOpen);
+    }
+  };
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+
+    if (onClose) {
+      onClose();
+    }
+  }, [onClose, setIsOpen]);
+
+  const handleEscapeKey = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.code === 'Escape') {
+        event.stopPropagation();
+
+        close();
+      }
+    },
+    [close],
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleEscapeKey, true);
+
+    return () => {
+      document.removeEventListener('keydown', handleEscapeKey, true);
+    };
+  }, []);
+
+  return submenuToggleLabel ? (
+    <DropdownListItem
+      testId={testId}
+      submenuToggleLabel={submenuToggleLabel}
+      onEnter={() => setIsOpen(true)}
+      onLeave={() => setIsOpen(false)}
+      ref={setReferenceElement}
+      {...otherProps}
+    >
+      {toggleElement &&
+        React.cloneElement(toggleElement, {
+          'aria-haspopup': 'menu',
+          'aria-expanded': isOpen,
+        })}
+      {isOpen && (
+        <DropdownContainer
+          className={dropdownContainerClassName}
+          getRef={getContainerRef}
+          isOpen={isOpen}
+          onClose={onClose}
+          openSubmenu={openSubmenu}
+          position={position}
+          ref={setPopperElement}
+          style={popperStyles.popper}
+          submenu
+          {...attributes.popper}
+        >
+          {children}
+        </DropdownContainer>
+      )}
+    </DropdownListItem>
+  ) : (
+    <div
+      data-test-id={testId}
+      className={classNames}
+      ref={setReferenceElement}
+      {...otherProps}
+    >
+      {toggleElement &&
+        React.cloneElement(toggleElement, {
+          'aria-haspopup': 'menu',
+          'aria-expanded': isOpen,
+        })}
+
+      {isOpen && (
+        <DropdownContainer
+          className={dropdownContainerClassName}
+          getRef={getContainerRef}
+          isOpen={isOpen}
+          onClose={onClose}
+          openSubmenu={openSubmenu}
+          position={position}
+          ref={setPopperElement}
+          style={popperStyles.popper}
+          submenu={false}
+          testId={containerTestId}
+          {...attributes.popper}
+        >
+          {children}
+        </DropdownContainer>
+      )}
+    </div>
+  );
+}
+
+Dropdown.defaultProps = {
+  testId: 'cf-ui-dropdown',
+  position: 'bottom-left',
+  isAutoalignmentEnabled: true,
+  isOpen: false,
+  getContainerRef: () => {},
+};
 
 export default Dropdown;

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.css
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.css
@@ -12,27 +12,16 @@
     var(--color-element-mid);
   list-style: none;
   padding: 0;
-  margin: 0;
+  /*
+   * @todo: Remove this in next breaking change, it's overriden by Popper,
+   * who uses absolute positioning
+   */
   position: fixed;
+  margin: 0;
+
   z-index: var(--z-index-dropdown);
 }
 
 .DropdownContainer > div {
   width: 100%;
-}
-
-.DropdownContainer__submenu {
-  position: absolute;
-}
-
-.DropdownContainer__container-position--right {
-  margin-top: 0;
-  top: 0;
-  left: 100%;
-}
-
-.DropdownContainer__container-position--left {
-  margin-top: 0;
-  top: 0;
-  right: 100%;
 }

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.test.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.test.tsx
@@ -4,21 +4,14 @@ import DropdownContainer from './DropdownContainer';
 
 it('renders the component', () => {
   const output = shallow(
-    <DropdownContainer
-      anchorDimensionsAndPositon={{ left: 0, top: 0, width: 100, height: 0 }}
-    >
-      DropdownContainer
-    </DropdownContainer>,
+    <DropdownContainer isOpen>DropdownContainer</DropdownContainer>,
   );
   expect(output).toMatchSnapshot();
 });
 
 it('renders the component with an additional class name', () => {
   const output = shallow(
-    <DropdownContainer
-      anchorDimensionsAndPositon={{ left: 0, top: 0, width: 100, height: 0 }}
-      className="extraClassName"
-    >
+    <DropdownContainer className="extraClassName" isOpen>
       DropdownContainer
     </DropdownContainer>,
   );
@@ -27,11 +20,7 @@ it('renders the component with an additional class name', () => {
 
 it('renders the component as a submenu', () => {
   const output = shallow(
-    <DropdownContainer
-      anchorDimensionsAndPositon={{ left: 0, top: 0, width: 100, height: 0 }}
-      className="extraClassName"
-      submenu
-    >
+    <DropdownContainer className="extraClassName" isOpen submenu>
       DropdownContainer
     </DropdownContainer>,
   );
@@ -40,11 +29,7 @@ it('renders the component as a submenu', () => {
 
 it('has no a11y issues', async () => {
   const output = shallow(
-    <DropdownContainer
-      anchorDimensionsAndPositon={{ left: 0, top: 0, width: 100, height: 0 }}
-    >
-      DropdownContainer
-    </DropdownContainer>,
+    <DropdownContainer isOpen>DropdownContainer</DropdownContainer>,
   );
   expect(output).toMatchSnapshot();
 });

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/__snapshots__/DropdownContainer.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/__snapshots__/DropdownContainer.test.tsx.snap
@@ -10,23 +10,8 @@ exports[`has no a11y issues 1`] = `
     onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
-    style={
-      Object {
-        "left": 0,
-        "top": 0,
-      }
-    }
   >
-    <InViewport
-      offset={0}
-      onOverflowBottom={[Function]}
-      onOverflowLeft={[Function]}
-      onOverflowRight={[Function]}
-      onOverflowTop={[Function]}
-      testId="cf-ui-in-viewport"
-    >
-      DropdownContainer
-    </InViewport>
+    DropdownContainer
   </div>
 </Portal>
 `;
@@ -41,46 +26,21 @@ exports[`renders the component 1`] = `
     onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
-    style={
-      Object {
-        "left": 0,
-        "top": 0,
-      }
-    }
   >
-    <InViewport
-      offset={0}
-      onOverflowBottom={[Function]}
-      onOverflowLeft={[Function]}
-      onOverflowRight={[Function]}
-      onOverflowTop={[Function]}
-      testId="cf-ui-in-viewport"
-    >
-      DropdownContainer
-    </InViewport>
+    DropdownContainer
   </div>
 </Portal>
 `;
 
 exports[`renders the component as a submenu 1`] = `
 <div
-  className="extraClassName DropdownContainer DropdownContainer__submenu DropdownContainer__container-position--bottom-left"
+  className="extraClassName DropdownContainer"
   data-test-id="cf-ui-dropdown-portal"
   onFocus={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
-  style={Object {}}
 >
-  <InViewport
-    offset={0}
-    onOverflowBottom={[Function]}
-    onOverflowLeft={[Function]}
-    onOverflowRight={[Function]}
-    onOverflowTop={[Function]}
-    testId="cf-ui-in-viewport"
-  >
-    DropdownContainer
-  </InViewport>
+  DropdownContainer
 </div>
 `;
 
@@ -94,23 +54,8 @@ exports[`renders the component with an additional class name 1`] = `
     onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
-    style={
-      Object {
-        "left": 0,
-        "top": 0,
-      }
-    }
   >
-    <InViewport
-      offset={0}
-      onOverflowBottom={[Function]}
-      onOverflowLeft={[Function]}
-      onOverflowRight={[Function]}
-      onOverflowTop={[Function]}
-      testId="cf-ui-in-viewport"
-    >
-      DropdownContainer
-    </InViewport>
+    DropdownContainer
   </div>
 </Portal>
 `;

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownList/DropdownList.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownList/DropdownList.tsx
@@ -1,7 +1,8 @@
-import React, { Component } from 'react';
+import React from 'react';
 import cn from 'classnames';
-import cssStyles from './DropdownList.css';
 import * as CSS from 'csstype';
+
+import cssStyles from './DropdownList.css';
 
 export interface DropdownListProps {
   children: React.ReactNode;
@@ -13,46 +14,40 @@ export interface DropdownListProps {
   styles?: object;
 }
 
-const defaultProps: Partial<DropdownListProps> = {
-  testId: 'cf-ui-dropdown-list',
+export const DropdownList = ({
+  className,
+  border,
+  maxHeight,
+  testId,
+  children,
+  listRef,
+  styles,
+  ...otherProps
+}: DropdownListProps) => {
+  const classNames = cn(cssStyles['DropdownList'], className, {
+    [cssStyles[`DropdownList--border-${border}`]]: border,
+  });
+
+  return (
+    <ul
+      ref={listRef}
+      data-test-id={testId}
+      role="menu"
+      style={{
+        maxHeight: maxHeight || 'auto',
+        overflowY: maxHeight ? 'auto' : 'visible',
+        ...styles,
+      }}
+      className={classNames}
+      {...otherProps}
+    >
+      {children}
+    </ul>
+  );
 };
 
-export class DropdownList extends Component<DropdownListProps> {
-  static defaultProps = defaultProps;
-
-  render() {
-    const {
-      className,
-      border,
-      maxHeight,
-      testId,
-      children,
-      listRef,
-      styles,
-      ...otherProps
-    } = this.props;
-
-    const classNames = cn(cssStyles['DropdownList'], className, {
-      [cssStyles[`DropdownList--border-${border}`]]: border,
-    });
-
-    return (
-      <ul
-        ref={listRef}
-        data-test-id={testId}
-        role="menu"
-        style={{
-          maxHeight: maxHeight || 'auto',
-          overflowY: maxHeight ? 'auto' : 'visible',
-          ...styles,
-        }}
-        className={classNames}
-        {...otherProps}
-      >
-        {children}
-      </ul>
-    );
-  }
-}
+DropdownList.defaultProps = {
+  testId: 'cf-ui-dropdown-list',
+};
 
 export default DropdownList;

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownList/__snapshots__/DropdownList.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownList/__snapshots__/DropdownList.test.tsx.snap
@@ -12,14 +12,14 @@ exports[`renders the component 1`] = `
     }
   }
 >
-  <DropdownListItem
+  <ForwardRef
     isActive={false}
     isDisabled={false}
     isTitle={false}
     testId="cf-ui-dropdown-list-item"
   >
     List Item
-  </DropdownListItem>
+  </ForwardRef>
 </ul>
 `;
 
@@ -35,14 +35,14 @@ exports[`renders the component with a border attribute 1`] = `
     }
   }
 >
-  <DropdownListItem
+  <ForwardRef
     isActive={false}
     isDisabled={false}
     isTitle={false}
     testId="cf-ui-dropdown-list-item"
   >
     List Item
-  </DropdownListItem>
+  </ForwardRef>
 </ul>
 `;
 
@@ -58,13 +58,13 @@ exports[`renders the component with an additional class name 1`] = `
     }
   }
 >
-  <DropdownListItem
+  <ForwardRef
     isActive={false}
     isDisabled={false}
     isTitle={false}
     testId="cf-ui-dropdown-list-item"
   >
     List Item
-  </DropdownListItem>
+  </ForwardRef>
 </ul>
 `;

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
@@ -1,16 +1,19 @@
 import React, {
-  Component,
+  forwardRef,
   MouseEventHandler,
   FocusEventHandler,
   MouseEvent as ReactMouseEvent,
+  useCallback,
 } from 'react';
 import cn from 'classnames';
+
 import TabFocusTrap from '../../TabFocusTrap/TabFocusTrap';
 import styles from './DropdownListItem.css';
 
-export interface DropdownListItemProps {
+export interface DropdownListItemProps
+  extends React.HTMLAttributes<HTMLElement> {
   isDisabled?: boolean;
-  listItemRef?: React.RefObject<HTMLLIElement>;
+  listItemRef?: React.MutableRefObject<HTMLLIElement | null>;
   isActive?: boolean;
   isTitle?: boolean;
   children: React.ReactNode;
@@ -25,126 +28,30 @@ export interface DropdownListItemProps {
   testId?: string;
 }
 
-const defaultProps: Partial<DropdownListItemProps> = {
-  testId: 'cf-ui-dropdown-list-item',
-  isDisabled: false,
-  isActive: false,
-  isTitle: false,
-};
-
-export class DropdownListItem extends Component<DropdownListItemProps> {
-  static defaultProps = defaultProps;
-
-  renderSubmenuToggle = () => {
-    const {
+export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
+  (
+    {
+      children,
+      isActive,
+      isDisabled,
+      isTitle,
       onClick,
       onEnter,
-      onLeave,
       onFocus,
-      children,
+      onLeave,
+      style,
       submenuToggleLabel,
       testId,
-      isDisabled,
-      isActive,
-      isTitle,
-      ...otherProps
-    } = this.props;
-
-    return (
-      <React.Fragment>
-        <button
-          type="button"
-          data-test-id="cf-ui-dropdown-submenu-toggle"
-          className={styles['DropdownListItem__button']}
-          onClick={onClick}
-          onMouseEnter={onEnter}
-          onFocus={onFocus}
-          onMouseLeave={onLeave}
-          {...otherProps}
-        >
-          <TabFocusTrap
-            className={styles['DropdownListItem__button__inner-wrapper']}
-          >
-            {submenuToggleLabel}
-          </TabFocusTrap>
-        </button>
-        {children}
-      </React.Fragment>
-    );
-  };
-
-  renderListItem = () => {
-    const {
-      onClick,
-      onMouseDown,
-      href,
-      isDisabled,
-      children,
-      isTitle,
-      isActive,
-      testId,
-      listItemRef,
-      ...otherProps
-    } = this.props;
-
-    const isClickable = onClick || onMouseDown || href;
-
-    if (isClickable) {
-      const Element = href ? 'a' : 'button';
-
-      const buttonProps = {
-        disabled: isDisabled,
-        'aria-disabled': isDisabled,
-      };
-
-      const linkProps = {
-        href,
-      };
-
-      return (
-        <Element
-          type="button"
-          onClick={(e: ReactMouseEvent) => {
-            if (!isDisabled && onClick) {
-              onClick(e);
-            }
-          }}
-          onMouseDown={(e: ReactMouseEvent) => {
-            if (!isDisabled && onMouseDown) {
-              onMouseDown(e);
-            }
-          }}
-          {...(href ? linkProps : buttonProps)}
-          {...otherProps}
-          data-test-id="cf-ui-dropdown-list-item-button"
-          className={styles['DropdownListItem__button']}
-        >
-          <TabFocusTrap
-            className={styles['DropdownListItem__button__inner-wrapper']}
-          >
-            {children}
-          </TabFocusTrap>
-        </Element>
-      );
-    }
-
-    return <span {...otherProps}>{children}</span>;
-  };
-
-  render() {
-    const {
-      className,
-      isDisabled,
-      testId,
-      listItemRef,
-      isActive,
-      onClick,
-      onMouseDown,
-      href,
-      submenuToggleLabel,
-      isTitle,
-    } = this.props;
-
+      ...props
+    },
+    refCallback,
+  ) => {
+    const { className, href, listItemRef, onMouseDown, ...otherProps } = props;
+    // We're not dealing with React RefObjects but with useState (because we
+    // want to re-render on all changes)
+    const setReference = refCallback as React.Dispatch<
+      React.SetStateAction<HTMLLIElement | null>
+    >;
     const classNames = cn(styles['DropdownListItem'], className, {
       [styles['DropdownListItem__submenu-toggle']]:
         submenuToggleLabel || onClick || onMouseDown || href,
@@ -153,19 +60,102 @@ export class DropdownListItem extends Component<DropdownListItemProps> {
       [styles['DropdownListItem--title']]: isTitle,
     });
 
+    const renderListItem = useCallback(() => {
+      const { onMouseDown, href, listItemRef, ...otherProps } = props;
+
+      const isClickable = onClick || onMouseDown || href;
+
+      if (isClickable) {
+        const Element = href ? 'a' : 'button';
+
+        const buttonProps = {
+          disabled: isDisabled,
+          'aria-disabled': isDisabled,
+        };
+
+        const linkProps = {
+          href,
+        };
+
+        return (
+          <Element
+            className={styles['DropdownListItem__button']}
+            data-test-id="cf-ui-dropdown-list-item-button"
+            onClick={(e: ReactMouseEvent) => {
+              if (!isDisabled && onClick) {
+                onClick(e);
+              }
+            }}
+            onMouseDown={(e: ReactMouseEvent) => {
+              if (!isDisabled && onMouseDown) {
+                onMouseDown(e);
+              }
+            }}
+            type="button"
+            {...(href ? linkProps : buttonProps)}
+            {...otherProps}
+          >
+            <TabFocusTrap
+              className={styles['DropdownListItem__button__inner-wrapper']}
+            >
+              {children}
+            </TabFocusTrap>
+          </Element>
+        );
+      }
+
+      return <span {...otherProps}>{children}</span>;
+    }, [children, isActive, isDisabled, isTitle, onClick, props]);
+
     return (
       <li
         className={classNames}
         data-test-id={testId}
-        ref={listItemRef}
         role="menuitem"
+        ref={(node) => {
+          if (setReference) {
+            setReference(node);
+          }
+
+          if (listItemRef) {
+            listItemRef.current = node;
+          }
+        }}
+        style={style}
       >
-        {submenuToggleLabel
-          ? this.renderSubmenuToggle()
-          : this.renderListItem()}
+        {submenuToggleLabel ? (
+          <React.Fragment>
+            <button
+              className={styles['DropdownListItem__button']}
+              data-test-id="cf-ui-dropdown-submenu-toggle"
+              onClick={onClick}
+              onFocus={onFocus}
+              onMouseEnter={onEnter}
+              onMouseLeave={onLeave}
+              type="button"
+              {...otherProps}
+            >
+              <TabFocusTrap
+                className={styles['DropdownListItem__button__inner-wrapper']}
+              >
+                {submenuToggleLabel}
+              </TabFocusTrap>
+            </button>
+            {children}
+          </React.Fragment>
+        ) : (
+          renderListItem()
+        )}
       </li>
     );
-  }
-}
+  },
+);
+
+DropdownListItem.defaultProps = {
+  testId: 'cf-ui-dropdown-list-item',
+  isDisabled: false,
+  isActive: false,
+  isTitle: false,
+};
 
 export default DropdownListItem;

--- a/packages/forma-36-react-components/src/components/Dropdown/README.mdx
+++ b/packages/forma-36-react-components/src/components/Dropdown/README.mdx
@@ -1,0 +1,243 @@
+Dropdowns allow users to access a list of multiple actions. A common use-case for Dropdowns is to build context menus.
+
+A Dropdown should contain at least one DropdownList, and multiple DropdownListItem components to represent each action.
+
+## Examples of usage
+
+```jsx
+import {
+  Button,
+  Dropdown,
+  DropdownList,
+  DropdownListItem,
+} from '@contentful/forma-36-react-components';
+
+function DropdownExample() {
+  const [isOpen, setOpen] = React.useState(false);
+  return (
+    <Dropdown
+      isOpen={isOpen}
+      onClose={() => setOpen(false)}
+      toggleElement={
+        <Button
+          size="small"
+          buttonType="muted"
+          indicateDropdown
+          onClick={() => setOpen(!isOpen)}
+        >
+          Trigger Dropdown
+        </Button>
+      }
+    >
+      <DropdownList>
+        <DropdownListItem onClick="() => ()">
+          Dropdown list item 1
+        </DropdownListItem>
+        <DropdownListItem onClick="() => ()">
+          Dropdown list item 2
+        </DropdownListItem>
+      </DropdownList>
+    </Dropdown>
+  );
+}
+```
+
+Dropdown with a title – Use a title to clarify the purpose of a dropdown.
+
+```jsx
+import {
+  Button,
+  Dropdown,
+  DropdownList,
+  DropdownListItem,
+} from '@contentful/forma-36-react-components';
+
+function DropdownExample() {
+  const [isOpen, setOpen] = React.useState(false);
+  return (
+    <Dropdown
+      isOpen={isOpen}
+      onClose={() => setOpen(false)}
+      toggleElement={
+        <Button
+          size="small"
+          buttonType="muted"
+          indicateDropdown
+          onClick={() => setOpen(!isOpen)}
+        >
+          Trigger Dropdown with a title
+        </Button>
+      }
+    >
+      <DropdownList>
+        <DropdownListItem isTitle>Dropdown title</DropdownListItem>
+        <DropdownListItem onClick="() => ()">
+          Dropdown list item 1
+        </DropdownListItem>
+        <DropdownListItem onClick="() => ()">
+          Dropdown list item 2
+        </DropdownListItem>
+      </DropdownList>
+    </Dropdown>
+  );
+}
+```
+
+Dropdown with multiple DropdownLists – Use multiple DropdownLists to group actions together. A DropdownList can contain a border to visually separating these lists.
+
+```jsx
+import {
+  Button,
+  Dropdown,
+  DropdownList,
+  DropdownListItem,
+} from '@contentful/forma-36-react-components';
+
+function DropdownExample() {
+  const [isOpen, setOpen] = React.useState(false);
+  return (
+    <Dropdown
+      isOpen={isOpen}
+      onClose={() => setOpen(false)}
+      toggleElement={
+        <Button
+          size="small"
+          buttonType="muted"
+          indicateDropdown
+          onClick={() => setOpen(!isOpen)}
+        >
+          Trigger Dropdown with multiple DropdownLists
+        </Button>
+      }
+    >
+      <DropdownList>
+        <DropdownListItem onClick="() => ()">
+          Dropdown list item 1
+        </DropdownListItem>
+        <DropdownListItem onClick="() => ()">
+          Dropdown list item 2
+        </DropdownListItem>
+      </DropdownList>
+      <DropdownList border="top">
+        <DropdownListItem onClick="() => ()">
+          Dropdown list item 1
+        </DropdownListItem>
+        <DropdownListItem onClick="() => ()">
+          Dropdown list item 2
+        </DropdownListItem>
+      </DropdownList>
+    </Dropdown>
+  );
+}
+```
+
+Dropdown with links – DropdownListItems can also contain TextLinks. These are often used to highlight related actions to the content of the DropdownList.
+
+```jsx
+import {
+  Button,
+  Dropdown,
+  DropdownList,
+  DropdownListItem,
+} from '@contentful/forma-36-react-components';
+
+function DropdownExample() {
+  const [isOpen, setOpen] = React.useState(false);
+  return (
+    <Dropdown
+      isOpen={isOpen}
+      onClose={() => setOpen(false)}
+      key={Date.now()} // Force Reinit
+      toggleElement={
+        <Button
+          size="small"
+          buttonType="muted"
+          indicateDropdown
+          onClick={() => setOpen(!isOpen)}
+        >
+          Trigger Dropdown with links
+        </Button>
+      }
+    >
+      <DropdownList>
+        <DropdownListItem onClick="() => ()">Kitten</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Puppy</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Piglet</DropdownListItem>
+      </DropdownList>
+      <DropdownList border="top">
+        <DropdownListItem>
+          <TextLink icon="Plus">Add a cute animal</TextLink>
+        </DropdownListItem>
+      </DropdownList>
+    </Dropdown>
+  );
+}
+```
+
+Dropdown with max height – DropdownLists can have a max height to limit the height of the dropdown and introduce scrolling. This should be used when dropdowns need to contain a lot of data.
+
+```jsx
+import {
+  Button,
+  Dropdown,
+  DropdownList,
+  DropdownListItem,
+} from '@contentful/forma-36-react-components';
+
+function DropdownExample() {
+  const [isOpen, setOpen] = React.useState(false);
+  return (
+    <Dropdown
+      isOpen={isOpen}
+      onClose={() => setOpen(false)}
+      key={Date.now()} // Force Reinit
+      toggleElement={
+        <Button
+          size="small"
+          buttonType="muted"
+          indicateDropdown
+          onClick={() => setOpen(!isOpen)}
+        >
+          Trigger Dropdown with max height
+        </Button>
+      }
+    >
+      <DropdownList maxHeight={175}>
+        <DropdownListItem onClick="() => ()">Item 1</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 2</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 3</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 4</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 5</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 6</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 7</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 8</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 9</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 10</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 11</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 12</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 13</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 14</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 15</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 16</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 17</DropdownListItem>
+        <DropdownListItem onClick="() => ()">Item 18</DropdownListItem>
+      </DropdownList>
+    </Dropdown>
+  );
+}
+```
+
+## Best practices
+
+- If there is a single action to display, use TextLink or Button instead
+- Use lists and titles to group similar actions
+- Use a single TextLink at the bottom of the list for an action that is considerably different than the rest
+
+## Content recommendations:
+
+- To make Dropdown action-oriented, use a verb. For example, "Add field", not "New field"
+- Use clear and succinct copy
+
+## Accessibility
+
+- Missing

--- a/packages/forma-36-react-components/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`renders the component 1`] = `
 <div
   className="Dropdown"
   data-test-id="cf-ui-dropdown"
-  position="bottom-left"
 >
   <Button
     aria-expanded={false}
@@ -27,7 +26,6 @@ exports[`renders the component as open 1`] = `
 <div
   className="Dropdown"
   data-test-id="cf-ui-dropdown"
-  position="bottom-left"
 >
   <Button
     aria-expanded={true}
@@ -44,33 +42,31 @@ exports[`renders the component as open 1`] = `
     Toggle
   </Button>
   <DropdownContainer
-    anchorDimensionsAndPositon={
-      Object {
-        "height": 0,
-        "left": 0,
-        "top": 0,
-        "width": 0,
-      }
-    }
-    dropdownAnchor={null}
     getRef={[Function]}
-    isAutoalignmentEnabled={true}
+    isOpen={true}
     openSubmenu={[Function]}
     position="bottom-left"
+    style={
+      Object {
+        "left": "0",
+        "position": "absolute",
+        "top": "0",
+      }
+    }
     submenu={false}
     testId="cf-ui-dropdown-container"
   >
     <DropdownList
       testId="cf-ui-dropdown-list"
     >
-      <DropdownListItem
+      <ForwardRef
         isActive={false}
         isDisabled={false}
         isTitle={false}
         testId="cf-ui-dropdown-list-item"
       >
         entry
-      </DropdownListItem>
+      </ForwardRef>
     </DropdownList>
   </DropdownContainer>
 </div>
@@ -80,7 +76,6 @@ exports[`renders the component with a submenu 1`] = `
 <div
   className="Dropdown"
   data-test-id="cf-ui-dropdown"
-  position="bottom-left"
 >
   <Button
     aria-expanded={true}
@@ -97,33 +92,31 @@ exports[`renders the component with a submenu 1`] = `
     Toggle
   </Button>
   <DropdownContainer
-    anchorDimensionsAndPositon={
-      Object {
-        "height": 0,
-        "left": 0,
-        "top": 0,
-        "width": 0,
-      }
-    }
-    dropdownAnchor={null}
     getRef={[Function]}
-    isAutoalignmentEnabled={true}
+    isOpen={true}
     openSubmenu={[Function]}
     position="bottom-left"
+    style={
+      Object {
+        "left": "0",
+        "position": "absolute",
+        "top": "0",
+      }
+    }
     submenu={false}
     testId="cf-ui-dropdown-container"
   >
     <DropdownList
       testId="cf-ui-dropdown-list"
     >
-      <DropdownListItem
+      <ForwardRef
         isActive={false}
         isDisabled={false}
         isTitle={false}
         testId="cf-ui-dropdown-list-item"
       >
         entry
-      </DropdownListItem>
+      </ForwardRef>
       <Dropdown
         getContainerRef={[Function]}
         isAutoalignmentEnabled={true}
@@ -132,14 +125,14 @@ exports[`renders the component with a submenu 1`] = `
         submenuToggleLabel="Submenu"
         testId="cf-ui-dropdown"
       >
-        <DropdownListItem
+        <ForwardRef
           isActive={false}
           isDisabled={false}
           isTitle={false}
           testId="cf-ui-dropdown-list-item"
         >
           entry
-        </DropdownListItem>
+        </ForwardRef>
       </Dropdown>
       ,
     </DropdownList>
@@ -151,7 +144,6 @@ exports[`renders the component with an additional class name 1`] = `
 <div
   className="Dropdown"
   data-test-id="cf-ui-dropdown"
-  position="bottom-left"
 >
   <Button
     aria-expanded={false}

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
@@ -1033,15 +1033,15 @@ exports[`renders the component with dropdownListElements 1`] = `
           <DropdownList
             testId="cf-ui-dropdown-list"
           >
-            <DropdownListItem
+            <ForwardRef
               isActive={false}
               isDisabled={false}
               isTitle={true}
               testId="cf-ui-dropdown-list-item"
             >
               Actions
-            </DropdownListItem>
-            <DropdownListItem
+            </ForwardRef>
+            <ForwardRef
               isActive={false}
               isDisabled={false}
               isTitle={false}
@@ -1049,8 +1049,8 @@ exports[`renders the component with dropdownListElements 1`] = `
               testId="cf-ui-dropdown-list-item"
             >
               Edit
-            </DropdownListItem>
-            <DropdownListItem
+            </ForwardRef>
+            <ForwardRef
               isActive={false}
               isDisabled={false}
               isTitle={false}
@@ -1058,8 +1058,8 @@ exports[`renders the component with dropdownListElements 1`] = `
               testId="cf-ui-dropdown-list-item"
             >
               Download
-            </DropdownListItem>
-            <DropdownListItem
+            </ForwardRef>
+            <ForwardRef
               isActive={false}
               isDisabled={false}
               isTitle={false}
@@ -1067,7 +1067,7 @@ exports[`renders the component with dropdownListElements 1`] = `
               testId="cf-ui-dropdown-list-item"
             >
               Remove
-            </DropdownListItem>
+            </ForwardRef>
           </DropdownList>
         </CardActions>
       </div>

--- a/packages/forma-36-react-components/yarn.lock
+++ b/packages/forma-36-react-components/yarn.lock
@@ -15850,16 +15850,6 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@16.8:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
-  integrity sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.13.6"
-
 react-dom@^16.8.3:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
@@ -16077,16 +16067,6 @@ react-transition-group@^4.3.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-
-react@16.8:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
-  integrity sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.13.6"
 
 react@^16.13.1, react@^16.8.3, react@^16.9.17:
   version "16.13.1"
@@ -16959,14 +16939,6 @@ sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-
-scheduler@^0.13.6:
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
-  integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.19.1:
   version "0.19.1"


### PR DESCRIPTION
# Purpose of PR

This PR refactors the Dropdown component to use [Popper.js](https://popper.js.org/) instead of the current, custom positioning calculation.

Resolves #361 

# Todo

- [x] Dynamic content
- [x] Don't re-open when toggling on the `toggleElement`
- [ ] ~~What to do about the `isAutoalignmentEnabled` prop? It doesn't serve much of a purpose with Popper doing the positioning automatically. Is it considered a breaking change to remove it?~~

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
