### PR TITLE
revert(card-actions): revert to class component

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
@@ -1,11 +1,9 @@
-import React, { useCallback, useState } from 'react';
-import type { MouseEvent as ReactMouseEvent } from 'react';
-
-import Dropdown, { DropdownProps } from '../../Dropdown';
+import React, { Component, MouseEvent as ReactMouseEvent } from 'react';
+import Dropdown from '../../Dropdown';
 import DropdownList from '../../Dropdown/DropdownList';
 import IconButton, { IconButtonProps } from '../../IconButton';
 
-export interface CardActionsPropTypes extends DropdownProps {
+export interface CardActionsPropTypes {
   /**
    * Class names to be appended to the className prop of the component
    */
@@ -30,76 +28,95 @@ export interface CardActionsPropTypes extends DropdownProps {
   testId?: string;
 }
 
-export function CardActions({
-  className,
-  children,
-  testId = 'cf-ui-card-actions',
-  iconButtonProps,
-  isDisabled = false,
-  ...otherProps
-}: CardActionsPropTypes): React.ReactElement {
-  const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
+export interface CardActionsState {
+  isDropdownOpen: boolean;
+}
 
-  const handleClick = useCallback(
-    (event: ReactMouseEvent) => {
-      setIsDropdownOpen((prevState) => !prevState);
+const defaultProps: Partial<CardActionsPropTypes> = {
+  testId: 'cf-ui-card-actions',
+  isDisabled: false,
+};
 
-      if (iconButtonProps && iconButtonProps.onClick) {
-        event.stopPropagation();
-      }
-    },
-    [iconButtonProps],
-  );
+export class CardActions extends Component<
+  CardActionsPropTypes,
+  CardActionsState
+> {
+  static defaultProps = defaultProps;
 
-  return (
-    <Dropdown
-      onClose={() => {
-        setIsDropdownOpen(false);
-      }}
-      position="bottom-right"
-      className={className}
-      isOpen={isDropdownOpen}
-      testId={testId}
-      toggleElement={
-        <IconButton
-          iconProps={{ icon: 'MoreHorizontal' }}
-          buttonType="secondary"
-          disabled={isDisabled}
-          label="Actions"
-          {...iconButtonProps}
-          onClick={(event) => {
-            event.preventDefault();
-            handleClick(event);
-          }}
-        />
-      }
-      {...otherProps}
-    >
-      {React.Children.map(children, (listItems: React.ReactElement) => {
-        return React.Children.map(listItems, (item: React.ReactElement) => {
-          // React.Children behaves differently if the object is a Fragment.
-          const resolvedChildren =
-            item.type === React.Fragment ? item.props.children : item;
+  state = { isDropdownOpen: false };
 
-          const enhancedChildren = React.Children.map(
-            resolvedChildren,
-            (child: React.ReactElement) =>
-              React.cloneElement(child, {
-                onClick: (e: ReactMouseEvent) => {
-                  if (child.props.onClick) {
-                    child.props.onClick(e);
-                  }
-                  setIsDropdownOpen(false);
-                  e.stopPropagation();
-                },
-              }),
-          );
+  handleClick = (event: ReactMouseEvent) => {
+    this.setState((prevState) => ({
+      isDropdownOpen: !prevState.isDropdownOpen,
+    }));
 
-          return enhancedChildren;
-        });
-      })}
-    </Dropdown>
-  );
+    if (this.props.iconButtonProps && this.props.iconButtonProps.onClick) {
+      event.stopPropagation();
+    }
+  };
+
+  render() {
+    const {
+      className,
+      children,
+      testId,
+      iconButtonProps,
+      isDisabled,
+      ...otherProps
+    } = this.props;
+
+    return (
+      <Dropdown
+        onClose={() => {
+          this.setState({
+            isDropdownOpen: false,
+          });
+        }}
+        position="bottom-right"
+        className={className}
+        isOpen={this.state.isDropdownOpen}
+        testId={testId}
+        toggleElement={
+          <IconButton
+            iconProps={{ icon: 'MoreHorizontal' }}
+            buttonType="secondary"
+            disabled={isDisabled}
+            label="Actions"
+            {...iconButtonProps}
+            onClick={(event) => {
+              event.preventDefault();
+              this.handleClick(event);
+            }}
+          />
+        }
+        {...otherProps}
+      >
+        {React.Children.map(children, (listItems: React.ReactElement) => {
+          return React.Children.map(listItems, (item: React.ReactElement) => {
+            // React.Children behaves differently if the object is a Fragment.
+            const resolvedChildren =
+              item.type === React.Fragment ? item.props.children : item;
+
+            const enhancedChildren = React.Children.map(
+              resolvedChildren,
+              (child: React.ReactElement) =>
+                React.cloneElement(child, {
+                  onClick: (e: ReactMouseEvent) => {
+                    if (child.props.onClick) {
+                      child.props.onClick(e);
+                    }
+                    this.setState({ isDropdownOpen: false });
+                    e.stopPropagation();
+                  },
+                }),
+            );
+
+            return enhancedChildren;
+          });
+        })}
+      </Dropdown>
+    );
+  }
 }
 
 export default CardActions;

--- a/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.tsx
@@ -1,9 +1,9 @@
 import React, { Component, MouseEvent as ReactMouseEvent } from 'react';
-import Dropdown from '../../Dropdown';
+import Dropdown, { DropdownProps } from '../../Dropdown';
 import DropdownList from '../../Dropdown/DropdownList';
 import IconButton, { IconButtonProps } from '../../IconButton';
 
-export interface CardActionsPropTypes {
+export interface CardActionsPropTypes extends DropdownProps {
   /**
    * Class names to be appended to the className prop of the component
    */


### PR DESCRIPTION
# Purpose of PR

We have revert to a class component for now.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
