### PR TITLE
feat(dropdown): add usePortal boolean prop

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.stories.tsx
@@ -19,6 +19,7 @@ function DefaultStory() {
       isFullWidth={boolean('isFullWidth', false)}
       key={Date.now()} // Force Reinit
       isAutoalignmentEnabled={boolean('isAutoalignmentEnabled', true)}
+      usePortal={boolean('usePortal', true)}
       position={select(
         'position',
         {
@@ -84,6 +85,7 @@ function ScrollableStory() {
       isOpen={isOpen}
       onClose={() => setOpen(false)}
       isAutoalignmentEnabled={boolean('isAutoalignmentEnabled', true)}
+      usePortal={boolean('usePortal', true)}
       position={select(
         'position',
         {
@@ -142,6 +144,7 @@ function DynamicContentStory() {
       isOpen={isOpen}
       onClose={onClose}
       isAutoalignmentEnabled={boolean('isAutoalignmentEnabled', true)}
+      usePortal={boolean('usePortal', true)}
       position={select(
         'position',
         {

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
@@ -116,6 +116,15 @@ export interface DropdownProps {
    * React element to use as the toggle, opening and closing the Dropdown
    */
   toggleElement?: React.ReactElement;
+  /**
+   * Boolean to control whether or not to render the dropdown in a React Portal.
+   * Rendering content inside a Portal allows the dropdown to escape the bounds
+   * of its parent while still being positioned correctly. Using a Portal is
+   * necessary if an ancestor of the dropdown hides overflow.
+   *
+   * Defaults to `true`
+   */
+  usePortal?: boolean;
 }
 
 export function Dropdown({
@@ -131,6 +140,7 @@ export function Dropdown({
   submenuToggleLabel,
   testId,
   toggleElement,
+  usePortal,
   ...otherProps
 }: DropdownProps) {
   const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(
@@ -237,6 +247,7 @@ export function Dropdown({
           ref={setPopperElement}
           style={popperStyles.popper}
           submenu
+          usePortal={usePortal}
           {...attributes.popper}
         >
           {children}
@@ -268,6 +279,7 @@ export function Dropdown({
           style={popperStyles.popper}
           submenu={false}
           testId={containerTestId}
+          usePortal={usePortal}
           {...attributes.popper}
         >
           {children}

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef, useCallback, useEffect, useRef } from 'react';
 import cn from 'classnames';
-import ReactDOM from 'react-dom';
 
 import { positionType } from '../Dropdown';
 import styles from './DropdownContainer.css';
+import Portal from '../../Portal';
 
 export interface DropdownContainerProps
   extends React.HTMLAttributes<HTMLElement> {
@@ -16,6 +16,7 @@ export interface DropdownContainerProps
   position?: positionType;
   submenu?: boolean;
   testId?: string;
+  usePortal?: boolean;
 }
 
 export const DropdownContainer = forwardRef<
@@ -34,6 +35,7 @@ export const DropdownContainer = forwardRef<
       style,
       submenu,
       testId,
+      usePortal,
       ...props
     },
     refCallback,
@@ -44,7 +46,6 @@ export const DropdownContainer = forwardRef<
       React.SetStateAction<HTMLElement | null>
     >;
     const dropdown = useRef<HTMLDivElement | null>(null);
-    const portalTarget = useRef<HTMLDivElement>(document.createElement('div'));
     const classNames = cn(className, styles['DropdownContainer']);
 
     const trackOutsideClick = useCallback(
@@ -65,15 +66,11 @@ export const DropdownContainer = forwardRef<
 
     useEffect(() => {
       if (isOpen) {
-        const portalContainer = portalTarget.current;
-
-        document.body.appendChild(portalContainer);
         document.addEventListener('click', trackOutsideClick, {
           capture: true,
         });
 
         return () => {
-          document.body.removeChild(portalContainer);
           document.removeEventListener('click', trackOutsideClick, {
             capture: true,
           });
@@ -117,9 +114,11 @@ export const DropdownContainer = forwardRef<
       </div>
     );
 
-    return submenu
-      ? dropdownComponent
-      : ReactDOM.createPortal(dropdownComponent, portalTarget.current);
+    return submenu || !usePortal ? (
+      dropdownComponent
+    ) : (
+      <Portal>{dropdownComponent}</Portal>
+    );
   },
 );
 

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -1,6 +1,7 @@
-import React, { forwardRef, useCallback, useEffect, useRef } from 'react';
+import React, { forwardRef, useEffect, useRef } from 'react';
 import cn from 'classnames';
 
+import { useOnClickOutside } from '../../../utils/useOnClickOutside';
 import { positionType } from '../Dropdown';
 import styles from './DropdownContainer.css';
 import Portal from '../../Portal';
@@ -22,105 +23,81 @@ export interface DropdownContainerProps
 export const DropdownContainer = forwardRef<
   HTMLElement,
   DropdownContainerProps
->(
-  (
-    {
-      children,
-      className,
-      getRef,
-      isOpen,
-      onClose,
-      openSubmenu,
-      position,
-      style,
-      submenu,
-      testId,
-      usePortal,
-      ...props
-    },
-    refCallback,
-  ) => {
-    // We're not dealing with React RefObjects but with useState (because we
-    // want to re-render on all changes)
-    const setReference = refCallback as React.Dispatch<
-      React.SetStateAction<HTMLElement | null>
-    >;
-    const dropdown = useRef<HTMLDivElement | null>(null);
-    const classNames = cn(className, styles['DropdownContainer']);
-
-    const trackOutsideClick = useCallback(
-      (event: MouseEvent) => {
-        if (
-          isOpen &&
-          onClose &&
-          dropdown.current &&
-          !dropdown.current.contains(event.target as Node)
-        ) {
-          event.stopImmediatePropagation();
-
-          onClose();
-        }
-      },
-      [isOpen, onClose],
-    );
-
-    useEffect(() => {
-      if (isOpen) {
-        document.addEventListener('click', trackOutsideClick, {
-          capture: true,
-        });
-
-        return () => {
-          document.removeEventListener('click', trackOutsideClick, {
-            capture: true,
-          });
-        };
-      }
-    }, [isOpen, trackOutsideClick]);
-
-    useEffect(() => {
-      if (getRef && dropdown.current) {
-        getRef(dropdown.current);
-      }
-    }, [getRef]);
-
-    const dropdownComponent = (
-      <div
-        {...props}
-        className={classNames}
-        data-test-id={testId}
-        onMouseEnter={() => {
-          if (openSubmenu) {
-            openSubmenu(true);
-          }
-        }}
-        onFocus={() => {
-          if (openSubmenu) {
-            openSubmenu(true);
-          }
-        }}
-        onMouseLeave={() => {
-          if (openSubmenu) {
-            openSubmenu(false);
-          }
-        }}
-        ref={(node) => {
-          setReference(node);
-          dropdown.current = node;
-        }}
-        style={style}
-      >
-        {children}
-      </div>
-    );
-
-    return submenu || !usePortal ? (
-      dropdownComponent
-    ) : (
-      <Portal>{dropdownComponent}</Portal>
-    );
+>(function DropdownContainer(
+  {
+    children,
+    className,
+    getRef,
+    isOpen,
+    onClose,
+    openSubmenu,
+    position,
+    style,
+    submenu,
+    testId,
+    usePortal,
+    ...props
   },
-);
+  refCallback,
+) {
+  // We're not dealing with React RefObjects but with useState (because we
+  // want to re-render on all changes)
+  const setReference = refCallback as React.Dispatch<
+    React.SetStateAction<HTMLElement | null>
+  >;
+  const dropdown = useRef<HTMLDivElement | null>(null);
+  const classNames = cn(className, styles['DropdownContainer']);
+
+  useOnClickOutside(dropdown, (event) => {
+    if (isOpen && onClose) {
+      event.stopImmediatePropagation();
+
+      onClose(event);
+    }
+  });
+
+  useEffect(() => {
+    if (getRef && dropdown.current) {
+      getRef(dropdown.current);
+    }
+  }, [getRef]);
+
+  const dropdownComponent = (
+    <div
+      {...props}
+      className={classNames}
+      data-test-id={testId}
+      onMouseEnter={() => {
+        if (openSubmenu) {
+          openSubmenu(true);
+        }
+      }}
+      onFocus={() => {
+        if (openSubmenu) {
+          openSubmenu(true);
+        }
+      }}
+      onMouseLeave={() => {
+        if (openSubmenu) {
+          openSubmenu(false);
+        }
+      }}
+      ref={(node) => {
+        setReference(node);
+        dropdown.current = node;
+      }}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+
+  return submenu || !usePortal ? (
+    dropdownComponent
+  ) : (
+    <Portal>{dropdownComponent}</Portal>
+  );
+});
 
 DropdownContainer.displayName = 'DropdownContainer';
 

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/__snapshots__/DropdownContainer.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/__snapshots__/DropdownContainer.test.tsx.snap
@@ -1,35 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`has no a11y issues 1`] = `
-<Portal
-  containerInfo={<div />}
+<div
+  className="DropdownContainer"
+  data-test-id="cf-ui-dropdown-portal"
+  onFocus={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
-  <div
-    className="DropdownContainer"
-    data-test-id="cf-ui-dropdown-portal"
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-  >
-    DropdownContainer
-  </div>
-</Portal>
+  DropdownContainer
+</div>
 `;
 
 exports[`renders the component 1`] = `
-<Portal
-  containerInfo={<div />}
+<div
+  className="DropdownContainer"
+  data-test-id="cf-ui-dropdown-portal"
+  onFocus={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
-  <div
-    className="DropdownContainer"
-    data-test-id="cf-ui-dropdown-portal"
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-  >
-    DropdownContainer
-  </div>
-</Portal>
+  DropdownContainer
+</div>
 `;
 
 exports[`renders the component as a submenu 1`] = `
@@ -45,17 +37,13 @@ exports[`renders the component as a submenu 1`] = `
 `;
 
 exports[`renders the component with an additional class name 1`] = `
-<Portal
-  containerInfo={<div />}
+<div
+  className="extraClassName DropdownContainer"
+  data-test-id="cf-ui-dropdown-portal"
+  onFocus={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
-  <div
-    className="extraClassName DropdownContainer"
-    data-test-id="cf-ui-dropdown-portal"
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-  >
-    DropdownContainer
-  </div>
-</Portal>
+  DropdownContainer
+</div>
 `;

--- a/packages/forma-36-react-components/src/components/Dropdown/README.mdx
+++ b/packages/forma-36-react-components/src/components/Dropdown/README.mdx
@@ -2,6 +2,22 @@ Dropdowns allow users to access a list of multiple actions. A common use-case fo
 
 A Dropdown should contain at least one DropdownList, and multiple DropdownListItem components to represent each action.
 
+## Props
+
+- `children`: Child nodes to be rendered in the component.
+- `className`: Class names to be appended to the className prop of the Dropdown wrapper.
+- `dropdownContainerClassName`: Class names to be appended to the className prop of the `DropdownContainer`.
+- `getContainerRef`: A callback reference function to get the reference of the `DropdownContainer`.
+- `isAutoalignmentEnabled`: Boolean to disable automatic positioning of the element to fit the available viewport. Instead this forces the element to follow the given or default value of the `position` prop.
+- `isFullWidth`: Boolean to determine if the Dropdown should take the full width of the container.
+- `isOpen`: Boolean to control whether or not the Dropdown is open.
+- `onClose`: Callback function to run when the Dropdown closes.
+- `position`: Determines the preferred position of the Dropdown. This position is not guaranteed, as the Dropdown might be moved to fit the viewport.
+- `submenuToggleLabel`: A text label to use as the toggle element for the submenu.
+- `testId`: An ID used for testing purposes applied as a data attribute (`data-test-id`).
+- `toggleElement`: React element to use as the toggle, opening and closing the Dropdown.
+- `usePortal`: Boolean to control whether or not to render the dropdown in a [React Portal](https://reactjs.org/docs/portals.html). Rendering content inside a Portal allows the dropdown to escape the bounds of its parent while still being positioned correctly. Using a Portal is necessary if an ancestor of the dropdown hides overflow. Defaults to `true`.
+
 ## Examples of usage
 
 ```jsx

--- a/packages/forma-36-react-components/src/components/Portal/Portal.test.tsx
+++ b/packages/forma-36-react-components/src/components/Portal/Portal.test.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable jsx-a11y/accessible-emoji */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Portal from './Portal';
+
+it('renders the component', () => {
+  const output = shallow(
+    <Portal>
+      <React.Fragment>👋</React.Fragment>
+    </Portal>,
+  );
+  expect(output).toMatchSnapshot();
+});
+
+it('renders the component in a separate container', () => {
+  const container = document.createElement('span');
+  document.body.appendChild(container);
+
+  const output = shallow(
+    <Portal container={container}>
+      <React.Fragment>👋</React.Fragment>
+    </Portal>,
+  );
+  expect(output).toMatchSnapshot();
+});

--- a/packages/forma-36-react-components/src/components/Portal/Portal.tsx
+++ b/packages/forma-36-react-components/src/components/Portal/Portal.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+export interface PortalProps {
+  children: React.ReactElement;
+  container?: Document | HTMLElement;
+}
+
+export default function Portal({
+  children,
+  container: containerElement,
+}: PortalProps): React.ReactPortal | null {
+  const container = useRef<Document | HTMLElement | undefined>(
+    containerElement,
+  );
+  const portal = useRef<HTMLDivElement>(document.createElement('div'));
+
+  useEffect(() => {
+    if (!container.current) {
+      container.current = document.body;
+    }
+
+    container.current.appendChild(portal.current);
+
+    return () => {
+      if (container.current) {
+        container.current.removeChild(portal.current);
+      }
+    };
+  }, []);
+
+  return portal.current ? createPortal(children, portal.current) : null;
+}

--- a/packages/forma-36-react-components/src/components/Portal/Portal.tsx
+++ b/packages/forma-36-react-components/src/components/Portal/Portal.tsx
@@ -20,11 +20,12 @@ export default function Portal({
       container.current = document.body;
     }
 
-    container.current.appendChild(portal.current);
+    const portalContainer = portal.current;
+    container.current.appendChild(portalContainer);
 
     return () => {
       if (container.current) {
-        container.current.removeChild(portal.current);
+        container.current.removeChild(portalContainer);
       }
     };
   }, []);

--- a/packages/forma-36-react-components/src/components/Portal/__snapshots__/Portal.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Portal/__snapshots__/Portal.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders the component 1`] = `
+<Portal
+  containerInfo={<div />}
+>
+  👋
+</Portal>
+`;
+
+exports[`renders the component in a separate container 1`] = `
+<Portal
+  containerInfo={<div />}
+>
+  👋
+</Portal>
+`;

--- a/packages/forma-36-react-components/src/components/Portal/index.ts
+++ b/packages/forma-36-react-components/src/components/Portal/index.ts
@@ -1,0 +1,2 @@
+export * from './Portal';
+export { default } from './Portal';

--- a/packages/forma-36-react-components/src/utils/useOnClickOutside.ts
+++ b/packages/forma-36-react-components/src/utils/useOnClickOutside.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Runs the given handler when a click event is fired outside the HTMLElement
+ * the given RefObject points to.
+ *
+ * @param ref - RefObject pointing to a HTMLElement to track clicks outside
+ * @param handler - Event handler to run on click outside
+ */
+export function useOnClickOutside(
+  ref: React.RefObject<HTMLElement>,
+  handler: (event: MouseEvent) => void | null,
+) {
+  const noHandler = !handler;
+  const handlerRef = useRef(handler);
+
+  useEffect(() => {
+    if (noHandler) {
+      return;
+    }
+
+    const listener = (event: MouseEvent) => {
+      if (
+        !ref.current ||
+        !handlerRef.current ||
+        ref.current.contains(event.target as Node)
+      ) {
+        return;
+      }
+
+      handlerRef.current(event);
+    };
+
+    document.addEventListener('click', listener, {});
+
+    return () => {
+      document.removeEventListener('click', listener, {});
+    };
+  }, [noHandler, ref]);
+}


### PR DESCRIPTION
# Purpose of PR

This PR adds a prop to the `<Dropdown />` component called `usePortal`. As the name implies this boolean decides whether or not to render the dropdown in a React Portal. Defaults to true to keep all existing dropdowns working 😄 I think it's proven useful to be able to control this on an individual level.

To achieve this I've also added a simple `<Portal />` component I image we can reuse elsewhere. I have a few ideas myself 🙂 

I also did a bit of refactoring and used the code from #615

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
