### PR TITLE
fix(timepicker): allow clicking on input without closing dropdown

### DIFF
--- a/packages/components/timepicker/src/Timepicker.tsx
+++ b/packages/components/timepicker/src/Timepicker.tsx
@@ -274,13 +274,13 @@ export const Timepicker: React.FC<TimepickerProps> = ({
     }
   }, []);
 
-  const handleFocus = useCallback((e) => {
+  const handleFocus = useCallback<FocusEventHandler<HTMLInputElement>>((e) => {
     e.preventDefault();
     e.target.select();
     setTimeSuggestionOpen(true);
   }, []);
 
-  const handleBlur = useCallback(
+  const handleBlur = useCallback<FocusEventHandler<HTMLInputElement>>(
     (e) => {
       const time = getTimeFromUserInputOrDefaultToValue();
       setSelectedTime(time);
@@ -310,6 +310,7 @@ export const Timepicker: React.FC<TimepickerProps> = ({
           dropdownContainerClassName={styles.dropdownContainer}
           // TODO: Fix getContainerRef on Dropdown to accept ref object. F36 4.0 Breaking Change
           getContainerRef={setDropdownContainer}
+          nonClosingRefs={[inputRef]}
           toggleElement={
             <TextInput
               id={inputId}


### PR DESCRIPTION
# Purpose of PR

* fix(timepicker): allow clicking on input without closing dropdown

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
