### PR TITLE
fix: Form elements placeholder improvements

### DIFF
--- a/packages/forma-36-react-components/src/components/Select/Select.css
+++ b/packages/forma-36-react-components/src/components/Select/Select.css
@@ -16,7 +16,7 @@
   padding: calc(1rem * (10 / var(--font-base-default)));
   padding-right: calc(1rem * (39 / var(--font-base-default)));
   background-color: var(--color-white);
-  color: var(--color-text-mid);
+  color: var(--color-text-dark);
   font-size: var(--font-size-m);
   font-family: var(--font-stack-primary);
   border: 1px solid var(--color-element-mid);

--- a/packages/forma-36-react-components/src/components/TextField/TextField.stories.tsx
+++ b/packages/forma-36-react-components/src/components/TextField/TextField.stories.tsx
@@ -39,7 +39,7 @@ Basic.args = {
 };
 
 export const WithTextarea = (args: TextFieldProps) => (
-  <TextField className={text('className', '')} textarea {...args} />
+  <TextField textarea {...args} />
 );
 
 WithTextarea.args = {

--- a/packages/forma-36-react-components/src/components/TextField/TextField.stories.tsx
+++ b/packages/forma-36-react-components/src/components/TextField/TextField.stories.tsx
@@ -1,7 +1,4 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { text, boolean, select, number } from '@storybook/addon-knobs';
-import { action } from '@storybook/addon-actions';
 
 import TextField, { TextFieldProps } from './TextField';
 import SectionHeading from '../Typography/SectionHeading';
@@ -102,8 +99,6 @@ export const Overview = (args: TextFieldProps) => (
         textInputProps={{
           disabled: true,
         }}
-        helpText={text('helpText', '')}
-        validationMessage={text('validationMessage', '')}
       />
     </Flex>
   </>

--- a/packages/forma-36-react-components/src/components/TextField/TextField.stories.tsx
+++ b/packages/forma-36-react-components/src/components/TextField/TextField.stories.tsx
@@ -3,282 +3,112 @@ import { storiesOf } from '@storybook/react';
 import { text, boolean, select, number } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
-import TextField from './TextField';
+import TextField, { TextFieldProps } from './TextField';
 import SectionHeading from '../Typography/SectionHeading';
 import Flex from '../Flex/Flex';
 
-storiesOf('Components/TextField', module)
-  .addParameters({
-    propTypes: TextField['__docgenInfo'],
-    component: TextField,
-  })
-  .add('default', () => (
-    <TextField
-      className={text('className', '')}
-      required={boolean('required', false)}
-      formLabelProps={{
-        requiredText: text('requiredText', undefined),
-      }}
-      name="emailInput"
-      id="emailInput"
-      labelText={text('labelText', 'Label')}
-      value={text('value', '123456')}
-      width={select(
-        'width',
-        {
-          'Full (default)': 'full',
-          large: 'large',
-          medium: 'medium',
-          small: 'small',
-        },
-        'full',
-      )}
-      onBlur={action('onBlur')}
-      onChange={action('onChange')}
-      textInputProps={{
-        withCopyButton: boolean('withCopyButton', false),
-        disabled: boolean('disabled', false),
-        placeholder: text('placeholder', 'Placeholder text'),
-        maxLength: number('maxLength', 50),
-        type: select(
-          'type',
-          {
-            'Text (default)': 'text',
-            password: 'password',
-            email: 'email',
-            number: 'number',
-            url: 'url',
-            search: 'search',
-          },
-          'text',
-        ),
-      }}
-      helpText={text('helpText', '')}
-      validationMessage={text('validationMessage', '')}
-    />
-  ))
-  .add('with Textarea', () => (
-    <TextField
-      className={text('className', '')}
-      textarea
-      required={boolean('required', false)}
-      formLabelProps={{
-        requiredText: text('requiredText', undefined),
-      }}
-      name="emailInput"
-      id="emailInput"
-      labelText={text('labelText', 'Label')}
-      value={text('value', '123456')}
-      width={select(
-        'width',
-        {
-          'Full (default)': 'full',
-          large: 'large',
-          medium: 'medium',
-          small: 'small',
-        },
-        'full',
-      )}
-      onBlur={action('onBlur')}
-      onChange={action('onChange')}
-      textInputProps={{
-        disabled: boolean('disabled', false),
-        placeholder: text('placeholder', 'Placeholder text'),
-        maxLength: number('maxLength', 50),
-        rows: number('rows', 2),
-        type: select(
-          'type',
-          {
-            'Text (default)': 'text',
-            password: 'password',
-            email: 'email',
-            number: 'number',
-            url: 'url',
-            search: 'search',
-          },
-          'text',
-        ),
-      }}
-      helpText={text('helpText', '')}
-      validationMessage={text('validationMessage', '')}
-    />
-  ))
-  .add('with TextLink', () => (
-    <TextField
-      className={text('className', '')}
-      textarea
-      required={boolean('required', false)}
-      formLabelProps={{
-        requiredText: text('requiredText', undefined),
-      }}
-      labelText={text('labelText', 'Label')}
-      textLinkProps={{
-        icon: text('icon', 'Lock'),
-        text: text('text', 'Unlock to edit'),
-        onClick: action('onClick'),
-      }}
-      name="emailInput"
-      id="emailInput"
-      value={text('Value', '123456')}
-      width={select(
-        'width',
-        {
-          'Full (default)': 'full',
-          large: 'large',
-          medium: 'medium',
-          small: 'small',
-        },
-        'full',
-      )}
-      onBlur={action('onBlur')}
-      onChange={action('onChange')}
-      textInputProps={{
-        disabled: boolean('disabled', false),
-        placeholder: text('placeholder', 'Placeholder text'),
-        maxLength: number('maxLength', 50),
-        rows: number('rows', 2),
-        type: select(
-          'type',
-          {
-            'Text (default)': 'text',
-            password: 'password',
-            email: 'email',
-            number: 'number',
-            url: 'url',
-            search: 'search',
-          },
-          'text',
-        ),
-      }}
-      helpText={text('helpText', '')}
-      validationMessage={text('validationMessage', '')}
-    />
-  ))
-  .add('with Character count', () => (
-    <TextField
-      countCharacters={boolean('countCharacters', true)}
-      className={text('className', '')}
-      required={boolean('required', false)}
-      formLabelProps={{
-        requiredText: text('requiredText', undefined),
-      }}
-      labelText={text('labelText', 'Label')}
-      name="emailInput"
-      id="emailInput"
-      value={text('value', '123456')}
-      width={select(
-        'width',
-        {
-          'Full (default)': 'full',
-          large: 'large',
-          medium: 'medium',
-          small: 'small',
-        },
-        'full',
-      )}
-      onBlur={action('onBlur')}
-      onChange={action('onChange')}
-      textInputProps={{
-        disabled: boolean('disabled', false),
-        placeholder: text('placeholder', 'Placeholder text'),
-        maxLength: number('maxLength', 20),
-        rows: number('rows', 2),
-        type: select(
-          'type',
-          {
-            'Text (default)': 'text',
-            password: 'password',
-            email: 'email',
-            number: 'number',
-            url: 'url',
-            search: 'search',
-          },
-          'text',
-        ),
-      }}
-      helpText={text('helpText', '')}
-      validationMessage={text('validationMessage', '')}
-    />
-  ))
-  .add('overview', () => (
-    <>
-      <Flex marginBottom="spacingS">
-        <SectionHeading element="h3">
-          Textarea field default with countCharacters
-        </SectionHeading>
-      </Flex>
-      <Flex marginBottom="spacingS">
-        <TextField
-          countCharacters
-          labelText="Label"
-          name="emailInput"
-          id="emailInput"
-          value="123456"
-          textInputProps={{
-            placeholder: 'Placeholder text',
-            maxLength: 20,
-            rows: 2,
-            type: 'text',
-          }}
-        />
-      </Flex>
-      <Flex marginBottom="spacingS">
-        <SectionHeading element="h3">
-          Textarea field default with help text
-        </SectionHeading>
-      </Flex>
-      <Flex marginBottom="spacingS">
-        <TextField
-          labelText="Label"
-          name="emailInput"
-          id="emailInput"
-          value="123456"
-          textInputProps={{
-            placeholder: 'Placeholder text',
-            maxLength: 20,
-            rows: 2,
-            type: 'text',
-          }}
-          helpText="help text"
-        />
-      </Flex>
-      <Flex marginBottom="spacingS">
-        <SectionHeading element="h3">Textarea field error</SectionHeading>
-      </Flex>
-      <Flex marginBottom="spacingS">
-        <TextField
-          labelText="Label"
-          name="emailInput"
-          id="emailInput"
-          value="123456"
-          textInputProps={{
-            placeholder: 'Placeholder text',
-            maxLength: 20,
-            rows: 2,
-            type: 'text',
-          }}
-          validationMessage="validationMessage"
-        />
-      </Flex>
-      <Flex marginBottom="spacingS">
-        <SectionHeading element="h3">Textarea field disabled</SectionHeading>
-      </Flex>
-      <Flex marginBottom="spacingS">
-        <TextField
-          labelText="Label"
-          name="emailInput"
-          id="emailInput"
-          value="123456"
-          textInputProps={{
-            disabled: true,
-            placeholder: 'Placeholder text',
-            maxLength: 20,
-            rows: 2,
-            type: 'text',
-          }}
-          helpText={text('helpText', '')}
-          validationMessage={text('validationMessage', '')}
-        />
-      </Flex>
-    </>
-  ));
+export default {
+  title: 'Components/TextField',
+  component: TextField,
+  parameters: {
+    propTypes: [TextField['__docgenInfo']],
+  },
+  argTypes: {
+    className: { control: { disable: true } },
+    testId: { control: { disable: true } },
+    isReadOnly: { control: { disable: true } },
+    onChange: { control: { disable: true } },
+    onBlur: { control: { disable: true } },
+    onCopy: { control: { disable: true } },
+    onFocus: { control: { disable: true } },
+    onKeyPress: { control: { disable: true } },
+    textLinkProps: { control: { disable: true } },
+  },
+};
+
+export const Basic = (args: TextFieldProps) => (
+  <TextField name="emailInput" id="emailInput" {...args} />
+);
+
+Basic.args = {
+  width: 'full',
+  maxLength: 50,
+  labelText: 'Label text',
+  textInputProps: {
+    placeholder: 'Placeholder text',
+    maxLength: 50,
+    type: 'text',
+  },
+};
+
+export const WithTextarea = (args: TextFieldProps) => (
+  <TextField className={text('className', '')} textarea {...args} />
+);
+
+WithTextarea.args = {
+  ...Basic.args,
+};
+
+export const WithTextLink = (args: TextFieldProps) => (
+  <TextField textarea {...args} />
+);
+
+WithTextLink.args = {
+  textLinkProps: {
+    icon: 'Lock',
+    text: 'Unlock to edit',
+  },
+  ...Basic.args,
+};
+
+export const Overview = (args: TextFieldProps) => (
+  <>
+    <Flex marginBottom="spacingS">
+      <SectionHeading element="h3">
+        Textarea field default with countCharacters
+      </SectionHeading>
+    </Flex>
+    <Flex marginBottom="spacingS">
+      <TextField countCharacters {...args} />
+    </Flex>
+    <Flex marginBottom="spacingS">
+      <SectionHeading element="h3">
+        Textarea field default with value
+      </SectionHeading>
+    </Flex>
+    <Flex marginBottom="spacingS">
+      <TextField value="Example value" {...args} />
+    </Flex>
+    <Flex marginBottom="spacingS">
+      <SectionHeading element="h3">
+        Textarea field default with help text
+      </SectionHeading>
+    </Flex>
+    <Flex marginBottom="spacingS">
+      <TextField {...args} helpText="help text" />
+    </Flex>
+    <Flex marginBottom="spacingS">
+      <SectionHeading element="h3">Textarea field error</SectionHeading>
+    </Flex>
+    <Flex marginBottom="spacingS">
+      <TextField {...args} validationMessage="validationMessage" />
+    </Flex>
+    <Flex marginBottom="spacingS">
+      <SectionHeading element="h3">Textarea field disabled</SectionHeading>
+    </Flex>
+    <Flex marginBottom="spacingS">
+      <TextField
+        {...args}
+        textInputProps={{
+          disabled: true,
+        }}
+        helpText={text('helpText', '')}
+        validationMessage={text('validationMessage', '')}
+      />
+    </Flex>
+  </>
+);
+
+Overview.args = {
+  ...Basic.args,
+};

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.css
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.css
@@ -18,7 +18,7 @@
   border: 1px solid var(--color-element-mid);
   border-radius: var(--border-radius-medium);
   max-height: calc(1rem * (40 / var(--font-base-default)));
-  color: var(--color-text-mid);
+  color: var(--color-text-dark);
   font-family: var(--font-stack-primary);
   font-size: var(--font-size-m);
   padding: calc(1rem * (10.5 / var(--font-base-default)));
@@ -27,8 +27,8 @@
 
   -webkit-appearance: textfield;
 
-  &::-webkit-input-placeholder {
-    color: var(--color-ice-dark);
+  &::placeholder {
+    color: var(--color-text-light);
   }
 
   &::-webkit-search-decoration,

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.css
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.css
@@ -28,7 +28,7 @@
   -webkit-appearance: textfield;
 
   &::placeholder {
-    color: var(--color-text-light);
+    color: var(--color-text-lightest);
   }
 
   &::-webkit-search-decoration,

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.stories.tsx
@@ -66,6 +66,20 @@ export const controlledTextInput = (args: TextInputProps) => (
 export const overview = () => (
   <>
     <Flex marginBottom="spacingS">
+      <SectionHeading element="h3">
+        Text input default with placeholder
+      </SectionHeading>
+    </Flex>
+    <Flex marginBottom="spacingS">
+      <TextInput
+        value=""
+        maxLength={50}
+        name="emailInput"
+        id="emailInput"
+        placeholder="Placeholder text"
+      />
+    </Flex>
+    <Flex marginBottom="spacingS">
       <SectionHeading element="h3">Text input default</SectionHeading>
     </Flex>
     <Flex marginBottom="spacingS">

--- a/packages/forma-36-react-components/src/components/Textarea/Textarea.css
+++ b/packages/forma-36-react-components/src/components/Textarea/Textarea.css
@@ -25,7 +25,7 @@
   flex-basis: 100%;
 
   &::placeholder {
-    color: var(--color-text-light);
+    color: var(--color-text-lightest);
   }
 
   &:active {

--- a/packages/forma-36-react-components/src/components/Textarea/Textarea.css
+++ b/packages/forma-36-react-components/src/components/Textarea/Textarea.css
@@ -17,15 +17,15 @@
   border: 1px solid var(--color-element-mid);
   border-radius: var(--border-radius-medium);
   min-height: calc(1rem * (40 / var(--font-base-default)));
-  color: var(--color-text-mid);
+  color: var(--color-text-dark);
   font-family: var(--font-stack-primary);
   font-size: var(--font-size-m);
   line-height: var(--line-height-default);
   padding: calc(1rem * (11 / var(--font-base-default)));
   flex-basis: 100%;
 
-  &::-webkit-input-placeholder {
-    color: var(--color-ice-dark);
+  &::placeholder {
+    color: var(--color-text-light);
   }
 
   &:active {

--- a/packages/forma-36-react-components/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Textarea/Textarea.stories.tsx
@@ -61,6 +61,17 @@ export const overview = () => (
       <SectionHeading element="h3">Textarea default</SectionHeading>
     </Flex>
     <Flex marginBottom="spacingS">
+      <Textarea
+        name="someInput"
+        id="someInput"
+        placeholder="Placeholder value"
+        rows={2}
+      />
+    </Flex>
+    <Flex marginBottom="spacingS">
+      <SectionHeading element="h3">Textarea default with value</SectionHeading>
+    </Flex>
+    <Flex marginBottom="spacingS">
       <Textarea name="someInput" id="someInput" value="123456" rows={2} />
     </Flex>
     <Flex marginBottom="spacingS">


### PR DESCRIPTION
Hey!

In order to make it work, I need to adjust the placeholder color, but also the input color itself. Changes introduced into all related form components - Input, Textarea, and select.

Additionally one refactor on the stories into the new format.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
