### PR TITLE
fix: bugfix for Tag 

### DIFF
--- a/packages/forma-36-react-components/src/components/Tag/Tag.css
+++ b/packages/forma-36-react-components/src/components/Tag/Tag.css
@@ -10,6 +10,7 @@
   font-weight: var(--font-weight-medium);
   font-size: calc(1rem * (12 / var(--font-base-default)));
   line-height: 20px;
+  max-height: 20px;
   text-transform: uppercase;
   letter-spacing: 0.06rem; /*move to tokens or update wide letter spacing token*/
   padding: 0 var(--spacing-xs);


### PR DESCRIPTION
Small fix to make sure that Tag component would not scale it's height:

<img width="159" alt="Screenshot 2021-01-14 at 10 30 00" src="https://user-images.githubusercontent.com/4272331/104571699-aecee100-5653-11eb-91e1-0fc6a838b6bd.png">

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
