### PR TITLE
feat: new design for modals and allow change buttons positions

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/Modal.stories.tsx
@@ -124,12 +124,12 @@ export const ControllerModal: Story<ModalProps> = (props) => {
           <React.Fragment>
             <Modal.Header title={title} onClose={onClose} />
             <Modal.Content>Hello from controlled modal window</Modal.Content>
-            <Modal.Controls>
-              <Button onClick={onClose} buttonType="positive">
-                Confirm
-              </Button>
-              <Button onClick={onClose} buttonType="muted">
+            <Modal.Controls position="right">
+              <Button size="small" onClick={onClose} buttonType="muted">
                 Close
+              </Button>
+              <Button size="small" onClick={onClose} buttonType="positive">
+                Confirm
               </Button>
             </Modal.Controls>
           </React.Fragment>

--- a/packages/forma-36-react-components/src/components/Modal/Modal.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/Modal.tsx
@@ -48,7 +48,7 @@ export interface ModalProps {
    */
   shouldCloseOnEscapePress?: boolean;
   /**
-   * Boolean indicating if modal is centered
+   * Indicating if modal is centered or linked to the top
    */
   position?: 'center' | 'top';
   /**

--- a/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.stories.tsx
@@ -43,7 +43,7 @@ export default {
   },
 } as Meta;
 
-export const Default: Story<ModalConfirmProps> = (props) => {
+function SimpleDemo(props: ModalConfirmProps) {
   const [isShown, setShown] = useState(true);
   return (
     <div>
@@ -66,10 +66,24 @@ export const Default: Story<ModalConfirmProps> = (props) => {
           action('onSecondary')();
         }}
       >
-        <p>You are about to delete SOMETHING. Think twice!</p>
+        <div>You are about to delete SOMETHING. Think twice!</div>
       </ModalConfirm>
     </div>
   );
+}
+
+export const Default: Story<ModalConfirmProps> = (props) => {
+  return <SimpleDemo {...props} />;
+};
+
+export const RightButtons: Story<ModalConfirmProps> = (props) => {
+  return <SimpleDemo {...props} />;
+};
+
+RightButtons.args = {
+  modalControlsProps: {
+    position: 'right',
+  },
 };
 
 export function ComplexStory(props: ModalConfirmProps) {
@@ -102,9 +116,9 @@ export function ComplexStory(props: ModalConfirmProps) {
         }}
         {...props}
       >
-        <p>
+        <div>
           Type <strong>unlock</strong> to allow confirming this modal
-        </p>
+        </div>
         <TextInput
           value={repeat}
           onChange={(e) => setRepeat((e.target as HTMLInputElement).value)}

--- a/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.stories.tsx
@@ -4,6 +4,8 @@ import { action } from '@storybook/addon-actions';
 
 import ModalConfirm, { ModalConfirmProps } from './ModalConfirm';
 import Button from '../../Button';
+import Paragraph from '../../Typography/Paragraph';
+import Typography from '../../Typography/Typography';
 import TextInput from '../../TextInput';
 
 export default {
@@ -116,9 +118,11 @@ export function ComplexStory(props: ModalConfirmProps) {
         }}
         {...props}
       >
-        <div>
-          Type <strong>unlock</strong> to allow confirming this modal
-        </div>
+        <Typography>
+          <Paragraph>
+            Type <strong>unlock</strong> to allow confirming this modal
+          </Paragraph>
+        </Typography>
         <TextInput
           value={repeat}
           onChange={(e) => setRepeat((e.target as HTMLInputElement).value)}

--- a/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.test.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 
 import axe from '../../../utils/axeHelper';
 import ModalConfirm from './ModalConfirm';
+import '@contentful/forma-36-fcss/dist/styles.css';
 
 jest.mock(
   'react-modal',

--- a/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.tsx
@@ -131,6 +131,60 @@ export function ModalConfirm({
   testId = 'cf-ui-modal-confirm',
   title = 'Are you sure?',
 }: ModalConfirmProps): React.ReactElement {
+  const confirmButton = confirmLabel ? (
+    <Button
+      size="small"
+      testId={confirmTestId}
+      disabled={isConfirmDisabled}
+      loading={isConfirmLoading}
+      buttonType={intent}
+      onClick={() => onConfirm()}
+    >
+      {confirmLabel}
+    </Button>
+  ) : null;
+
+  const secondaryButton = secondaryLabel ? (
+    <Button
+      size="small"
+      testId={secondaryTestId}
+      disabled={isSecondaryDisabled}
+      loading={isSecondaryLoading}
+      buttonType={secondaryIntent}
+      onClick={() => onSecondary && onSecondary()}
+    >
+      {secondaryLabel}
+    </Button>
+  ) : null;
+
+  const cancelButton = cancelLabel ? (
+    <Button
+      size="small"
+      testId={cancelTestId}
+      buttonType="muted"
+      onClick={() => onCancel()}
+    >
+      {cancelLabel}
+    </Button>
+  ) : null;
+
+  let buttons = (
+    <>
+      {confirmButton}
+      {secondaryButton}
+      {cancelButton}
+    </>
+  );
+
+  if (modalControlsProps && modalControlsProps.position === 'right') {
+    buttons = (
+      <>
+        {cancelButton}
+        {secondaryButton}
+        {confirmButton}
+      </>
+    );
+  }
   return (
     <Modal
       testId={testId}
@@ -145,39 +199,7 @@ export function ModalConfirm({
         <div>
           <Modal.Header title={title || ''} {...modalHeaderProps} />
           <Modal.Content {...modalContentProps}>{children}</Modal.Content>
-          <Modal.Controls {...modalControlsProps}>
-            {confirmLabel && (
-              <Button
-                testId={confirmTestId}
-                disabled={isConfirmDisabled}
-                loading={isConfirmLoading}
-                buttonType={intent}
-                onClick={() => onConfirm()}
-              >
-                {confirmLabel}
-              </Button>
-            )}
-            {secondaryLabel && (
-              <Button
-                testId={secondaryTestId}
-                disabled={isSecondaryDisabled}
-                loading={isSecondaryLoading}
-                buttonType={secondaryIntent}
-                onClick={() => onSecondary && onSecondary()}
-              >
-                {secondaryLabel}
-              </Button>
-            )}
-            {cancelLabel && (
-              <Button
-                testId={cancelTestId}
-                buttonType="muted"
-                onClick={() => onCancel()}
-              >
-                {cancelLabel}
-              </Button>
-            )}
-          </Modal.Controls>
+          <Modal.Controls {...modalControlsProps}>{buttons}</Modal.Controls>
         </div>
       )}
     </Modal>

--- a/packages/forma-36-react-components/src/components/Modal/ModalContent/ModalContent.css
+++ b/packages/forma-36-react-components/src/components/Modal/ModalContent/ModalContent.css
@@ -1,9 +1,10 @@
 @import 'settings/colors';
 @import 'settings/typography';
+@import 'settings/dimensions';
 @import 'settings/transitions';
 
 .ModalContent {
-  padding: calc(1rem * (30 / var(--font-base-default)));
+  padding: var(--spacing-m) var(--spacing-l) var(--spacing-l) var(--spacing-l);
   color: var(--color-text-mid);
   font-size: var(--font-size-m);
   font-family: var(--font-stack-primary);

--- a/packages/forma-36-react-components/src/components/Modal/ModalControls/ModalControls.css
+++ b/packages/forma-36-react-components/src/components/Modal/ModalControls/ModalControls.css
@@ -15,7 +15,7 @@
 
 .ModalControls.ModalControls--right button {
   margin-right: 0;
-  margin-left: var(--spacing-m);
+  margin-left: var(--spacing-xs);
 
   &:first-child {
     margin-left: 0;
@@ -23,7 +23,7 @@
 }
 
 .ModalControls button {
-  margin-right: var(--spacing-m);
+  margin-right: var(--spacing-xs);
 
   &:last-child {
     margin-right: 0;

--- a/packages/forma-36-react-components/src/components/Modal/ModalControls/ModalControls.css
+++ b/packages/forma-36-react-components/src/components/Modal/ModalControls/ModalControls.css
@@ -1,10 +1,31 @@
 @import 'settings/typography';
+@import 'settings/dimensions';
 
 .ModalControls {
-  padding: calc(1rem * (30 / var(--font-base-default)));
-  padding-top: 0;
+  width: calc(100% - 2 * var(--spacing-l));
+  display: flex;
+  flex-direction: row;
+  padding: 0 var(--spacing-l) var(--spacing-l) var(--spacing-l);
+  margin-top: calc(-1 * var(--spacing-xs));
+}
+
+.ModalControls--right {
+  justify-content: flex-end;
+}
+
+.ModalControls.ModalControls--right button {
+  margin-right: 0;
+  margin-left: var(--spacing-m);
+
+  &:first-child {
+    margin-left: 0;
+  }
 }
 
 .ModalControls button {
-  margin-right: 1rem;
+  margin-right: var(--spacing-m);
+
+  &:last-child {
+    margin-right: 0;
+  }
 }

--- a/packages/forma-36-react-components/src/components/Modal/ModalControls/ModalControls.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalControls/ModalControls.tsx
@@ -8,10 +8,12 @@ export interface ModalControlsProps {
   className?: string;
   children: React.ReactNode;
   style?: React.CSSProperties;
+  position?: 'left' | 'right';
 }
 
 export function ModalControls({
   testId = 'cf-ui-modal-controls',
+  position = 'left',
   className,
   children,
   ...rest
@@ -19,7 +21,13 @@ export function ModalControls({
   return (
     <div
       {...rest}
-      className={cn(styles.ModalControls, className)}
+      className={cn(
+        styles.ModalControls,
+        {
+          [styles['ModalControls--right']]: position === 'right',
+        },
+        className,
+      )}
       data-test-id={testId}
     >
       {children}

--- a/packages/forma-36-react-components/src/components/Modal/ModalHeader/ModalHeader.css
+++ b/packages/forma-36-react-components/src/components/Modal/ModalHeader/ModalHeader.css
@@ -8,8 +8,7 @@
   display: flex;
   flex-shrink: 0;
   align-items: center;
-  /* prettier-ignore */
-  padding: var(--spacing-m) var(--spacing-m) var(--spacing-m)  var(--spacing-l);
+  padding: var(--spacing-m) var(--spacing-m) var(--spacing-m) var(--spacing-l);
   border-radius: var(--border-radius-medium) var(--border-radius-medium) 0 0;
   border-bottom: 1px solid var(--color-element-mid);
 }

--- a/packages/forma-36-react-components/src/components/Modal/ModalHeader/ModalHeader.css
+++ b/packages/forma-36-react-components/src/components/Modal/ModalHeader/ModalHeader.css
@@ -1,4 +1,5 @@
 @import 'settings/colors';
+@import 'settings/dimensions';
 @import 'settings/typography';
 @import 'settings/transitions';
 @import 'settings/borders';
@@ -8,17 +9,16 @@
   flex-shrink: 0;
   align-items: center;
   /* prettier-ignore */
-  padding: calc(1rem * (23 / var(--font-base-default))) calc(1rem * (30 / var(--font-base-default)));
-  background-color: var(--color-element-lightest);
+  padding: var(--spacing-m) var(--spacing-m) var(--spacing-m)  var(--spacing-l);
   border-radius: var(--border-radius-medium) var(--border-radius-medium) 0 0;
-  border-bottom: 1px solid var(--color-element-dark);
+  border-bottom: 1px solid var(--color-element-mid);
 }
 
 .ModalHeader__title {
   flex-grow: 1;
   margin: 0;
   color: var(--color-text-dark);
-  font-weight: var(--font-weight-demi-bold);
+  font-weight: var(--font-weight-medium);
   font-family: var(--font-stack-primary);
   font-size: 1rem;
   line-height: var(--line-height-default);

--- a/packages/forma-36-react-components/src/components/Modal/ModalHeader/ModalHeader.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalHeader/ModalHeader.tsx
@@ -34,7 +34,7 @@ export function ModalHeader({
       <h1 className={titleClassNames}>{title}</h1>
       {onClose && (
         <IconButton
-          iconProps={{ icon: 'Close' }}
+          iconProps={{ icon: 'Close', size: 'small' }}
           buttonType="muted"
           label="Close"
           onClick={() => onClose()}

--- a/packages/forma-36-react-components/src/components/Typography/Typography/Typography.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Typography/Typography/Typography.stories.tsx
@@ -9,6 +9,7 @@ import Subheading from './../Subheading';
 import SectionHeading from '../SectionHeading';
 import Paragraph from './../Paragraph';
 import Flex from '../../Flex/Flex';
+import '@contentful/forma-36-fcss/dist/styles.css';
 
 storiesOf('Components/Typography/Typography', module)
   .addParameters({

--- a/scripts/.storybook/main.js
+++ b/scripts/.storybook/main.js
@@ -46,10 +46,24 @@ module.exports = {
       ],
     });
 
+    config.module.rules.push({
+      test: /forma-36-fcss\/dist\/styles.css$/,
+      loaders: [
+        'style-loader',
+        'css-loader',
+        {
+          loader: 'postcss-loader',
+          options: {
+            postcssOptions,
+          },
+        },
+      ],
+    });
+
     // CSS Modules
     config.module.rules.push({
       test: /\.css$/,
-      exclude: [/node_modules/, /\.global\.css$/],
+      exclude: [/node_modules/, /\.global\.css$/, /forma-36-fcss/],
       loaders: [
         'style-loader',
         {


### PR DESCRIPTION

# Purpose of PR

Implements all v3 changes for Modal and ModalConfirm

* New paddings
* Change ModalHeader background
* By default, all buttons in ModalConfirm have `small` size
* Added optional ability to align button on the right side
   * The aligning on the right side will be a default behavior in V4

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
