### PR TITLE
refactor(form-controls): use functional components and react hooks

### DIFF
--- a/packages/components/forma-36-react-timepicker/src/Timepicker.tsx
+++ b/packages/components/forma-36-react-timepicker/src/Timepicker.tsx
@@ -5,6 +5,7 @@ import React, {
   FocusEventHandler,
   useEffect,
   FocusEvent,
+  ChangeEvent,
 } from 'react';
 import isHotkey from 'is-hotkey';
 import orderBy from 'lodash.orderby';
@@ -323,7 +324,9 @@ const TimePicker: React.FC<TimepickerProps> = ({
               onKeyDown={handleKeyDown}
               onFocus={handleFocus}
               onBlur={handleBlur}
-              onChange={(e) => handleChange(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                handleChange(e.target.value)
+              }
               disabled={disabled}
               autoComplete="off"
             />

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useReducer, useRef } from 'react';
+import React, { useMemo, useReducer, useRef, ChangeEvent } from 'react';
 
 import TextInput from '../TextInput';
 import Dropdown, { DropdownProps } from '../Dropdown';
@@ -192,7 +192,9 @@ export const Autocomplete = <T extends {}>({
       <div className={styles.autocompleteInput}>
         <TextInput
           value={toggleProps.query}
-          onChange={(e) => toggleProps.onChange(e.target.value)}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            toggleProps.onChange(e.target.value)
+          }
           onFocus={toggleProps.onFocus}
           onKeyDown={toggleProps.onKeyDown}
           disabled={toggleProps.disabled}

--- a/packages/forma-36-react-components/src/components/Button/Button.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.tsx
@@ -1,10 +1,10 @@
 import React, {
-  Component,
   CSSProperties,
   FocusEvent,
   MouseEvent as ReactMouseEvent,
   FocusEventHandler,
   MouseEventHandler,
+  ElementType,
 } from 'react';
 import cn from 'classnames';
 import { CSSTransition } from 'react-transition-group';
@@ -49,109 +49,106 @@ const defaultProps: Partial<ButtonProps> = {
   type: 'button',
 };
 
-export class Button extends Component<ButtonProps> {
-  static defaultProps = defaultProps;
+export const Button = (props: ButtonProps) => {
+  const {
+    className,
+    children,
+    icon,
+    buttonType,
+    size,
+    isFullWidth,
+    onBlur,
+    testId,
+    onClick,
+    loading,
+    disabled,
+    indicateDropdown,
+    href,
+    type,
+    isActive,
+    ...otherProps
+  } = props;
 
-  render() {
-    const {
-      className,
-      children,
-      icon,
-      buttonType,
-      size,
-      isFullWidth,
-      onBlur,
-      testId,
-      onClick,
-      loading,
-      disabled,
-      indicateDropdown,
-      href,
-      type,
-      isActive,
-      ...otherProps
-    } = this.props;
+  const classNames = cn(
+    styles.Button,
+    className,
+    styles[`Button--${buttonType}`],
+    {
+      [styles['Button--disabled']]: disabled,
+      [styles[`Button--${size}`]]: size,
+      [styles['Button--full-width']]: isFullWidth,
+      [styles['Button--is-active']]: isActive,
+    },
+  );
 
-    const classNames = cn(
-      styles.Button,
-      className,
-      styles[`Button--${buttonType}`],
-      {
-        [styles['Button--disabled']]: disabled,
-        [styles[`Button--${size}`]]: size,
-        [styles['Button--full-width']]: isFullWidth,
-        [styles['Button--is-active']]: isActive,
-      },
-    );
+  const iconColor =
+    buttonType === 'muted' || buttonType === 'naked' ? 'secondary' : 'white';
 
-    const iconColor =
-      buttonType === 'muted' || buttonType === 'naked' ? 'secondary' : 'white';
+  const Element: ElementType = href ? 'a' : 'button';
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const Element: any = href ? 'a' : 'button';
+  return (
+    <Element
+      onBlur={(e: FocusEvent) => {
+        if (onBlur && !disabled) {
+          onBlur(e);
+        }
+      }}
+      onClick={(e: ReactMouseEvent) => {
+        if (onClick && !disabled && !loading) {
+          onClick(e);
+        }
+      }}
+      data-test-id={testId}
+      className={classNames}
+      disabled={disabled}
+      href={!disabled ? href : undefined}
+      type={type}
+      {...otherProps}
+    >
+      <TabFocusTrap className={styles['Button__inner-wrapper']}>
+        {icon && (
+          <Icon
+            className={styles.Button__icon}
+            size={size === 'small' ? 'tiny' : 'small'}
+            icon={icon}
+            color={iconColor}
+          />
+        )}
+        {children && <span className={styles.Button__label}>{children}</span>}
+        {indicateDropdown && (
+          <Icon
+            className={styles['Button__dropdown-icon']}
+            icon="ArrowDown"
+            color={iconColor}
+          />
+        )}
+        <CSSTransition
+          in={loading}
+          timeout={1000}
+          classNames={{
+            enter: styles['Button--spinner--enter'],
+            enterActive: styles['Button--spinner-active'],
+            exit: styles['Button--spinner--exit'],
+            exitActive: styles['Button--spinner-exit-active'],
+          }}
+          mountOnEnter
+          unmountOnExit
+        >
+          <Spinner
+            className={styles.Button__spinner}
+            size="small"
+            color={
+              buttonType === 'muted' || buttonType === 'naked'
+                ? 'default'
+                : 'white'
+            }
+          />
+        </CSSTransition>
+      </TabFocusTrap>
+    </Element>
+  );
+};
 
-    return (
-      <Element
-        onBlur={(e: FocusEvent) => {
-          if (onBlur && !disabled) {
-            onBlur(e);
-          }
-        }}
-        onClick={(e: ReactMouseEvent) => {
-          if (onClick && !disabled && !loading) {
-            onClick(e);
-          }
-        }}
-        data-test-id={testId}
-        className={classNames}
-        disabled={disabled}
-        href={!disabled ? href : null}
-        type={type}
-        {...otherProps}
-      >
-        <TabFocusTrap className={styles['Button__inner-wrapper']}>
-          {icon && (
-            <Icon
-              className={styles.Button__icon}
-              size={size === 'small' ? 'tiny' : 'small'}
-              icon={icon}
-              color={iconColor}
-            />
-          )}
-          {children && <span className={styles.Button__label}>{children}</span>}
-          {indicateDropdown && (
-            <Icon
-              className={styles['Button__dropdown-icon']}
-              icon="ArrowDown"
-              color={iconColor}
-            />
-          )}
-          <CSSTransition
-            in={loading}
-            timeout={1000}
-            classNames={{
-              enter: styles['Button--spinner--enter'],
-              enterActive: styles['Button--spinner-active'],
-              exit: styles['Button--spinner--exit'],
-              exitActive: styles['Button--spinner-exit-active'],
-            }}
-            mountOnEnter
-            unmountOnExit
-          >
-            <Spinner
-              className={styles.Button__spinner}
-              size="small"
-              color={
-                buttonType === 'muted' || buttonType === 'naked'
-                  ? 'default'
-                  : 'white'
-              }
-            />
-          </CSSTransition>
-        </TabFocusTrap>
-      </Element>
-    );
-  }
-}
+Button.defaultProps = defaultProps;
 
 export default Button;

--- a/packages/forma-36-react-components/src/components/Button/Button.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.tsx
@@ -89,11 +89,13 @@ export const Button = (props: ButtonProps) => {
   return (
     <Element
       onBlur={(e: FocusEvent) => {
+        e.persist();
         if (onBlur && !disabled) {
           onBlur(e);
         }
       }}
       onClick={(e: ReactMouseEvent) => {
+        e.persist();
         if (onClick && !disabled && !loading) {
           onClick(e);
         }

--- a/packages/forma-36-react-components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/forma-36-react-components/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ControlledInput, { ControlledInputPropTypes } from '../ControlledInput';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -12,13 +12,9 @@ const defaultProps: Partial<CheckboxProps> = {
   willBlurOnEsc: true,
 };
 
-export class Checkbox extends Component<CheckboxProps> {
-  static defaultProps = defaultProps;
-
-  render() {
-    return <ControlledInput {...this.props} />;
-  }
-}
+export const Checkbox = (props: CheckboxProps) => {
+  return <ControlledInput {...props} />;
+};
 
 Checkbox.defaultProps = defaultProps;
 

--- a/packages/forma-36-react-components/src/components/CheckboxField/CheckboxField.tsx
+++ b/packages/forma-36-react-components/src/components/CheckboxField/CheckboxField.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ControlledInputField, {
   ControlledInputFieldPropTypes,
 } from '../ControlledInputField';
@@ -13,20 +13,18 @@ const defaultProps: Partial<CheckboxFieldProps> = {
   testId: 'cf-ui-checkbox-field',
 };
 
-export class CheckboxField extends Component<CheckboxFieldProps> {
-  static defaultProps = defaultProps;
+export const CheckboxField = (props: CheckboxFieldProps) => {
+  const { testId, ...otherProps } = props;
 
-  render() {
-    const { testId, ...otherProps } = this.props;
+  return (
+    <ControlledInputField
+      testId={testId}
+      {...otherProps}
+      inputType="checkbox"
+    />
+  );
+};
 
-    return (
-      <ControlledInputField
-        testId={testId}
-        {...otherProps}
-        inputType="checkbox"
-      />
-    );
-  }
-}
+CheckboxField.defaultProps = defaultProps;
 
 export default CheckboxField;

--- a/packages/forma-36-react-components/src/components/ControlledInput/ControlledInput.tsx
+++ b/packages/forma-36-react-components/src/components/ControlledInput/ControlledInput.tsx
@@ -3,6 +3,7 @@ import React, {
   ChangeEvent,
   FocusEvent,
   KeyboardEvent,
+  useCallback,
 } from 'react';
 import cn from 'classnames';
 
@@ -56,13 +57,17 @@ export const ControlledInput = (props: ControlledInputPropTypes) => {
     [styles['ControlledInput--disabled']]: disabled,
   });
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    const ESC = 27;
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      e.persist();
+      const ESC = 27;
 
-    if (e.keyCode === ESC && willBlurOnEsc) {
-      e.currentTarget.blur();
-    }
-  };
+      if (e.keyCode === ESC && willBlurOnEsc) {
+        e.currentTarget.blur();
+      }
+    },
+    [willBlurOnEsc],
+  );
 
   return (
     <input

--- a/packages/forma-36-react-components/src/components/ControlledInput/ControlledInput.tsx
+++ b/packages/forma-36-react-components/src/components/ControlledInput/ControlledInput.tsx
@@ -60,9 +60,9 @@ export const ControlledInput = (props: ControlledInputPropTypes) => {
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
       e.persist();
-      const ESC = 27;
+      const ESC = '27';
 
-      if (e.keyCode === ESC && willBlurOnEsc) {
+      if (e.nativeEvent.code === ESC && willBlurOnEsc) {
         e.currentTarget.blur();
       }
     },

--- a/packages/forma-36-react-components/src/components/ControlledInput/ControlledInput.tsx
+++ b/packages/forma-36-react-components/src/components/ControlledInput/ControlledInput.tsx
@@ -60,9 +60,8 @@ export const ControlledInput = (props: ControlledInputPropTypes) => {
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
       e.persist();
-      const ESC = '27';
 
-      if (e.nativeEvent.code === ESC && willBlurOnEsc) {
+      if (e.nativeEvent.code === 'Escape' && willBlurOnEsc) {
         e.currentTarget.blur();
       }
     },

--- a/packages/forma-36-react-components/src/components/ControlledInput/ControlledInput.tsx
+++ b/packages/forma-36-react-components/src/components/ControlledInput/ControlledInput.tsx
@@ -1,5 +1,4 @@
 import React, {
-  Component,
   EventHandler,
   ChangeEvent,
   FocusEvent,
@@ -34,72 +33,70 @@ const defaultProps: Partial<ControlledInputPropTypes> = {
   willBlurOnEsc: true,
 };
 
-export class ControlledInput extends Component<ControlledInputPropTypes> {
-  static defaultProps = defaultProps;
+export const ControlledInput = (props: ControlledInputPropTypes) => {
+  const {
+    className,
+    id,
+    testId,
+    required,
+    disabled,
+    onFocus,
+    onBlur,
+    name,
+    onChange,
+    checked,
+    value,
+    type,
+    labelText,
+    willBlurOnEsc,
+    ...otherProps
+  } = props;
 
-  handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+  const classNames = cn(styles['ControlledInput'], className, {
+    [styles['ControlledInput--disabled']]: disabled,
+  });
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     const ESC = 27;
 
-    if (e.keyCode === ESC && this.props.willBlurOnEsc) {
+    if (e.keyCode === ESC && willBlurOnEsc) {
       e.currentTarget.blur();
     }
   };
 
-  render() {
-    const {
-      className,
-      id,
-      testId,
-      required,
-      disabled,
-      onFocus,
-      onBlur,
-      name,
-      onChange,
-      checked,
-      value,
-      type,
-      labelText,
-      willBlurOnEsc,
-      ...otherProps
-    } = this.props;
+  return (
+    <input
+      className={classNames}
+      value={value}
+      name={name}
+      checked={props.checked}
+      type={type}
+      data-test-id={testId}
+      onChange={(e) => {
+        if (onChange) {
+          onChange(e);
+        }
+      }}
+      onBlur={(e) => {
+        if (onBlur) {
+          onBlur(e);
+        }
+      }}
+      onFocus={(e) => {
+        if (onFocus) {
+          onFocus(e);
+        }
+      }}
+      aria-label={labelText}
+      id={id}
+      required={required}
+      disabled={disabled}
+      onKeyDown={handleKeyDown}
+      {...otherProps}
+    />
+  );
+};
 
-    const classNames = cn(styles['ControlledInput'], className, {
-      [styles['ControlledInput--disabled']]: disabled,
-    });
-
-    return (
-      <input
-        className={classNames}
-        value={value}
-        name={name}
-        checked={this.props.checked}
-        type={type}
-        data-test-id={testId}
-        onChange={(e) => {
-          if (onChange) {
-            onChange(e);
-          }
-        }}
-        onBlur={(e) => {
-          if (onBlur) {
-            onBlur(e);
-          }
-        }}
-        onFocus={(e) => {
-          if (onFocus) {
-            onFocus(e);
-          }
-        }}
-        aria-label={labelText}
-        id={id}
-        required={required}
-        disabled={disabled}
-        onKeyDown={this.handleKeyDown}
-        {...otherProps}
-      />
-    );
-  }
-}
+ControlledInput.defaultProps = defaultProps;
 
 export default ControlledInput;

--- a/packages/forma-36-react-components/src/components/ControlledInputField/ControlledInputField.tsx
+++ b/packages/forma-36-react-components/src/components/ControlledInputField/ControlledInputField.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEventHandler } from 'react';
+import React, { ChangeEventHandler, ReactNode } from 'react';
 import cn from 'classnames';
 import FormLabel from '../FormLabel';
 import HelpText from '../HelpText';
@@ -24,7 +24,7 @@ export interface ControlledInputFieldPropTypes {
   onChange?: ChangeEventHandler;
   className?: string;
   testId?: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 const defaultProps: Partial<ControlledInputFieldPropTypes> = {

--- a/packages/forma-36-react-components/src/components/ControlledInputField/ControlledInputField.tsx
+++ b/packages/forma-36-react-components/src/components/ControlledInputField/ControlledInputField.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ChangeEventHandler } from 'react';
+import React, { ChangeEventHandler } from 'react';
 import cn from 'classnames';
 import FormLabel from '../FormLabel';
 import HelpText from '../HelpText';
@@ -34,83 +34,79 @@ const defaultProps: Partial<ControlledInputFieldPropTypes> = {
   inputType: 'checkbox',
 };
 
-export class ControlledInputField extends Component<
-  ControlledInputFieldPropTypes
-> {
-  static defaultProps = defaultProps;
+export const ControlledInputField = (props: ControlledInputFieldPropTypes) => {
+  const {
+    id,
+    labelIsLight,
+    testId,
+    required,
+    helpText,
+    disabled,
+    labelText,
+    helpTextProps,
+    formLabelProps,
+    className,
+    checked,
+    value,
+    validationMessage,
+    onChange,
+    children,
+    inputType,
+    inputProps,
+    name,
+    ...otherProps
+  } = props;
 
-  render() {
-    const {
-      id,
-      labelIsLight,
-      testId,
-      required,
-      helpText,
-      disabled,
-      labelText,
-      helpTextProps,
-      formLabelProps,
-      className,
-      checked,
-      value,
-      validationMessage,
-      onChange,
-      children,
-      inputType,
-      inputProps,
-      name,
-      ...otherProps
-    } = this.props;
+  const classNames = cn(styles['ControlledInputField'], className, {
+    [styles['ControlledInputField--disabled']]: disabled,
+  });
 
-    const classNames = cn(styles['ControlledInputField'], className, {
-      [styles['ControlledInputField--disabled']]: disabled,
-    });
-
-    return (
-      <div data-test-id={testId} className={classNames} {...otherProps}>
-        <ControlledInput
-          id={id}
-          labelText={labelText}
-          type={inputType}
-          name={name}
+  return (
+    <div data-test-id={testId} className={classNames} {...otherProps}>
+      <ControlledInput
+        id={id}
+        labelText={labelText}
+        type={inputType}
+        name={name}
+        required={required}
+        checked={checked}
+        disabled={disabled}
+        value={value}
+        onChange={onChange}
+        className={styles.ControlledInputField__input}
+        {...inputProps}
+      />
+      <div className={styles['Checkbox__label-wrapper']}>
+        <FormLabel
+          className={cn(styles.ControlledInputField__label, {
+            [styles['ControlledInputField__label--light']]: labelIsLight,
+          })}
           required={required}
-          checked={checked}
-          disabled={disabled}
-          value={value}
-          onChange={onChange}
-          className={styles.ControlledInputField__input}
-          {...inputProps}
-        />
-        <div className={styles['Checkbox__label-wrapper']}>
-          <FormLabel
-            className={cn(styles.ControlledInputField__label, {
-              [styles['ControlledInputField__label--light']]: labelIsLight,
-            })}
-            required={required}
-            htmlFor={id}
-            {...formLabelProps}
+          htmlFor={id}
+          {...formLabelProps}
+        >
+          {labelText}
+        </FormLabel>
+        {helpText && (
+          <HelpText
+            className={styles['ControlledInputField__help-text']}
+            {...helpTextProps}
           >
-            {labelText}
-          </FormLabel>
-          {helpText && (
-            <HelpText
-              className={styles['ControlledInputField__help-text']}
-              {...helpTextProps}
-            >
-              {helpText}
-            </HelpText>
-          )}
-          {validationMessage && (
-            <ValidationMessage
-              className={styles['ControlledInputField__validation-message']}
-            >
-              {validationMessage}
-            </ValidationMessage>
-          )}
-        </div>
+            {helpText}
+          </HelpText>
+        )}
+        {validationMessage && (
+          <ValidationMessage
+            className={styles['ControlledInputField__validation-message']}
+          >
+            {validationMessage}
+          </ValidationMessage>
+        )}
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
+ControlledInputField.defaultProps = defaultProps;
 
 export default ControlledInputField;

--- a/packages/forma-36-react-components/src/components/Form/FieldGroup/FieldGroup.tsx
+++ b/packages/forma-36-react-components/src/components/Form/FieldGroup/FieldGroup.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import cn from 'classnames';
 
 import styles from './FieldGroup.css';
@@ -16,24 +16,22 @@ const defaultProps: Partial<FieldGroupProps> = {
   testId: 'cf-ui-field-group',
 };
 
-export class FieldGroup extends Component<FieldGroupProps> {
-  static defaultProps = defaultProps;
+export const FieldGroup = (props: FieldGroupProps) => {
+  const { className, children, row, testId, ...otherProps } = props;
 
-  render() {
-    const { className, children, row, testId, ...otherProps } = this.props;
+  const classNames = cn(styles.FieldGroup, className, {
+    [styles['FieldGroup--row']]: row,
+  });
 
-    const classNames = cn(styles.FieldGroup, className, {
-      [styles['FieldGroup--row']]: row,
-    });
+  return (
+    <div {...otherProps} data-test-id={testId} className={classNames}>
+      {React.Children.map(children, (child) => (
+        <div className={styles.FieldGroup__item}>{child}</div>
+      ))}
+    </div>
+  );
+};
 
-    return (
-      <div {...otherProps} data-test-id={testId} className={classNames}>
-        {React.Children.map(children, (child) => (
-          <div className={styles.FieldGroup__item}>{child}</div>
-        ))}
-      </div>
-    );
-  }
-}
+FieldGroup.defaultProps = defaultProps;
 
 export default FieldGroup;

--- a/packages/forma-36-react-components/src/components/Form/Form.tsx
+++ b/packages/forma-36-react-components/src/components/Form/Form.tsx
@@ -1,4 +1,12 @@
-import React, { FormEventHandler, FormEvent } from 'react';
+import React, {
+  Children,
+  useCallback,
+  CSSProperties,
+  FormEventHandler,
+  FormEvent,
+  ReactChild,
+  ReactNodeArray,
+} from 'react';
 import cn from 'classnames';
 
 import styles from './Form.css';
@@ -7,9 +15,9 @@ export interface FormProps {
   onSubmit?: FormEventHandler;
   spacing?: 'condensed' | 'default';
   testId?: string;
-  style?: React.CSSProperties;
+  style?: CSSProperties;
   className?: string;
-  children: React.ReactChild | React.ReactNodeArray;
+  children: ReactChild | ReactNodeArray;
 }
 
 const defaultProps: Partial<FormProps> = {
@@ -34,12 +42,15 @@ export const Form = (props: FormProps) => {
     styles[`Form__item--${spacing}`],
   );
 
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault();
-    if (onSubmit) {
-      onSubmit(event);
-    }
-  };
+  const handleSubmit = useCallback(
+    (event: FormEvent) => {
+      event.preventDefault();
+      if (onSubmit) {
+        onSubmit(event);
+      }
+    },
+    [onSubmit],
+  );
 
   return (
     <form
@@ -48,7 +59,7 @@ export const Form = (props: FormProps) => {
       onSubmit={handleSubmit}
       {...otherProps}
     >
-      {React.Children.map(children, (child) => {
+      {Children.map(children, (child) => {
         if (child) {
           return <div className={formItemClassNames}>{child}</div>;
         }

--- a/packages/forma-36-react-components/src/components/Form/Form.tsx
+++ b/packages/forma-36-react-components/src/components/Form/Form.tsx
@@ -1,4 +1,4 @@
-import React, { Component, FormEventHandler, FormEvent } from 'react';
+import React, { FormEventHandler, FormEvent } from 'react';
 import cn from 'classnames';
 
 import styles from './Form.css';
@@ -17,49 +17,47 @@ const defaultProps: Partial<FormProps> = {
   testId: 'cf-ui-form',
 };
 
-export class Form extends Component<FormProps> {
-  static defaultProps = defaultProps;
+export const Form = (props: FormProps) => {
+  const {
+    className,
+    children,
+    testId,
+    onSubmit,
+    spacing,
+    ...otherProps
+  } = props;
 
-  handleSubmit = (event: FormEvent) => {
+  const classNames = cn(styles.Form, className);
+
+  const formItemClassNames = cn(
+    styles.Form__item,
+    styles[`Form__item--${spacing}`],
+  );
+
+  const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
-    if (this.props.onSubmit) {
-      this.props.onSubmit(event);
+    if (onSubmit) {
+      onSubmit(event);
     }
   };
 
-  render() {
-    const {
-      className,
-      children,
-      testId,
-      onSubmit,
-      spacing,
-      ...otherProps
-    } = this.props;
+  return (
+    <form
+      className={classNames}
+      data-test-id={testId}
+      onSubmit={handleSubmit}
+      {...otherProps}
+    >
+      {React.Children.map(children, (child) => {
+        if (child) {
+          return <div className={formItemClassNames}>{child}</div>;
+        }
+        return null;
+      })}
+    </form>
+  );
+};
 
-    const classNames = cn(styles.Form, className);
-
-    const formItemClassNames = cn(
-      styles.Form__item,
-      styles[`Form__item--${spacing}`],
-    );
-
-    return (
-      <form
-        className={classNames}
-        data-test-id={testId}
-        onSubmit={this.handleSubmit}
-        {...otherProps}
-      >
-        {React.Children.map(children, (child) => {
-          if (child) {
-            return <div className={formItemClassNames}>{child}</div>;
-          }
-          return null;
-        })}
-      </form>
-    );
-  }
-}
+Form.defaultProps = defaultProps;
 
 export default Form;

--- a/packages/forma-36-react-components/src/components/FormLabel/FormLabel.tsx
+++ b/packages/forma-36-react-components/src/components/FormLabel/FormLabel.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import cn from 'classnames';
 
 import styles from './FormLabel.css';
@@ -18,39 +18,37 @@ const defaultProps: Partial<FormLabelProps> = {
   required: false,
 };
 
-export class FormLabel extends Component<FormLabelProps> {
-  static defaultProps = defaultProps;
+export const FormLabel = (props: FormLabelProps) => {
+  const {
+    className,
+    children,
+    testId,
+    htmlFor,
+    requiredText,
+    required,
+    ...otherProps
+  } = props;
 
-  render() {
-    const {
-      className,
-      children,
-      testId,
-      htmlFor,
-      requiredText,
-      required,
-      ...otherProps
-    } = this.props;
+  const classNames = cn(styles.FormLabel, className);
 
-    const classNames = cn(styles.FormLabel, className);
+  return (
+    <label
+      className={classNames}
+      data-test-id={testId}
+      htmlFor={htmlFor}
+      {...otherProps}
+    >
+      {children}
+      {required! && // eslint-disable-line @typescript-eslint/no-non-null-assertion
+        !!requiredText!.length && ( // eslint-disable-line @typescript-eslint/no-non-null-assertion
+          <span className={styles['FormLabel__required-text']}>
+            ({requiredText})
+          </span>
+        )}
+    </label>
+  );
+};
 
-    return (
-      <label
-        className={classNames}
-        data-test-id={testId}
-        htmlFor={htmlFor}
-        {...otherProps}
-      >
-        {children}
-        {required! && // eslint-disable-line @typescript-eslint/no-non-null-assertion
-          !!requiredText!.length && ( // eslint-disable-line @typescript-eslint/no-non-null-assertion
-            <span className={styles['FormLabel__required-text']}>
-              ({requiredText})
-            </span>
-          )}
-      </label>
-    );
-  }
-}
+FormLabel.defaultProps = defaultProps;
 
 export default FormLabel;

--- a/packages/forma-36-react-components/src/components/IconButton/IconButton.tsx
+++ b/packages/forma-36-react-components/src/components/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import cn from 'classnames';
 import Icon, { IconProps } from '../Icon';
 import TabFocusTrap from '../TabFocusTrap';
@@ -29,69 +29,67 @@ const defaultProps: Partial<IconButtonProps> = {
   withDropdown: false,
 };
 
-export class IconButton extends Component<IconButtonProps> {
-  static defaultProps = defaultProps;
+export const IconButton = (props: IconButtonProps) => {
+  const {
+    label,
+    iconProps,
+    href,
+    testId,
+    disabled,
+    onClick,
+    buttonType,
+    withDropdown,
+    className,
+    ...otherProps
+  } = props;
 
-  render() {
-    const {
-      label,
-      iconProps,
-      href,
-      testId,
-      disabled,
-      onClick,
-      buttonType,
-      withDropdown,
-      className,
-      ...otherProps
-    } = this.props;
+  const classNames = cn(styles.IconButton, className, {
+    [styles['IconButton--disabled']]: disabled,
+    [styles[`IconButton--${buttonType}`]]: buttonType,
+  });
 
-    const classNames = cn(styles.IconButton, className, {
-      [styles['IconButton--disabled']]: disabled,
-      [styles[`IconButton--${buttonType}`]]: buttonType,
-    });
+  const elementProps = {
+    className: classNames,
+    onClick: !disabled ? onClick : undefined,
+    'data-test-id': testId,
+    ...otherProps,
+  };
 
-    const elementProps = {
-      className: classNames,
-      onClick: !disabled ? onClick : undefined,
-      'data-test-id': testId,
-      ...otherProps,
-    };
-
-    const content = (
-      <TabFocusTrap className={styles.IconButton__inner}>
+  const content = (
+    <TabFocusTrap className={styles.IconButton__inner}>
+      <Icon
+        {...iconProps}
+        className={cn(styles.IconButton__icon, iconProps.className)}
+      />
+      <span className={styles.IconButton__label}>{label}</span>
+      {withDropdown && (
         <Icon
-          {...iconProps}
-          className={cn(styles.IconButton__icon, iconProps.className)}
+          icon="ChevronDown"
+          color="secondary"
+          className={styles.IconButton__dropdown}
         />
-        <span className={styles.IconButton__label}>{label}</span>
-        {withDropdown && (
-          <Icon
-            icon="ChevronDown"
-            color="secondary"
-            className={styles.IconButton__dropdown}
-          />
-        )}
-      </TabFocusTrap>
-    );
+      )}
+    </TabFocusTrap>
+  );
 
-    if (href) {
-      if (disabled) {
-        return <a {...elementProps}>{content}</a>;
-      }
-      return (
-        <a {...elementProps} href={href}>
-          content
-        </a>
-      );
+  if (href) {
+    if (disabled) {
+      return <a {...elementProps}>{content}</a>;
     }
-
     return (
-      <button {...elementProps} type="button" disabled={disabled}>
-        {content}
-      </button>
+      <a {...elementProps} href={href}>
+        content
+      </a>
     );
   }
-}
+
+  return (
+    <button {...elementProps} type="button" disabled={disabled}>
+      {content}
+    </button>
+  );
+};
+
+IconButton.defaultProps = defaultProps;
 
 export default IconButton;

--- a/packages/forma-36-react-components/src/components/RadioButton/RadioButton.tsx
+++ b/packages/forma-36-react-components/src/components/RadioButton/RadioButton.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ControlledInput, { ControlledInputPropTypes } from '../ControlledInput';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -12,13 +12,9 @@ const defaultProps: Partial<RadioButtonProps> = {
   willBlurOnEsc: true,
 };
 
-export class RadioButton extends Component<RadioButtonProps> {
-  static defaultProps = defaultProps;
-
-  render() {
-    return <ControlledInput {...this.props} />;
-  }
-}
+export const RadioButton = (props: RadioButtonProps) => {
+  return <ControlledInput {...props} />;
+};
 
 RadioButton.defaultProps = defaultProps;
 

--- a/packages/forma-36-react-components/src/components/RadioButtonField/RadioButtonField.tsx
+++ b/packages/forma-36-react-components/src/components/RadioButtonField/RadioButtonField.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ControlledInputField, {
   ControlledInputFieldPropTypes,
 } from '../ControlledInputField';
@@ -13,16 +13,14 @@ const defaultProps: Partial<RadioButtonFieldProps> = {
   testId: 'cf-ui-radio-button-field',
 };
 
-export class RadioButtonField extends Component<RadioButtonFieldProps> {
-  static defaultProps = defaultProps;
+export const RadioButtonField = (props: RadioButtonFieldProps) => {
+  const { testId, ...otherProps } = props;
 
-  render() {
-    const { testId, ...otherProps } = this.props;
+  return (
+    <ControlledInputField testId={testId} {...otherProps} inputType="radio" />
+  );
+};
 
-    return (
-      <ControlledInputField testId={testId} {...otherProps} inputType="radio" />
-    );
-  }
-}
+RadioButtonField.defaultProps = defaultProps;
 
 export default RadioButtonField;

--- a/packages/forma-36-react-components/src/components/Select/Option/Option.tsx
+++ b/packages/forma-36-react-components/src/components/Select/Option/Option.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 export interface OptionProps {
   value: string;
@@ -10,18 +10,16 @@ const defaultProps: Partial<OptionProps> = {
   testId: 'cf-ui-select-option',
 };
 
-export class Option extends Component<OptionProps> {
-  static defaultProps = defaultProps;
+export const Option = (props: OptionProps) => {
+  const { value, children, testId, ...otherProps } = props;
 
-  render() {
-    const { value, children, testId, ...otherProps } = this.props;
+  return (
+    <option value={value} data-test-id={testId} {...otherProps}>
+      {children}
+    </option>
+  );
+};
 
-    return (
-      <option value={value} data-test-id={testId} {...otherProps}>
-        {children}
-      </option>
-    );
-  }
-}
+Option.defaultProps = defaultProps;
 
 export default Option;

--- a/packages/forma-36-react-components/src/components/Select/Select.tsx
+++ b/packages/forma-36-react-components/src/components/Select/Select.tsx
@@ -1,5 +1,6 @@
 import React, {
   useCallback,
+  useEffect,
   useState,
   ChangeEventHandler,
   FocusEventHandler,
@@ -75,6 +76,10 @@ export const Select = (props: SelectProps) => {
     },
     [onChange, isDisabled],
   );
+
+  useEffect(() => {
+    setValueState(value);
+  }, [value]);
 
   const widthClass = `Select--${width}`;
   const classNames = cn(styles['Select'], {

--- a/packages/forma-36-react-components/src/components/Select/Select.tsx
+++ b/packages/forma-36-react-components/src/components/Select/Select.tsx
@@ -1,8 +1,10 @@
 import React, {
-  Component,
+  useState,
+  useEffect,
   ChangeEventHandler,
   FocusEventHandler,
   KeyboardEvent,
+  ChangeEvent,
 } from 'react';
 import cn from 'classnames';
 import Icon from '../Icon';
@@ -25,10 +27,6 @@ export interface SelectProps {
   willBlurOnEsc?: boolean;
 }
 
-export interface SelectState {
-  value?: string;
-}
-
 const defaultProps: Partial<SelectProps> = {
   testId: 'cf-ui-select',
   required: false,
@@ -38,95 +36,84 @@ const defaultProps: Partial<SelectProps> = {
   willBlurOnEsc: true,
 };
 
-export class Select extends Component<SelectProps, SelectState> {
-  static defaultProps = defaultProps;
+export const Select = (props: SelectProps) => {
+  const {
+    id,
+    name,
+    required,
+    children,
+    width,
+    className,
+    testId,
+    onChange,
+    onBlur,
+    onFocus,
+    isDisabled,
+    hasError,
+    value,
+    willBlurOnEsc,
+    ...otherProps
+  } = props;
+  const [valueState, setValueState] = useState<string | undefined>();
 
-  state = {
-    value: this.props.value,
-  };
-
-  UNSAFE_componentWillReceiveProps(nextProps: SelectProps) {
-    if (this.props.value !== nextProps.value) {
-      this.setState({
-        value: nextProps.value,
-      });
-    }
-  }
-
-  handleKeyDown = (e: KeyboardEvent<HTMLSelectElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLSelectElement>) => {
     const ESC = 27;
 
-    if (e.keyCode === ESC && this.props.willBlurOnEsc) {
+    if (e.keyCode === ESC && willBlurOnEsc) {
       e.currentTarget.blur();
     }
   };
 
-  render() {
-    const {
-      id,
-      name,
-      required,
-      children,
-      width,
-      className,
-      testId,
-      onChange,
-      onBlur,
-      onFocus,
-      isDisabled,
-      hasError,
-      willBlurOnEsc,
-      ...otherProps
-    } = this.props;
+  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    if (!isDisabled) {
+      setValueState(e.target.value);
 
-    const widthClass = `Select--${width}`;
-    const classNames = cn(styles['Select'], {
-      [styles['Select--disabled']]: isDisabled,
-      [styles['Select--negative']]: hasError,
-    });
+      if (onChange) {
+        onChange(e);
+      }
+    }
+  };
 
-    const wrapperClassNames = cn(
-      styles['Select__wrapper'],
-      styles[widthClass],
-      className,
-    );
+  useEffect(() => {
+    setValueState(value);
+  }, [value]);
 
-    return (
-      <div className={wrapperClassNames}>
-        <select
-          id={id}
-          required={required}
-          name={name}
-          aria-label={name}
-          data-test-id={testId}
-          className={classNames}
-          value={this.state.value}
-          disabled={isDisabled}
-          onFocus={onFocus}
-          onChange={(e) => {
-            if (!isDisabled) {
-              this.setState({
-                value: e.target.value,
-              });
-              if (onChange) {
-                onChange(e);
-              }
-            }
-          }}
-          onBlur={onBlur}
-          onKeyDown={this.handleKeyDown}
-          {...otherProps}
-        >
-          {children}
-        </select>
-        <Icon
-          className={styles['Select__icon']}
-          icon="ArrowDown"
-          color="muted"
-        />
-      </div>
-    );
-  }
-}
+  const widthClass = `Select--${width}`;
+  const classNames = cn(styles['Select'], {
+    [styles['Select--disabled']]: isDisabled,
+    [styles['Select--negative']]: hasError,
+  });
+
+  const wrapperClassNames = cn(
+    styles['Select__wrapper'],
+    styles[widthClass],
+    className,
+  );
+
+  return (
+    <div className={wrapperClassNames}>
+      <select
+        id={id}
+        required={required}
+        name={name}
+        aria-label={name}
+        data-test-id={testId}
+        className={classNames}
+        value={valueState}
+        disabled={isDisabled}
+        onFocus={onFocus}
+        onChange={handleChange}
+        onBlur={onBlur}
+        onKeyDown={handleKeyDown}
+        {...otherProps}
+      >
+        {children}
+      </select>
+      <Icon className={styles['Select__icon']} icon="ArrowDown" color="muted" />
+    </div>
+  );
+};
+
+Select.defaultProps = defaultProps;
 
 export default Select;

--- a/packages/forma-36-react-components/src/components/Select/Select.tsx
+++ b/packages/forma-36-react-components/src/components/Select/Select.tsx
@@ -58,9 +58,7 @@ export const Select = (props: SelectProps) => {
   const [valueState, setValueState] = useState<string | undefined>(value);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLSelectElement>) => {
-    const ESC = '27';
-
-    if (e.nativeEvent.code === ESC && willBlurOnEsc) {
+    if (e.nativeEvent.code === 'Escape' && willBlurOnEsc) {
       e.currentTarget.blur();
     }
   };

--- a/packages/forma-36-react-components/src/components/Select/Select.tsx
+++ b/packages/forma-36-react-components/src/components/Select/Select.tsx
@@ -1,10 +1,11 @@
 import React, {
+  useCallback,
   useState,
-  useEffect,
   ChangeEventHandler,
   FocusEventHandler,
   KeyboardEvent,
   ChangeEvent,
+  ReactNode,
 } from 'react';
 import cn from 'classnames';
 import Icon from '../Icon';
@@ -23,7 +24,7 @@ export interface SelectProps {
   width?: 'auto' | 'small' | 'medium' | 'large' | 'full';
   testId?: string;
   className?: string;
-  children: React.ReactNode;
+  children: ReactNode;
   willBlurOnEsc?: boolean;
 }
 
@@ -54,29 +55,28 @@ export const Select = (props: SelectProps) => {
     willBlurOnEsc,
     ...otherProps
   } = props;
-  const [valueState, setValueState] = useState<string | undefined>();
+  const [valueState, setValueState] = useState<string | undefined>(value);
 
   const handleKeyDown = (e: KeyboardEvent<HTMLSelectElement>) => {
-    const ESC = 27;
+    const ESC = '27';
 
-    if (e.keyCode === ESC && willBlurOnEsc) {
+    if (e.nativeEvent.code === ESC && willBlurOnEsc) {
       e.currentTarget.blur();
     }
   };
 
-  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    if (!isDisabled) {
-      setValueState(e.target.value);
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLSelectElement>) => {
+      if (!isDisabled) {
+        setValueState(e.target.value);
 
-      if (onChange) {
-        onChange(e);
+        if (onChange) {
+          onChange(e);
+        }
       }
-    }
-  };
-
-  useEffect(() => {
-    setValueState(value);
-  }, [value]);
+    },
+    [onChange, isDisabled],
+  );
 
   const widthClass = `Select--${width}`;
   const classNames = cn(styles['Select'], {

--- a/packages/forma-36-react-components/src/components/SelectField/SelectField.tsx
+++ b/packages/forma-36-react-components/src/components/SelectField/SelectField.tsx
@@ -1,6 +1,5 @@
 import React, {
   useState,
-  useEffect,
   ChangeEvent,
   FocusEventHandler,
   ChangeEventHandler,
@@ -65,15 +64,12 @@ export const SelectField = (props: SelectFieldProps) => {
   // This is used by this component when the `countCharacters`
   // option is on
   const handleOnChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    e.persist();
     setValueState(e.currentTarget.value);
     if (onChange) {
       onChange(e);
     }
   };
-
-  useEffect(() => {
-    setValueState(value);
-  }, [value]);
 
   const classNames = cn(styles['SelectField'], className);
 
@@ -85,26 +81,22 @@ export const SelectField = (props: SelectFieldProps) => {
         </FormLabel>
         {textLinkProps && (
           <TextLink
-            {...{
-              ...textLinkProps,
-              className: styles['SelectField__label-link'],
-            }}
+            className={styles['SelectField__label-link']}
+            {...textLinkProps}
           >
             {textLinkProps.text}
           </TextLink>
         )}
       </div>
       <Select
-        {...{
-          hasError: !!validationMessage,
-          name,
-          id,
-          onBlur,
-          onChange: handleOnChange,
-          value: valueState,
-          required,
-          ...selectProps,
-        }}
+        hasError={!!validationMessage}
+        name={name}
+        id={id}
+        onBlur={onBlur}
+        onChange={handleOnChange}
+        value={valueState}
+        required={required}
+        {...selectProps}
       >
         {children}
       </Select>

--- a/packages/forma-36-react-components/src/components/SelectField/SelectField.tsx
+++ b/packages/forma-36-react-components/src/components/SelectField/SelectField.tsx
@@ -1,5 +1,6 @@
 import React, {
-  Component,
+  useState,
+  useEffect,
   ChangeEvent,
   FocusEventHandler,
   ChangeEventHandler,
@@ -39,101 +40,94 @@ const defaultProps: Partial<SelectFieldProps> = {
   required: false,
 };
 
-export class SelectField extends Component<SelectFieldProps, SelectFieldState> {
-  static defaultProps = defaultProps;
-
-  state = { value: this.props.value };
-
-  UNSAFE_componentWillReceiveProps(nextProps: SelectFieldProps) {
-    if (this.props.value !== nextProps.value) {
-      this.setState({
-        value: nextProps.value,
-      });
-    }
-  }
+export const SelectField = (props: SelectFieldProps) => {
+  const {
+    validationMessage,
+    className,
+    children,
+    selectProps,
+    testId,
+    formLabelProps,
+    textLinkProps,
+    labelText,
+    helpText,
+    required,
+    onChange,
+    onBlur,
+    value,
+    name,
+    id,
+    ...otherProps
+  } = props;
+  const [valueState, setValueState] = useState<string | undefined>(value);
 
   // Store a copy of the value in state.
   // This is used by this component when the `countCharacters`
   // option is on
-  handleOnChange = (evt: ChangeEvent) => {
-    this.setState({ value: (evt.target as HTMLSelectElement).value });
-    if (this.props.onChange) {
-      this.props.onChange(evt);
+  const handleOnChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    setValueState(e.currentTarget.value);
+    if (onChange) {
+      onChange(e);
     }
   };
 
-  render() {
-    const {
-      validationMessage,
-      className,
-      children,
-      selectProps,
-      testId,
-      formLabelProps,
-      textLinkProps,
-      labelText,
-      helpText,
-      required,
-      onChange,
-      onBlur,
-      value,
-      name,
-      id,
-      ...otherProps
-    } = this.props;
+  useEffect(() => {
+    setValueState(value);
+  }, [value]);
 
-    const classNames = cn(styles['SelectField'], className);
+  const classNames = cn(styles['SelectField'], className);
 
-    return (
-      <div className={classNames} {...otherProps} data-test-id={testId}>
-        <div className={styles['SelectField__label-wrapper']}>
-          <FormLabel {...{ ...formLabelProps, htmlFor: id, required }}>
-            {labelText}
-          </FormLabel>
-          {textLinkProps && (
-            <TextLink
-              {...{
-                ...textLinkProps,
-                className: styles['SelectField__label-link'],
-              }}
-            >
-              {textLinkProps.text}
-            </TextLink>
-          )}
-        </div>
-        <Select
-          {...{
-            hasError: !!validationMessage,
-            name,
-            id,
-            onBlur,
-            onChange: this.handleOnChange,
-            value: this.state.value,
-            required,
-            ...selectProps,
-          }}
-        >
-          {children}
-        </Select>
-        {validationMessage && (
-          <ValidationMessage
-            className={styles['SelectField__validation-message']}
+  return (
+    <div className={classNames} {...otherProps} data-test-id={testId}>
+      <div className={styles['SelectField__label-wrapper']}>
+        <FormLabel {...{ ...formLabelProps, htmlFor: id, required }}>
+          {labelText}
+        </FormLabel>
+        {textLinkProps && (
+          <TextLink
+            {...{
+              ...textLinkProps,
+              className: styles['SelectField__label-link'],
+            }}
           >
-            {validationMessage}
-          </ValidationMessage>
-        )}
-        {helpText && (
-          <div className={styles['SelectField__hints']}>
-            {helpText && (
-              <HelpText className={styles['SelectField__help-text']}>
-                {helpText}
-              </HelpText>
-            )}
-          </div>
+            {textLinkProps.text}
+          </TextLink>
         )}
       </div>
-    );
-  }
-}
+      <Select
+        {...{
+          hasError: !!validationMessage,
+          name,
+          id,
+          onBlur,
+          onChange: handleOnChange,
+          value: valueState,
+          required,
+          ...selectProps,
+        }}
+      >
+        {children}
+      </Select>
+      {validationMessage && (
+        <ValidationMessage
+          className={styles['SelectField__validation-message']}
+        >
+          {validationMessage}
+        </ValidationMessage>
+      )}
+      {helpText && (
+        <div className={styles['SelectField__hints']}>
+          {helpText && (
+            <HelpText className={styles['SelectField__help-text']}>
+              {helpText}
+            </HelpText>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+SelectField.defaultProps = defaultProps;
 
 export default SelectField;

--- a/packages/forma-36-react-components/src/components/SelectField/SelectField.tsx
+++ b/packages/forma-36-react-components/src/components/SelectField/SelectField.tsx
@@ -1,4 +1,5 @@
 import React, {
+  useEffect,
   useState,
   ChangeEvent,
   FocusEventHandler,
@@ -70,6 +71,10 @@ export const SelectField = (props: SelectFieldProps) => {
       onChange(e);
     }
   };
+
+  useEffect(() => {
+    setValueState(value);
+  }, [value]);
 
   const classNames = cn(styles['SelectField'], className);
 

--- a/packages/forma-36-react-components/src/components/TextField/TextField.tsx
+++ b/packages/forma-36-react-components/src/components/TextField/TextField.tsx
@@ -1,8 +1,9 @@
 import React, {
-  Component,
+  useState,
   ChangeEvent,
   ChangeEventHandler,
   FocusEventHandler,
+  ElementType,
 } from 'react';
 import cn from 'classnames';
 import ValidationMessage from '../ValidationMessage';
@@ -47,118 +48,104 @@ const defaultProps: Partial<TextFieldProps> = {
   width: 'full',
 };
 
-export class TextField extends Component<TextFieldProps, TextFieldState> {
-  static defaultProps = defaultProps;
-
-  state = { value: this.props.value || '', initialValue: this.props.value };
+export const TextField = (props: TextFieldProps) => {
+  const {
+    validationMessage,
+    className,
+    textInputProps,
+    testId,
+    width,
+    formLabelProps,
+    textLinkProps,
+    labelText,
+    helpText,
+    textarea,
+    countCharacters,
+    required,
+    onChange,
+    onBlur,
+    onFocus,
+    value,
+    name,
+    id,
+    ...otherProps
+  } = props;
+  const [valueState, setValueState] = useState<string | undefined>(value);
 
   // Store a copy of the value in state.
   // This is used by this component when the `countCharacters`
   // option is on
-  handleOnChange = (evt: ChangeEvent) => {
-    this.setState({ value: (evt.target as HTMLInputElement).value });
-    if (this.props.onChange) this.props.onChange(evt);
+  const handleOnChange = (
+    e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
+  ) => {
+    setValueState(e.target.value);
+    if (onChange) onChange(e);
   };
 
-  static getDerivedStateFromProps(
-    props: TextFieldProps,
-    state: TextFieldState,
-  ) {
-    if (props.value !== state.initialValue) {
-      return { ...state, value: props.value, initialValue: props.value };
-    }
-    return state;
-  }
+  const widthClass = `TextField--${width}`;
+  const classNames = cn(styles['TextField'], styles[widthClass], className);
 
-  render() {
-    const {
-      validationMessage,
-      className,
-      textInputProps,
-      testId,
-      width,
-      formLabelProps,
-      textLinkProps,
-      labelText,
-      helpText,
-      textarea,
-      countCharacters,
-      required,
-      onChange,
-      onBlur,
-      onFocus,
-      value,
-      name,
-      id,
-      ...otherProps
-    } = this.props;
+  const Element: ElementType = textarea ? Textarea : TextInput;
 
-    const widthClass = `TextField--${width}`;
-    const classNames = cn(styles['TextField'], styles[widthClass], className);
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const Element: any = textarea ? Textarea : TextInput;
-    return (
-      <div className={classNames} {...otherProps} data-test-id={testId}>
-        <div className={styles['TextField__label-wrapper']}>
-          <FormLabel {...formLabelProps} htmlFor={id} required={required}>
-            {labelText}
-          </FormLabel>
-          {textLinkProps && (
-            <TextLink
-              {...{
-                ...textLinkProps,
-                className: styles['TextField__label-link'],
-              }}
-            >
-              {textLinkProps.text}
-            </TextLink>
-          )}
-        </div>
-        <Element
-          {...{
-            error: !!validationMessage,
-            name,
-            id,
-            onBlur,
-            onFocus,
-            onChange: this.handleOnChange,
-            value,
-            required,
-            ...textInputProps,
-            width: 'full',
-          }}
-        />
-        {validationMessage && (
-          <ValidationMessage
-            className={styles['TextField__validation-message']}
+  return (
+    <div className={classNames} {...otherProps} data-test-id={testId}>
+      <div className={styles['TextField__label-wrapper']}>
+        <FormLabel {...formLabelProps} htmlFor={id} required={required}>
+          {labelText}
+        </FormLabel>
+        {textLinkProps && (
+          <TextLink
+            {...{
+              ...textLinkProps,
+              className: styles['TextField__label-link'],
+            }}
           >
-            {validationMessage}
-          </ValidationMessage>
-        )}
-        {(helpText || countCharacters) && (
-          <div className={styles['TextField__hints']}>
-            {helpText && (
-              <HelpText className={styles['TextField__help-text']}>
-                {helpText}
-              </HelpText>
-            )}
-            {countCharacters && textInputProps && textInputProps.maxLength && (
-              <HelpText
-                className={cn(
-                  styles['TextField__help-text'],
-                  styles['TextField__count'],
-                )}
-              >
-                {this.state.value ? this.state.value.length : 0}/
-                {textInputProps.maxLength}
-              </HelpText>
-            )}
-          </div>
+            {textLinkProps.text}
+          </TextLink>
         )}
       </div>
-    );
-  }
-}
+      <Element
+        {...{
+          error: !!validationMessage,
+          name,
+          id,
+          onBlur,
+          onFocus,
+          onChange: handleOnChange,
+          value,
+          required,
+          ...textInputProps,
+          width: 'full',
+        }}
+      />
+      {validationMessage && (
+        <ValidationMessage className={styles['TextField__validation-message']}>
+          {validationMessage}
+        </ValidationMessage>
+      )}
+      {(helpText || countCharacters) && (
+        <div className={styles['TextField__hints']}>
+          {helpText && (
+            <HelpText className={styles['TextField__help-text']}>
+              {helpText}
+            </HelpText>
+          )}
+          {countCharacters && textInputProps && textInputProps.maxLength && (
+            <HelpText
+              className={cn(
+                styles['TextField__help-text'],
+                styles['TextField__count'],
+              )}
+            >
+              {valueState ? valueState.length : 0}/{textInputProps.maxLength}
+            </HelpText>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+TextField.defaultProps = defaultProps;
 
 export default TextField;

--- a/packages/forma-36-react-components/src/components/TextField/TextField.tsx
+++ b/packages/forma-36-react-components/src/components/TextField/TextField.tsx
@@ -1,4 +1,5 @@
 import React, {
+  useCallback,
   useState,
   ChangeEvent,
   ChangeEventHandler,
@@ -75,12 +76,13 @@ export const TextField = (props: TextFieldProps) => {
   // Store a copy of the value in state.
   // This is used by this component when the `countCharacters`
   // option is on
-  const handleOnChange = (
-    e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
-  ) => {
-    setValueState(e.target.value);
-    if (onChange) onChange(e);
-  };
+  const handleOnChange = useCallback(
+    (e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+      setValueState(e.target.value);
+      if (onChange) onChange(e);
+    },
+    [onChange],
+  );
 
   const widthClass = `TextField--${width}`;
   const classNames = cn(styles['TextField'], styles[widthClass], className);
@@ -95,28 +97,23 @@ export const TextField = (props: TextFieldProps) => {
         </FormLabel>
         {textLinkProps && (
           <TextLink
-            {...{
-              ...textLinkProps,
-              className: styles['TextField__label-link'],
-            }}
+            className={styles['TextField__label-link']}
+            {...textLinkProps}
           >
             {textLinkProps.text}
           </TextLink>
         )}
       </div>
       <Element
-        {...{
-          error: !!validationMessage,
-          name,
-          id,
-          onBlur,
-          onFocus,
-          onChange: handleOnChange,
-          value,
-          required,
-          ...textInputProps,
-          width: 'full',
-        }}
+        error={!!validationMessage}
+        name={name}
+        id={id}
+        onBlur={onBlur}
+        onFocus={onFocus}
+        onChange={handleOnChange}
+        value={value}
+        required={required}
+        width={'full'}
       />
       {validationMessage && (
         <ValidationMessage className={styles['TextField__validation-message']}>

--- a/packages/forma-36-react-components/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -58,45 +58,6 @@ exports[`renders the component with a copybutton 1`] = `
       name="someComponent"
       value=""
     />
-    <div
-      class="CopyButton TextInput__copy-button"
-      data-test-id="cf-ui-copy-button"
-      id="copyButton"
-    >
-      <span>
-        <button
-          class="CopyButton__button"
-          type="button"
-        >
-          <span
-            class="TabFocusTrap CopyButton__TabFocusTrap"
-            tabindex="-1"
-          >
-            <span
-              class="CopyButton__text"
-            >
-              Copy 
-               to clipboard
-            </span>
-            <svg
-              class="Icon Icon--small Icon--muted"
-              data-test-id="cf-ui-icon"
-              height="1em"
-              viewBox="0 0 24 24"
-              width="1em"
-            >
-              <path
-                d="M0 0h24v24H0z"
-                fill="none"
-              />
-              <path
-                d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
-              />
-            </svg>
-          </span>
-        </button>
-      </span>
-    </div>
   </div>
 </div>
 `;
@@ -126,7 +87,6 @@ exports[`renders the component with a placeholder text 1`] = `
       data-test-id="cf-ui-text-input"
       id="someComponent"
       name="someComponent"
-      placeholder="placeholder"
       value=""
     />
   </div>
@@ -158,7 +118,6 @@ exports[`renders the component with a rows defined 1`] = `
       data-test-id="cf-ui-text-input"
       id="someComponent"
       name="someComponent"
-      rows="2"
       value=""
     />
   </div>
@@ -280,7 +239,7 @@ exports[`renders the component with additional prop 1`] = `
     <input
       aria-label="someComponent"
       class="TextInput__input"
-      data-test-id="test"
+      data-test-id="cf-ui-text-input"
       id="someComponent"
       name="someComponent"
       value=""
@@ -374,7 +333,6 @@ exports[`renders the component with characters count 1`] = `
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
-      maxlength="20"
       name="someComponent"
       value=""
     />
@@ -459,7 +417,6 @@ exports[`renders the component with max length of characters 1`] = `
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
-      maxlength="10"
       name="someComponent"
       value=""
     />

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.stories.tsx
@@ -18,7 +18,7 @@ storiesOf('Components/TextInput', module)
       disabled={boolean('disabled', false)}
       isReadOnly={boolean('isReadOnly', false)}
       withCopyButton={boolean('withCopyButton', false)}
-      value={text('valiue', '123456')}
+      value={text('value', '123456')}
       maxLength={number('maxLength', 50)}
       width={select(
         'width',

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
@@ -96,13 +96,12 @@ export const TextInput = (props: TextInputProps) => {
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
       e.persist();
-      const ESC = '27';
 
       if (onKeyDown) {
         onKeyDown(e);
       }
 
-      if (e.nativeEvent.code === ESC && willBlurOnEsc) {
+      if (e.nativeEvent.code === 'Escape' && willBlurOnEsc) {
         e.currentTarget.blur();
       }
     },

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
@@ -1,6 +1,7 @@
 import React, {
   useState,
   useEffect,
+  useCallback,
   RefObject,
   FocusEvent,
   KeyboardEvent,
@@ -67,6 +68,7 @@ export const TextInput = (props: TextInputProps) => {
     id,
     inputRef,
     willBlurOnEsc,
+    onKeyDown,
     ...otherProps
   } = props;
 
@@ -79,6 +81,7 @@ export const TextInput = (props: TextInputProps) => {
   };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    e.persist();
     if (disabled || isReadOnly) return;
 
     if (onChange) {
@@ -87,17 +90,20 @@ export const TextInput = (props: TextInputProps) => {
     setValueState(e.currentTarget.value);
   };
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    const ESC = 27;
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      const ESC = 27;
 
-    if (props.onKeyDown) {
-      props.onKeyDown(e);
-    }
+      if (onKeyDown) {
+        onKeyDown(e);
+      }
 
-    if (e.keyCode === ESC && props.willBlurOnEsc) {
-      e.currentTarget.blur();
-    }
-  };
+      if (e.keyCode === ESC && willBlurOnEsc) {
+        e.currentTarget.blur();
+      }
+    },
+    [willBlurOnEsc, onKeyDown],
+  );
 
   useEffect(() => {
     setValueState(value);

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
@@ -1,6 +1,5 @@
 import React, {
   useState,
-  useEffect,
   useCallback,
   RefObject,
   FocusEvent,
@@ -75,6 +74,7 @@ export const TextInput = (props: TextInputProps) => {
   const [valueState, setValueState] = useState<string | undefined>(value);
 
   const handleFocus = (e: FocusEvent) => {
+    e.persist();
     if (disabled) {
       (e.target as HTMLInputElement).select();
     }
@@ -92,22 +92,19 @@ export const TextInput = (props: TextInputProps) => {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
-      const ESC = 27;
+      e.persist();
+      const ESC = '27';
 
       if (onKeyDown) {
         onKeyDown(e);
       }
 
-      if (e.keyCode === ESC && willBlurOnEsc) {
+      if (e.nativeEvent.code === ESC && willBlurOnEsc) {
         e.currentTarget.blur();
       }
     },
     [willBlurOnEsc, onKeyDown],
   );
-
-  useEffect(() => {
-    setValueState(value);
-  }, [value]);
 
   const widthClass = `TextInput--${width}`;
   const classNames = cn(styles['TextInput'], className, styles[widthClass], {

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
@@ -1,5 +1,6 @@
 import React, {
   useState,
+  useEffect,
   useCallback,
   RefObject,
   FocusEvent,
@@ -107,6 +108,10 @@ export const TextInput = (props: TextInputProps) => {
     },
     [willBlurOnEsc, onKeyDown],
   );
+
+  useEffect(() => {
+    setValueState(value);
+  }, [value]);
 
   const widthClass = `TextInput--${width}`;
   const classNames = cn(styles['TextInput'], className, styles[widthClass], {

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
@@ -80,15 +80,18 @@ export const TextInput = (props: TextInputProps) => {
     }
   };
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    e.persist();
-    if (disabled || isReadOnly) return;
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      e.persist();
+      if (disabled || isReadOnly) return;
 
-    if (onChange) {
-      onChange(e);
-    }
-    setValueState(e.currentTarget.value);
-  };
+      if (onChange) {
+        onChange(e);
+      }
+      setValueState(e.currentTarget.value);
+    },
+    [onChange, disabled, isReadOnly],
+  );
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {

--- a/packages/forma-36-react-components/src/components/Textarea/Textarea.tsx
+++ b/packages/forma-36-react-components/src/components/Textarea/Textarea.tsx
@@ -7,6 +7,7 @@ import React, {
   KeyboardEventHandler,
   RefObject,
   ChangeEvent,
+  useCallback,
 } from 'react';
 import cn from 'classnames';
 import styles from './Textarea.css';
@@ -73,19 +74,24 @@ export const Textarea = (props: TextareaProps) => {
     setValueState(value);
   }, [value]);
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    const ESC = 27;
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      e.persist();
+      const ESC = 27;
 
-    if (onKeyDown) {
-      onKeyDown(e);
-    }
+      if (onKeyDown) {
+        onKeyDown(e);
+      }
 
-    if (e.keyCode === ESC && willBlurOnEsc) {
-      e.currentTarget.blur();
-    }
-  };
+      if (e.keyCode === ESC && willBlurOnEsc) {
+        e.currentTarget.blur();
+      }
+    },
+    [willBlurOnEsc, onKeyDown],
+  );
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    e.persist();
     setValueState(e.target.value);
     if (onChange) {
       onChange(e);

--- a/packages/forma-36-react-components/src/components/Textarea/Textarea.tsx
+++ b/packages/forma-36-react-components/src/components/Textarea/Textarea.tsx
@@ -1,10 +1,12 @@
 import React, {
-  Component,
+  useState,
+  useEffect,
   KeyboardEvent,
   FocusEventHandler,
   ChangeEventHandler,
   KeyboardEventHandler,
   RefObject,
+  ChangeEvent,
 } from 'react';
 import cn from 'classnames';
 import styles from './Textarea.css';
@@ -44,87 +46,81 @@ const defaultProps: Partial<TextareaProps> = {
   willBlurOnEsc: true,
 };
 
-export class Textarea extends Component<TextareaProps, TextareaState> {
-  static defaultProps = defaultProps;
+export const Textarea = (props: TextareaProps) => {
+  const {
+    className,
+    testId,
+    placeholder,
+    maxLength,
+    onChange,
+    disabled,
+    required,
+    onBlur,
+    onKeyDown,
+    error,
+    width,
+    value,
+    name,
+    rows,
+    id,
+    willBlurOnEsc,
+    textareaRef,
+    ...otherProps
+  } = props;
+  const [valueState, setValueState] = useState<string | undefined>(value);
 
-  state = {
-    value: this.props.value,
-  };
+  useEffect(() => {
+    setValueState(value);
+  }, [value]);
 
-  UNSAFE_componentWillReceiveProps(nextProps: TextareaProps) {
-    if (this.props.value !== nextProps.value) {
-      this.setState({
-        value: nextProps.value,
-      });
-    }
-  }
-
-  handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     const ESC = 27;
 
-    if (this.props.onKeyDown) {
-      this.props.onKeyDown(e);
+    if (onKeyDown) {
+      onKeyDown(e);
     }
 
-    if (e.keyCode === ESC && this.props.willBlurOnEsc) {
+    if (e.keyCode === ESC && willBlurOnEsc) {
       e.currentTarget.blur();
     }
   };
 
-  render() {
-    const {
-      className,
-      testId,
-      placeholder,
-      maxLength,
-      onChange,
-      disabled,
-      required,
-      onBlur,
-      error,
-      width,
-      value,
-      name,
-      rows,
-      id,
-      willBlurOnEsc,
-      textareaRef,
-      ...otherProps
-    } = this.props;
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setValueState(e.target.value);
+    if (onChange) {
+      onChange(e);
+    }
+  };
 
-    const widthClass = `Textarea--${width}`;
-    const classNames = cn(styles['Textarea'], className, styles[widthClass], {
-      [styles['Textarea--disabled']]: disabled,
-      [styles['Textarea--negative']]: error,
-    });
+  const widthClass = `Textarea--${width}`;
+  const classNames = cn(styles['Textarea'], className, styles[widthClass], {
+    [styles['Textarea--disabled']]: disabled,
+    [styles['Textarea--negative']]: error,
+  });
 
-    return (
-      <div className={classNames}>
-        <textarea
-          data-test-id={testId}
-          aria-label={name}
-          className={styles['Textarea__textarea']}
-          id={id}
-          rows={rows}
-          onBlur={onBlur}
-          disabled={disabled}
-          placeholder={placeholder}
-          name={name}
-          onChange={(e) => {
-            if (onChange) {
-              onChange(e);
-            }
-            this.setState({ value: e.target.value });
-          }}
-          maxLength={maxLength}
-          value={disabled ? value : this.state && this.state.value}
-          onKeyDown={this.handleKeyDown}
-          ref={textareaRef}
-          {...otherProps}
-        />
-      </div>
-    );
-  }
-}
+  return (
+    <div className={classNames}>
+      <textarea
+        data-test-id={testId}
+        aria-label={name}
+        className={styles['Textarea__textarea']}
+        id={id}
+        rows={rows}
+        onBlur={onBlur}
+        disabled={disabled}
+        placeholder={placeholder}
+        name={name}
+        onChange={handleChange}
+        maxLength={maxLength}
+        value={disabled ? value : valueState}
+        onKeyDown={handleKeyDown}
+        ref={textareaRef}
+        {...otherProps}
+      />
+    </div>
+  );
+};
+
+Textarea.defaultProps = defaultProps;
 
 export default Textarea;

--- a/packages/forma-36-react-components/src/components/Textarea/Textarea.tsx
+++ b/packages/forma-36-react-components/src/components/Textarea/Textarea.tsx
@@ -77,13 +77,12 @@ export const Textarea = (props: TextareaProps) => {
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       e.persist();
-      const ESC = '27';
 
       if (onKeyDown) {
         onKeyDown(e);
       }
 
-      if (e.nativeEvent.code === ESC && willBlurOnEsc) {
+      if (e.nativeEvent.code === 'Escape' && willBlurOnEsc) {
         e.currentTarget.blur();
       }
     },

--- a/packages/forma-36-react-components/src/components/Textarea/Textarea.tsx
+++ b/packages/forma-36-react-components/src/components/Textarea/Textarea.tsx
@@ -77,26 +77,29 @@ export const Textarea = (props: TextareaProps) => {
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       e.persist();
-      const ESC = 27;
+      const ESC = '27';
 
       if (onKeyDown) {
         onKeyDown(e);
       }
 
-      if (e.keyCode === ESC && willBlurOnEsc) {
+      if (e.nativeEvent.code === ESC && willBlurOnEsc) {
         e.currentTarget.blur();
       }
     },
     [willBlurOnEsc, onKeyDown],
   );
 
-  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    e.persist();
-    setValueState(e.target.value);
-    if (onChange) {
-      onChange(e);
-    }
-  };
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLTextAreaElement>) => {
+      e.persist();
+      setValueState(e.target.value);
+      if (onChange) {
+        onChange(e);
+      }
+    },
+    [onChange],
+  );
 
   const widthClass = `Textarea--${width}`;
   const classNames = cn(styles['Textarea'], className, styles[widthClass], {

--- a/packages/forma-36-react-components/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/forma-36-react-components/src/components/ToggleButton/ToggleButton.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import cn from 'classnames';
 import Card from '../Card/Card';
 import Icon, { IconType } from '../Icon/Icon';
@@ -22,66 +22,63 @@ const defaultProps: Partial<ToggleButtonProps> = {
   isDisabled: false,
 };
 
-export class ToggleButton extends Component<ToggleButtonProps> {
-  static defaultProps = defaultProps;
+export const ToggleButton = (props: ToggleButtonProps) => {
+  const {
+    className,
+    icon,
+    children,
+    isActive,
+    isDisabled,
+    onToggle,
+    ...otherProps
+  } = props;
 
-  handleToggle = () => {
-    if (!this.props.isDisabled) {
-      if (this.props.onToggle) {
-        this.props.onToggle();
-      }
+  const classNames = cn(styles.Toggle, className, {
+    [styles['Toggle--active']]: isActive,
+    [styles['Toggle--disabled']]: isDisabled,
+    [styles['Toggle--square']]: !children,
+  });
+
+  const handleToggle = () => {
+    if (!isDisabled && onToggle) {
+      onToggle();
     }
   };
 
-  render() {
-    const {
-      className,
-      icon,
-      children,
-      isActive,
-      isDisabled,
-      ...otherProps
-    } = this.props;
-
-    const classNames = cn(styles.Toggle, className, {
-      [styles['Toggle--active']]: isActive,
-      [styles['Toggle--disabled']]: isDisabled,
-      [styles['Toggle--square']]: !children,
-    });
-
-    return (
-      <Card
-        className={classNames}
-        padding="none"
-        selected={isActive}
-        {...otherProps}
+  return (
+    <Card
+      className={classNames}
+      padding="none"
+      selected={isActive}
+      {...otherProps}
+    >
+      <button
+        type="button"
+        className={styles.Toggle__button}
+        disabled={isDisabled}
+        data-test-id="button"
+        onClick={handleToggle}
+        aria-pressed={isActive}
       >
-        <button
-          type="button"
-          className={styles.Toggle__button}
-          disabled={isDisabled}
-          data-test-id="button"
-          onClick={this.handleToggle}
-          aria-pressed={isActive}
-        >
-          <TabFocusTrap className={styles['Toggle__button__inner-wrapper']}>
-            {icon && (
-              <Icon
-                icon={icon}
-                color="secondary"
-                className={styles.Toggle__button__icon}
-              />
-            )}
-            {children && (
-              <span className={styles['Toggle__content-wrapper']}>
-                {children}
-              </span>
-            )}
-          </TabFocusTrap>
-        </button>
-      </Card>
-    );
-  }
-}
+        <TabFocusTrap className={styles['Toggle__button__inner-wrapper']}>
+          {icon && (
+            <Icon
+              icon={icon}
+              color="secondary"
+              className={styles.Toggle__button__icon}
+            />
+          )}
+          {children && (
+            <span className={styles['Toggle__content-wrapper']}>
+              {children}
+            </span>
+          )}
+        </TabFocusTrap>
+      </button>
+    </Card>
+  );
+};
+
+ToggleButton.defaultProps = defaultProps;
 
 export default ToggleButton;


### PR DESCRIPTION
# Purpose of PR

Refactor form controls to use functional components and react hooks, why:
* https://reactjs.org/docs/hooks-intro.html#motivation
* Remove `UNSAFE` lifecycle methods
* Cleaner code
* Should help with tree shaking and less bundle size, see #304

**Note:** This shouldn't introduce any breaking changes, so if you see anything please flag it.


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
