### PR TITLE
feat: refactor table components to functional components [PUL-1298]

### DIFF
--- a/packages/forma-36-react-components/src/components/Table/Table.tsx
+++ b/packages/forma-36-react-components/src/components/Table/Table.tsx
@@ -1,11 +1,10 @@
-import React, { Component } from 'react';
+import React, { HTMLProps } from 'react';
 import cn from 'classnames';
 import styles from './Table.css';
 
-export interface TableProps {
+export interface TableProps extends HTMLProps<HTMLTableElement> {
   testId?: string;
   className?: string;
-  style?: React.CSSProperties;
   children: React.ReactNode;
 }
 
@@ -13,24 +12,22 @@ const defaultProps: Partial<TableProps> = {
   testId: 'cf-ui-table',
 };
 
-export class Table extends Component<TableProps> {
-  static defaultProps = defaultProps;
+const Table = (props: TableProps) => {
+  const { className, children, testId, ...otherProps } = props;
 
-  render() {
-    const { className, children, testId, ...otherProps } = this.props;
+  return (
+    <table
+      className={cn(className, styles['Table'])}
+      cellPadding="0"
+      cellSpacing="0"
+      data-test-id={testId}
+      {...otherProps}
+    >
+      {children}
+    </table>
+  );
+};
 
-    return (
-      <table
-        className={cn(className, styles['Table'])}
-        cellPadding="0"
-        cellSpacing="0"
-        data-test-id={testId}
-        {...otherProps}
-      >
-        {children}
-      </table>
-    );
-  }
-}
+Table.defaultProps = defaultProps;
 
 export default Table;

--- a/packages/forma-36-react-components/src/components/Table/Table.tsx
+++ b/packages/forma-36-react-components/src/components/Table/Table.tsx
@@ -12,7 +12,7 @@ const defaultProps: Partial<TableProps> = {
   testId: 'cf-ui-table',
 };
 
-const Table = (props: TableProps) => {
+export const Table = (props: TableProps) => {
   const { className, children, testId, ...otherProps } = props;
 
   return (

--- a/packages/forma-36-react-components/src/components/Table/TableBody/TableBody.tsx
+++ b/packages/forma-36-react-components/src/components/Table/TableBody/TableBody.tsx
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
+import React, { HTMLProps } from 'react';
 
-export interface TableBodyProps {
+export interface TableBodyProps extends HTMLProps<HTMLTableSectionElement> {
   className?: string;
   style?: React.CSSProperties;
   testId?: string;
@@ -11,18 +11,16 @@ const defaultProps: Partial<TableBodyProps> = {
   testId: 'cf-ui-table-body',
 };
 
-export class TableBody extends Component<TableBodyProps> {
-  static defaultProps = defaultProps;
+const TableBody = (props: TableBodyProps) => {
+  const { className, children, testId, ...otherProps } = props;
 
-  render() {
-    const { className, children, testId, ...otherProps } = this.props;
+  return (
+    <tbody data-test-id={testId} className={className} {...otherProps}>
+      {children}
+    </tbody>
+  );
+};
 
-    return (
-      <tbody data-test-id={testId} className={className} {...otherProps}>
-        {children}
-      </tbody>
-    );
-  }
-}
+TableBody.defaultProps = defaultProps;
 
 export default TableBody;

--- a/packages/forma-36-react-components/src/components/Table/TableBody/TableBody.tsx
+++ b/packages/forma-36-react-components/src/components/Table/TableBody/TableBody.tsx
@@ -11,7 +11,7 @@ const defaultProps: Partial<TableBodyProps> = {
   testId: 'cf-ui-table-body',
 };
 
-const TableBody = (props: TableBodyProps) => {
+export const TableBody = (props: TableBodyProps) => {
   const { className, children, testId, ...otherProps } = props;
 
   return (

--- a/packages/forma-36-react-components/src/components/Table/TableCell/TableCell/TableCell.tsx
+++ b/packages/forma-36-react-components/src/components/Table/TableCell/TableCell/TableCell.tsx
@@ -1,9 +1,10 @@
-import React, { Component } from 'react';
+import React, { HTMLProps } from 'react';
 import cn from 'classnames';
 
 import { TableCellContext } from './TableCellContext';
 
 import styles from './TableCell.css';
+import { ElementType } from 'react';
 
 export const sortingDirections = {
   asc: 'asc',
@@ -12,10 +13,9 @@ export const sortingDirections = {
 
 export type TableCellSorting = keyof typeof sortingDirections | boolean;
 
-export interface TableCellProps {
+export interface TableCellProps extends HTMLProps<HTMLTableCellElement> {
   align?: 'center' | 'left' | 'right';
   sorting?: TableCellSorting;
-  style?: React.CSSProperties;
   className?: string;
   testId?: string;
   children?: React.ReactNode;
@@ -27,44 +27,34 @@ const defaultProps: Partial<TableCellProps> = {
   testId: 'cf-ui-table-cell',
 };
 
-export class TableCell extends Component<TableCellProps> {
-  static defaultProps = defaultProps;
+const TableCell = (props: TableCellProps) => {
+  const { className, children, sorting, align, testId, ...otherProps } = props;
 
-  render() {
-    const {
-      className,
-      children,
-      sorting,
-      align,
-      testId,
-      ...otherProps
-    } = this.props;
+  return (
+    <TableCellContext.Consumer>
+      {({ name: context, element, offsetTop }) => {
+        const Element = element as ElementType;
+        return (
+          <Element
+            className={cn(styles['TableCell'], className, {
+              [styles['TableCell--head']]: context === 'head',
+              [styles['TableCell--head__sorting']]: sorting,
+            })}
+            style={{
+              top: offsetTop,
+            }}
+            align={align}
+            data-test-id={testId}
+            {...otherProps}
+          >
+            {children}
+          </Element>
+        );
+      }}
+    </TableCellContext.Consumer>
+  );
+};
 
-    return (
-      <TableCellContext.Consumer>
-        {({ name: context, element, offsetTop }) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const Element = element as any;
-          return (
-            <Element
-              className={cn(styles['TableCell'], className, {
-                [styles['TableCell--head']]: context === 'head',
-                [styles['TableCell--head__sorting']]: sorting,
-              })}
-              style={{
-                top: offsetTop,
-              }}
-              align={align}
-              data-test-id={testId}
-              {...otherProps}
-            >
-              {children}
-            </Element>
-          );
-        }}
-      </TableCellContext.Consumer>
-    );
-  }
-}
+TableCell.defaultProps = defaultProps;
 
 export default TableCell;

--- a/packages/forma-36-react-components/src/components/Table/TableCell/TableCell/TableCell.tsx
+++ b/packages/forma-36-react-components/src/components/Table/TableCell/TableCell/TableCell.tsx
@@ -27,7 +27,7 @@ const defaultProps: Partial<TableCellProps> = {
   testId: 'cf-ui-table-cell',
 };
 
-const TableCell = (props: TableCellProps) => {
+export const TableCell = (props: TableCellProps) => {
   const { className, children, sorting, align, testId, ...otherProps } = props;
 
   return (

--- a/packages/forma-36-react-components/src/components/Table/TableCell/TableSortingLabel/TableSortingLabel.tsx
+++ b/packages/forma-36-react-components/src/components/Table/TableCell/TableSortingLabel/TableSortingLabel.tsx
@@ -19,7 +19,7 @@ const defaultProps: Partial<TableSortingLabelProps> = {
   testId: 'cf-ui-table-sorting-label',
 };
 
-const TableSortingLabel = (props: TableSortingLabelProps) => {
+export const TableSortingLabel = (props: TableSortingLabelProps) => {
   const { className, children, active, testId, ...otherProps } = props;
 
   const renderIcon = () => {

--- a/packages/forma-36-react-components/src/components/Table/TableCell/TableSortingLabel/TableSortingLabel.tsx
+++ b/packages/forma-36-react-components/src/components/Table/TableCell/TableSortingLabel/TableSortingLabel.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 import cn from 'classnames';
 
 import Icon from '../../../Icon/Icon';
@@ -6,7 +6,8 @@ import { sortingDirections } from '../TableCell/TableCell';
 import TabFocusTrap from '../../../TabFocusTrap/TabFocusTrap';
 import styles from './TableSortingLabel.css';
 
-export interface TableSortingLabelProps {
+export interface TableSortingLabelProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
   direction: keyof typeof sortingDirections;
   active: boolean;
@@ -18,36 +19,34 @@ const defaultProps: Partial<TableSortingLabelProps> = {
   testId: 'cf-ui-table-sorting-label',
 };
 
-export class TableSortingLabel extends Component<TableSortingLabelProps> {
-  static defaultProps = defaultProps;
+const TableSortingLabel = (props: TableSortingLabelProps) => {
+  const { className, children, active, testId, ...otherProps } = props;
 
-  renderIcon() {
-    const { direction } = this.props;
+  const renderIcon = () => {
+    const { direction } = props;
     const classNames = cn(
       styles['TableSortingLabel__icon'],
       styles[`TableSortingLabel__icon--${direction as string}`],
     );
 
     return <Icon className={classNames} icon="ArrowUp" color="muted" />;
-  }
+  };
 
-  render() {
-    const { className, children, active, testId, ...otherProps } = this.props;
+  return (
+    <button
+      type="button"
+      className={cn(styles['TableSortingLabel__button'], className)}
+      data-test-id={testId}
+      {...otherProps}
+    >
+      <TabFocusTrap className={styles['TableSortingLabel__button__text']}>
+        {children}
+        {active && renderIcon()}
+      </TabFocusTrap>
+    </button>
+  );
+};
 
-    return (
-      <button
-        type="button"
-        className={cn(styles['TableSortingLabel__button'], className)}
-        data-test-id={testId}
-        {...otherProps}
-      >
-        <TabFocusTrap className={styles['TableSortingLabel__button__text']}>
-          {children}
-          {active && this.renderIcon()}
-        </TabFocusTrap>
-      </button>
-    );
-  }
-}
+TableSortingLabel.defaultProps = defaultProps;
 
 export default TableSortingLabel;

--- a/packages/forma-36-react-components/src/components/Table/TableHead/TableHead.tsx
+++ b/packages/forma-36-react-components/src/components/Table/TableHead/TableHead.tsx
@@ -17,7 +17,7 @@ const defaultProps: Partial<TableHeadProps> = {
   testId: 'cf-ui-table-head',
 };
 
-const TableHead = (props: TableHeadProps) => {
+export const TableHead = (props: TableHeadProps) => {
   const {
     className,
     testId,

--- a/packages/forma-36-react-components/src/components/Table/TableHead/TableHead.tsx
+++ b/packages/forma-36-react-components/src/components/Table/TableHead/TableHead.tsx
@@ -1,15 +1,14 @@
-import React, { Component } from 'react';
+import React, { HTMLProps } from 'react';
 import cn from 'classnames';
 import styles from './TableHead.css';
 
 import { TableCellContext, contextOptions } from '../TableCell';
 
-export interface TableHeadProps {
+export interface TableHeadProps extends HTMLProps<HTMLTableSectionElement> {
   isSticky?: boolean;
   offsetTop?: number | string;
   className?: string;
   testId?: string;
-  style?: React.CSSProperties;
   children: React.ReactNode;
 }
 
@@ -18,32 +17,31 @@ const defaultProps: Partial<TableHeadProps> = {
   testId: 'cf-ui-table-head',
 };
 
-export class TableHead extends Component<TableHeadProps> {
-  static defaultProps = defaultProps;
+const TableHead = (props: TableHeadProps) => {
+  const {
+    className,
+    testId,
+    offsetTop,
+    isSticky,
+    children,
+    ...otherProps
+  } = props;
 
-  render() {
-    const {
-      className,
-      testId,
-      offsetTop,
-      isSticky,
-      children,
-      ...otherProps
-    } = this.props;
+  const classNames = cn(className, {
+    [styles[`TableHead--sticky`]]: isSticky,
+  });
 
-    const classNames = cn(className, {
-      [styles[`TableHead--sticky`]]: isSticky,
-    });
-    return (
-      <TableCellContext.Provider
-        value={{ ...contextOptions.head, offsetTop: offsetTop || 0 }}
-      >
-        <thead className={classNames} data-test-id={testId} {...otherProps}>
-          {children}
-        </thead>
-      </TableCellContext.Provider>
-    );
-  }
-}
+  return (
+    <TableCellContext.Provider
+      value={{ ...contextOptions.head, offsetTop: offsetTop || 0 }}
+    >
+      <thead className={classNames} data-test-id={testId} {...otherProps}>
+        {children}
+      </thead>
+    </TableCellContext.Provider>
+  );
+};
+
+TableHead.defaultProps = defaultProps;
 
 export default TableHead;

--- a/packages/forma-36-react-components/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/forma-36-react-components/src/components/Table/TableRow/TableRow.tsx
@@ -1,11 +1,10 @@
-import React, { Component } from 'react';
+import React, { HTMLProps } from 'react';
 import cn from 'classnames';
 
 import styles from './TableRow.css';
 
-export interface TableRowProps {
+export interface TableRowProps extends HTMLProps<HTMLTableRowElement> {
   className?: string;
-  style?: React.CSSProperties;
   testId?: string;
   children: React.ReactNode;
 }
@@ -14,22 +13,20 @@ const defaultProps: Partial<TableRowProps> = {
   testId: 'cf-ui-table-row',
 };
 
-export class TableRow extends Component<TableRowProps> {
-  static defaultProps = defaultProps;
+const TableRow = (props: TableRowProps) => {
+  const { className, children, testId, ...otherProps } = props;
 
-  render() {
-    const { className, children, testId, ...otherProps } = this.props;
+  return (
+    <tr
+      className={cn(styles['TableRow'], className)}
+      data-test-id={testId}
+      {...otherProps}
+    >
+      {children}
+    </tr>
+  );
+};
 
-    return (
-      <tr
-        className={cn(styles['TableRow'], className)}
-        data-test-id={testId}
-        {...otherProps}
-      >
-        {children}
-      </tr>
-    );
-  }
-}
+TableRow.defaultProps = defaultProps;
 
 export default TableRow;

--- a/packages/forma-36-react-components/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/forma-36-react-components/src/components/Table/TableRow/TableRow.tsx
@@ -13,7 +13,7 @@ const defaultProps: Partial<TableRowProps> = {
   testId: 'cf-ui-table-row',
 };
 
-const TableRow = (props: TableRowProps) => {
+export const TableRow = (props: TableRowProps) => {
   const { className, children, testId, ...otherProps } = props;
 
   return (


### PR DESCRIPTION
# Purpose of PR

Refactor table components to functional components, and extend prop types properly. Part of #651

Although we are spreading `{...otherProps}` but ts doesn't really recognise any props the consumer passes that doesn't exist in the props definition. with extending the actual html type it recognises `otherProps` and tight it to the supported attributes

e.g. 
```tsx
export interface TableRowProps extends HTMLProps<HTMLTableRowElement> {
  className?: string;
  testId?: string;
  children: React.ReactNode;
}

// TS works, and recognises onClick
<TableRow onClick={...} /> 


export interface TableRowProps {
  className?: string;
  style?: React.CSSProperties;
  testId?: string;
  children: React.ReactNode;
}
// Won't work
<TableRow onClick={...} /> 
```

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
