### PR TITLE
fix(tabs): 100% height

### DIFF
--- a/packages/forma-36-react-components/src/components/Tabs/Tabs.css
+++ b/packages/forma-36-react-components/src/components/Tabs/Tabs.css
@@ -13,10 +13,11 @@
   align-items: center;
   color: var(--color-text-lightest);
   display: flex;
+  height: 100%;
+  min-height: 56px; /* @todo: change to var(--spacing-2xl) */
   position: relative;
   cursor: pointer;
   padding: 0 var(--spacing-m);
-  height: var(--spacing-2xl);
   font-size: var(--font-size-m);
   font-family: var(--font-stack-primary);
   font-weight: var(--font-weight-medium);


### PR DESCRIPTION
I'd rather fix this in consumer apps but this is a faster fix if we need it.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
