### PR TITLE
refactor: return early after all the hooks

### DIFF
--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
@@ -94,14 +94,6 @@ export const Tooltip = ({
   testId,
   ...otherProps
 }: TooltipProps) => {
-  if (!content) {
-    return (
-      <ContainerElement className={targetWrapperClassName}>
-        {children}
-      </ContainerElement>
-    );
-  }
-
   const [show, setShow] = useState(isVisible);
   const [arrowPosition, setArrowPosition] = useState<ArrowPositionState>(
     getArrowPosition('bottom'),
@@ -157,6 +149,14 @@ export const Tooltip = ({
     maxWidth: contentMaxWidth,
     ...popperStyles.popper,
   };
+
+  if (!content) {
+    return (
+      <ContainerElement className={targetWrapperClassName}>
+        {children}
+      </ContainerElement>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
# Purpose of PR

![Screenshot 2020-10-22 at 14 55 56](https://user-images.githubusercontent.com/6597467/96874713-bcbafe80-1476-11eb-9dcf-5f75991972a1.png)
https://github.com/facebook/react/issues/15792#issuecomment-497952680

@andipaetzold reminded me and Dan Abramov confirms it, that we need to return early a component after all the calls to Hooks

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
