### PR TITLE
chore: explicitly set entry title to demi-bold

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.css
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.css
@@ -79,6 +79,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   color: var(--color-text-dark);
+  font-weight: var(--font-weight-demi-bold);
 }
 
 .EntryCard__description {


### PR DESCRIPTION
# Purpose of PR

Currently the boldness of `EntryCard` title depends on global CSS for h1. This fix sets explicit boldness to the entry card title so it's bold even if h1 were reset.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
