### PR TITLE
feat(tooltip): use Popper for arrow placement

### DIFF
--- a/packages/forma-36-react-components/.size-limit
+++ b/packages/forma-36-react-components/.size-limit
@@ -12,7 +12,7 @@
   {
     "path": "dist/styles.css",
     "name": "gzipped css",
-    "limit": "91 KB",
+    "limit": "92 KB",
     "gzip": false
   }
 ]

--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.css
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.css
@@ -1,4 +1,6 @@
+@import 'settings/borders';
 @import 'settings/colors';
+@import 'settings/dimensions';
 @import 'settings/typography';
 @import 'settings/transitions';
 @import 'settings/z-index';
@@ -15,16 +17,15 @@
 .Tooltip {
   background: var(--color-contrast-mid);
   font-family: var(--font-stack-primary);
-  font-size: calc(1rem * (12 / var(--font-base-default)));
+  font-size: var(--font-size-s);
   font-weight: var(--font-weight-medium);
   font-style: normal;
   text-decoration: none;
   color: var(--color-white);
   text-align: center;
   line-height: var(--line-height-default);
-  padding: calc(1rem * (8 / var(--font-base-default)))
-    calc(1rem * (10 / var(--font-base-default)));
-  border-radius: calc(1rem * (4 / var(--font-base-default)));
+  padding: var(--spacing-xs) calc(1rem * (10 / var(--font-base-default)));
+  border-radius: var(--border-radius-small);
   white-space: normal;
 }
 
@@ -35,8 +36,37 @@
 }
 
 .Tooltip__arrow {
+  position: absolute;
+}
+
+.Tooltip__arrow[data-placement*='top'] {
+  bottom: 0;
+  left: 0;
+  margin-bottom: calc(-1 * ((1rem * (10 / var(--font-base-default))) / 2));
+}
+
+.Tooltip__arrow[data-placement*='right'] {
+  left: 0;
+  margin-left: calc(-1 * ((1rem * (10 / var(--font-base-default))) / 2));
+}
+
+.Tooltip__arrow[data-placement*='bottom'] {
+  left: 0;
+  margin-top: calc(-1 * ((1rem * (10 / var(--font-base-default))) / 2));
+  top: 0;
+}
+
+.Tooltip__arrow[data-placement*='left'] {
+  margin-right: calc(-1 * ((1rem * (10 / var(--font-base-default))) / 2));
+  right: 0;
+}
+
+.Tooltip__arrow::before {
+  content: '';
+  display: block;
   height: var(--tooltip-chevron-size);
   width: var(--tooltip-chevron-size);
   background-color: var(--color-contrast-mid);
+  transform: rotate3d(0, 0, 1, 45deg);
   z-index: var(--z-index-negative);
 }

--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
@@ -86,11 +86,6 @@ export interface TooltipProps {
   usePortal?: boolean;
 }
 
-interface ArrowPositionState {
-  top: string;
-  left: string;
-}
-
 export const Tooltip = ({
   children,
   className,
@@ -111,9 +106,6 @@ export const Tooltip = ({
   ...otherProps
 }: TooltipProps) => {
   const [show, setShow] = useState(false);
-  const [arrowPosition, setArrowPosition] = useState<ArrowPositionState>(
-    getArrowPosition('bottom'),
-  );
 
   const elementRef = useRef(null);
   const popperRef = useRef(null);
@@ -124,7 +116,13 @@ export const Tooltip = ({
     {
       placement: place,
       modifiers: [
-        { name: 'arrow', options: { element: arrowRef } },
+        {
+          name: 'arrow',
+          options: {
+            element: arrowRef,
+            padding: parseFloat(tokens.borderRadiusSmall),
+          },
+        },
         {
           name: 'offset',
           options: {
@@ -142,15 +140,6 @@ export const Tooltip = ({
     }
   }, [content, forceUpdate]);
 
-  useEffect(() => {
-    if (attributes.popper) {
-      const newPosition = getArrowPosition(
-        attributes.popper['data-popper-placement'],
-      );
-      setArrowPosition(newPosition);
-    }
-  }, [attributes.popper]);
-
   const [isHoveringTarget, setIsHoveringTarget] = useState(false);
   const [isHoveringContent, setIsHoveringContent] = useState(false);
   useEffect(() => {
@@ -161,12 +150,6 @@ export const Tooltip = ({
     if (isVisible) setShow(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const arrowStyles = {
-    ...popperStyles.arrow,
-    ...arrowPosition,
-    transform: 'rotate(45deg)',
-  };
 
   const contentMaxWidth =
     typeof maxWidth === 'string' ? maxWidth : `${maxWidth}px`;
@@ -185,18 +168,13 @@ export const Tooltip = ({
     );
   }
 
-  // const delay = !hideDelay ? (closeOnMouseLeave ? 0 : 300) : hideDelay;
-
   const tooltip = (
     <span
       id={id}
       ref={popperRef}
-      aria-hidden={show ? 'true' : 'false'}
       role="tooltip"
       style={contentStyles}
-      className={cn(styles.Tooltip, className, {
-        [styles['Tooltip--hidden']]: !show,
-      })}
+      className={cn(styles.Tooltip, className)}
       data-test-id={testId}
       onMouseEnter={() => {
         setIsHoveringContent(true);
@@ -206,11 +184,14 @@ export const Tooltip = ({
       }}
       {...attributes.popper}
     >
-      {content}
+      <span>{content}</span>
       <span
+        className={styles['Tooltip__arrow']}
+        data-placement={
+          attributes.popper && attributes.popper['data-popper-placement']
+        }
         ref={setArrowRef}
-        style={arrowStyles}
-        className={styles.Tooltip__arrow}
+        style={popperStyles.arrow}
       />
     </span>
   );
@@ -245,41 +226,5 @@ export const Tooltip = ({
     </>
   );
 };
-
-function getArrowPosition(popperPlacement: string) {
-  const centered = 'calc(50% - 5px)';
-  const oppositeToThisSide = 'calc(100% - 5px)';
-  const atThisSide = '-5px';
-  const atStart = '10px';
-  const atEnd = 'calc(100% - 20px)';
-
-  // the arrow is 10x10, that's why we need the -5px to correct its center
-  switch (popperPlacement) {
-    case 'top':
-      return { top: oppositeToThisSide, left: centered }; // arrow will be V
-    case 'top-start':
-      return { top: oppositeToThisSide, left: atStart };
-    case 'top-end':
-      return { top: oppositeToThisSide, left: atEnd };
-    case 'right':
-      return { top: centered, left: atThisSide }; // arrow will be <
-    case 'right-start':
-      return { top: atStart, left: atThisSide };
-    case 'right-end':
-      return { top: atEnd, left: atThisSide };
-    case 'left':
-      return { top: centered, left: oppositeToThisSide }; // arrow will be >
-    case 'left-start':
-      return { top: atStart, left: oppositeToThisSide };
-    case 'left-end':
-      return { top: atEnd, left: oppositeToThisSide };
-    case 'bottom-start':
-      return { top: atThisSide, left: atStart }; // arrow will be ^
-    case 'bottom-end':
-      return { top: atThisSide, left: atEnd };
-    default:
-      return { top: atThisSide, left: centered };
-  }
-}
 
 export default Tooltip;


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Uses Popper to position the Tooltip arrow. Also uses some new tokens.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
