### PR TITLE
V3: fix center icon and label in full width button

### DIFF
--- a/packages/forma-36-react-components/src/components/Button/Button.css
+++ b/packages/forma-36-react-components/src/components/Button/Button.css
@@ -235,12 +235,10 @@
 .Button--is-dropdown {
   & .Button__inner-wrapper {
     padding-right: calc(1rem * (8 / var(--font-base-default)));
-    justify-content: space-between;
   }
 }
 
 .Button__label {
-  width: 100%;
   margin: 0 calc(1rem * (4 / var(--font-base-default)));
   font-size: calc(1rem * (14 / var(--font-base-default)));
   color: var(--color-contrast-mid);


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

When I worked on the full-width button fix, @fabe told me the label and icons should be aligned like this:

![Screenshot 2021-01-13 at 15 45 51](https://user-images.githubusercontent.com/6597467/104467921-2569d100-55b7-11eb-9e14-7d5ea912aabf.png)

I made the change but I forgot to push it 🤦 


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
