### PR TITLE
feat(table): visual changes

### DIFF
--- a/packages/forma-36-react-components/src/components/Skeleton/SkeletonRow/__snapshots__/SkeletonRow.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Skeleton/SkeletonRow/__snapshots__/SkeletonRow.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`renders the component 1`] = `
 <table
   cellpadding="0"
   cellspacing="0"
-  class="Table"
+  class="Table Table--inline"
   data-test-id="cf-ui-table"
 >
   <tbody
@@ -448,7 +448,7 @@ exports[`renders the component with 10 cells 1`] = `
 <table
   cellpadding="0"
   cellspacing="0"
-  class="Table"
+  class="Table Table--inline"
   data-test-id="cf-ui-table"
 >
   <tbody
@@ -1317,7 +1317,7 @@ exports[`renders the component with 10 rows 1`] = `
 <table
   cellpadding="0"
   cellspacing="0"
-  class="Table"
+  class="Table Table--inline"
   data-test-id="cf-ui-table"
 >
   <tbody

--- a/packages/forma-36-react-components/src/components/Table/Table.css
+++ b/packages/forma-36-react-components/src/components/Table/Table.css
@@ -1,6 +1,19 @@
 @import 'settings/colors';
+@import 'settings/borders';
 
 .Table {
   width: 100%;
-  border: 1px solid var(--color-element-light);
+}
+
+.Table--inline {
+  border-radius: var(--border-radius-medium);
+  box-shadow: 0 0 0 1px var(--color-element-light);
+}
+
+.Table--inline th:first-child {
+  border-top-left-radius: var(--border-radius-medium);
+}
+
+.Table--inline th:last-child {
+  border-top-right-radius: var(--border-radius-medium);
 }

--- a/packages/forma-36-react-components/src/components/Table/Table.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Table/Table.stories.tsx
@@ -1,23 +1,42 @@
 import React, { useState } from 'react';
-import { storiesOf } from '@storybook/react';
-import { boolean, text, number, button } from '@storybook/addon-knobs';
+import { button } from '@storybook/addon-knobs';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 
-import notes from './Table.md';
 import Table from './Table';
 import TableHead from './TableHead';
 import TableBody from './TableBody';
 import TableCell from './TableCell';
 import TableRow from './TableRow';
 import SkeletonRow from '../Skeleton/SkeletonRow';
+import notes from './Table.md';
+import Flex from '../Flex/Flex';
+import SectionHeading from '../Typography/SectionHeading';
 
-function DefaultStory() {
+export default {
+  argTypes: {
+    className: { control: { disable: true } },
+    testId: { control: { disable: true } },
+  },
+  component: Table,
+  parameters: {
+    propTypes: [
+      Table['__docgenInfo'],
+      TableHead['__docgenInfo'],
+      TableBody['__docgenInfo'],
+      TableCell['__docgenInfo'],
+      TableRow['__docgenInfo'],
+    ],
+    notes,
+  },
+  subcomponents: { TableHead, TableBody, TableCell, TableRow },
+  title: 'Components/Table',
+} as Meta;
+
+export const Default: Story = (args) => {
   return (
     <div style={{ width: '800px' }}>
-      <Table>
-        <TableHead
-          isSticky={boolean('isSticky', false)}
-          offsetTop={text('offsetTop', '0px')}
-        >
+      <Table {...args}>
+        <TableHead>
           <TableRow>
             <TableCell>Name</TableCell>
             <TableCell>Email</TableCell>
@@ -42,12 +61,15 @@ function DefaultStory() {
       </Table>
     </div>
   );
-}
+};
 
-function WithLoadingStateStory() {
+export const WithLoadingState: Story = () => {
   const [isLoading, setIsLoading] = useState(true);
 
-  button('toggle isLoading', () => setIsLoading(!isLoading));
+  button('toggle isLoading', () => {
+    setIsLoading((state) => !state);
+    return false;
+  });
 
   return (
     <div style={{ width: '800px' }}>
@@ -62,10 +84,7 @@ function WithLoadingStateStory() {
         </TableHead>
         <TableBody>
           {isLoading ? (
-            <SkeletonRow
-              rowCount={number('loadingRowCount', 4)}
-              columnCount={number('loadingColumnCount', 4)}
-            />
+            <SkeletonRow rowCount={4} columnCount={4} />
           ) : (
             <>
               <TableRow>
@@ -86,19 +105,70 @@ function WithLoadingStateStory() {
       </Table>
     </div>
   );
-}
+};
 
-storiesOf('Components/Table', module)
-  .addParameters({
-    propTypes: [
-      Table['__docgenInfo'],
-      TableHead['__docgenInfo'],
-      TableBody['__docgenInfo'],
-      TableCell['__docgenInfo'],
-      TableRow['__docgenInfo'],
-    ],
-    component: Table,
-    subcomponents: { TableHead, TableBody, TableCell, TableRow },
-  })
-  .add('default', () => <DefaultStory />, { notes })
-  .add('with loading state', () => <WithLoadingStateStory />, { notes });
+export const Overview = () => (
+  <>
+    <Flex flexDirection="column" marginBottom="spacingL">
+      <Flex marginBottom="spacingS">
+        <SectionHeading element="h3">Inline Table</SectionHeading>
+      </Flex>
+
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Email</TableCell>
+            <TableCell>Organization role</TableCell>
+            <TableCell>Last activity</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell>Jane Roe</TableCell>
+            <TableCell>jane@roe.com</TableCell>
+            <TableCell>CEO</TableCell>
+            <TableCell>August 29, 2018</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>John Doe</TableCell>
+            <TableCell>john@doe.com</TableCell>
+            <TableCell>CTO</TableCell>
+            <TableCell>July 27, 2019</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </Flex>
+
+    <Flex flexDirection="column" marginBottom="spacingL">
+      <Flex marginBottom="spacingS">
+        <SectionHeading element="h3">Embedded Table</SectionHeading>
+      </Flex>
+
+      <Table layout="embedded">
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Email</TableCell>
+            <TableCell>Organization role</TableCell>
+            <TableCell>Last activity</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell>Jane Roe</TableCell>
+            <TableCell>jane@roe.com</TableCell>
+            <TableCell>CEO</TableCell>
+            <TableCell>August 29, 2018</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>John Doe</TableCell>
+            <TableCell>john@doe.com</TableCell>
+            <TableCell>CTO</TableCell>
+            <TableCell>July 27, 2019</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </Flex>
+  </>
+);

--- a/packages/forma-36-react-components/src/components/Table/Table.tsx
+++ b/packages/forma-36-react-components/src/components/Table/Table.tsx
@@ -7,18 +7,22 @@ import styles from './Table.css';
 export interface TableProps extends HTMLProps<HTMLTableElement> {
   testId?: string;
   className?: string;
-  children: React.ReactNode;
+  children: React.ReactNode | React.ReactElement | React.ReactElement[];
+  layout?: 'inline' | 'embedded';
 }
 
 export const Table = ({
   className,
   children,
+  layout = 'inline',
   testId = 'cf-ui-table',
   ...otherProps
 }: TableProps) => {
   return (
     <table
-      className={cn(className, styles['Table'])}
+      className={cn(className, styles['Table'], {
+        [styles['Table--inline']]: layout === 'inline',
+      })}
       cellPadding="0"
       cellSpacing="0"
       data-test-id={testId}

--- a/packages/forma-36-react-components/src/components/Table/TableCell/TableCell/TableCell.css
+++ b/packages/forma-36-react-components/src/components/Table/TableCell/TableCell/TableCell.css
@@ -1,13 +1,6 @@
 @import 'settings/colors';
+@import 'settings/dimensions';
 @import 'settings/typography';
-
-:root {
-  --table-cell-padding-vertical: calc(1rem * (15 / var(--font-base-default)));
-  --table-cell-padding-vertical-compact: calc(
-    1rem * (10 / var(--font-base-default))
-  );
-  --table-cell-padding-horizontal: calc(1rem * (20 / var(--font-base-default)));
-}
 
 .TableCell {
   border-bottom: 1px solid var(--color-element-light);
@@ -16,8 +9,7 @@
   font-family: var(--font-stack-primary);
   font-weight: var(--font-weight-normal);
   line-height: 1.5;
-  padding: var(--table-cell-padding-vertical)
-    var(--table-cell-padding-horizontal);
+  padding: var(--spacing-s) var(--spacing-m);
   vertical-align: top;
 }
 
@@ -26,14 +18,11 @@ tbody tr:last-child .TableCell {
 }
 
 .TableCell--head {
-  color: var(--color-text-light);
   background-color: var(--color-element-lightest);
-  padding: var(--table-cell-padding-vertical-compact)
-    var(--table-cell-padding-horizontal);
+  font-size: var(--font-size-s);
+  font-weight: var(--font-weight-medium);
 }
 
 .TableCell--head__sorting {
-  padding: 0;
-  font-weight: var(--font-weight-demi-bold);
-  color: var(--color-text-light);
+  color: var(--color-text-dark);
 }

--- a/packages/forma-36-react-components/src/components/Table/TableCell/TableSortingLabel/TableSortingLabel.css
+++ b/packages/forma-36-react-components/src/components/Table/TableCell/TableSortingLabel/TableSortingLabel.css
@@ -12,7 +12,6 @@
   display: flex;
   font-weight: inherit;
   font-size: inherit;
-  padding: 0;
   text-align: inherit;
   width: 100%;
 
@@ -26,8 +25,7 @@
 }
 
 .TableSortingLabel__button__text {
-  padding: var(--table-cell-padding-vertical-compact)
-    var(--table-cell-padding-horizontal);
+  padding: var(--spacing-s) var(--spacing-m);
   align-items: center;
   width: 100%;
 }

--- a/packages/forma-36-react-components/src/components/Table/TableRow/TableRow.css
+++ b/packages/forma-36-react-components/src/components/Table/TableRow/TableRow.css
@@ -1,5 +1,6 @@
 @import 'settings/colors';
 
-.TableRow:hover {
-  background-color: var(--color-element-lightest);
+tbody .TableRow:hover {
+  background-color: var(--color-blue-lightest);
+  box-shadow: inset -2px 0 0 var(--color-blue-mid);
 }


### PR DESCRIPTION
# Purpose of PR

V3 visual changes.

A thing to note, Webkit (Safari) doesn't support `box-shadow` on `tr` elements, which is used to show the blue line at the end of the row. I tried with an absolutely positioned pseudo element instead but `position: relative` on table elements is actually against the CSS spec, so this doesn't work at all. I think we can drop the behaviour in Safari and hope they choose to implement `box-shadow` at some point.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
