### PR TITLE
fix(DropdownListItem): extract rendering to methods like old class

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
@@ -169,15 +169,15 @@ exports[`renders the component with actions 1`] = `
         <DropdownList
           testId="cf-ui-dropdown-list"
         >
-          <ForwardRef(DropdownListItem)
+          <DropdownListItem
             isActive={false}
             isDisabled={false}
             isTitle={true}
             testId="cf-ui-dropdown-list-item"
           >
             Actions
-          </ForwardRef(DropdownListItem)>
-          <ForwardRef(DropdownListItem)
+          </DropdownListItem>
+          <DropdownListItem
             isActive={false}
             isDisabled={false}
             isTitle={false}
@@ -185,7 +185,7 @@ exports[`renders the component with actions 1`] = `
             testId="cf-ui-dropdown-list-item"
           >
             Edit
-          </ForwardRef(DropdownListItem)>
+          </DropdownListItem>
         </DropdownList>
       </CardActions>
     </div>

--- a/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`renders the component as disabled 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <ForwardRef(DropdownListItem)
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -37,7 +37,7 @@ exports[`renders the component as disabled 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </ForwardRef(DropdownListItem)>
+    </DropdownListItem>
   </DropdownList>
 </Dropdown>
 `;
@@ -71,7 +71,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <ForwardRef(DropdownListItem)
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -79,8 +79,8 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </ForwardRef(DropdownListItem)>
-    <ForwardRef(DropdownListItem)
+    </DropdownListItem>
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -88,8 +88,8 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </ForwardRef(DropdownListItem)>
-    <ForwardRef(DropdownListItem)
+    </DropdownListItem>
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -97,14 +97,14 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </ForwardRef(DropdownListItem)>
+    </DropdownListItem>
   </DropdownList>
   <DropdownList
     key=".1/.$.0/.$.0"
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <ForwardRef(DropdownListItem)
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -112,8 +112,8 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </ForwardRef(DropdownListItem)>
-    <ForwardRef(DropdownListItem)
+    </DropdownListItem>
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -121,8 +121,8 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </ForwardRef(DropdownListItem)>
-    <ForwardRef(DropdownListItem)
+    </DropdownListItem>
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -130,7 +130,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </ForwardRef(DropdownListItem)>
+    </DropdownListItem>
   </DropdownList>
 </Dropdown>
 `;
