### PR TITLE
feat(tooltip): make the tooltip stay open when hovering on the content

### DIFF
--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -44,7 +44,7 @@ basic.parameters = {
 export const withHtml = (args: { content: string }) => {
   return (
     <Paragraph>
-      Lorem Ipsum dolor sit amet &nbsp;
+      Lorem Ipsum dolor sit amet&nbsp;
       <Tooltip {...args}>
         <TextLink>Hover me</TextLink>.
       </Tooltip>
@@ -117,6 +117,48 @@ autoPlacement.parameters = {
   docs: {
     source: {
       code: autoPlacementSourceCode,
+    },
+  },
+};
+
+export const contentHover = (args: { content: string }) => {
+  return (
+    <Paragraph>
+      Lorem Ipsum dolor sit amet&nbsp;
+      <Tooltip {...args}>
+        <TextLink>Hover me</TextLink>.
+      </Tooltip>
+      &nbsp; Lorem Ipsum dolor sit amet.
+    </Paragraph>
+  );
+};
+contentHover.args = {
+  closeOnMouseLeave: false,
+  content: (
+    <>
+      You can interact with the content in me
+      <br />
+      <button type="button">Button</button>
+      <br />
+      <a style={{ color: 'white' }} href="/" target="_blank" rel="noopener noreferrer">Click me!</a> 
+    </>
+  ),
+};
+const contentHoverSourceCode = `<Tooltip closeOnMouseLeave={false} content={(
+  <>
+    You can interact with the content in me
+    <br />
+    <button type="button">Button</button>
+    <br />
+    <a style={{ color: 'white' }} href="/" target="_blank" rel="noopener noreferrer">Click me!</a> 
+  </>
+)}>
+  <TextLink>Hover me</TextLink>
+</Tooltip>`;
+contentHover.parameters = {
+  docs: {
+    source: {
+      code: contentHoverSourceCode,
     },
   },
 };

--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
@@ -39,6 +39,10 @@ export interface TooltipProps {
    */
   isVisible?: boolean;
   /**
+   * It controls whether or not the tooltip stays open when hovering on the content
+   */
+  closeOnMouseLeave?: boolean;
+  /**
    * It sets a max-width for the Tooltip
    */
   maxWidth?: number | CSS.MaxWidthProperty<string>;
@@ -84,6 +88,7 @@ export const Tooltip = ({
   content,
   id,
   isVisible,
+  closeOnMouseLeave,
   maxWidth,
   onBlur,
   onFocus,
@@ -135,6 +140,18 @@ export const Tooltip = ({
     }
   }, [attributes.popper]);
 
+  const [isHoveringTarget, setIsHoveringTarget] = useState(false)
+  const [isHoveringContent, setIsHoveringContent] = useState(false)
+  useEffect(() => {
+    if (closeOnMouseLeave) {
+      setShow(isHoveringTarget)
+    } else {
+      setShow(isHoveringContent || isHoveringTarget)
+    }
+  }, [closeOnMouseLeave, isHoveringTarget, isHoveringContent])
+
+  const delay = closeOnMouseLeave ? 0 : 1000;
+
   const arrowStyles = {
     ...popperStyles.arrow,
     ...arrowPosition,
@@ -164,19 +181,19 @@ export const Tooltip = ({
         ref={elementRef}
         className={targetWrapperClassName}
         onMouseEnter={(evt: MouseEvent) => {
-          setShow(true);
+          setIsHoveringTarget(true);
           if (onMouseOver) onMouseOver(evt);
         }}
         onMouseLeave={(evt: MouseEvent) => {
-          setShow(false);
+          setTimeout(() => setIsHoveringTarget(false), delay);
           if (onMouseLeave) onMouseLeave(evt);
-        }}
+      }}
         onFocus={(evt: FocusEvent) => {
-          setShow(true);
+          setIsHoveringTarget(true);
           if (onFocus) onFocus(evt);
         }}
         onBlur={(evt: FocusEvent) => {
-          setShow(false);
+          setTimeout(() => setIsHoveringTarget(false), delay);
           if (onBlur) onBlur(evt);
         }}
         {...otherProps}
@@ -195,6 +212,12 @@ export const Tooltip = ({
             [styles['Tooltip--hidden']]: !show,
           })}
           data-test-id={testId}
+          onMouseEnter={() => {
+            setIsHoveringContent(true)
+          }}
+          onMouseLeave={() => {
+            setIsHoveringContent(false)
+          }}
           {...attributes.popper}
         >
           {content}
@@ -211,6 +234,7 @@ export const Tooltip = ({
 Tooltip.defaultProps = {
   containerElement: 'span',
   isVisible: false,
+  closeOnMouseLeave: true,
   maxWidth: 360,
   testId: 'cf-ui-tooltip',
   place: 'auto',


### PR DESCRIPTION
# Purpose of PR

This PR adds the ability for the tooltip to stay open while the user interacts with its content.
i.e. Useful when implementing the below design (see the pic) 
<img width="229" alt="Screenshot 2020-11-11 at 15 03 12" src="https://user-images.githubusercontent.com/22014714/98970396-30997580-2510-11eb-9f9a-ecb3616cd842.png">


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
