### PR TITLE
chore: lint fixes

### DIFF
--- a/packages/forma-36-react-components/.eslintrc.js
+++ b/packages/forma-36-react-components/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
   ],
   parserOptions: {
     ecmaVersion: 7,
-    project: 'tsconfig.json',
+    project: './tsconfig.json',
     sourceType: 'module',
   },
   env: {
@@ -25,19 +25,19 @@ module.exports = {
   },
   settings: {
     react: {
-      version: '16.3.0',
+      version: 'detect',
     },
   },
   rules: {
     'react/prop-types': 'off',
-    'react/prefer-stateless-function': [0, { ignorePureComponents: true }],
-    'react/jsx-filename-extension': { extensions: ['.js', '.jsx'] },
-    'react/forbid-prop-types': 0,
-    'react/destructuring-assignment': 0,
-    'react/jsx-one-expression-per-line': 0,
-    'react/sort-comp': 0,
-    'react/jsx-wrap-multilines': 0,
-    'function-paren-newline': 0,
+    'react/prefer-stateless-function': ['off', { ignorePureComponents: true }],
+    'react/jsx-filename-extension': ['off', { extensions: ['.js', '.tsx'] }],
+    'react/forbid-prop-types': 'off',
+    'react/destructuring-assignment': 'off',
+    'react/jsx-one-expression-per-line': 'off',
+    'react/sort-comp': 'off',
+    'react/jsx-wrap-multilines': 'off',
+    'function-paren-newline': 'off',
     'react/button-has-type': 'error',
     'react/jsx-no-target-blank': 'error',
     'react/jsx-no-bind': ['error', { allowArrowFunctions: true }],
@@ -57,6 +57,7 @@ module.exports = {
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
     '@typescript-eslint/no-non-null-assertion': 'error',
+    '@typescript-eslint/no-empty-function': 'off',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn'
   },

--- a/packages/forma-36-react-components/src/components/Accordion/Accordion.test.tsx
+++ b/packages/forma-36-react-components/src/components/Accordion/Accordion.test.tsx
@@ -59,11 +59,11 @@ it('calls onExpand && onCollapse when an accordion item is expanded and collapse
   );
 
   output.find('button').simulate('click');
-  expect(onExpand).toBeCalledTimes(1);
-  expect(onCollapse).toBeCalledTimes(0);
+  expect(onExpand).toHaveBeenCalledTimes(1);
+  expect(onCollapse).toHaveBeenCalledTimes(0);
   output.find('button').simulate('click');
-  expect(onExpand).toBeCalledTimes(1);
-  expect(onCollapse).toBeCalledTimes(1);
+  expect(onExpand).toHaveBeenCalledTimes(1);
+  expect(onCollapse).toHaveBeenCalledTimes(1);
 });
 
 it('has no a11y issues', async () => {

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -21,11 +21,14 @@ const items: Item[] = [
 const AutocompleteDefaultStory = ({ items }: { items: Item[] }) => {
   const [filteredItems, setFilteredItems] = useState(items);
 
-  const handleQueryChange = useCallback((query: string) => {
-    setFilteredItems(
-      query ? items.filter(item => item.label.includes(query)) : items,
-    );
-  }, []);
+  const handleQueryChange = useCallback(
+    (query: string) => {
+      setFilteredItems(
+        query ? items.filter((item) => item.label.includes(query)) : items,
+      );
+    },
+    [items, setFilteredItems],
+  );
 
   return (
     <Autocomplete<Item>

--- a/packages/forma-36-react-components/src/components/DateTime/DateTime/DateTime.stories.tsx
+++ b/packages/forma-36-react-components/src/components/DateTime/DateTime/DateTime.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import DateTime, { DateTimeProps } from './DateTime';
 
-const exampleDate = '2020-08-13T13:45:56.0123Z'
+const exampleDate = '2020-08-13T13:45:56.0123Z';
 
 import notes from '../README.md';
 
@@ -15,23 +15,28 @@ export default {
   },
   argTypes: {
     date: { control: { type: 'date' } },
-    format: { control: { type: 'select', options: ['FULL', 'DATE_ONLY', 'TIME_ONLY', 'WEEKDAY_DATE'] }},
+    format: {
+      control: {
+        type: 'select',
+        options: ['FULL', 'DATE_ONLY', 'TIME_ONLY', 'WEEKDAY_DATE'],
+      },
+    },
     className: { control: { type: 'text' } },
-    testId: { control: { type: 'text' }}
-  }
-}
+    testId: { control: { type: 'text' } },
+  },
+};
 
-const DateTimeStory = (args: DateTimeProps) => (
-  <DateTime {...args} />
-)
+const DateTimeStory = (args: DateTimeProps) => <DateTime {...args} />;
 
-export const basic: any = DateTimeStory.bind({})
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const basic: any = DateTimeStory.bind({});
 basic.args = {
-  date: exampleDate
-}
+  date: exampleDate,
+};
 
-export const withOtherFormats: any = DateTimeStory.bind({})
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const withOtherFormats: any = DateTimeStory.bind({});
 withOtherFormats.args = {
   date: exampleDate,
-  format: 'DATE_ONLY'
-}
+  format: 'DATE_ONLY',
+};

