### PR TITLE
chore: enable publishing canary releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,9 @@ workflows:
       - release:
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - v3-visual-changes
           requires:
             - lint-and-test
             - chromatic-deployment

--- a/bin/deploy
+++ b/bin/deploy
@@ -2,5 +2,5 @@
 #
 # publish a new version depending on conventional commits
 set -e
-yarn lerna publish --conventional-commits --conventional-prerelease=@contentful/forma-36-react-datepicker,@contentful/forma-36-react-timepicker --github-release --yes
+yarn lerna publish --canary --dist-tag next-v3 --conventional-commits --conventional-prerelease=@contentful/forma-36-react-datepicker,@contentful/forma-36-react-timepicker --yes
 set +e


### PR DESCRIPTION
# Purpose of PR

Allows publishing canary releases from `v3-visual-changes` branch