### PR TITLE
fix: Autocomplete component docs

### DIFF
--- a/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
@@ -1,0 +1,37 @@
+# Autocomplete (alpha)
+
+The autocomplete component is an input field that provides selectable suggestions as a user types into it. It allows users to quickly search through and select from large collections of options.
+
+## Example of usage
+
+```jsx
+import {Autocomplete } from '@contentful/forma-36-react-components/dist/alpha';
+
+<Autocomplete
+  items={items}
+  width={'full'}
+  onQueryChange={onQueryChange}
+  onChange={onChange}
+  isLoading={isLoading}
+  placeholder={'search'}
+  emptyListMessage={'no result found'}
+  noMatchesMessage={'no matches'}
+  dropdownProps={{ isFullWidth: true }}
+  disabled={disabled}
+  {(options) => options.map((option) => <span key={option.value}>{option.label}</span>)}
+</Autocomplete>
+```
+
+## Content recommendations
+
+ - Autocomplete label should be short, contain 1 to 3 words
+ - Label should be written in a sentence case (the first word capitalized, the rest lowercase)
+ - Autocomplete placeholder text
+
+## Best practices
+
+ - Autocomplete should have a clear label so user understands what type of action is possible
+
+## Accessibility
+
+ - dismisses the dropdown when selecting with the enter key

--- a/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
@@ -1,6 +1,7 @@
 # Autocomplete (alpha)
 
 The autocomplete component is an input field that provides selectable suggestions as a user types into it. It allows users to quickly search through and select from large collections of options.
+Keep in mind that this component is still in alpha state, which means it's unsupported and subject to breaking changes without warning.
 
 ## Example of usage
 

--- a/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
@@ -31,6 +31,7 @@ import {Autocomplete } from '@contentful/forma-36-react-components/dist/alpha';
 ## Best practices
 
  - Autocomplete should have a clear label so user understands what type of action is possible
+ - Consider using autocomplete over selects if user will be will be choosing from a very long list, like for example country list.
 
 ## Accessibility
 

--- a/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
@@ -27,7 +27,6 @@ import {Autocomplete } from '@contentful/forma-36-react-components/dist/alpha';
 
  - Autocomplete label should be short, contain 1 to 3 words
  - Label should be written in a sentence case (the first word capitalized, the rest lowercase)
- - Autocomplete placeholder text
 
 ## Best practices
 


### PR DESCRIPTION
Hey!
Docs for Autocomplete. I think there is a room for improvements when it comes to the component itself (Maybe visual might be improved and accessibility). We might want to tackle that for v4?

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
