### PR TITLE
fix: Grid shorthand conflicts

### DIFF
--- a/packages/forma-36-react-components/src/components/Grid/GridItem/GridItem.test.tsx
+++ b/packages/forma-36-react-components/src/components/Grid/GridItem/GridItem.test.tsx
@@ -28,30 +28,30 @@ describe('should have correct styles', () => {
   it('should result to gridColumn', () => {
     const output = shallow(<GridItem columnStart={3} columnEnd={6} />);
     const outputStyles = output.get(0).props.style;
-    expect(outputStyles).toMatchObject({ gridColumn: '3 / 6' });
+    expect(outputStyles).toMatchObject({ gridArea: 'auto / 3 / auto / 6' });
   });
 
   it('columnStart should have the correct value', () => {
     const output = shallow(<GridItem columnStart={3} />);
     const outputStyles = output.get(0).props.style;
-    expect(outputStyles).toMatchObject({ gridColumnStart: 3 });
+    expect(outputStyles).toMatchObject({ gridArea: 'auto / 3 / auto / auto' });
   });
 
   it('columnEnd should have the correct value', () => {
     const output = shallow(<GridItem columnEnd={4} />);
     const outputStyles = output.get(0).props.style;
-    expect(outputStyles).toMatchObject({ gridColumnEnd: 4 });
+    expect(outputStyles).toMatchObject({ gridArea: 'auto / auto / auto / 4' });
   });
 
   it('rowStart should have the correct value', () => {
     const output = shallow(<GridItem rowStart={3} />);
     const outputStyles = output.get(0).props.style;
-    expect(outputStyles).toMatchObject({ gridRowStart: 3 });
+    expect(outputStyles).toMatchObject({ gridArea: '3 / auto / auto / auto' });
   });
 
   it('rowEnd should have the correct value', () => {
     const output = shallow(<GridItem rowEnd={4} />);
     const outputStyles = output.get(0).props.style;
-    expect(outputStyles).toMatchObject({ gridRowEnd: 4 });
+    expect(outputStyles).toMatchObject({ gridArea: 'auto / auto / 4 / auto' });
   });
 });

--- a/packages/forma-36-react-components/src/components/Grid/GridItem/GridItem.tsx
+++ b/packages/forma-36-react-components/src/components/Grid/GridItem/GridItem.tsx
@@ -51,24 +51,17 @@ export const GridItem = (props: GridItemProps) => {
     ...otherProps
   } = props;
 
-  const handleShorthand = (
-    property: string,
-    start?: string | number,
-    end?: string | number,
-  ) => {
-    if (start && end) {
-      return { [`grid${property}`]: `${start} / ${end}` };
-    } else if (start && !end) {
-      return { [`grid${property}Start`]: start };
-    } else if (end && !start) {
-      return { [`grid${property}End`]: end };
-    }
-  };
+  const calculatedArea = area
+    ? area
+    : [
+        rowStart || 'auto',
+        columnStart || 'auto',
+        rowEnd || 'auto',
+        columnEnd || 'auto',
+      ].join(' / ');
 
   const style = {
-    ...handleShorthand('Column', columnStart, columnEnd),
-    ...handleShorthand('Row', rowStart, rowEnd),
-    gridArea: area,
+    gridArea: calculatedArea,
     order,
     ...props.style,
   };

--- a/packages/forma-36-react-components/src/components/Grid/GridItem/__snapshots__/GridItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Grid/GridItem/__snapshots__/GridItem.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`renders the component 1`] = `
 <div
   style={
     Object {
-      "gridArea": undefined,
+      "gridArea": "auto / auto / auto / auto",
       "order": undefined,
     }
   }
@@ -18,7 +18,7 @@ exports[`renders the component with an additional class name 1`] = `
   className="my-extra-class"
   style={
     Object {
-      "gridArea": undefined,
+      "gridArea": "auto / auto / auto / auto",
       "order": undefined,
     }
   }


### PR DESCRIPTION
Happy Friday! It's me again 😄 

# Purpose of PR

As you can see in the [storybook](https://f36-storybook.contentful.com/?path=/story/alpha-grid-griditem--default), the GridItem is not displayed correctly. The default knobs are `columnStart=1; columnEnd=3; rowStart=1; rowEnd=4`.

<img width="1187" alt="Screenshot 2020-10-23 at 17 41 37" src="https://user-images.githubusercontent.com/4947671/97024360-02e78f00-1557-11eb-9c2b-733a808b4271.png">

When you look at the rendered code, you see that the `style` prop is empty. When manually changing the `columnStart` and `rowStart` react prop with the react dev tools to another value and then back to the original, the GridItem is displayed correctly. The knobs are still the same.

<img width="1194" alt="Screenshot 2020-10-23 at 17 43 48" src="https://user-images.githubusercontent.com/4947671/97024621-5063fc00-1557-11eb-9daf-2a81faae078a.png">

When doing this in dev mode locally, you get the following error message

> Updating a style property during rerender (gridColumn) when a conflicting property is set (gridArea) can lead to styling bugs. To avoid this, don't mix shorthand and non-shorthand properties for the same value; instead, replace the shorthand with separate values.

Issue is that `grid-area` is actually a shorthand for `gridColumn` and `gridRow` and it's not allowed to set the shorthand and the actual attribute at the same time.

With this PR, we only set a single attribute: `grid-area`. The props `columnStart`, `columnEnd`, `rowStart` and `rowEnd` are always combined and set as `grid-area`. The values fall back to 'auto'. This resolves the issue and the rendering is correct on page load. Now when passing in an `area`, the other grid related props are ignored. This was previously not the case and broken attributes were set.


I understand that this issue happens in the storybook as the `area` is an empty string by default and this causes conflicts. The strange thing is that I run into the identical issue when using the library. I assumed `gridArea: undefined` would be equal to not setting the `gridArea`, but looks like React just checks which style attributes exist at the same time and not whether they are `undefined` or not.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