--- a/packages/forma-36-react-components/src/components/DateTime/DateTime/DateTime.test.tsx
+++ b/packages/forma-36-react-components/src/components/DateTime/DateTime/DateTime.test.tsx
@@ -44,6 +44,7 @@ describe('DateTime', () => {
   });
 
   it('does not allow for an unknown format', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const format = 'NOT_REAL' as any;
     try {
       shallow(<DateTime date={exampleDate} format={format} />);

--- a/packages/forma-36-react-components/src/components/DateTime/RelativeDate/RelativeDate.stories.tsx
+++ b/packages/forma-36-react-components/src/components/DateTime/RelativeDate/RelativeDate.stories.tsx
@@ -17,22 +17,24 @@ export default {
     date: { control: { type: 'date' } },
     baseDate: { control: { type: 'date', disabled: true } },
     className: { control: { type: 'text' } },
-    testId: { control: { type: 'text' }}
-  }
-}
+    testId: { control: { type: 'text' } },
+  },
+};
 
 const RelativeDateStory = (args: RelativeDateProps) => (
   <RelativeDate {...args} />
-)
+);
 
-export const basic: any = RelativeDateStory.bind({})
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const basic: any = RelativeDateStory.bind({});
 basic.args = {
   date: Date.now() - THREE_MINUTES,
   baseDate: undefined,
-}
+};
 
