### PR TITLE
fix: modals extend too far vertically

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/Modal.css
+++ b/packages/forma-36-react-components/src/components/Modal/Modal.css
@@ -15,6 +15,7 @@
 
 .Modal__overlay {
   display: flex;
+  align-items: baseline;
   flex-wrap: wrap;
   top: 0;
   right: 0;


### PR DESCRIPTION
## Purpose of PR

Modals components using `position="top"` extend too far vertically, which can block outside clicks underneath the modal. For some users, this makes it feel like outside clicks don't close the modal, or only work sporadically.

I propose setting `align-items` to `baseline` on the wrapper, which will reset flex behavior and set the vertical size to the original size of the children, unblocking the space for outside clicks. See images:

![forma-bug-1](https://user-images.githubusercontent.com/29887157/102108709-86c14780-3e33-11eb-9fbb-1b03f74c1f25.png)
![forma-bug-2](https://user-images.githubusercontent.com/29887157/102108714-87f27480-3e33-11eb-80fc-cb718dd38a38.png)


Modals using `position="center"` already add the `align-items: center` property, so they don't need to be changed.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support) (I need help here, I only have Chrome/Firefox/Opera)
- [x] Doesn't contain any sensitive information
