### PR TITLE
fix: loading Spinner position in button

### DIFF
--- a/packages/forma-36-react-components/src/components/Button/Button.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.tsx
@@ -108,6 +108,7 @@ export const Button = ({
             color={iconColor}
           />
         )}
+        {children && <span className={styles.Button__label}>{children}</span>}
         <CSSTransition
           in={loading}
           timeout={1000}
@@ -132,7 +133,6 @@ export const Button = ({
             }
           />
         </CSSTransition>
-        {children && <span className={styles.Button__label}>{children}</span>}
         {indicateDropdown && (
           <Icon
             className={styles['Button__dropdown-icon']}

--- a/packages/forma-36-react-components/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -145,6 +145,11 @@ exports[`renders the component in loading state 1`] = `
     class="TabFocusTrap Button__inner-wrapper"
     tabindex="-1"
   >
+    <span
+      class="Button__label"
+    >
+      Embed entry
+    </span>
     <svg
       class="Spinner Button__spinner Spinner--default Spinner--white"
       data-test-id="cf-ui-spinner"
@@ -198,11 +203,6 @@ exports[`renders the component in loading state 1`] = `
         </g>
       </g>
     </svg>
-    <span
-      class="Button__label"
-    >
-      Embed entry
-    </span>
   </span>
 </button>
 `;


### PR DESCRIPTION
Hey!

Just a small fix of the loading position in the button.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
