### PR TITLE
fix(dropdown): use capture event in outside click handler

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -55,6 +55,8 @@ export const DropdownContainer = forwardRef<
           dropdown.current &&
           !dropdown.current.contains(event.target as Node)
         ) {
+          event.stopImmediatePropagation();
+
           onClose();
         }
       },
@@ -67,12 +69,14 @@ export const DropdownContainer = forwardRef<
 
         document.body.appendChild(portalContainer);
         document.addEventListener('click', trackOutsideClick, {
-          passive: true,
+          capture: true,
         });
 
         return () => {
           document.body.removeChild(portalContainer);
-          document.removeEventListener('click', trackOutsideClick, {});
+          document.removeEventListener('click', trackOutsideClick, {
+            capture: true,
+          });
         };
       }
     }, [isOpen, trackOutsideClick]);


### PR DESCRIPTION
# Purpose of PR

This fix handles the situation where the dropdown is open and the user then clicks on the toggle element to close the dropdown, which fires both an open and a close event right after each other.

This happens as the event bubbles from the button and up to the document, where the outside click event handler is bound. The alternative is using a capture event like in this PR, where the event goes from the document and down to the button. This solves the issue of two events firing, but the downside is that it now also takes a second click to e.g. open another dropdown; the first to close the active dropdown and the second to trigger the event of the action.


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
