### PR TITLE
fix(card): make it a div even when onClick has a value

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/Card.tsx
+++ b/packages/forma-36-react-components/src/components/Card/Card.tsx
@@ -70,16 +70,22 @@ export const Card = ({
     [styles['Card--is-selected']]: selected,
   });
 
-  let Element: React.ElementType = 'div';
-
-  if (href) {
-    Element = 'a';
-  } else if (onClick) {
-    Element = 'button';
-  }
+  const Element: React.ElementType = href ? 'a' : 'div';
 
   const handleClick = onClick
     ? (event: MouseEvent<HTMLElement>) => onClick(event)
+    : undefined;
+
+  const handleKeyDown = onClick
+    ? (event: KeyboardEvent<HTMLElement>) => {
+        if (
+          event.nativeEvent.code === 'Enter' ||
+          event.nativeEvent.code === 'Space'
+        ) {
+          onClick(event);
+          event.currentTarget.focus();
+        }
+      }
     : undefined;
 
   return (
@@ -90,7 +96,10 @@ export const Card = ({
       data-test-id={testId}
       aria-label={otherProps.title || ariaLabel}
       aria-pressed={onClick ? (selected ? 'true' : 'false') : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      role={onClick ? 'button' : undefined}
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
       {...otherProps}
     >
       {children}

--- a/packages/forma-36-react-components/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -1,13 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`calls an onClick function 1`] = `
-<button
+<div
   aria-pressed="false"
   class="Card Card--padding-default Card--is-interactive"
   data-test-id="cf-ui-card"
+  role="button"
+  tabindex="0"
 >
   Card
-</button>
+</div>
 `;
 
 exports[`can be selected 1`] = `


### PR DESCRIPTION
# Purpose of PR

![Screenshot 2020-11-23 at 16 12 19](https://user-images.githubusercontent.com/6597467/99980130-2d23ab00-2da8-11eb-9b5f-8ca7c293064d.png)

@m10l remembered me that we have use cases where the card will have interactive elements inside of it, like an entry card with context menu, so making it a button when passing `onClick` is dangerous

This PR reverts the card to use `div` always without losing a11y features (... I hope 🙏 )

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
