### PR TITLE
docs: new release info on the F36 website

### DIFF
--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -3,9 +3,11 @@ const path = require('path');
 module.exports = {
   siteMetadata: {
     title: 'Forma 36 - The Contentful Design System',
-    promoText: '',
-    promoLink: '',
-    promoLinkText: '',
+    promoText: 'Introducing a visual refresh to Forma 36 components',
+    promoLink:
+      'https://github.com/contentful/forma-36/releases/tag/%40contentful%2Fforma-36-react-components%403.75.0',
+    promoLinkText: 'Release notes',
+    promoTagText: 'New release',
     menuLinks: [
       {
         name: 'Foundation',

--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
   siteMetadata: {
     title: 'Forma 36 - The Contentful Design System',
-    promoText: 'Introducing a visual refresh to Forma 36 components',
+    promoText: 'Introducing a visual refresh to Forma 36 React components',
     promoLink:
       'https://github.com/contentful/forma-36/releases/tag/%40contentful%2Fforma-36-react-components%403.75.0',
     promoLinkText: 'Release notes',

--- a/packages/forma-36-website/package.json
+++ b/packages/forma-36-website/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "version": "0.11.5",
   "dependencies": {
-    "@contentful/forma-36-fcss": "^0.2.13",
-    "@contentful/forma-36-react-components": "^3.73.5",
-    "@contentful/forma-36-tokens": "^0.9.3",
+    "@contentful/forma-36-fcss": "^0.3.0",
+    "@contentful/forma-36-react-components": "^3.75.0",
+    "@contentful/forma-36-tokens": "^0.10.0",
     "@emotion/core": "^10.0.16",
     "@emotion/styled": "^10.0.15",
     "@mdx-js/mdx": "^1.6.18",

--- a/packages/forma-36-website/src/components/Footer.js
+++ b/packages/forma-36-website/src/components/Footer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TextLink } from '@contentful/forma-36-react-components';
-import { Flex } from '@contentful/forma-36-react-components';
+import { Flex } from '@contentful/forma-36-react-components/dist/alpha';
 import tokens from '@contentful/forma-36-tokens';
 import { css } from '@emotion/core';
 

--- a/packages/forma-36-website/src/components/Footer.js
+++ b/packages/forma-36-website/src/components/Footer.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { TextLink } from '@contentful/forma-36-react-components';
-import { Flex } from '@contentful/forma-36-react-components/dist/alpha';
+import { TextLink, Flex } from '@contentful/forma-36-react-components';
 import tokens from '@contentful/forma-36-tokens';
 import { css } from '@emotion/core';
 

--- a/packages/forma-36-website/src/components/Layout.js
+++ b/packages/forma-36-website/src/components/Layout.js
@@ -33,6 +33,7 @@ const Layout = (props) => {
           promoText
           promoLink
           promoLinkText
+          promoTagText
           menuLinks {
             name
             link
@@ -100,6 +101,7 @@ const Layout = (props) => {
           text={data.site.siteMetadata.promoText}
           linkHref={data.site.siteMetadata.promoLink}
           linkText={data.site.siteMetadata.promoLinkText}
+          tagText={data.site.siteMetadata.promoTagText}
         />
       )}
 

--- a/packages/forma-36-website/src/components/Promo.js
+++ b/packages/forma-36-website/src/components/Promo.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import tokens from '@contentful/forma-36-tokens';
-import { Tag } from '@contentful/forma-36-react-components';
-import { Flex } from '@contentful/forma-36-react-components/dist/alpha';
+import { Tag, Flex } from '@contentful/forma-36-react-components';
 import { css } from '@emotion/core';
 
 const styles = {

--- a/packages/forma-36-website/src/components/Promo.js
+++ b/packages/forma-36-website/src/components/Promo.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import tokens from '@contentful/forma-36-tokens';
+import { Tag } from '@contentful/forma-36-react-components';
+import { Flex } from '@contentful/forma-36-react-components/dist/alpha';
 import { css } from '@emotion/core';
 
 const styles = {
@@ -9,20 +11,9 @@ const styles = {
     padding: ${tokens.spacingXs};
     display: flex;
     justify-content: center;
+    align-items: center;
     font-size: ${tokens.fontSizeM};
     font-weight: ${tokens.fontWeightMedium};
-  `,
-  new: css`
-    background-color: #fff;
-    display: flex;
-    color: ${tokens.colorTextDark};
-    align-items: center;
-    font-weight: ${tokens.fontWeightDemiBold};
-    text-transform: uppercase;
-    border-radius: 2px;
-    padding: 0 ${tokens.spacingS};
-    margin-right: ${tokens.spacingS};
-    font-size: ${tokens.fontSizeS};
   `,
   link: css`
     margin-left: ${tokens.spacingS};
@@ -30,9 +21,12 @@ const styles = {
   `,
 };
 
-const Promo = ({ text, linkText, linkHref }) => (
+const Promo = ({ text, linkText, linkHref, tagText }) => (
   <div css={styles.promo}>
-    <span css={styles.new}>New</span> {text}
+    <Flex marginRight="spacingXs">
+      <Tag tagType="primary">{tagText}</Tag>
+    </Flex>
+    {text}
     {linkHref && (
       <a
         href={linkHref}


### PR DESCRIPTION
Hey there!

Just a small update for the website to display information about the new release for F36

<img width="1790" alt="Screenshot 2021-01-21 at 14 13 34" src="https://user-images.githubusercontent.com/4272331/105355752-da713e80-5bf2-11eb-9d0d-70062757ff6e.png">


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
