### PR TITLE
docs: show components in the center of the canvas

### DIFF
--- a/packages/forma-36-react-components/src/components/Grid/Grid.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Grid/Grid.stories.tsx
@@ -1,24 +1,9 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { text, number, select } from '@storybook/addon-knobs';
 import tokens from '@contentful/forma-36-tokens';
 
 import Grid from './Grid';
 import GridItem from './GridItem';
-import notes from './Grid.md';
-
-const gridKnobsId = 'Grid Props';
-const spacingValues = [
-  'spacing2Xs',
-  'spacingXs',
-  'spacingS',
-  'spacingM',
-  'spacingL',
-  'spacingXl',
-  'spacing2Xl',
-  'spacing3Xl',
-  'spacing4Xl',
-];
+import notes from './README.md';
 
 const styles = {
   demoBox: {
@@ -26,6 +11,16 @@ const styles = {
   },
   demoBoxDark: {
     backgroundColor: tokens.colorContrastDark,
+  },
+};
+
+export default {
+  title: '(alpha)/Grid',
+  component: Grid,
+  subcomponents: { GridItem },
+  parameters: {
+    propTypes: [Grid['__docgenInfo'], GridItem['__docgenInfo']],
+    notes,
   },
 };
 
@@ -40,38 +35,21 @@ const DemoBox = ({ times, id }: { times?: number; id?: string }) => {
   return <GridItem style={styles.demoBox}></GridItem>;
 };
 
-storiesOf('(alpha)/Grid', module)
-  .addParameters({
-    propTypes: Grid['__docgenInfo'],
-    component: Grid,
-    subcomponents: { GridItem },
-  })
-  .add(
-    'default',
-    () => {
-      const knobs = {
-        columns: number('columns', 6, '', gridKnobsId),
-        rows: number('rows', 4, '', gridKnobsId),
-        columnGap: select('columnGap', spacingValues, 'spacingXs', gridKnobsId),
-        rowGap: select('rowGap', spacingValues, 'spacingXs', gridKnobsId),
-        className: text('className', '', gridKnobsId),
-        exampleBoxes: number('Example Items', 24),
-        exampleGridHeight: text('Example Grid Height', '90vh'),
-      };
-
-      return (
-        <Grid
-          columns={knobs.columns}
-          rows={knobs.rows}
-          columnGap={knobs.columnGap}
-          rowGap={knobs.rowGap}
-          flow="row"
-          className={knobs.className}
-          style={{ height: knobs.exampleGridHeight }}
-        >
-          <DemoBox id="g" times={knobs.exampleBoxes} />
-        </Grid>
-      );
-    },
-    { notes },
+export const Default = ({ exampleBoxes, exampleGridHeight, ...args }) => {
+  return (
+    <div style={{ width: '90vw' }}>
+      <Grid {...args} style={{ height: exampleGridHeight }}>
+        <DemoBox id="g" times={exampleBoxes} />
+      </Grid>
+    </div>
   );
+};
+Default.args = {
+  exampleBoxes: 24,
+  exampleGridHeight: '90vh',
+  columns: 6,
+  rows: 4,
+  columnGap: 'spacingXs',
+  rowGap: 'spacingXs',
+  flow: 'row',
+};

--- a/packages/forma-36-react-components/src/components/Grid/README.md
+++ b/packages/forma-36-react-components/src/components/Grid/README.md
@@ -1,37 +1,39 @@
-# Grid
-
 [CSS Grid](https://developer.mozilla.org/en-US/docs/Glossary/Grid) based React component, comes with predefined values to ensure design consistency, and ease of use.
 
 The Grid consists of two components:
+
 - Grid: Used as a container for GridItems
 - GridItem: Elements within the Grid
 
 ```js
 import { Grid, GridItem } from '@contenful/forma-36-react-components';
 ```
+
 <br />
 ## Usage
 
 ### columns
+
 When defined as a number, it will split the space into equally sized columns; it also accepts any of the [grid-template-columns](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns) css properties. e.g.
 
 ```jsx
 <Grid columns={6}></Grid>
-// Or 
+// Or
 <Grid columns={'auto 1fr'}></Grid>
 ```
 
-
 ### rows
+
 Accepts a number or any of [grid-template-rows](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-rows) css properties.
 
 ```jsx
 <Grid rows={6}></Grid>
-// Or 
+// Or
 <Grid rows={'auto 1fr'}></Grid>
 ```
 
 ### columnGap & rowGap
+
 `columnGap` represents space between columns, `rowGap` represents the space between rows, both accepts one of [spacing](https://f36.contentful.com/foundation/spacing/) token names.
 
 `spacing2xs` | `spacingXs` | `spacingXs` | `spacingS` | `spacingM` | `spacingL` | `spacingXl` | `spacing2Xl` | `spacing3Xl` | `spacing4Xl`
@@ -39,5 +41,5 @@ Accepts a number or any of [grid-template-rows](https://developer.mozilla.org/en
 **e.g.**
 
 ```jsx
-  <Grid columnGap='spacingXs' rowGap='spacingXl'></Grid>
+<Grid columnGap="spacingXs" rowGap="spacingXl"></Grid>
 ```

--- a/packages/forma-36-react-components/tools/.storybook/preview.js
+++ b/packages/forma-36-react-components/tools/.storybook/preview.js
@@ -1,11 +1,26 @@
+import React from 'react';
+
 // Storybook Addon Dependencies
 import { jsxDecorator } from 'storybook-addon-jsx';
+import { fontStackPrimary } from '@contentful/forma-36-tokens';
 
 // Setup Decorators
-export const decorators = [jsxDecorator];
+export const decorators = [
+  jsxDecorator,
+  (Story) => (
+    <div
+      style={{
+        fontFamily: fontStackPrimary,
+      }}
+    >
+      <Story />
+    </div>
+  ),
+];
 
 // Setup Parameters
 export const parameters = {
+  layout: 'centered',
   options: {
     storySort: {
       method: 'alphabetical',


### PR DESCRIPTION
What do you think about showing the components in the center of the canvas?

![Screenshot 2020-11-13 at 17 52 39](https://user-images.githubusercontent.com/6597467/99098545-6b1b1500-25d9-11eb-9c8c-41d21182641b.png)

this PR also wraps all stories in a container that sets our font-family, so components like the spinner are not using Times New Roman anymore

P.S.: I had to add a wrapper in the Grid story because the centered layout broke it and then I updated the story to storybook’s new format

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
