### PR TITLE
fix(dropdownlistitem): always apply button classname and test-id

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
@@ -169,15 +169,15 @@ exports[`renders the component with actions 1`] = `
         <DropdownList
           testId="cf-ui-dropdown-list"
         >
-          <ForwardRef
+          <ForwardRef(DropdownListItem)
             isActive={false}
             isDisabled={false}
             isTitle={true}
             testId="cf-ui-dropdown-list-item"
           >
             Actions
-          </ForwardRef>
-          <ForwardRef
+          </ForwardRef(DropdownListItem)>
+          <ForwardRef(DropdownListItem)
             isActive={false}
             isDisabled={false}
             isTitle={false}
@@ -185,7 +185,7 @@ exports[`renders the component with actions 1`] = `
             testId="cf-ui-dropdown-list-item"
           >
             Edit
-          </ForwardRef>
+          </ForwardRef(DropdownListItem)>
         </DropdownList>
       </CardActions>
     </div>

--- a/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`renders the component as disabled 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <ForwardRef
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -37,7 +37,7 @@ exports[`renders the component as disabled 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </ForwardRef>
+    </ForwardRef(DropdownListItem)>
   </DropdownList>
 </Dropdown>
 `;
@@ -71,7 +71,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <ForwardRef
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -79,8 +79,8 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </ForwardRef>
-    <ForwardRef
+    </ForwardRef(DropdownListItem)>
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -88,8 +88,8 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </ForwardRef>
-    <ForwardRef
+    </ForwardRef(DropdownListItem)>
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -97,14 +97,14 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </ForwardRef>
+    </ForwardRef(DropdownListItem)>
   </DropdownList>
   <DropdownList
     key=".1/.$.0/.$.0"
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <ForwardRef
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -112,8 +112,8 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </ForwardRef>
-    <ForwardRef
+    </ForwardRef(DropdownListItem)>
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -121,8 +121,8 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </ForwardRef>
-    <ForwardRef
+    </ForwardRef(DropdownListItem)>
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -130,7 +130,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </ForwardRef>
+    </ForwardRef(DropdownListItem)>
   </DropdownList>
 </Dropdown>
 `;
