### PR TITLE
fix(dropdown): remove offset to avoid dropdown unexpectedly closing

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { storiesOf } from '@storybook/react';
-import { text, select, boolean } from '@storybook/addon-knobs';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 import { action } from '@storybook/addon-actions';
 
 import Dropdown from './Dropdown';
@@ -11,27 +10,29 @@ import DropdownList from './DropdownList';
 import Flex from '../Flex/Flex';
 import SectionHeading from '../Typography/SectionHeading';
 
-function DefaultStory() {
+export default {
+  argTypes: {
+    className: { control: { disable: true } },
+    nonClosingRefs: { control: { disable: true } },
+  },
+  component: Dropdown,
+  propTypes: [
+    Dropdown['__docgenInfo'],
+    DropdownList['__docgenInfo'],
+    DropdownListItem['__docgenInfo'],
+  ],
+  subcomponents: { DropdownList, DropdownListItem },
+  title: 'Components/Dropdown',
+} as Meta;
+
+export const Default: Story = ({ submenuToggleLabel, ...args }) => {
   const [isOpen, setOpen] = useState(false);
 
   return (
     <Dropdown
+      {...args}
       isOpen={isOpen}
       onClose={() => setOpen(false)}
-      isFullWidth={boolean('isFullWidth', false)}
-      key={Date.now()} // Force Reinit
-      isAutoalignmentEnabled={boolean('isAutoalignmentEnabled', true)}
-      usePortal={boolean('usePortal', true)}
-      position={select(
-        'position',
-        {
-          'bottom-left': 'bottom-left',
-          'bottom-right': 'bottom-right',
-          'top-left': 'top-left',
-          'top-right': 'top-right',
-        },
-        'bottom-left',
-      )}
       toggleElement={
         <Button
           size="small"
@@ -42,25 +43,13 @@ function DefaultStory() {
           Choose more options and settings
         </Button>
       }
-      className={text('className', '')}
     >
       <DropdownList>
         <DropdownListItem isTitle>Entry Title</DropdownListItem>
         <DropdownListItem onClick={action('onClick Element')}>
           Embed existing entry
         </DropdownListItem>
-        <Dropdown
-          position={select(
-            'Submenu position',
-            {
-              left: 'left',
-              right: 'right',
-            },
-            'right',
-          )}
-          submenuToggleLabel="Create and embed existing entry"
-          className={text('className', '')}
-        >
+        <Dropdown position="left" submenuToggleLabel={submenuToggleLabel}>
           <DropdownList>
             <DropdownListItem onClick={action('submenu click')}>
               Embed as inline element
@@ -78,26 +67,20 @@ function DefaultStory() {
       </DropdownList>
     </Dropdown>
   );
-}
+};
 
-function ScrollableStory() {
+Default.args = {
+  submenuToggleLabel: 'Create and embed existing entry',
+};
+
+export const Scrollable: Story = (args) => {
   const [isOpen, setOpen] = useState(false);
+
   return (
     <Dropdown
+      {...args}
       isOpen={isOpen}
       onClose={() => setOpen(false)}
-      isAutoalignmentEnabled={boolean('isAutoalignmentEnabled', true)}
-      usePortal={boolean('usePortal', true)}
-      position={select(
-        'position',
-        {
-          'bottom-left': 'bottom-left',
-          'bottom-right': 'bottom-right',
-          'top-left': 'top-left',
-          'top-right': 'top-right',
-        },
-        'bottom-left',
-      )}
       toggleElement={
         <Button
           size="small"
@@ -108,7 +91,6 @@ function ScrollableStory() {
           toggle
         </Button>
       }
-      className={text('className', '')}
     >
       <DropdownList maxHeight={200}>
         {[...new Array(25)].map((entry, index) => (
@@ -120,9 +102,9 @@ function ScrollableStory() {
       </DropdownList>
     </Dropdown>
   );
-}
+};
 
-function DynamicContentStory() {
+export const DynamicContent: Story = (args) => {
   const messages = ['Loading...', 'This is my other piece of text'];
   const [isOpen, setOpen] = useState(false);
   const [text, setText] = useState(messages[0]);
@@ -143,20 +125,9 @@ function DynamicContentStory() {
 
   return (
     <Dropdown
+      {...args}
       isOpen={isOpen}
       onClose={onClose}
-      isAutoalignmentEnabled={boolean('isAutoalignmentEnabled', true)}
-      usePortal={boolean('usePortal', true)}
-      position={select(
-        'position',
-        {
-          'bottom-left': 'bottom-left',
-          'bottom-right': 'bottom-right',
-          'top-left': 'top-left',
-          'top-right': 'top-right',
-        },
-        'bottom-right',
-      )}
       toggleElement={
         <Button
           size="small"
@@ -173,66 +144,55 @@ function DynamicContentStory() {
       </DropdownList>
     </Dropdown>
   );
-}
+};
 
-storiesOf('Components/Dropdown', module)
-  .addParameters({
-    propTypes: [
-      Dropdown['__docgenInfo'],
-      DropdownList['__docgenInfo'],
-      DropdownListItem['__docgenInfo'],
-    ],
-    component: Dropdown,
-    subcomponents: { DropdownList, DropdownListItem },
-  })
-  .add('default', () => <DefaultStory />)
-  .add('scrollable', () => <ScrollableStory />)
-  .add('dynamic', () => <DynamicContentStory />)
-  .add('overview', () => (
-    <>
-      <Flex marginBottom="spacingS">
-        <SectionHeading element="h3">Dropdown default</SectionHeading>
-      </Flex>
-      <DefaultStory />
-      <Flex marginBottom="spacingS" marginTop="spacingM">
-        <SectionHeading element="h3">Dropdown default open</SectionHeading>
-      </Flex>
-      <Dropdown
-        isOpen
-        isAutoalignmentEnabled
-        usePortal
-        position="bottom-left"
-        toggleElement={
-          <Button size="small" buttonType="muted" indicateDropdown>
-            Choose more options and settings
-          </Button>
-        }
-        className={text('className', '')}
-      >
-        <DropdownList>
-          <DropdownListItem isTitle>Entry Title</DropdownListItem>
-          <DropdownListItem onClick={action('onClick Element')}>
-            Embed existing entry
-          </DropdownListItem>
-          <Dropdown
-            position="right"
-            submenuToggleLabel="Create and embed existing entry"
-          >
-            <DropdownList>
-              <DropdownListItem onClick={action('submenu click')}>
-                Embed as inline element
-              </DropdownListItem>
-              <DropdownListItem isDisabled>
-                Embed as block element
-              </DropdownListItem>
-            </DropdownList>
-          </Dropdown>
-        </DropdownList>
-        <DropdownList border="top">
-          <DropdownListItem>
-            <TextLink href="http://google.com">This is a Link</TextLink>
-          </DropdownListItem>
-        </DropdownList>
-      </Dropdown>
-    </>
-  ));
+export const Overview: Story = () => (
+  <>
+    <Flex marginBottom="spacingS">
+      <SectionHeading element="h3">Dropdown default</SectionHeading>
+    </Flex>
+
+    <Default />
+
+    <Flex marginBottom="spacingS" marginTop="spacingM">
+      <SectionHeading element="h3">Dropdown default open</SectionHeading>
+    </Flex>
+
+    <Dropdown
+      isOpen
+      isAutoalignmentEnabled
+      usePortal
+      position="bottom-left"
+      toggleElement={
+        <Button size="small" buttonType="muted" indicateDropdown>
+          Choose more options and settings
+        </Button>
+      }
+    >
+      <DropdownList>
+        <DropdownListItem isTitle>Entry Title</DropdownListItem>
+        <DropdownListItem onClick={action('onClick Element')}>
+          Embed existing entry
+        </DropdownListItem>
+        <Dropdown
+          position="right"
+          submenuToggleLabel="Create and embed existing entry"
+        >
+          <DropdownList>
+            <DropdownListItem onClick={action('submenu click')}>
+              Embed as inline element
+            </DropdownListItem>
+            <DropdownListItem isDisabled>
+              Embed as block element
+            </DropdownListItem>
+          </DropdownList>
+        </Dropdown>
+      </DropdownList>
+      <DropdownList border="top">
+        <DropdownListItem>
+          <TextLink href="http://google.com">This is a Link</TextLink>
+        </DropdownListItem>
+      </DropdownList>
+    </Dropdown>
+  </>
+);

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
@@ -10,7 +10,7 @@ import styles from './Dropdown.css';
 const offsetModifier = {
   name: 'offset',
   options: {
-    offset: [0, 6],
+    offset: [0, 0],
   },
 };
 


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

This is a hotfix that just removes the gap between dropdown and toggle element or dropdown and
subdropdown. We should fix this in v4

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
