### PR TITLE
fix(dropdown): only add keydown event handler when dropdown is open

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
@@ -176,7 +176,7 @@ export function Dropdown({
     if (forceUpdate) {
       forceUpdate();
     }
-  }, [children]);
+  }, [children, forceUpdate]);
 
   const openSubmenu = (isOpen: boolean) => {
     if (submenuToggleLabel) {
@@ -204,12 +204,13 @@ export function Dropdown({
   );
 
   useEffect(() => {
-    document.addEventListener('keydown', handleEscapeKey, true);
-
-    return () => {
-      document.removeEventListener('keydown', handleEscapeKey, true);
-    };
-  }, []);
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscapeKey, true);
+      return () => {
+        document.removeEventListener('keydown', handleEscapeKey, true);
+      };
+    }
+  }, [handleEscapeKey, isOpen]);
 
   return submenuToggleLabel ? (
     <DropdownListItem

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -58,7 +58,7 @@ export const DropdownContainer = forwardRef<
           onClose();
         }
       },
-      [isOpen, onClose, dropdown.current],
+      [isOpen, onClose],
     );
 
     useEffect(() => {
@@ -67,22 +67,19 @@ export const DropdownContainer = forwardRef<
         document.addEventListener('click', trackOutsideClick, {
           passive: true,
         });
-      } else {
-        document.body.removeChild(portalTarget.current);
-        document.removeEventListener('click', trackOutsideClick, {});
-      }
 
-      return () => {
-        document.body.removeChild(portalTarget.current);
-        document.removeEventListener('click', trackOutsideClick, {});
-      };
-    }, [isOpen]);
+        return () => {
+          document.body.removeChild(portalTarget.current);
+          document.removeEventListener('click', trackOutsideClick, {});
+        };
+      }
+    }, [isOpen, trackOutsideClick]);
 
     useEffect(() => {
       if (getRef && dropdown.current) {
         getRef(dropdown.current);
       }
-    }, [dropdown.current]);
+    }, [getRef]);
 
     const dropdownComponent = (
       <div


### PR DESCRIPTION
# Purpose of PR

This should prevent capturing escape press when we don't intend to.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
