### PR TITLE
docs(website homepage): change UI Kit link from Sketech to Figma

### DIFF
--- a/packages/forma-36-website/src/pages/index.mdx
+++ b/packages/forma-36-website/src/pages/index.mdx
@@ -34,11 +34,11 @@ import Resource from './../components/Home/Resource';
   </Paragraph>
   <Resources>
     <Resource
-      title="Create prototypes faster"
-      description="Get started creating UI design using the Forma 36 UI kit"
-      linkText="Get UI kit"
-      linkHref="https://sketch.cloud/s/dDdL3"
-      imageNode={<img src={uiKitImg} alt="Illustration for Sketch UI kit" />}
+      title="Prototype in Figma with Forma 36 components"
+      description="Open the F36 UI Kit in Figma and create a duplicate. Publish it as a Team library and start prototyping."
+      linkText="View the F36 UI Kit on Figma"
+      linkHref="https://www.figma.com/file/xkNH4KddWvI5Zrkbi6CYZJ/F36-UI-Kit?node-id=0%3A601"
+      imageNode={<img src={uiKitImg} alt="Illustration for Forma 36 UI Kit" />}
     />
     <Resource
       title="Get started with our React components"


### PR DESCRIPTION
# Purpose of PR

- Changed the link on the homepage to the active Figma file instead of the missing Sketch file

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