@@ -164,7 +164,7 @@ exports[`renders the component using a single dropdown list 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <ForwardRef
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -172,8 +172,8 @@ exports[`renders the component using a single dropdown list 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </ForwardRef>
-    <ForwardRef
+    </ForwardRef(DropdownListItem)>
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -181,8 +181,8 @@ exports[`renders the component using a single dropdown list 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </ForwardRef>
-    <ForwardRef
+    </ForwardRef(DropdownListItem)>
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -190,7 +190,7 @@ exports[`renders the component using a single dropdown list 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </ForwardRef>
+    </ForwardRef(DropdownListItem)>
   </DropdownList>
 </Dropdown>
 `;
@@ -225,7 +225,7 @@ exports[`renders the component with an additional class name 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <ForwardRef
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -233,8 +233,8 @@ exports[`renders the component with an additional class name 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </ForwardRef>
-    <ForwardRef
+    </ForwardRef(DropdownListItem)>
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -242,8 +242,8 @@ exports[`renders the component with an additional class name 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </ForwardRef>
-    <ForwardRef
+    </ForwardRef(DropdownListItem)>
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -251,7 +251,7 @@ exports[`renders the component with an additional class name 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </ForwardRef>
+    </ForwardRef(DropdownListItem)>
   </DropdownList>
 </Dropdown>
 `;
@@ -285,7 +285,7 @@ exports[`renders the component with published status 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <ForwardRef
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -293,8 +293,8 @@ exports[`renders the component with published status 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </ForwardRef>
-    <ForwardRef
+    </ForwardRef(DropdownListItem)>
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -302,8 +302,8 @@ exports[`renders the component with published status 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </ForwardRef>
-    <ForwardRef
+    </ForwardRef(DropdownListItem)>
+    <ForwardRef(DropdownListItem)
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -311,7 +311,7 @@ exports[`renders the component with published status 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </ForwardRef>
+    </ForwardRef(DropdownListItem)>
   </DropdownList>
 </Dropdown>
 `;

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
@@ -353,15 +353,15 @@ exports[`renders the component with dropdownListElements 1`] = `
         <DropdownList
           testId="cf-ui-dropdown-list"
         >
-          <ForwardRef
+          <ForwardRef(DropdownListItem)
             isActive={false}
             isDisabled={false}
             isTitle={true}
             testId="cf-ui-dropdown-list-item"
           >
             Actions
-          </ForwardRef>
-          <ForwardRef
+          </ForwardRef(DropdownListItem)>
+          <ForwardRef(DropdownListItem)
             isActive={false}
             isDisabled={false}
             isTitle={false}
@@ -369,8 +369,8 @@ exports[`renders the component with dropdownListElements 1`] = `
             testId="cf-ui-dropdown-list-item"
           >
             Edit
-          </ForwardRef>
-          <ForwardRef
+          </ForwardRef(DropdownListItem)>
+          <ForwardRef(DropdownListItem)
             isActive={false}
             isDisabled={false}
             isTitle={false}
@@ -378,8 +378,8 @@ exports[`renders the component with dropdownListElements 1`] = `
             testId="cf-ui-dropdown-list-item"
           >
             Download
-          </ForwardRef>
-          <ForwardRef
+          </ForwardRef(DropdownListItem)>
+          <ForwardRef(DropdownListItem)
             isActive={false}
             isDisabled={false}
             isTitle={false}
@@ -387,7 +387,7 @@ exports[`renders the component with dropdownListElements 1`] = `
             testId="cf-ui-dropdown-list-item"
           >
             Remove
-          </ForwardRef>
+          </ForwardRef(DropdownListItem)>
         </DropdownList>
       </CardActions>
     </div>

--- a/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`renders the component with a dropdown 1`] = `
     <DropdownList
       testId="cf-ui-dropdown-list"
     >
-      <ForwardRef
+      <ForwardRef(DropdownListItem)
         isActive={false}
         isDisabled={false}
         isTitle={false}
@@ -95,8 +95,8 @@ exports[`renders the component with a dropdown 1`] = `
         testId="cf-ui-dropdown-list-item"
       >
         Edit
-      </ForwardRef>
-      <ForwardRef
+      </ForwardRef(DropdownListItem)>
+      <ForwardRef(DropdownListItem)
         isActive={false}
         isDisabled={false}
         isTitle={false}
@@ -105,7 +105,7 @@ exports[`renders the component with a dropdown 1`] = `
         testId="cf-ui-dropdown-list-item"
       >
         Remove
-      </ForwardRef>
+      </ForwardRef(DropdownListItem)>
     </DropdownList>
   </CardActions>
 </Card>

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownList/__snapshots__/DropdownList.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownList/__snapshots__/DropdownList.test.tsx.snap
@@ -12,14 +12,14 @@ exports[`renders the component 1`] = `
     }
   }
 >
-  <ForwardRef
+  <ForwardRef(DropdownListItem)
     isActive={false}
     isDisabled={false}
     isTitle={false}
     testId="cf-ui-dropdown-list-item"
   >
     List Item
-  </ForwardRef>
+  </ForwardRef(DropdownListItem)>
 </ul>
 `;
 
@@ -35,14 +35,14 @@ exports[`renders the component with a border attribute 1`] = `
     }
   }
 >
-  <ForwardRef
+  <ForwardRef(DropdownListItem)
     isActive={false}
     isDisabled={false}
     isTitle={false}
     testId="cf-ui-dropdown-list-item"
   >
     List Item
-  </ForwardRef>
+  </ForwardRef(DropdownListItem)>
 </ul>
 `;
 
@@ -58,13 +58,13 @@ exports[`renders the component with an additional class name 1`] = `
     }
   }
 >
-  <ForwardRef
+  <ForwardRef(DropdownListItem)
     isActive={false}
     isDisabled={false}
     isTitle={false}
     testId="cf-ui-dropdown-list-item"
   >
     List Item
-  </ForwardRef>
+  </ForwardRef(DropdownListItem)>
 </ul>
 `;

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
@@ -79,6 +79,8 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
 
         return (
           <Element
+            className={styles['DropdownListItem__button']}
+            data-test-id="cf-ui-dropdown-list-item-button"
             onClick={!isDisabled && onClick !== undefined ? onClick : undefined}
             onMouseDown={
               !isDisabled && onMouseDown !== undefined ? onMouseDown : undefined
@@ -86,8 +88,6 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
             type="button"
             {...(href ? linkProps : buttonProps)}
             {...props}
-            className={styles['DropdownListItem__button']}
-            data-test-id="cf-ui-dropdown-list-item-button"
           >
             <TabFocusTrap
               className={styles['DropdownListItem__button__inner-wrapper']}

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
@@ -79,16 +79,10 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
 
         return (
           <Element
-            onClick={(e: ReactMouseEvent) => {
-              if (!isDisabled && onClick) {
-                onClick(e);
-              }
-            }}
-            onMouseDown={(e: ReactMouseEvent) => {
-              if (!isDisabled && onMouseDown) {
-                onMouseDown(e);
-              }
-            }}
+            onClick={!isDisabled && onClick !== undefined ? onClick : undefined}
+            onMouseDown={
+              !isDisabled && onMouseDown !== undefined ? onMouseDown : undefined
+            }
             type="button"
             {...(href ? linkProps : buttonProps)}
             {...props}

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
@@ -2,7 +2,6 @@ import React, {
   forwardRef,
   MouseEventHandler,
   FocusEventHandler,
-  MouseEvent as ReactMouseEvent,
   useCallback,
 } from 'react';
 import cn from 'classnames';
@@ -29,24 +28,27 @@ export interface DropdownListItemProps
 }
 
 export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
-  (
+  function DropdownListItem(
     {
       children,
+      className,
+      href,
       isActive,
       isDisabled,
       isTitle,
+      listItemRef,
       onClick,
       onEnter,
       onFocus,
       onLeave,
+      onMouseDown,
       style,
       submenuToggleLabel,
       testId,
       ...props
     },
     refCallback,
-  ) => {
-    const { className, href, listItemRef, onMouseDown, ...otherProps } = props;
+  ) {
     // We're not dealing with React RefObjects but with useState (because we
     // want to re-render on all changes)
     const setReference = refCallback as React.Dispatch<
@@ -61,8 +63,6 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
     });
 
     const renderListItem = useCallback(() => {
-      const { onMouseDown, href, listItemRef, ...otherProps } = props;
-
       const isClickable = onClick || onMouseDown || href;
 
       if (isClickable) {
@@ -79,8 +79,6 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
 
         return (
           <Element
-            className={styles['DropdownListItem__button']}
-            data-test-id="cf-ui-dropdown-list-item-button"
             onClick={(e: ReactMouseEvent) => {
               if (!isDisabled && onClick) {
                 onClick(e);
@@ -93,7 +91,9 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
             }}
             type="button"
             {...(href ? linkProps : buttonProps)}
-            {...otherProps}
+            {...props}
+            className={styles['DropdownListItem__button']}
+            data-test-id="cf-ui-dropdown-list-item-button"
           >
             <TabFocusTrap
               className={styles['DropdownListItem__button__inner-wrapper']}

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
@@ -104,8 +104,8 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
         );
       }
 
-      return <span {...otherProps}>{children}</span>;
-    }, [children, isDisabled, onClick, props]);
+      return <span {...props}>{children}</span>;
+    }, [children, href, isDisabled, onClick, onMouseDown, props]);
 
     return (
       <li
@@ -126,14 +126,14 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
         {submenuToggleLabel ? (
           <React.Fragment>
             <button
-              className={styles['DropdownListItem__button']}
-              data-test-id="cf-ui-dropdown-submenu-toggle"
               onClick={onClick}
               onFocus={onFocus}
               onMouseEnter={onEnter}
               onMouseLeave={onLeave}
               type="button"
-              {...otherProps}
+              {...props}
+              className={styles['DropdownListItem__button']}
+              data-test-id="cf-ui-dropdown-submenu-toggle"
             >
               <TabFocusTrap
                 className={styles['DropdownListItem__button__inner-wrapper']}

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/__snapshots__/DropdownListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/__snapshots__/DropdownListItem.test.tsx.snap
@@ -46,8 +46,6 @@ exports[`renders the component with a href 1`] = `
     className="DropdownListItem__button"
     data-test-id="cf-ui-dropdown-list-item-button"
     href="#"
-    onClick={[Function]}
-    onMouseDown={[Function]}
     type="button"
   >
     <TabFocusTrap
@@ -65,9 +63,7 @@ exports[`renders the component with an additional class name 1`] = `
   data-test-id="cf-ui-dropdown-list-item"
   role="menuitem"
 >
-  <span
-    className="my-extra-class"
-  >
+  <span>
     Entry
   </span>
 </li>

--- a/packages/forma-36-react-components/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -59,14 +59,14 @@ exports[`renders the component as open 1`] = `
     <DropdownList
       testId="cf-ui-dropdown-list"
     >
-      <ForwardRef
+      <ForwardRef(DropdownListItem)
         isActive={false}
         isDisabled={false}
         isTitle={false}
         testId="cf-ui-dropdown-list-item"
       >
         entry
-      </ForwardRef>
+      </ForwardRef(DropdownListItem)>
     </DropdownList>
   </DropdownContainer>
 </div>
@@ -109,14 +109,14 @@ exports[`renders the component with a submenu 1`] = `
     <DropdownList
       testId="cf-ui-dropdown-list"
     >
-      <ForwardRef
+      <ForwardRef(DropdownListItem)
         isActive={false}
         isDisabled={false}
         isTitle={false}
         testId="cf-ui-dropdown-list-item"
       >
         entry
-      </ForwardRef>
+      </ForwardRef(DropdownListItem)>
       <Dropdown
         getContainerRef={[Function]}
         isAutoalignmentEnabled={true}
@@ -125,14 +125,14 @@ exports[`renders the component with a submenu 1`] = `
         submenuToggleLabel="Submenu"
         testId="cf-ui-dropdown"
       >
-        <ForwardRef
+        <ForwardRef(DropdownListItem)
           isActive={false}
           isDisabled={false}
           isTitle={false}
           testId="cf-ui-dropdown-list-item"
         >
           entry
-        </ForwardRef>
+        </ForwardRef(DropdownListItem)>
       </Dropdown>
       ,
     </DropdownList>

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
@@ -1033,15 +1033,15 @@ exports[`renders the component with dropdownListElements 1`] = `
           <DropdownList
             testId="cf-ui-dropdown-list"
           >
-            <ForwardRef
+            <ForwardRef(DropdownListItem)
               isActive={false}
               isDisabled={false}
               isTitle={true}
               testId="cf-ui-dropdown-list-item"
             >
               Actions
-            </ForwardRef>
-            <ForwardRef
+            </ForwardRef(DropdownListItem)>
+            <ForwardRef(DropdownListItem)
               isActive={false}
               isDisabled={false}
               isTitle={false}
@@ -1049,8 +1049,8 @@ exports[`renders the component with dropdownListElements 1`] = `
               testId="cf-ui-dropdown-list-item"
             >
               Edit
-            </ForwardRef>
-            <ForwardRef
+            </ForwardRef(DropdownListItem)>
+            <ForwardRef(DropdownListItem)
               isActive={false}
               isDisabled={false}
               isTitle={false}
@@ -1058,8 +1058,8 @@ exports[`renders the component with dropdownListElements 1`] = `
               testId="cf-ui-dropdown-list-item"
             >
               Download
-            </ForwardRef>
-            <ForwardRef
+            </ForwardRef(DropdownListItem)>
+            <ForwardRef(DropdownListItem)
               isActive={false}
               isDisabled={false}
               isTitle={false}
@@ -1067,7 +1067,7 @@ exports[`renders the component with dropdownListElements 1`] = `
               testId="cf-ui-dropdown-list-item"
             >
               Remove
-            </ForwardRef>
+            </ForwardRef(DropdownListItem)>
           </DropdownList>
         </CardActions>
       </div>


### PR DESCRIPTION
# Purpose of PR

`DropdownListItem` class and test-id should not be overwritten by props. Also adds a React display name to the `forwardRef`.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
