### PR TITLE
refactor: function components with MDX documentation

### DIFF
--- a/packages/forma-36-react-components/src/components/Asset/Asset.tsx
+++ b/packages/forma-36-react-components/src/components/Asset/Asset.tsx
@@ -1,8 +1,8 @@
-import React, { Component } from 'react';
+import React from 'react';
 import cn from 'classnames';
-import { AssetState } from '../Card/AssetCard/AssetCard';
-import { AssetIcon } from './AssetIcon/AssetIcon';
 
+import { AssetIcon } from './AssetIcon/AssetIcon';
+import type { AssetState } from '../Card/AssetCard/AssetCard';
 import styles from './Asset.css';
 
 export const types = {
@@ -26,83 +26,85 @@ export function isAssetType(type: string): type is AssetType {
 export type AssetType = keyof typeof types;
 
 export interface AssetProps {
-  src: string;
-  title: string;
-  type?: AssetType;
+  /**
+   * Class names to be appended to the className prop of the Dropdown wrapper
+   */
   className?: string;
+  /**
+   * A `src` attribute to use for image assets
+   */
+  src?: string;
+  /**
+   * The publish status of the asset
+   */
   status?: AssetState;
+  /**
+   * An ID used for testing purposes applied as a data attribute (data-test-id)
+   */
   testId?: string;
+  /**
+   * The title of the asset
+   */
+  title?: string;
+  /**
+   * The type of asset being represented
+   */
+  type?: AssetType;
 }
 
-const defaultProps: Partial<AssetProps> = {
+export function Asset({
+  className,
+  src,
+  status,
+  testId,
+  title,
+  type,
+  ...otherProps
+}: AssetProps): React.ReactElement {
+  const classNames = cn(styles.Asset, className);
+  const isImage = type === 'image' && src !== undefined && src !== '';
+
+  // Do not show image previews when publish status is archived
+  const showPreview = isImage && status !== 'archived';
+
+  return (
+    <div className={classNames} data-test-id={testId} {...otherProps}>
+      {showPreview ? (
+        <React.Fragment>
+          <div className={styles['Asset__image-container']}>
+            <img
+              className={styles['Asset__image-container__image']}
+              src={src}
+              alt={title}
+            />
+          </div>
+          {title && (
+            <div className={styles['Asset__title-container']}>
+              <span className={styles['Asset__title-container__title']}>
+                {title}
+              </span>
+            </div>
+          )}
+        </React.Fragment>
+      ) : (
+        <div className={styles['Asset__asset-container']}>
+          <div className={styles['Asset__illustration-container']}>
+            <AssetIcon type={type} />
+          </div>
+          {title && (
+            <span className={styles['Asset__asset-container__title']}>
+              {title}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+Asset.defaultProps = {
   type: 'image',
   testId: 'cf-ui-asset',
 };
-
-export class Asset extends Component<AssetProps> {
-  static defaultProps = defaultProps;
-
-  renderImage = (src: string, title: string) => (
-    <React.Fragment>
-      <div className={styles['Asset__image-container']}>
-        <img
-          className={styles['Asset__image-container__image']}
-          src={src}
-          alt={title}
-        />
-      </div>
-      {title && (
-        <div className={styles['Asset__title-container']}>
-          <span className={styles['Asset__title-container__title']}>
-            {title}
-          </span>
-        </div>
-      )}
-    </React.Fragment>
-  );
-
-  renderAsset = (type: AssetType, title: string) => {
-    return (
-      <div className={styles['Asset__asset-container']}>
-        <div className={styles['Asset__illustration-container']}>
-          <AssetIcon type={type} />
-        </div>
-        {title && (
-          <span className={styles['Asset__asset-container__title']}>
-            {title}
-          </span>
-        )}
-      </div>
-    );
-  };
-
-  render() {
-    const {
-      className,
-      src,
-      status,
-      title,
-      type,
-      testId,
-      ...otherProps
-    } = this.props;
-
-    const classNames = cn(styles.Asset, className);
-
-    // Archived images will not have a preview available
-    const asImage =
-      type && type === 'image' && (!status || status !== 'archived') && src;
-
-    return (
-      <div className={classNames} data-test-id={testId} {...otherProps}>
-        {
-          asImage
-            ? this.renderImage(src, title)
-            : this.renderAsset(type!, title) // eslint-disable-line @typescript-eslint/no-non-null-assertion
-        }
-      </div>
-    );
-  }
-}
 
 export default Asset;

--- a/packages/forma-36-react-components/src/components/Asset/AssetIcon/AssetIcon.tsx
+++ b/packages/forma-36-react-components/src/components/Asset/AssetIcon/AssetIcon.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import {
   Illustration,
   IllustrationProps,
@@ -14,32 +14,26 @@ export interface AssetIconProps
   type?: AssetType;
 }
 
-const defaultProps: Partial<AssetIconProps> = {
-  type: 'archive',
-  testId: 'cf-ui-asset-icon',
-};
-
 /**
  * Renders only the Illustration that would represent this asset's type
  */
-export class AssetIcon extends Component<AssetIconProps> {
-  static defaultProps = defaultProps;
-
-  render() {
-    const { type, ...otherProps } = this.props;
-
-    let illustrationName = type!.charAt(0).toUpperCase() + type!.slice(1); // eslint-disable-line @typescript-eslint/no-non-null-assertion
-    if (!isIllustrationType(illustrationName)) {
-      illustrationName = DEFAULT_ILLUSTRATION_NAME;
-    }
-
-    return (
-      <Illustration
-        illustration={illustrationName as IllustrationType}
-        {...otherProps}
-      />
-    );
+export function AssetIcon({ type, ...otherProps }: AssetIconProps) {
+  let illustrationName = type!.charAt(0).toUpperCase() + type!.slice(1); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+  if (!isIllustrationType(illustrationName)) {
+    illustrationName = DEFAULT_ILLUSTRATION_NAME;
   }
+
+  return (
+    <Illustration
+      illustration={illustrationName as IllustrationType}
+      {...otherProps}
+    />
+  );
 }
+
+AssetIcon.defaultProps = {
+  type: 'archive',
+  testId: 'cf-ui-asset-icon',
+};
 
 export default AssetIcon;

--- a/packages/forma-36-react-components/src/components/Asset/README.mdx
+++ b/packages/forma-36-react-components/src/components/Asset/README.mdx
@@ -1,0 +1,64 @@
+import { Asset } from './Asset';
+
+# Asset
+
+The Asset component is a visual representation of an asset file such as a video or a PDF document.
+
+<Asset title="Archive of files" type="archive" />
+
+## Table of contents
+
+- [Usage](#usage)
+  - [An image asset and an archived image asset](#an-image-asset-and-an-archived-image-asset)
+- [Asset types](#asset-types)
+- [An archive asset](#an-archive-asset)
+
+## Usage
+
+```jsx
+import { Asset } from '@contentful/forma-36-react-components';
+
+<Asset
+  src="https://placekitten.com/200/300"
+  title="An archive asset"
+  type="archive"
+/>;
+```
+
+### An image asset and an archived image asset
+
+Image assets are rendered directly unless they have the prop `status="archived"`.
+
+```jsx
+import { Asset } from '@contentful/forma-36-react-components';
+
+<Asset
+  src="https://placekitten.com/200/300"
+  title="An image asset"
+  type="image"
+/>;
+```
+
+```jsx
+import { Asset } from '@contentful/forma-36-react-components';
+
+<Asset
+  src="https://placekitten.com/200/300"
+  status="archived"
+  title="An archived image asset"
+  type="image"
+/>;
+```
+
+## Asset types
+
+- **Archive**
+- **Audio**
+- **Code**
+- **Markup**
+- **PDF**
+- **Plaintext**
+- **Presentation**
+- **Richtext**
+- **Spreadsheet**
+- **Video**

--- a/packages/forma-36-react-components/src/components/Button/Button.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.stories.tsx
@@ -5,7 +5,7 @@ import { text, boolean, select } from '@storybook/addon-knobs';
 import { iconName } from '../Icon/constants';
 
 import Button from './Button';
-import notes from './README.md';
+import notes from './README.mdx';
 
 storiesOf('Components/Button', module)
   .addParameters({

--- a/packages/forma-36-react-components/src/components/Button/Button.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.tsx
@@ -1,5 +1,4 @@
 import React, {
-  Component,
   CSSProperties,
   FocusEvent,
   MouseEvent as ReactMouseEvent,
@@ -8,10 +7,11 @@ import React, {
 } from 'react';
 import cn from 'classnames';
 import { CSSTransition } from 'react-transition-group';
-import Icon, { IconType } from '../Icon';
+
+import Icon from '../Icon';
+import type { IconType } from '../Icon';
 import TabFocusTrap from '../TabFocusTrap';
 import Spinner from '../Spinner';
-
 import styles from './Button.css';
 
 export interface ButtonProps {
@@ -39,7 +39,106 @@ export interface ButtonProps {
   isActive?: boolean;
 }
 
-const defaultProps: Partial<ButtonProps> = {
+export function Button({
+  className,
+  children,
+  icon,
+  buttonType,
+  size,
+  isFullWidth,
+  onBlur,
+  testId,
+  onClick,
+  loading,
+  disabled,
+  indicateDropdown,
+  href,
+  type,
+  isActive,
+  ...otherProps
+}: ButtonProps) {
+  const classNames = cn(
+    styles.Button,
+    className,
+    styles[`Button--${buttonType}`],
+    {
+      [styles['Button--disabled']]: disabled,
+      [styles[`Button--${size}`]]: size,
+      [styles['Button--full-width']]: isFullWidth,
+      [styles['Button--is-active']]: isActive,
+    },
+  );
+
+  const iconColor =
+    buttonType === 'muted' || buttonType === 'naked' ? 'secondary' : 'white';
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const Element: any = href ? 'a' : 'button';
+
+  return (
+    <Element
+      onBlur={(e: FocusEvent) => {
+        if (onBlur && !disabled) {
+          onBlur(e);
+        }
+      }}
+      onClick={(e: ReactMouseEvent) => {
+        if (onClick && !disabled && !loading) {
+          onClick(e);
+        }
+      }}
+      data-test-id={testId}
+      className={classNames}
+      disabled={disabled}
+      href={!disabled ? href : null}
+      type={type}
+      {...otherProps}
+    >
+      <TabFocusTrap className={styles['Button__inner-wrapper']}>
+        {icon && (
+          <Icon
+            className={styles.Button__icon}
+            size={size === 'small' ? 'tiny' : 'small'}
+            icon={icon}
+            color={iconColor}
+          />
+        )}
+        {children && <span className={styles.Button__label}>{children}</span>}
+        {indicateDropdown && (
+          <Icon
+            className={styles['Button__dropdown-icon']}
+            icon="ArrowDown"
+            color={iconColor}
+          />
+        )}
+        <CSSTransition
+          in={loading}
+          timeout={1000}
+          classNames={{
+            enter: styles['Button--spinner--enter'],
+            enterActive: styles['Button--spinner-active'],
+            exit: styles['Button--spinner--exit'],
+            exitActive: styles['Button--spinner-exit-active'],
+          }}
+          mountOnEnter
+          unmountOnExit
+        >
+          <Spinner
+            className={styles.Button__spinner}
+            size="small"
+            color={
+              buttonType === 'muted' || buttonType === 'naked'
+                ? 'default'
+                : 'white'
+            }
+          />
+        </CSSTransition>
+      </TabFocusTrap>
+    </Element>
+  );
+}
+
+Button.defaultProps = {
   loading: false,
   isFullWidth: false,
   indicateDropdown: false,
@@ -48,110 +147,5 @@ const defaultProps: Partial<ButtonProps> = {
   buttonType: 'primary',
   type: 'button',
 };
-
-export class Button extends Component<ButtonProps> {
-  static defaultProps = defaultProps;
-
-  render() {
-    const {
-      className,
-      children,
-      icon,
-      buttonType,
-      size,
-      isFullWidth,
-      onBlur,
-      testId,
-      onClick,
-      loading,
-      disabled,
-      indicateDropdown,
-      href,
-      type,
-      isActive,
-      ...otherProps
-    } = this.props;
-
-    const classNames = cn(
-      styles.Button,
-      className,
-      styles[`Button--${buttonType}`],
-      {
-        [styles['Button--disabled']]: disabled,
-        [styles[`Button--${size}`]]: size,
-        [styles['Button--full-width']]: isFullWidth,
-        [styles['Button--is-active']]: isActive,
-      },
-    );
-
-    const iconColor =
-      buttonType === 'muted' || buttonType === 'naked' ? 'secondary' : 'white';
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const Element: any = href ? 'a' : 'button';
-
-    return (
-      <Element
-        onBlur={(e: FocusEvent) => {
-          if (onBlur && !disabled) {
-            onBlur(e);
-          }
-        }}
-        onClick={(e: ReactMouseEvent) => {
-          if (onClick && !disabled && !loading) {
-            onClick(e);
-          }
-        }}
-        data-test-id={testId}
-        className={classNames}
-        disabled={disabled}
-        href={!disabled ? href : null}
-        type={type}
-        {...otherProps}
-      >
-        <TabFocusTrap className={styles['Button__inner-wrapper']}>
-          {icon && (
-            <Icon
-              className={styles.Button__icon}
-              size={size === 'small' ? 'tiny' : 'small'}
-              icon={icon}
-              color={iconColor}
-            />
-          )}
-          {children && <span className={styles.Button__label}>{children}</span>}
-          {indicateDropdown && (
-            <Icon
-              className={styles['Button__dropdown-icon']}
-              icon="ArrowDown"
-              color={iconColor}
-            />
-          )}
-          <CSSTransition
-            in={loading}
-            timeout={1000}
-            classNames={{
-              enter: styles['Button--spinner--enter'],
-              enterActive: styles['Button--spinner-active'],
-              exit: styles['Button--spinner--exit'],
-              exitActive: styles['Button--spinner-exit-active'],
-            }}
-            mountOnEnter
-            unmountOnExit
-          >
-            <Spinner
-              className={styles.Button__spinner}
-              size="small"
-              color={
-                buttonType === 'muted' || buttonType === 'naked'
-                  ? 'default'
-                  : 'white'
-              }
-            />
-          </CSSTransition>
-        </TabFocusTrap>
-      </Element>
-    );
-  }
-}
 
 export default Button;

--- a/packages/forma-36-react-components/src/components/Button/README.mdx
+++ b/packages/forma-36-react-components/src/components/Button/README.mdx
@@ -1,4 +1,39 @@
+import { Button } from './Button';
+
+# Button
+
 Buttons communicate the action that will occur when the user clicks them. They communicate calls to action to the user and allow users to interact with pages in a variety of ways. They contain a text label to describe the action, and an icon if appropriate.
+
+<Button buttonType="primary">Add content type</Button>;
+
+## Table of contents
+
+- [Usage](#usage)
+  - [With icon](#with-icon)
+- [Button types](#button-types)
+- [Best practices](#best-practices)
+- [Content recommendations](#content-recommendations)
+- [Accessibility](#accessibility)
+
+## Usage
+
+```jsx
+import { Button } from '@contentful/forma-36-react-components';
+
+<Button buttonType="primary" data-test-id="create-content-type-empty-state">
+  Add content type
+</Button>;
+```
+
+### With icon
+
+```jsx
+import { Button } from '@contentful/forma-36-react-components';
+
+<Button buttonType="primary" icon="Star">
+  Primary star
+</Button>;
+```
 
 ## Button types
 
@@ -17,33 +52,21 @@ Buttons communicate the action that will occur when the user clicks them. They c
   <Button buttonType="naked">Naked</Button>
 </>
 ```
+
 Buttons can be used in couple of different variations, like active, disabled or loading. Worth mentioning is `indicateDropdown` property in the component, which enables chevron icon on the right side of the button. Using `icon` property in the Button on the other hand, enables choosen icon on the left side of the button.
 
-Contentful buttons are available in 3 different sizes: 
+Contentful buttons are available in 3 different sizes:
+
 ```jsx
 <>
-  <Button buttonType="positive" size="large">Large</Button>
+  <Button buttonType="positive" size="large">
+    Large
+  </Button>
   <Button buttonType="positive">Default</Button>
-  <Button buttonType="positive" size="small">Small</Button>
+  <Button buttonType="positive" size="small">
+    Small
+  </Button>
 </>
-```
-
-## Examples of usage
-
-```jsx
-import {Button} from '@contentful/forma-36-react-components';
-
-<Button buttonType="primary" data-test-id="create-content-type-empty-state">Add content type</Button>
-
-```
-
-Usage of the button with icon
-
-```jsx
-import {Button} from '@contentful/forma-36-react-components';
-
-<Button buttonType="primary" icon="Star">Primary star</Button>
-
 ```
 
 ## Best practices
@@ -51,13 +74,13 @@ import {Button} from '@contentful/forma-36-react-components';
 - Position buttons in consistent places in the interface
 - Reduce complexity by using a small number of actions. Too many actions can create confusion when having to decide
 
-## Content recommendations:
+## Content recommendations
 
- - UI usage - Button labels should be no longer than 3 words
- - Webpage usage - Button labels should be no longer than 5 words
- - Start labels with action verbs. If the button is part of an action dialog, make sure it matches the dialog header.
- - Use specific words, ideally ones that align with preceding content.
- - For buttons that are used to cancel destructive actions: label them "Never mind" or similar, instead of cancel. It makes things much easier for users to understand.
+- UI usage - Button labels should be no longer than 3 words
+- Webpage usage - Button labels should be no longer than 5 words
+- Start labels with action verbs. If the button is part of an action dialog, make sure it matches the dialog header.
+- Use specific words, ideally ones that align with preceding content.
+- For buttons that are used to cancel destructive actions: label them "Never mind" or similar, instead of cancel. It makes things much easier for users to understand.
 
 ## Accessibility
 


### PR DESCRIPTION
# Purpose of PR

This PR refactors class components to function components, that are preferable for a few reasons:
- They allow for the use of hooks.
- They allow us to migrate away from `defaultProps` to normal JS default values.
- Hopefully building all components in the same way makes it easier to understand the codebase and should make it easier to contribute to F36.

Are there any components we can skip/delete?

<details>
<summary>List of progress</summary>

- [x] ~~Accordion: Is already a function component~~
- [x] Asset
- [x] ~~Autocomplete: Is already a function component~~
- [x] Button
- [ ] Card: work is underway in #648
- [x] Checkbox
- [x] CheckboxField
- [ ] ControlledInput
- [ ] ControlledInputField
- [ ] CopyButton
- [ ] DateTime
- [ ] RelativeDate
- [x] ~~Dropdown: Is already a function component~~
- [ ] EditorToolbar
- [ ] EmptyState
- [x] ~~EntityList: Is already a function component~~
- [x] ~~Flex: Is already a function component~~
- [ ] Form
- [ ] FormLabel
- [x] ~~Grid: Is already a function component~~
- [ ] HelpText
- [ ] Icon
- [ ] IconButton
- [ ] Illustration
- [ ] InViewport: This is going to be bothersome to changerefactor
- [ ] List
- [ ] Modal
- [ ] Note
- [ ] Notification components
- [ ] Pill
- [x] ~~Portal: Is already a function component.~~
- [x] ~~ProductIcon: Is already a function component.~~
- [ ] RadioButton
- [ ] RadioButtonField
- [ ] Select
- [ ] SelectField
- [ ] Skeleton components
- [ ] Spinner
- [x] ~~Switch: Is already a function component.~~
- [ ] TabFocusTrap
- [ ] Table components
- [ ] Tabs
- [ ] Tag
- [ ] Textarea
- [ ] TextField
- [ ] TextInput
- [ ] TextLink
- [ ] ToggleButton
- [x] ~~Tooltip: Is already a function component.~~
- [ ] Typography components
- [ ] ValidationMessage
- [x] ~~Workbench: Is already a function component.~~
</details>
