### PR TITLE
fix(grid): GapTypes typos

### DIFF
--- a/packages/forma-36-react-components/src/components/Flex/Flex.tsx
+++ b/packages/forma-36-react-components/src/components/Flex/Flex.tsx
@@ -7,7 +7,7 @@ import styles from './Flex.css';
 
 export type SpacingTypes =
   | 'none'
-  | 'spacing2xs'
+  | 'spacing2Xs'
   | 'spacingXs'
   | 'spacingS'
   | 'spacingM'

--- a/packages/forma-36-react-components/src/components/Flex/README.md
+++ b/packages/forma-36-react-components/src/components/Flex/README.md
@@ -41,7 +41,7 @@ import { Flex, Button, TextLink, Paragraph } from '@contenful/forma-36-react-com
 Margins and padding for Flex component are based on our [spacing system](https://f36.contentful.com/foundation/spacing/).
 Here is an overview of spacings that are availeble:
 
-`spacing2xs` | `spacingXs` | `spacingXs` | `spacingS` | `spacingM` | `spacingL` | `spacingXl` | `spacing2Xl` | `spacing3Xl` | `spacing4Xl`
+`spacing2Xs` | `spacingXs` | `spacingXs` | `spacingS` | `spacingM` | `spacingL` | `spacingXl` | `spacing2Xl` | `spacing3Xl` | `spacing4Xl`
 
 Flex, as any other element, can get margin value, which will be added evenly to all of it's sides or more specific instructions like margin-top or margin-right. those 2 can not be added at the same time - they will overwrite itself. That's why, please remember to not use them together:
 

--- a/packages/forma-36-react-components/src/components/Grid/Grid.md
+++ b/packages/forma-36-react-components/src/components/Grid/Grid.md
@@ -34,7 +34,7 @@ Accepts a number or any of [grid-template-rows](https://developer.mozilla.org/en
 ### columnGap & rowGap
 `columnGap` represents space between columns, `rowGap` represents the space between rows, both accepts one of [spacing](https://f36.contentful.com/foundation/spacing/) token names.
 
-`spacing2xs` | `spacingXs` | `spacingXs` | `spacingS` | `spacingM` | `spacingL` | `spacingXl` | `spacing2Xl` | `spacing3Xl` | `spacing4Xl`
+`spacing2Xs` | `spacingXs` | `spacingXs` | `spacingS` | `spacingM` | `spacingL` | `spacingXl` | `spacing2Xl` | `spacing3Xl` | `spacing4Xl`
 
 **e.g.**
 

--- a/packages/forma-36-react-components/src/components/Grid/Grid.tsx
+++ b/packages/forma-36-react-components/src/components/Grid/Grid.tsx
@@ -7,7 +7,7 @@ import styles from './Grid.css';
 
 export type GapTypes =
   | 'none'
-  | 'spacing2xs'
+  | 'spacing2Xs'
   | 'spacingXs'
   | 'spacingS'
   | 'spacingM'


### PR DESCRIPTION
# Purpose of PR

I toy around with Forma36 every few months to see what is new. Today I decided I would like to take your Grid / GridItem components for a drive, but I encountered an issue in which they do not seem to be exported from `@contentful/forma-36-react-components@3.67.0`.

([Input](https://user-images.githubusercontent.com/19484365/99481100-02a49e80-291f-11eb-8d1d-0bb27ca0f549.png) and [output](https://user-images.githubusercontent.com/19484365/99481079-f4ef1900-291e-11eb-9ab7-76c913b4b284.png).)

I dug into the repo and found that extracting these 2 components would be relatively simple, so I did. And that is when I encountered this super-massive, show-stopping, brain melting, beast of a bug inside of `Grid.tsx`.

![image](https://user-images.githubusercontent.com/19484365/99481748-69768780-2920-11eb-9d5c-a72ced5355de.png)

I cloned it all down and found that the typo actually exists a few other places, as well.

![image](https://user-images.githubusercontent.com/19484365/99482314-3680c380-2921-11eb-8b0d-ceecb82f6711.png)

I confirmed that the `2X.` was the standardized format, rather than `2x.`.

![image](https://user-images.githubusercontent.com/19484365/99482486-97a89700-2921-11eb-8f09-8d4f92bcc1a0.png)

Fixed up the typos and did a little...

```bash
yarn build
npm rebuild node-sass
yarn-build
nvm install 13
yarn build
npm rebuild node-sass
yarn build
yarn test
```

Build succeeded, tests passed, and here is my PR.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
