### PR TITLE
feat(tooltip): implement usePortal prop

### DIFF
--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
@@ -13,6 +13,7 @@ import type * as CSS from 'csstype';
 
 import styles from './Tooltip.css';
 import tokens from '@contentful/forma-36-tokens';
+import Portal from '../Portal';
 
 export type TooltipPlace = Placement;
 
@@ -74,6 +75,15 @@ export interface TooltipProps {
    * An ID used for testing purposes applied as a data attribute (data-test-id)
    */
   testId?: string;
+  /**
+   * Boolean to control whether or not to render the tooltip in a React Portal.
+   * Rendering content inside a Portal allows the tooltip to escape the bounds
+   * of its parent while still being positioned correctly. Using a Portal is
+   * necessary if an ancestor of the tooltip hides overflow.
+   *
+   * Defaults to `false`
+   */
+  usePortal?: boolean;
 }
 
 interface ArrowPositionState {
@@ -97,6 +107,7 @@ export const Tooltip = ({
   maxWidth = 360,
   testId = 'cf-ui-tooltip',
   place = 'auto',
+  usePortal = false,
   ...otherProps
 }: TooltipProps) => {
   const [show, setShow] = useState(false);
@@ -176,6 +187,34 @@ export const Tooltip = ({
 
   // const delay = !hideDelay ? (closeOnMouseLeave ? 0 : 300) : hideDelay;
 
+  const tooltip = (
+    <span
+      id={id}
+      ref={popperRef}
+      aria-hidden={show ? 'true' : 'false'}
+      role="tooltip"
+      style={contentStyles}
+      className={cn(styles.Tooltip, className, {
+        [styles['Tooltip--hidden']]: !show,
+      })}
+      data-test-id={testId}
+      onMouseEnter={() => {
+        setIsHoveringContent(true);
+      }}
+      onMouseLeave={() => {
+        setIsHoveringContent(false);
+      }}
+      {...attributes.popper}
+    >
+      {content}
+      <span
+        ref={setArrowRef}
+        style={arrowStyles}
+        className={styles.Tooltip__arrow}
+      />
+    </span>
+  );
+
   return (
     <>
       <ContainerElement
@@ -202,33 +241,7 @@ export const Tooltip = ({
         {children}
       </ContainerElement>
 
-      {show && (
-        <span
-          id={id}
-          ref={popperRef}
-          aria-hidden={show ? 'true' : 'false'}
-          role="tooltip"
-          style={contentStyles}
-          className={cn(styles.Tooltip, className, {
-            [styles['Tooltip--hidden']]: !show,
-          })}
-          data-test-id={testId}
-          onMouseEnter={() => {
-            setIsHoveringContent(true);
-          }}
-          onMouseLeave={() => {
-            setIsHoveringContent(false);
-          }}
-          {...attributes.popper}
-        >
-          {content}
-          <span
-            ref={setArrowRef}
-            style={arrowStyles}
-            className={styles.Tooltip__arrow}
-          />
-        </span>
-      )}
+      {show ? <>{usePortal ? <Portal>{tooltip}</Portal> : tooltip}</> : null}
     </>
   );
 };


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

Allow use of React portals wil Tooltip

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
