### PR TITLE
fix(Autocomplete): Make use of dropdownProp.isOpen

### DIFF
--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -59,18 +59,12 @@ type Action =
   | { type: typeof TOGGLED_LIST; payload?: boolean }
   | { type: typeof NAVIGATED_ITEMS; payload: number | null }
   | { type: typeof QUERY_CHANGED; payload: string }
-  | { type: typeof ITEM_SELECTED };
+  | { type: typeof ITEM_SELECTED; payload: State };
 
 enum Direction {
   DOWN = 1,
   UP = -1,
 }
-
-const initialState: State = {
-  isOpen: false,
-  query: '',
-  highlightedItemIndex: null,
-};
 
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {
@@ -94,7 +88,7 @@ const reducer = (state: State, action: Action): State => {
         query: action.payload,
       };
     case ITEM_SELECTED:
-      return { ...initialState };
+      return { ...action.payload };
     default:
       return state;
   }
@@ -121,6 +115,12 @@ export const Autocomplete = <T extends {}>({
   const listRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
+  const initialState: State = {
+    isOpen: dropdownProps?.isOpen ?? false,
+    query: '',
+    highlightedItemIndex: null,
+  };
+
   const [{ isOpen, query, highlightedItemIndex }, dispatch] = useReducer(
     reducer,
     initialState,
@@ -131,7 +131,7 @@ export const Autocomplete = <T extends {}>({
   };
 
   const selectItem = (item: T) => {
-    dispatch({ type: ITEM_SELECTED });
+    dispatch({ type: ITEM_SELECTED, payload: initialState });
     onQueryChange('');
     onChange(item);
   };


### PR DESCRIPTION
# Purpose of PR

We have an useReducer hook in the **Autocomplete**  component that handles an **isOpen** flag that was not taken in account the **dropDown props** in the initialState, this was producing an unexpected behaviour in the Autocomplete dropdown.

We have a current bug in the Search component, since [TagsMultiSelectAutocomplete](https://github.com/contentful/experience-packages/blob/master/packages/entity-search/src/Search/TagsMultiSelectAutocomplete/TagsMultiSelectAutocomplete.tsx) makes use of this **Autocomplete**.

## PR Checklist

- [x ] I have read the relevant `readme.md` file(s)
- [ x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ x] Tests are added/updated/not required
- [ x] Tests are passing
- [ x] Storybook stories are added/updated/not required
- [ x] Usage notes are added/updated/not required
- [ x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ x] Doesn't contain any sensitive information
