### PR TITLE
fix(DropDownListItem): render children directly

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.stories.tsx
@@ -15,6 +15,7 @@ storiesOf('Components/Dropdown/DropdownListItem', module)
       isDisabled={boolean('isDisabled', false)}
       isActive={boolean('isActive', false)}
       isTitle={boolean('isTitle', false)}
+      className={text('className', '')}
       href={text('href', '')}
     >
       {text('children', 'Menu Entry')}

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownListItem/DropdownListItem.tsx
@@ -110,7 +110,7 @@ export const DropdownListItem = forwardRef<HTMLElement, DropdownListItemProps>(
         );
       }
 
-      return <span {...otherProps}>{children}</span>;
+      return children;
     }, [onClick, props]);
 
     const { className, listItemRef, onMouseDown, href } = props;


### PR DESCRIPTION
# Purpose of PR

This PR removes the `span` wrapper in `DropdownListItem` as it's causing:
 * Spreading `{...otherProps}` causing duplicate classnames on `span` and wrapper `li`
 * Rendering `div`s inside a `span` overriding browser default behaviour `display: block`

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
