### PR TITLE
fix: add small improvements for readme around alpha components

### DIFF
--- a/packages/forma-36-react-components/README.md
+++ b/packages/forma-36-react-components/README.md
@@ -53,6 +53,13 @@ import { Input } from '@contentful/forma-36-react-components';
 import '@contentful/forma-36-react-components/dist/styles.css';
 ```
 
+NOTE: If a component is still in alpha state:
+
+```js
+import { AlphaComponent } from '@contentful/forma-36-react-components/dist/alpha';
+```
+
+
 ## Development
 
 ### Switch to the correct version of Node (using NVM)

--- a/packages/forma-36-react-components/src/components/Flex/README.mdx
+++ b/packages/forma-36-react-components/src/components/Flex/README.mdx
@@ -2,6 +2,7 @@
 
 
 [Flex](https://developer.mozilla.org/en-US/docs/Glossary/Flex) is a great tool when you wan't to line things up in one direction. For example boxes in the limited amout of space, that would wrap or not wrap. When it comes to Flex, browser calculate things only in one direction, each row at the time. When for example CSS Grid calculates always rows and columns at the same time. If you think CSS Grid component is what you are looking for go ahead and have a look on our [Grid component](../Grid/Grid.md)
+*This component is in an alpha state. Breaking changes to the API can happen with any future updates. We don't recommend using the component in production environments*
 
 ## Usage
 

--- a/packages/forma-36-react-components/src/components/Grid/README.mdx
+++ b/packages/forma-36-react-components/src/components/Grid/README.mdx
@@ -1,4 +1,5 @@
 [CSS Grid](https://developer.mozilla.org/en-US/docs/Glossary/Grid) based React component, comes with predefined values to ensure design consistency, and ease of use.
+*This component is in an alpha state. Breaking changes to the API can happen with any future updates. We don't recommend using the component in production environments*
 
 The Grid consists of two components:
 
@@ -6,7 +7,8 @@ The Grid consists of two components:
 - GridItem: Elements within the Grid
 
 ```js
-import { Grid, GridItem } from '@contenful/forma-36-react-components';
+// Grid component is still in alpha stage
+import { Grid, GridItem } from '@contenful/forma-36-react-components/dist/alpha';
 ```
 
 <br />

--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -152,6 +152,10 @@ module.exports = {
             link: '/components/entity-list/',
           },
           {
+            name: 'Flex',
+            link: '/components/flex/',
+          },
+          {
             name: 'Form',
             link: '/components/form/',
           },

--- a/packages/forma-36-website/src/pages/components/autocomplete/index.mdx
+++ b/packages/forma-36-website/src/pages/components/autocomplete/index.mdx
@@ -5,5 +5,6 @@ status: 'alpha'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components/src/components/Autocomplete'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-tag--default'
 ---
+*This component is in an alpha state. Breaking changes to the API can happen with any future updates. We don't recommend using the component in production environments*
 
 Detailed documentation will be provided soon. For now, please have a look into the storybook for implementation details.

--- a/packages/forma-36-website/src/pages/components/flex/index.mdx
+++ b/packages/forma-36-website/src/pages/components/flex/index.mdx
@@ -1,9 +1,10 @@
 ---
-title: 'Workbench'
+title: 'Flex'
 type: 'component'
 status: 'alpha'
-github: 'https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components/src/components/Workbench'
-storybook: 'https://f36-storybook.contentful.com/?path=/story/alpha-workbench--default'
+github: 'https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components/src/components/Flex'
+storybook: 'https://f36-storybook.contentful.com/?path=/story/alpha-flex--default'
 ---
 *This component is in an alpha state. Breaking changes to the API can happen with any future updates. We don't recommend using the component in production environments*
+
 Detailed documentation will be provided soon. For now, please have a look into the storybook for implementation details.

--- a/packages/forma-36-website/src/pages/components/grid/index.mdx
+++ b/packages/forma-36-website/src/pages/components/grid/index.mdx
@@ -5,6 +5,7 @@ status: 'alpha'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components/src/components/Grid'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-grid--default'
 ---
+*This component is in an alpha state. Breaking changes to the API can happen with any future updates. We don't recommend using the component in production environments*
 
 CSS Grid Layout (aka “Grid”), is a two-dimensional layouting system that uses a series of containers, rows, and columns to layout and align content. Below are examples and an in-depth look at how the grid comes together.
 


### PR DESCRIPTION
Hey F36!

We had some small issues around alpha docs visibility. I tried to add some small tweaks to make it more clear for users. WDYT?

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
