### PR TITLE
refactor(dropdown): add comment about onClose function

### DIFF
--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,24 +1,30 @@
 import React, { useState, useCallback } from 'react';
-import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { boolean, number, object, text, select } from '@storybook/addon-knobs';
 
-import Autocomplete from './Autocomplete';
+import Autocomplete, { AutocompleteProps } from './Autocomplete';
 
-interface Item {
+export default {
+  title: '(alpha)/Autocomplete',
+  component: Autocomplete,
+  parameters: {
+    propTypes: [Autocomplete['__docgenInfo']],
+  },
+};
+
+interface Fruit {
   value: number;
   label: string;
 }
 
-const items: Item[] = [
-  { value: 1, label: 'entry foo' },
-  { value: 2, label: 'entry bar' },
-  { value: 3, label: 'entry baz' },
-  { value: 4, label: 'entry fooBar' },
-  { value: 5, label: 'entry out of viewport' },
+const items: Fruit[] = [
+  { value: 1, label: 'Apple' },
+  { value: 2, label: 'Banana' },
+  { value: 3, label: 'Orange' },
+  { value: 4, label: 'Tomato' },
+  { value: 5, label: 'Strawberry' },
 ];
 
-const AutocompleteDefaultStory = ({ items }: { items: Item[] }) => {
+export const Default = ({ items, ...args }: AutocompleteProps<Fruit>) => {
   const [filteredItems, setFilteredItems] = useState(items);
 
   const handleQueryChange = useCallback(
@@ -31,36 +37,13 @@ const AutocompleteDefaultStory = ({ items }: { items: Item[] }) => {
   );
 
   return (
-    <Autocomplete<Item>
-      maxHeight={number('maxHeight', 100)}
+    <Autocomplete<Fruit>
+      {...args}
       items={filteredItems}
       onQueryChange={handleQueryChange}
-      onChange={action('onChange')}
-      placeholder={text(
-        'placeholder',
-        'Choose from spaces in your organization',
-      )}
-      isLoading={boolean('isLoading', false)}
-      width={select(
-        'width',
-        {
-          'Full (default)': 'full',
-          large: 'large',
-          medium: 'medium',
-          small: 'small',
-        },
-        'full',
-      )}
-      disabled={boolean('disabled', false)}
-      emptyListMessage={text(
-        'emptyListMessage',
-        'There are no items to choose from',
-      )}
-      noMatchesMessage={text('noMatchesMessage', 'No matches')}
-      dropdownProps={object('dropdownProps', { isFullWidth: true })}
     >
-      {(options: Item[]) =>
-        options.map((option: Item) => (
+      {(options: Fruit[]) =>
+        options.map((option: Fruit) => (
           <span key={option.value}>{option.label}</span>
         ))
       }
@@ -68,11 +51,12 @@ const AutocompleteDefaultStory = ({ items }: { items: Item[] }) => {
   );
 };
 
-storiesOf('(alpha)/Autocomplete', module)
-  .addParameters({
-    propTypes: Autocomplete['__docgenInfo'],
-    component: Autocomplete,
-  })
-  .add('default', () => (
-    <AutocompleteDefaultStory items={object('items', items)} />
-  ));
+Default.args = {
+  maxHeight: 100,
+  width: 'full',
+  items,
+  onChange: action('on Change'),
+  emptyListMessage: 'There are no items to choose from',
+  noMatchesMessage: 'No matches',
+  dropdownProps: { isFullWidth: true },
+};

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -239,7 +239,10 @@ export const Autocomplete = <T extends {}>({
       className={dropdownClassNames}
       isOpen={isOpen}
       onClose={() => {
-        if (inputRef.current !== document.activeElement) {
+        const inputIsFocused = inputRef.current === document.activeElement;
+
+        // we only want to close the dropdown with list of options if the input is not focused
+        if (!inputIsFocused) {
           willClearQueryOnClose && updateQuery('');
           dispatch({ type: TOGGLED_LIST, payload: false });
         }


### PR DESCRIPTION
# Purpose of PR

After some debugging and talking to @denkristoffer , I think the current solution to solve the problem should be kept as the official solution until we refactor the Dropdown and the Autocomplete in a breaking change version

I just added a comment explaining why we are doing that and refactored Autocomplete.stories.tsx to use storybook CSF

## Why?

The list of options is getting closed as soon as it opens and this happens because the list is a Dropdown. The Dropdown component is using the `useOnClickOutside` hook which makes it possible for the user to click outside the dropdown and close it. Well, the input in the autocomplete is outside, so when you click on the input it focuses it and opens the list, but immediately closes it

I think the hook is doing the right job in adding the event listener, so the components using it should tell the hook when not to call the handler. That's why the current solution is good, and we can improve how the dropdown works in the future to avoid this since it needs some refactoring anyway

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
