### PR TITLE
feat(button): add additional optional properties for using Buttons as external links

### DIFF
--- a/packages/forma-36-react-components/src/components/Button/Button.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.stories.tsx
@@ -24,9 +24,9 @@ export default {
   },
 };
 
-interface Args extends ButtonProps {
+type Args = ButtonProps & {
   label?: string;
-}
+};
 
 export const basic = ({ label, ...args }: Args) => (
   <Button {...args}>{label}</Button>

--- a/packages/forma-36-react-components/src/components/Button/Button.test.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.test.tsx
@@ -100,6 +100,16 @@ it('renders the button as link', () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
+it('renders the button as an external link', () => {
+  const { container } = render(
+    <Button href="/" target="_blank" rel="noreferrer noopener">
+      Button link
+    </Button>,
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
 it('renders the button as active', () => {
   const { container } = render(<Button isActive>Active button</Button>);
 

--- a/packages/forma-36-react-components/src/components/Button/Button.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { HTMLProps } from 'react';
 import type {
   CSSProperties,
   FocusEvent,
@@ -15,7 +15,19 @@ import Spinner from '../Spinner';
 
 import styles from './Button.css';
 
-export interface ButtonProps {
+type AnchorProps =
+  | {
+      href?: undefined;
+      rel?: never;
+      target?: never;
+    }
+  | {
+      href: string;
+      rel?: HTMLProps<HTMLAnchorElement>['rel'];
+      target?: HTMLProps<HTMLAnchorElement>['target'];
+    };
+
+export type ButtonProps = {
   icon?: IconType;
   indicateDropdown?: boolean;
   onClick?: MouseEventHandler;
@@ -33,12 +45,11 @@ export interface ButtonProps {
     | 'naked';
   type?: 'button' | 'submit' | 'reset';
   size?: 'small' | 'medium' | 'large';
-  href?: string;
   style?: CSSProperties;
   className?: string;
   children?: React.ReactNode;
   isActive?: boolean;
-}
+} & AnchorProps;
 
 export const Button = ({
   buttonType = 'primary',
@@ -46,6 +57,8 @@ export const Button = ({
   className,
   disabled = false,
   href,
+  rel,
+  target,
   icon,
   indicateDropdown = false,
   isActive,
@@ -96,6 +109,8 @@ export const Button = ({
       className={classNames}
       disabled={disabled}
       href={!disabled ? href : undefined}
+      rel={rel}
+      target={target}
       type={type}
       {...otherProps}
     >

--- a/packages/forma-36-react-components/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -19,6 +19,28 @@ exports[`renders the button as active 1`] = `
 </button>
 `;
 
+exports[`renders the button as an external link 1`] = `
+<a
+  class="Button Button--primary Button--medium"
+  data-test-id="cf-ui-button"
+  href="/"
+  rel="noreferrer noopener"
+  target="_blank"
+  type="button"
+>
+  <span
+    class="TabFocusTrap Button__inner-wrapper"
+    tabindex="-1"
+  >
+    <span
+      class="Button__label"
+    >
+      Button link
+    </span>
+  </span>
+</a>
+`;
+
 exports[`renders the button as link 1`] = `
 <a
   class="Button Button--primary Button--medium"


### PR DESCRIPTION
# Purpose of PR

~~Adds the optional "isExternalLink" boolean property to the Button component, which, if enabled
together with the "href" property, sets 'target="_blank"' and 'rel="noopener noreferrer"' on the
resulting html tag.~~

~~I have previously worked around this by using an onclick={() => window.open(url, '_blank');}, which isn't as nice for accessibility.~~

**Edit:**
Adds the optional `target` and `rel` props for the Button component, which only get rendered if the component gets rendered as an anchor tag.
As Kristoffer mentioned, you're already able to use these but the types are complaining, which is alleviated by this PR.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added
- [x] Tests are passing
- [x] Storybook stories are not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support) (not required, am only adding optional properties without UI)
- [x] Doesn't contain any sensitive information
