### PR TITLE
fix(circle-ci): remove postinstall in favour of yarn workspaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,9 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Yarn
+          command: yarn
+      - run:
           name: Lint
           command: yarn lint
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           root: .
           paths:
             - .
-  lint:
+  lint-and-test:
     docker:
       - image: circleci/node:12.0-browsers
     resource_class: xlarge
@@ -40,7 +40,10 @@ jobs:
       - run:
           name: Lint
           command: yarn lint
-  test:
+      - run:
+          name: Test
+          command: yarn test
+  build:
     docker:
       - image: circleci/node:12.0-browsers
     resource_class: xlarge
@@ -48,8 +51,8 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Test
-          command: yarn test
+          name: Build
+          command: yarn build
   release:
     docker:
       - image: circleci/node:12.0-browsers
@@ -70,10 +73,10 @@ workflows:
   commit-check:
     jobs:
       - prepare-dependencies
-      - lint:
+      - lint-and-test:
           requires:
             - prepare-dependencies
-      - test:
+      - build:
           requires:
             - prepare-dependencies
       - release:
@@ -81,5 +84,5 @@ workflows:
             branches:
               only: master
           requires:
-            - lint
-            - test
+            - lint-and-test
+            - build

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "commit": "git-cz",
     "travis-deploy-once": "travis-deploy-once --pro",
     "semantic-release": "lerna exec --concurrency 1 -- npx --no-install semantic-release -e semantic-release-monorepo",
-    "postinstall": "lerna bootstrap && lerna run --scope @contentful/forma-36-tokens build && lerna run --scope @contentful/forma-36-fcss build && lerna run --scope @contentful/forma-36-react-components build",
     "commitmsg": "validate-commit-msg",
     "build": "lerna run build",
     "test": "lerna run test",


### PR DESCRIPTION
# Purpose of PR

- Remove `postinstall` in favour of yarn workspaces
- Combine circleci `lint` and `test` jobs for faster build time, and less resources consumption
- Run `build` job in parallel with `lint-and-test`