-export const withBaseDate: any = RelativeDateStory.bind({})
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const withBaseDate: any = RelativeDateStory.bind({});
 withBaseDate.args = {
   date: Date.now() - THREE_MINUTES,
   baseDate: Date.now() + THREE_MINUTES,
-}
+};

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -63,13 +63,15 @@ export const DropdownContainer = forwardRef<
 
     useEffect(() => {
       if (isOpen) {
-        document.body.appendChild(portalTarget.current);
+        const portalContainer = portalTarget.current;
+
+        document.body.appendChild(portalContainer);
         document.addEventListener('click', trackOutsideClick, {
           passive: true,
         });
 
         return () => {
-          document.body.removeChild(portalTarget.current);
+          document.body.removeChild(portalContainer);
           document.removeEventListener('click', trackOutsideClick, {});
         };
       }

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
@@ -105,7 +105,7 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
       }
 
       return <span {...otherProps}>{children}</span>;
-    }, [children, isActive, isDisabled, isTitle, onClick, props]);
+    }, [children, isDisabled, onClick, props]);
 
     return (
       <li

--- a/packages/forma-36-react-components/src/components/Flex/Flex.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Flex/Flex.stories.tsx
@@ -63,7 +63,7 @@ const styles = {
 
 const DemoBox = ({ times }: { times?: number }) => {
   if (times) {
-    let result = [];
+    const result = [];
     for (let i = 0; i < times; i++) {
       result.push(
         <Flex

--- a/packages/forma-36-react-components/src/components/Grid/Grid.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Grid/Grid.stories.tsx
@@ -31,7 +31,7 @@ const styles = {
 
 const DemoBox = ({ times, id }: { times?: number; id?: string }) => {
   if (times) {
-    let result = [];
+    const result = [];
     for (let i = 0; i < times; i++) {
       result.push(<GridItem key={`${id}-${i}`} style={styles.demoBox} />);
     }

--- a/packages/forma-36-react-components/src/components/Grid/GridItem/GridItem.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Grid/GridItem/GridItem.stories.tsx
@@ -32,7 +32,7 @@ const styles = {
 
 const DemoBox = ({ times, id }: { times?: number; id?: string }) => {
   if (times) {
-    let result = [];
+    const result = [];
     for (let i = 0; i < times; i++) {
       result.push(<GridItem key={`${id}-${i}`} style={styles.demoBox} />);
     }

--- a/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.stories.tsx
@@ -13,7 +13,7 @@ function DefaultStory() {
     <React.Fragment>
       <Button
         onClick={() => {
-          ModalLauncher.open(({ isShown, onClose }) => (
+          ModalLauncher.open<string>(({ isShown, onClose }) => (
             <Modal
               title="Reveal hidden text"
               isShown={isShown}
@@ -41,7 +41,7 @@ function DefaultStory() {
                 </React.Fragment>
               )}
             </Modal>
-          )).then(text => {
+          )).then((text) => {
             setHiddenText(text);
           });
         }}

--- a/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.tsx
@@ -1,6 +1,8 @@
 /* global Promise */
 import ReactDOM from 'react-dom';
 
+// @todo: change any to unknown
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 interface ModalLauncherComponentRendererProps<T = any> {
   isShown: boolean;
   onClose: (result?: T) => void;
@@ -12,6 +14,7 @@ interface ModalLauncherOpenOptions {
   delay?: number;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function open<T = any>(
   componentRenderer: (
     props: ModalLauncherComponentRendererProps<T>,
@@ -42,7 +45,7 @@ function open<T = any>(
     return rootDom;
   };
 
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     let currentConfig = { onClose, isShown: true };
 
     function render({
@@ -58,7 +61,7 @@ function open<T = any>(
         isShown: false,
       };
       render(currentConfig);
-      await new Promise(resolveDelay =>
+      await new Promise((resolveDelay) =>
         setTimeout(resolveDelay, options.delay),
       );
       ReactDOM.unmountComponentAtNode(getRoot());

--- a/packages/forma-36-react-components/src/components/Notification/NotificationsManager.tsx
+++ b/packages/forma-36-react-components/src/components/Notification/NotificationsManager.tsx
@@ -137,7 +137,7 @@ export class NotificationsManager extends PureComponent<
     const notificationId =
       settings && settings.id ? settings.id : getUniqueId();
 
-    let notification = {
+    const notification = {
       id: notificationId,
       text,
       close: () => this.closeAndDelete(notificationId),

--- a/packages/forma-36-react-components/src/components/Notification/index.tsx
+++ b/packages/forma-36-react-components/src/components/Notification/index.tsx
@@ -24,7 +24,7 @@ export interface NotificationsAPI {
 }
 
 let initiated = false;
-let internalAPI: Partial<NotificationsAPI> = {};
+const internalAPI: Partial<NotificationsAPI> = {};
 
 function registerAPI(fnName: string, fn: Function) {
   internalAPI[fnName] = fn;
@@ -37,18 +37,20 @@ function createRoot(callback: () => void) {
   render(<NotificationManager register={registerAPI} />, container, callback);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const afterInit = (fn: Function) => (...args: any[]) => {
-  if (!initiated) {
-    initiated = true;
-    return new Promise(resolve => {
-      createRoot(() => {
-        resolve(fn(...args));
+const afterInit = (fn: Function) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (...args: any[]) => {
+    if (!initiated) {
+      initiated = true;
+      return new Promise((resolve) => {
+        createRoot(() => {
+          resolve(fn(...args));
+        });
       });
-    });
-  } else {
-    return Promise.resolve(fn(...args));
-  }
+    } else {
+      return Promise.resolve(fn(...args));
+    }
+  };
 };
 
 const show = (intent: NotificationIntent) => (

--- a/packages/forma-36-react-components/src/components/Tabs/Tab.tsx
+++ b/packages/forma-36-react-components/src/components/Tabs/Tab.tsx
@@ -57,7 +57,7 @@ export class Tab extends Component<TabProps> {
       children,
       tabIndex,
     } = this.props;
-    let elementProps = {
+    const elementProps = {
       className: classNames(
         styles.Tab,
         {

--- a/packages/forma-36-react-components/src/utils/throttle.ts
+++ b/packages/forma-36-react-components/src/utils/throttle.ts
@@ -1,4 +1,4 @@
-const throttle = (delay: number = 200, fn: Function) => {
+const throttle = (delay = 200, fn: Function) => {
   let lastCall = 0;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const throttleExec = (...args: any[]) => {


### PR DESCRIPTION
# Purpose of PR

Lint fixes. This PR should make it easier to land some other changes we have coming 🙂

We should decide what we want to do with the eslint rule `@typescript-eslint/no-explicit-any`, which is producing the last warnings. I'm thinking we can turn it off and trust people to know when to use `any`. I did the same with `@typescript-eslint/no-empty-function`.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
