### PR TITLE
test(text-field): add test to ensure value changes when typing

### DIFF
--- a/packages/forma-36-react-components/src/components/TextField/TextField.test.tsx
+++ b/packages/forma-36-react-components/src/components/TextField/TextField.test.tsx
@@ -97,6 +97,21 @@ it('renders the component with a value', () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
+it('updates the value', () => {
+  const { container } = render(
+    <TextField labelText="test" data-test-id="input" value="" />,
+  );
+
+  const input = container.querySelector(
+    '[data-test-id="cf-ui-text-field"] input',
+  );
+
+  userEvent.type(input, 'new value');
+
+  expect(screen.getByDisplayValue('new value')).toBeInTheDocument();
+  expect(container.firstChild).toMatchSnapshot();
+});
+
 it('renders the component with as textarea', () => {
   const { container } = render(
     <TextField

--- a/packages/forma-36-react-components/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -584,3 +584,30 @@ exports[`renders the component with validation message 1`] = `
   </div>
 </div>
 `;
+
+exports[`updates the value 1`] = `
+<div
+  class="TextField TextField--full"
+  data-test-id="cf-ui-text-field"
+>
+  <div
+    class="TextField__label-wrapper"
+  >
+    <label
+      class="FormLabel"
+      data-test-id="cf-ui-form-label"
+    >
+      test
+    </label>
+  </div>
+  <div
+    class="TextInput TextInput--full"
+  >
+    <input
+      class="TextInput__input"
+      data-test-id="cf-ui-text-input"
+      value="new value"
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->
Adds a test for typing in the `TextField` component.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