@@ -164,7 +164,7 @@ exports[`renders the component using a single dropdown list 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <ForwardRef(DropdownListItem)
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -172,8 +172,8 @@ exports[`renders the component using a single dropdown list 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </ForwardRef(DropdownListItem)>
-    <ForwardRef(DropdownListItem)
+    </DropdownListItem>
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -181,8 +181,8 @@ exports[`renders the component using a single dropdown list 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </ForwardRef(DropdownListItem)>
-    <ForwardRef(DropdownListItem)
+    </DropdownListItem>
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -190,7 +190,7 @@ exports[`renders the component using a single dropdown list 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </ForwardRef(DropdownListItem)>
+    </DropdownListItem>
   </DropdownList>
 </Dropdown>
 `;
@@ -225,7 +225,7 @@ exports[`renders the component with an additional class name 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <ForwardRef(DropdownListItem)
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -233,8 +233,8 @@ exports[`renders the component with an additional class name 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </ForwardRef(DropdownListItem)>
-    <ForwardRef(DropdownListItem)
+    </DropdownListItem>
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -242,8 +242,8 @@ exports[`renders the component with an additional class name 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </ForwardRef(DropdownListItem)>
-    <ForwardRef(DropdownListItem)
+    </DropdownListItem>
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -251,7 +251,7 @@ exports[`renders the component with an additional class name 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </ForwardRef(DropdownListItem)>
+    </DropdownListItem>
   </DropdownList>
 </Dropdown>
 `;
@@ -285,7 +285,7 @@ exports[`renders the component with published status 1`] = `
     onClick={[Function]}
     testId="cf-ui-dropdown-list"
   >
-    <ForwardRef(DropdownListItem)
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -293,8 +293,8 @@ exports[`renders the component with published status 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Edit
-    </ForwardRef(DropdownListItem)>
-    <ForwardRef(DropdownListItem)
+    </DropdownListItem>
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -302,8 +302,8 @@ exports[`renders the component with published status 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Download
-    </ForwardRef(DropdownListItem)>
-    <ForwardRef(DropdownListItem)
+    </DropdownListItem>
+    <DropdownListItem
       isActive={false}
       isDisabled={false}
       isTitle={false}
@@ -311,7 +311,7 @@ exports[`renders the component with published status 1`] = `
       testId="cf-ui-dropdown-list-item"
     >
       Remove
-    </ForwardRef(DropdownListItem)>
+    </DropdownListItem>
   </DropdownList>
 </Dropdown>
 `;

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
@@ -353,15 +353,15 @@ exports[`renders the component with dropdownListElements 1`] = `
         <DropdownList
           testId="cf-ui-dropdown-list"
         >
-          <ForwardRef(DropdownListItem)
+          <DropdownListItem
             isActive={false}
             isDisabled={false}
             isTitle={true}
             testId="cf-ui-dropdown-list-item"
           >
             Actions
-          </ForwardRef(DropdownListItem)>
-          <ForwardRef(DropdownListItem)
+          </DropdownListItem>
+          <DropdownListItem
             isActive={false}
             isDisabled={false}
             isTitle={false}
@@ -369,8 +369,8 @@ exports[`renders the component with dropdownListElements 1`] = `
             testId="cf-ui-dropdown-list-item"
           >
             Edit
-          </ForwardRef(DropdownListItem)>
-          <ForwardRef(DropdownListItem)
+          </DropdownListItem>
+          <DropdownListItem
             isActive={false}
             isDisabled={false}
             isTitle={false}
@@ -378,8 +378,8 @@ exports[`renders the component with dropdownListElements 1`] = `
             testId="cf-ui-dropdown-list-item"
           >
             Download
-          </ForwardRef(DropdownListItem)>
-          <ForwardRef(DropdownListItem)
+          </DropdownListItem>
+          <DropdownListItem
             isActive={false}
             isDisabled={false}
             isTitle={false}
@@ -387,7 +387,7 @@ exports[`renders the component with dropdownListElements 1`] = `
             testId="cf-ui-dropdown-list-item"
           >
             Remove
-          </ForwardRef(DropdownListItem)>
+          </DropdownListItem>
         </DropdownList>
       </CardActions>
     </div>

--- a/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`renders the component with a dropdown 1`] = `
     <DropdownList
       testId="cf-ui-dropdown-list"
     >
-      <ForwardRef(DropdownListItem)
+      <DropdownListItem
         isActive={false}
         isDisabled={false}
         isTitle={false}
@@ -95,8 +95,8 @@ exports[`renders the component with a dropdown 1`] = `
         testId="cf-ui-dropdown-list-item"
       >
         Edit
-      </ForwardRef(DropdownListItem)>
-      <ForwardRef(DropdownListItem)
+      </DropdownListItem>
+      <DropdownListItem
         isActive={false}
         isDisabled={false}
         isTitle={false}
@@ -105,7 +105,7 @@ exports[`renders the component with a dropdown 1`] = `
         testId="cf-ui-dropdown-list-item"
       >
         Remove
-      </ForwardRef(DropdownListItem)>
+      </DropdownListItem>
     </DropdownList>
   </CardActions>
 </Card>

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownList/__snapshots__/DropdownList.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownList/__snapshots__/DropdownList.test.tsx.snap
@@ -12,14 +12,14 @@ exports[`renders the component 1`] = `
     }
   }
 >
-  <ForwardRef(DropdownListItem)
+  <DropdownListItem
     isActive={false}
     isDisabled={false}
     isTitle={false}
     testId="cf-ui-dropdown-list-item"
   >
     List Item
-  </ForwardRef(DropdownListItem)>
+  </DropdownListItem>
 </ul>
 `;
 
@@ -35,14 +35,14 @@ exports[`renders the component with a border attribute 1`] = `
     }
   }
 >
-  <ForwardRef(DropdownListItem)
+  <DropdownListItem
     isActive={false}
     isDisabled={false}
     isTitle={false}
     testId="cf-ui-dropdown-list-item"
   >
     List Item
-  </ForwardRef(DropdownListItem)>
+  </DropdownListItem>
 </ul>
 `;
 
@@ -58,13 +58,13 @@ exports[`renders the component with an additional class name 1`] = `
     }
   }
 >
-  <ForwardRef(DropdownListItem)
+  <DropdownListItem
     isActive={false}
     isDisabled={false}
     isTitle={false}
     testId="cf-ui-dropdown-list-item"
   >
     List Item
-  </ForwardRef(DropdownListItem)>
+  </DropdownListItem>
 </ul>
 `;

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
@@ -30,19 +30,10 @@ export interface DropdownListItemProps
 export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
   function DropdownListItem(
     {
-      children,
-      className,
-      href,
       isActive,
       isDisabled,
       isTitle,
-      listItemRef,
       onClick,
-      onEnter,
-      onFocus,
-      onLeave,
-      onMouseDown,
-      style,
       submenuToggleLabel,
       testId,
       ...props
@@ -54,15 +45,36 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
     const setReference = refCallback as React.Dispatch<
       React.SetStateAction<HTMLLIElement | null>
     >;
-    const classNames = cn(styles['DropdownListItem'], className, {
-      [styles['DropdownListItem__submenu-toggle']]:
-        submenuToggleLabel || onClick || onMouseDown || href,
-      [styles['DropdownListItem--disabled']]: isDisabled,
-      [styles['DropdownListItem--active']]: isActive,
-      [styles['DropdownListItem--title']]: isTitle,
-    });
+
+    const renderSubmenuToggle = useCallback(() => {
+      const { onEnter, onLeave, onFocus, children, ...otherProps } = props;
+
+      return (
+        <React.Fragment>
+          <button
+            type="button"
+            data-test-id="cf-ui-dropdown-submenu-toggle"
+            className={styles['DropdownListItem__button']}
+            onClick={onClick}
+            onMouseEnter={onEnter}
+            onFocus={onFocus}
+            onMouseLeave={onLeave}
+            {...otherProps}
+          >
+            <TabFocusTrap
+              className={styles['DropdownListItem__button__inner-wrapper']}
+            >
+              {submenuToggleLabel}
+            </TabFocusTrap>
+          </button>
+          {children}
+        </React.Fragment>
+      );
+    }, [onClick, props]);
 
     const renderListItem = useCallback(() => {
+      const { onMouseDown, href, children, listItemRef, ...otherProps } = props;
+
       const isClickable = onClick || onMouseDown || href;
 
       if (isClickable) {
@@ -85,7 +97,7 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
             }
             type="button"
             {...(href ? linkProps : buttonProps)}
-            {...props}
+            {...otherProps}
             className={styles['DropdownListItem__button']}
             data-test-id="cf-ui-dropdown-list-item-button"
           >
@@ -98,8 +110,18 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
         );
       }
 
-      return <span {...props}>{children}</span>;
-    }, [children, href, isDisabled, onClick, onMouseDown, props]);
+      return <span {...otherProps}>{children}</span>;
+    }, [onClick, props]);
+
+    const { className, listItemRef, onMouseDown, href } = props;
+
+    const classNames = cn(styles['DropdownListItem'], className, {
+      [styles['DropdownListItem__submenu-toggle']]:
+        submenuToggleLabel || onClick || onMouseDown || href,
+      [styles['DropdownListItem--disabled']]: isDisabled,
+      [styles['DropdownListItem--active']]: isActive,
+      [styles['DropdownListItem--title']]: isTitle,
+    });
 
     return (
       <li
@@ -115,35 +137,14 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
             listItemRef.current = node;
           }
         }}
-        style={style}
       >
-        {submenuToggleLabel ? (
-          <React.Fragment>
-            <button
-              className={className || styles['DropdownListItem__button']}
-              data-test-id="cf-ui-dropdown-submenu-toggle"
-              onClick={onClick}
-              onFocus={onFocus}
-              onMouseEnter={onEnter}
-              onMouseLeave={onLeave}
-              type="button"
-              {...props}
-            >
-              <TabFocusTrap
-                className={styles['DropdownListItem__button__inner-wrapper']}
-              >
-                {submenuToggleLabel}
-              </TabFocusTrap>
-            </button>
-            {children}
-          </React.Fragment>
-        ) : (
-          renderListItem()
-        )}
+        {submenuToggleLabel ? renderSubmenuToggle() : renderListItem()}
       </li>
     );
   },
 );
