### PR TITLE
fix(text-input): specify input element type in ChangeEventHandler

### DIFF
--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
@@ -29,7 +29,7 @@ export type TextInputProps = {
   className?: string;
   withCopyButton?: boolean;
   testId?: string;
-  onChange?: ChangeEventHandler;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
   onCopy?: (value: string) => void;
   value?: string;
   inputRef?: RefObject<HTMLInputElement>;


### PR DESCRIPTION
# Purpose of PR

Specify input element type in ChangeEventHandler

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
