### PR TITLE
fix(component): Add delay property to Toolbox component

### DIFF
--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -133,7 +133,7 @@ export const contentHover = (args: { content: string }) => {
   );
 };
 contentHover.args = {
-  closeOnMouseLeave: false,
+  hideDelay: 300,
   content: (
     <>
       You can interact with the content in me
@@ -151,13 +151,13 @@ contentHover.args = {
     </>
   ),
 };
-const contentHoverSourceCode = `<Tooltip closeOnMouseLeave={false} content={(
+const contentHoverSourceCode = `<Tooltip hideDelay={300} content={(
   <>
     You can interact with the content in me
     <br />
     <button type="button">Button</button>
     <br />
-    <a style={{ color: 'white' }} href="/" target="_blank" rel="noopener noreferrer">Click me!</a> 
+    <a style={{ color: 'white' }} href="/" target="_blank" rel="noopener noreferrer">Click me!</a>
   </>
 )}>
   <TextLink>Hover me</TextLink>

--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
@@ -47,6 +47,10 @@ export interface TooltipProps {
    */
   maxWidth?: number | CSS.Property.MaxWidth;
   /**
+   * It sets a delay period for the Tooltip
+   */
+  delay?: Partial<DelayProps>;
+  /**
    * Function that will be called when target gets blurred
    */
   onBlur?: (evt: FocusEvent) => void;
@@ -80,6 +84,10 @@ interface ArrowPositionState {
   top: string;
   left: string;
 }
+export interface DelayProps {
+  hide: number;
+  show: number;
+}
 
 export const Tooltip = ({
   children,
@@ -90,6 +98,7 @@ export const Tooltip = ({
   isVisible,
   closeOnMouseLeave,
   maxWidth,
+  delay,
   onBlur,
   onFocus,
   onMouseLeave,
@@ -100,6 +109,7 @@ export const Tooltip = ({
   ...otherProps
 }: TooltipProps) => {
   const [show, setShow] = useState(false);
+  const [delaySettings, setDelaySettings] = useState(delay);
   const [arrowPosition, setArrowPosition] = useState<ArrowPositionState>(
     getArrowPosition('bottom'),
   );
@@ -153,9 +163,15 @@ export const Tooltip = ({
   useEffect(() => {
     if (isVisible) setShow(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (!delay) {
+      if (closeOnMouseLeave) {
+        setDelaySettings({ hide: 0, show: 0 });
+      } else {
+        setDelaySettings({ hide: 500, show: 0 });
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const delay = closeOnMouseLeave ? 0 : 1000;
 
   const arrowStyles = {
     ...popperStyles.arrow,
@@ -186,11 +202,17 @@ export const Tooltip = ({
         ref={elementRef}
         className={targetWrapperClassName}
         onMouseEnter={(evt: MouseEvent) => {
-          setIsHoveringTarget(true);
+          setTimeout(
+            () => setIsHoveringTarget(true),
+            delaySettings && delaySettings.show,
+          );
           if (onMouseOver) onMouseOver(evt);
         }}
         onMouseLeave={(evt: MouseEvent) => {
-          setTimeout(() => setIsHoveringTarget(false), delay);
+          setTimeout(
+            () => setIsHoveringTarget(false),
+            delaySettings && delaySettings.hide,
+          );
           if (onMouseLeave) onMouseLeave(evt);
         }}
         onFocus={(evt: FocusEvent) => {
@@ -198,7 +220,10 @@ export const Tooltip = ({
           if (onFocus) onFocus(evt);
         }}
         onBlur={(evt: FocusEvent) => {
-          setTimeout(() => setIsHoveringTarget(false), delay);
+          setTimeout(
+            () => setIsHoveringTarget(false),
+            delaySettings && delaySettings.hide,
+          );
           if (onBlur) onBlur(evt);
         }}
         {...otherProps}

--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
@@ -39,17 +39,13 @@ export interface TooltipProps {
    */
   isVisible?: boolean;
   /**
-   * It controls whether or not the tooltip stays open when hovering on the content
-   */
-  closeOnMouseLeave?: boolean;
-  /**
    * It sets a max-width for the Tooltip
    */
   maxWidth?: number | CSS.Property.MaxWidth;
   /**
    * It sets a delay period for the Tooltip
    */
-  delay?: Partial<DelayProps>;
+  hideDelay?: number;
   /**
    * Function that will be called when target gets blurred
    */
@@ -84,10 +80,6 @@ interface ArrowPositionState {
   top: string;
   left: string;
 }
-export interface DelayProps {
-  hide: number;
-  show: number;
-}
 
 export const Tooltip = ({
   children,
@@ -95,21 +87,19 @@ export const Tooltip = ({
   containerElement: ContainerElement = 'span',
   content,
   id,
-  isVisible,
-  closeOnMouseLeave,
-  maxWidth,
-  delay,
+  isVisible = false,
+  hideDelay = 0,
   onBlur,
   onFocus,
   onMouseLeave,
   onMouseOver,
-  place,
   targetWrapperClassName,
-  testId,
+  maxWidth = 360,
+  testId = 'cf-ui-tooltip',
+  place = 'auto',
   ...otherProps
 }: TooltipProps) => {
   const [show, setShow] = useState(false);
-  const [delaySettings, setDelaySettings] = useState(delay);
   const [arrowPosition, setArrowPosition] = useState<ArrowPositionState>(
     getArrowPosition('bottom'),
   );
@@ -153,23 +143,11 @@ export const Tooltip = ({
   const [isHoveringTarget, setIsHoveringTarget] = useState(false);
   const [isHoveringContent, setIsHoveringContent] = useState(false);
   useEffect(() => {
-    if (closeOnMouseLeave) {
-      setShow(isHoveringTarget);
-    } else {
-      setShow(isHoveringContent || isHoveringTarget);
-    }
-  }, [closeOnMouseLeave, isHoveringTarget, isHoveringContent]);
+    setShow(isHoveringContent || isHoveringTarget);
+  }, [isHoveringTarget, isHoveringContent]);
 
   useEffect(() => {
     if (isVisible) setShow(true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    if (!delay) {
-      if (closeOnMouseLeave) {
-        setDelaySettings({ hide: 0, show: 0 });
-      } else {
-        setDelaySettings({ hide: 500, show: 0 });
-      }
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -196,23 +174,19 @@ export const Tooltip = ({
     );
   }
 
+  // const delay = !hideDelay ? (closeOnMouseLeave ? 0 : 300) : hideDelay;
+
   return (
     <>
       <ContainerElement
         ref={elementRef}
         className={targetWrapperClassName}
         onMouseEnter={(evt: MouseEvent) => {
-          setTimeout(
-            () => setIsHoveringTarget(true),
-            delaySettings && delaySettings.show,
-          );
+          setIsHoveringTarget(true);
           if (onMouseOver) onMouseOver(evt);
         }}
         onMouseLeave={(evt: MouseEvent) => {
-          setTimeout(
-            () => setIsHoveringTarget(false),
-            delaySettings && delaySettings.hide,
-          );
+          setTimeout(() => setIsHoveringTarget(false), hideDelay);
           if (onMouseLeave) onMouseLeave(evt);
         }}
         onFocus={(evt: FocusEvent) => {
@@ -220,10 +194,7 @@ export const Tooltip = ({
           if (onFocus) onFocus(evt);
         }}
         onBlur={(evt: FocusEvent) => {
-          setTimeout(
-            () => setIsHoveringTarget(false),
-            delaySettings && delaySettings.hide,
-          );
+          setTimeout(() => setIsHoveringTarget(false), hideDelay);
           if (onBlur) onBlur(evt);
         }}
         {...otherProps}
@@ -260,14 +231,6 @@ export const Tooltip = ({
       )}
     </>
   );
-};
-Tooltip.defaultProps = {
-  containerElement: 'span',
-  isVisible: false,
-  closeOnMouseLeave: true,
-  maxWidth: 360,
-  testId: 'cf-ui-tooltip',
-  place: 'auto',
 };
 
 function getArrowPosition(popperPlacement: string) {


### PR DESCRIPTION

# Purpose of PR

This adds `delay` property to `Toolbox` component.

- Previous delay of 1000ms was too long
- We think it’d be beneficial to be able to set custom delay via props, separately for `show` and `hide` (so that there will be no request just to change the delay time etc)
 - We aren’t sure if `show` delay is useful as usually we want to show the tooltip right away. But lots of library like https://material.angular.io/components/tooltip/overview and bootstrap has `show` and `hide` delay as props. For the sake of completeness, we can have it. Otherwise, just keep the delay for `hide`.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