+
+DropdownListItem.displayName = 'DropdownListItem';
 
 DropdownListItem.defaultProps = {
   testId: 'cf-ui-dropdown-list-item',

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/__snapshots__/DropdownListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/__snapshots__/DropdownListItem.test.tsx.snap
@@ -63,7 +63,9 @@ exports[`renders the component with an additional class name 1`] = `
   data-test-id="cf-ui-dropdown-list-item"
   role="menuitem"
 >
-  <span>
+  <span
+    className="my-extra-class"
+  >
     Entry
   </span>
 </li>

--- a/packages/forma-36-react-components/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -59,14 +59,14 @@ exports[`renders the component as open 1`] = `
     <DropdownList
       testId="cf-ui-dropdown-list"
     >
-      <ForwardRef(DropdownListItem)
+      <DropdownListItem
         isActive={false}
         isDisabled={false}
         isTitle={false}
         testId="cf-ui-dropdown-list-item"
       >
         entry
-      </ForwardRef(DropdownListItem)>
+      </DropdownListItem>
     </DropdownList>
   </DropdownContainer>
 </div>
@@ -109,14 +109,14 @@ exports[`renders the component with a submenu 1`] = `
     <DropdownList
       testId="cf-ui-dropdown-list"
     >
-      <ForwardRef(DropdownListItem)
+      <DropdownListItem
         isActive={false}
         isDisabled={false}
         isTitle={false}
         testId="cf-ui-dropdown-list-item"
       >
         entry
-      </ForwardRef(DropdownListItem)>
+      </DropdownListItem>
       <Dropdown
         getContainerRef={[Function]}
         isAutoalignmentEnabled={true}
@@ -125,14 +125,14 @@ exports[`renders the component with a submenu 1`] = `
         submenuToggleLabel="Submenu"
         testId="cf-ui-dropdown"
       >
-        <ForwardRef(DropdownListItem)
+        <DropdownListItem
           isActive={false}
           isDisabled={false}
           isTitle={false}
           testId="cf-ui-dropdown-list-item"
         >
           entry
-        </ForwardRef(DropdownListItem)>
+        </DropdownListItem>
       </Dropdown>
       ,
     </DropdownList>

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
@@ -1033,15 +1033,15 @@ exports[`renders the component with dropdownListElements 1`] = `
           <DropdownList
             testId="cf-ui-dropdown-list"
           >
-            <ForwardRef(DropdownListItem)
+            <DropdownListItem
               isActive={false}
               isDisabled={false}
               isTitle={true}
               testId="cf-ui-dropdown-list-item"
             >
               Actions
-            </ForwardRef(DropdownListItem)>
-            <ForwardRef(DropdownListItem)
+            </DropdownListItem>
+            <DropdownListItem
               isActive={false}
               isDisabled={false}
               isTitle={false}
@@ -1049,8 +1049,8 @@ exports[`renders the component with dropdownListElements 1`] = `
               testId="cf-ui-dropdown-list-item"
             >
               Edit
-            </ForwardRef(DropdownListItem)>
-            <ForwardRef(DropdownListItem)
+            </DropdownListItem>
+            <DropdownListItem
               isActive={false}
               isDisabled={false}
               isTitle={false}
@@ -1058,8 +1058,8 @@ exports[`renders the component with dropdownListElements 1`] = `
               testId="cf-ui-dropdown-list-item"
             >
               Download
-            </ForwardRef(DropdownListItem)>
-            <ForwardRef(DropdownListItem)
+            </DropdownListItem>
+            <DropdownListItem
               isActive={false}
               isDisabled={false}
               isTitle={false}
@@ -1067,7 +1067,7 @@ exports[`renders the component with dropdownListElements 1`] = `
               testId="cf-ui-dropdown-list-item"
             >
               Remove
-            </ForwardRef(DropdownListItem)>
+            </DropdownListItem>
           </DropdownList>
         </CardActions>
       </div>


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

Last refactor, I promise 🙏 This PR ensures no props are unintentionally being overridden. Also adds a `displayName` to the `DropdownListItem` component for easier debugging in the web inspector.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
