### PR TITLE
fix: fixed input color

### DIFF
--- a/packages/forma-36-react-components/src/components/Select/Select.css
+++ b/packages/forma-36-react-components/src/components/Select/Select.css
@@ -16,7 +16,7 @@
   padding: calc(1rem * (10 / var(--font-base-default)));
   padding-right: calc(1rem * (39 / var(--font-base-default)));
   background-color: var(--color-white);
-  color: var(--color-text-dark);
+  color: var(--color-text-mid);
   font-size: var(--font-size-m);
   font-family: var(--font-stack-primary);
   border: 1px solid var(--color-element-mid);

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.css
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.css
@@ -18,7 +18,7 @@
   border: 1px solid var(--color-element-mid);
   border-radius: var(--border-radius-medium);
   max-height: calc(1rem * (40 / var(--font-base-default)));
-  color: var(--color-text-dark);
+  color: var(--color-text-mid);
   font-family: var(--font-stack-primary);
   font-size: var(--font-size-m);
   padding: calc(1rem * (10.5 / var(--font-base-default)));

--- a/packages/forma-36-react-components/src/components/Textarea/Textarea.css
+++ b/packages/forma-36-react-components/src/components/Textarea/Textarea.css
@@ -17,7 +17,7 @@
   border: 1px solid var(--color-element-mid);
   border-radius: var(--border-radius-medium);
   min-height: calc(1rem * (40 / var(--font-base-default)));
-  color: var(--color-text-dark);
+  color: var(--color-text-mid);
   font-family: var(--font-stack-primary);
   font-size: var(--font-size-m);
   line-height: var(--line-height-default);


### PR DESCRIPTION
Hey!

Fix for input color. Not so black anymore 😉

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
