### PR TITLE
feat: export previous alpha components as stable

### DIFF
--- a/packages/forma-36-react-components/.size-limit
+++ b/packages/forma-36-react-components/.size-limit
@@ -3,7 +3,7 @@
     "path": "dist/index.js",
     "name": "gzipped js",
     "gzip": false,
-    "limit": "385 KB",
+    "limit": "388 KB",
     "ignore": [
       "react",
       "react-dom"

--- a/packages/forma-36-react-components/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Accordion/Accordion.stories.tsx
@@ -11,7 +11,7 @@ import Paragraph from '../Typography/Paragraph';
 import notes from './README.mdx';
 
 export default {
-  title: '(alpha)/Accordion',
+  title: 'Components/Accordion',
   component: Accordion,
   subcomponents: { AccordionItem },
   parameters: {

--- a/packages/forma-36-react-components/src/components/Accordion/README.mdx
+++ b/packages/forma-36-react-components/src/components/Accordion/README.mdx
@@ -1,5 +1,3 @@
-_This component is in an alpha state. Breaking changes to the API can happen with any future updates. We don't recommend using the component in production environments_
-
 Accordions are a good way to deliver a large amount of information. An accordion is a list of headers that after being clicked reveal or hide more content related to them.
 The header gives the user a summary of the content and the user decides if they need to see the extended content or not.
 
@@ -22,7 +20,7 @@ The accordion has two variations that define the alignment of the chevron icon: 
 ## Code examples
 
 ```jsx
-// import { Accordion, AccordionItem } from '@contentful/forma-36-react-components/dist/alpha';
+// import { Accordion, AccordionItem } from '@contentful/forma-36-react-components';
 
 <Accordion>
   <AccordionItem title="What payment methods do you accept?">
@@ -36,8 +34,7 @@ The accordion has two variations that define the alignment of the chevron icon: 
 Other typographic components can be passed as the accordion's title and anything can be used as the accordion's content. For example:
 
 ```jsx
-// import { Accordion, AccordionItem } from '@contentful/forma-36-react-components/dist/alpha';
-// import { SectionHeading, Paragraph, Button } from '@contentful/forma-36-react-components';
+// import { Accordion, AccordionItem, SectionHeading, Paragraph, Button } from '@contentful/forma-36-react-components';
 
 <Accordion>
   <AccordionItem

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -68,7 +68,7 @@ const AutocompleteDefaultStory = ({ items }: { items: Item[] }) => {
   );
 };
 
-storiesOf('(alpha)/Autocomplete', module)
+storiesOf('Components/Autocomplete', module)
   .addParameters({
     propTypes: Autocomplete['__docgenInfo'],
     component: Autocomplete,

--- a/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
@@ -1,5 +1,3 @@
-_This component is in an alpha state. Breaking changes to the API can happen with any future updates. We don't recommend using the component in production environments_
-
 The autocomplete component is an input field that provides selectable suggestions as a user types into it. It allows users to quickly search through and select from large collections of options.
 Keep in mind that this component is still in alpha state, which means it's unsupported and subject to breaking changes without warning.
 
@@ -18,7 +16,7 @@ Keep in mind that this component is still in alpha state, which means it's unsup
 ## Code examples
 
 ```jsx
-// import {Autocomplete } from '@contentful/forma-36-react-components/dist/alpha';
+// import { Autocomplete } from '@contentful/forma-36-react-components';
 <Autocomplete
   items={[
     {

--- a/packages/forma-36-react-components/src/components/Flex/Flex.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Flex/Flex.stories.tsx
@@ -82,7 +82,7 @@ const DemoBox = ({ times }: { times?: number }) => {
   return <Flex style={styles.demoBox}>Example element</Flex>;
 };
 
-storiesOf('(alpha)/Flex', module)
+storiesOf('Components/Flex', module)
   .addParameters({
     propTypes: Flex['__docgenInfo'],
     component: Flex,

--- a/packages/forma-36-react-components/src/components/Flex/README.mdx
+++ b/packages/forma-36-react-components/src/components/Flex/README.mdx
@@ -1,5 +1,3 @@
-_This component is in an alpha state. Breaking changes to the API can happen with any future updates. We don't recommend using the component in production environments_
-
 [Flex](https://developer.mozilla.org/en-US/docs/Glossary/Flex) is a great tool when you wan't to line things up in one direction. For example boxes in the limited amout of space, that would wrap or not wrap. When it comes to Flex, browser calculate things only in one direction, each row at the time. When for example CSS Grid calculates always rows and columns at the same time. If you think CSS Grid component is what you are looking for go ahead and have a look on our [Grid component](../Grid/Grid.md)
 
 ## Table of contents
@@ -22,8 +20,6 @@ Flex, as any other element, can get margin value, which will be added evenly to 
 
 ```jsx
 // import { Flex } from '@contenful/forma-36-react-components';
-// if component is still in alpha stage
-// import { Flex } from '@contenful/forma-36-react-components/dist/alpha';
 
 <Flex marginTop="spacingXs" margin="spacingXs">
   Element
@@ -34,8 +30,6 @@ Flex, as any other element, can get margin value, which will be added evenly to 
 
 ```jsx
 // import { Flex } from '@contenful/forma-36-react-components';
-// if component is still in alpha stage
-// import { Flex } from '@contenful/forma-36-react-components/dist/alpha';
 
 <Flex marginTop="spacingXs" marginLeft="spacingXs">
   Element
@@ -46,8 +40,6 @@ Flex, as any other element, can get margin value, which will be added evenly to 
 
 ```js
 // import { Flex } from '@contenful/forma-36-react-components';
-// if component is still in alpha stage
-// import { Flex } from '@contenful/forma-36-react-components/dist/alpha';
 
 <Flex
   justifyContent="space-between"
@@ -64,8 +56,6 @@ Flex, as any other element, can get margin value, which will be added evenly to 
 
 ```jsx
 // import { Flex, Button, TextLink, Paragraph } from '@contenful/forma-36-react-components';
-// if component is still in alpha stage
-// import { Flex } from '@contenful/forma-36-react-components/dist/alpha';
 
 <Flex
   justifyContent="space-between"

--- a/packages/forma-36-react-components/src/components/Grid/Grid.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Grid/Grid.stories.tsx
@@ -15,7 +15,7 @@ const styles = {
 };
 
 export default {
-  title: '(alpha)/Grid',
+  title: 'Components/Grid',
   component: Grid,
   subcomponents: { GridItem },
   parameters: {

--- a/packages/forma-36-react-components/src/components/Grid/GridItem/GridItem.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Grid/GridItem/GridItem.stories.tsx
@@ -41,7 +41,7 @@ const DemoBox = ({ times, id }: { times?: number; id?: string }) => {
   return <GridItem style={styles.demoBox}></GridItem>;
 };
 
-storiesOf('(alpha)/Grid/GridItem', module)
+storiesOf('Components/Grid/GridItem', module)
   .addParameters({
     propTypes: GridItem['__docgenInfo'],
     component: GridItem,

--- a/packages/forma-36-react-components/src/components/Grid/README.mdx
+++ b/packages/forma-36-react-components/src/components/Grid/README.mdx
@@ -1,5 +1,3 @@
-_This component is in an alpha state. Breaking changes to the API can happen with any future updates. We don't recommend using the component in production environments_
-
 [CSS Grid](https://developer.mozilla.org/en-US/docs/Glossary/Grid) based React component, comes with predefined values to ensure design consistency, and ease of use.
 
 ## Table of contents
@@ -22,8 +20,7 @@ The Grid consists of two components:
 When defined as a number, it will split the space into equally sized columns; it also accepts any of the [grid-template-columns](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns) css properties. e.g.
 
 ```jsx
-// Grid component is still in alpha stage
-// import { Grid, GridItem } from '@contenful/forma-36-react-components/dist/alpha';
+// import { Grid, GridItem } from '@contenful/forma-36-react-components';
 
 <React.Fragment>
   <Grid columns={6}></Grid>
@@ -36,8 +33,7 @@ When defined as a number, it will split the space into equally sized columns; it
 Accepts a number or any of [grid-template-rows](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-rows) css properties.
 
 ```jsx
-// Grid component is still in alpha stage
-// import { Grid, GridItem } from '@contenful/forma-36-react-components/dist/alpha';
+// import { Grid, GridItem } from '@contenful/forma-36-react-components';
 
 <React.Fragment>
   <Grid rows={6}></Grid>
@@ -54,8 +50,7 @@ Accepts a number or any of [grid-template-rows](https://developer.mozilla.org/en
 **e.g.**
 
 ```jsx
-// Grid component is still in alpha stage
-// import { Grid, GridItem } from '@contenful/forma-36-react-components/dist/alpha';
+// import { Grid, GridItem } from '@contenful/forma-36-react-components';
 
 <Grid columnGap="spacingXs" rowGap="spacingXl"></Grid>
 ```

--- a/packages/forma-36-react-components/src/index.ts
+++ b/packages/forma-36-react-components/src/index.ts
@@ -74,4 +74,11 @@ export { EntityListItem } from './components/EntityList/EntityListItem/EntityLis
 export { EmptyState } from './components/EmptyState/EmptyState';
 export { Switch } from './components/Switch/Switch';
 export { Workbench } from './components/Workbench/Workbench';
+export { Autocomplete } from './components/Autocomplete/Autocomplete';
+export { Grid } from './components/Grid';
+export { GridItem } from './components/Grid/GridItem';
+export { Flex } from './components/Flex';
+export { Accordion } from './components/Accordion/Accordion';
+export { AccordionItem } from './components/Accordion/AccordionItem';
+export { ModalLauncher } from './components/Modal/ModalLauncher/ModalLauncher';
 // -- Add imports above this line (required by plopfile.js) --

--- a/packages/forma-36-website/src/components/Footer.js
+++ b/packages/forma-36-website/src/components/Footer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TextLink } from '@contentful/forma-36-react-components';
-import { Flex } from '@contentful/forma-36-react-components/dist/alpha';
+import { Flex } from '@contentful/forma-36-react-components';
 import tokens from '@contentful/forma-36-tokens';
 import { css } from '@emotion/core';
 

--- a/packages/forma-36-website/src/pages/components/accordion/index.mdx
+++ b/packages/forma-36-website/src/pages/components/accordion/index.mdx
@@ -3,5 +3,5 @@ title: 'Accordion'
 type: 'component'
 status: 'alpha'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components/src/components/Accordion'
-storybook: 'https://forma-36-react-components.netlify.app/?path=/story/alpha-accordion--basic'
+storybook: 'https://forma-36-react-components.netlify.app/?path=/story/components-accordion--basic'
 ---

--- a/packages/forma-36-website/src/pages/components/autocomplete/index.mdx
+++ b/packages/forma-36-website/src/pages/components/autocomplete/index.mdx
@@ -3,5 +3,5 @@ title: 'Autocomplete'
 type: 'component'
 status: 'alpha'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components/src/components/Autocomplete'
-storybook: 'https://f36-storybook.contentful.com/?path=/story/alpha-autocomplete--default'
+storybook: 'https://f36-storybook.contentful.com/?path=/story/components-autocomplete--default'
 ---

--- a/packages/forma-36-website/src/pages/components/flex/index.mdx
+++ b/packages/forma-36-website/src/pages/components/flex/index.mdx
@@ -3,5 +3,5 @@ title: 'Flex'
 type: 'component'
 status: 'alpha'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components/src/components/Flex'
-storybook: 'https://f36-storybook.contentful.com/?path=/story/alpha-flex--default'
+storybook: 'https://f36-storybook.contentful.com/?path=/story/components-flex--default'
 ---

--- a/packages/forma-36-website/src/pages/components/workbench/index.mdx
+++ b/packages/forma-36-website/src/pages/components/workbench/index.mdx
@@ -3,5 +3,5 @@ title: 'Workbench'
 type: 'component'
 status: 'stable'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components/src/components/Workbench'
-storybook: 'https://f36-storybook.contentful.com/?path=/story/alpha-workbench--default'
+storybook: 'https://f36-storybook.contentful.com/?path=/story/components-workbench--default'
 ---


### PR DESCRIPTION
# Purpose of PR

Autocomplete, Grid, GridItem, Flex, Accordion, AccordionItem, and ModalLauncher are now stable.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
