### PR TITLE
fix(AssetCard): dont force width onto small AssetCard

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.css
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.css
@@ -23,7 +23,6 @@
 
 .AssetCard--size-small .AssetCard__asset {
   height: calc(1rem * (142 / var(--font-base-default)));
-  width: calc(1rem * (142 / var(--font-base-default)));
 }
 
 .AssetCard--drag-active {


### PR DESCRIPTION
# Purpose of PR

This one is a bit of a questionable change. Small asset cards were given a fixed width but the default sized ones are not. To have a more consistent view/behaviour I dropped that. Looking for opinions.
