### PR TITLE
fix: build components packages before publish

### DIFF
--- a/packages/components/forma-36-react-datepicker/package.json
+++ b/packages/components/forma-36-react-datepicker/package.json
@@ -12,7 +12,8 @@
     "start": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test",
-    "lint": "tsdx lint"
+    "lint": "tsdx lint",
+    "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
     "@contentful/forma-36-react-components": "^3.21.1",

--- a/packages/components/forma-36-react-timepicker/package.json
+++ b/packages/components/forma-36-react-timepicker/package.json
@@ -13,7 +13,8 @@
     "start": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test --env=jsdom",
-    "lint": "tsdx lint"
+    "lint": "tsdx lint",
+    "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/packages/forma-36-react-components/src/components/Grid/Grid.tsx
+++ b/packages/forma-36-react-components/src/components/Grid/Grid.tsx
@@ -5,7 +5,17 @@ import cn from 'classnames';
 
 import styles from './Grid.css';
 
-export type GapTypes = 'none' | 'spacing2xs' | 'spacingXs' | 'spacingS' | 'spacingM' | 'spacingL' | 'spacingXl' | 'spacing2Xl' | 'spacing3Xl' | 'spacing4Xl';
+export type GapTypes =
+  | 'none'
+  | 'spacing2xs'
+  | 'spacingXs'
+  | 'spacingS'
+  | 'spacingM'
+  | 'spacingL'
+  | 'spacingXl'
+  | 'spacing2Xl'
+  | 'spacing3Xl'
+  | 'spacing4Xl';
 
 export interface GridProps {
   /**
@@ -31,7 +41,7 @@ export interface GridProps {
   columnGap?: GapTypes;
   /**
    * One of grid-auto-flow css values */
-  flow?: CSS.GridAutoFlowProperty
+  flow?: CSS.GridAutoFlowProperty;
   /**
    * Sets display:inline-grid */
   inline?: boolean;
@@ -72,19 +82,19 @@ export const Grid = (props: GridProps) => {
   } = props;
 
   const handleGridTemplate = (value?: string | number) => {
-    if(typeof value === 'number') {
-      return `repeat(${value}, minmax(0, 1fr)`
+    if (typeof value === 'number') {
+      return `repeat(${value}, minmax(0, 1fr)`;
     }
     return value;
-  }
+  };
 
   const handleGap = (value: GapTypes) => {
-    if(value === 'none') {
+    if (value === 'none') {
       return 0;
     } else {
-      return tokens[value]
+      return tokens[value];
     }
-  }
+  };
 
   const inlineStyle = {
     gridTemplateColumns: handleGridTemplate(columns),
@@ -94,19 +104,24 @@ export const Grid = (props: GridProps) => {
     alignContent,
     gridColumnGap: columnGap && handleGap(columnGap),
     gridRowGap: rowGap && handleGap(rowGap),
-    ...style
-  }
+    ...style,
+  };
 
   const classNames = cn(styles.Grid, className, {
-    [styles.Grid__inline]: inline
+    [styles.Grid__inline]: inline,
   });
 
   return (
-    <div {...otherProps} style={inlineStyle} className={classNames} data-test-id={testId}>
+    <div
+      {...otherProps}
+      style={inlineStyle}
+      className={classNames}
+      data-test-id={testId}
+    >
       {children}
     </div>
   );
-}
+};
 Grid.defaultProps = defaultProps;
 
 export default Grid;


### PR DESCRIPTION
# Purpose of PR

Previously there was a separate `bin/build` job to build all packages before release, and `prepublishOnly` script that repeats the build process.

Currently `release` job on circleci relies on `prepublishOnly` only to avoid repetition. 

This PR adds `prepublishOnly` to the components packages. Later we should look into having `prepublishOnly` on the root and see if it builds on all packages.
