### PR TITLE
feat: handle tag change in the List component

### DIFF
--- a/packages/forma-36-react-components/src/components/List/List.css
+++ b/packages/forma-36-react-components/src/components/List/List.css
@@ -1,3 +1,7 @@
 .List {
   margin: 0;
 }
+
+.List--unordered {
+  list-style-type: disc;
+}

--- a/packages/forma-36-react-components/src/components/List/List.stories.tsx
+++ b/packages/forma-36-react-components/src/components/List/List.stories.tsx
@@ -1,30 +1,92 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
-import { text } from '@storybook/addon-knobs';
 
-import List from './List';
+import List, { ListProps } from './List';
 import ListItem from './ListItem';
 import TextLink from '../TextLink';
+import Flex from '../Flex/Flex';
+import SectionHeading from '../Typography/SectionHeading';
 
-storiesOf('Components/List', module)
-  .addParameters({
+import notes from './README.mdx';
+
+export default {
+  title: 'Components/List',
+  component: List,
+  subcomponents: { ListItem },
+  parameters: {
     propTypes: [List['__docgenInfo'], ListItem['__docgenInfo']],
-    component: List,
-    subcomponents: { ListItem },
-  })
-  .add('default', () => (
-    <List className={text('className', '')}>
-      <ListItem>List Item 1</ListItem>
-      <ListItem>List Item 2</ListItem>
-      <ListItem>
-        List Item with a&nbsp;
-        <TextLink>text link</TextLink>&nbsp;
-      </ListItem>
-      <ListItem>
-        <List>
-          <ListItem>Sublist Item 1</ListItem>
-          <ListItem>Sublist Item 2</ListItem>
+    notes,
+  },
+  argTypes: {
+    element: {
+      table: { defaultValue: { summary: 'ul' } },
+      control: { type: 'select', options: ['ul', 'ol'] },
+    },
+    className: { control: { disable: true } },
+    testId: { control: { disable: true } },
+    children: { control: { disable: true } },
+  },
+};
+
+export const basic = ({ ...args }: ListProps) => (
+  <List {...args}>
+    <ListItem>List Item 1</ListItem>
+    <ListItem>List Item 2</ListItem>
+    <ListItem>
+      List Item with a&nbsp;
+      <TextLink>text link</TextLink>&nbsp;
+    </ListItem>
+    <ListItem>
+      <List>
+        <ListItem>Sublist Item 1</ListItem>
+        <ListItem>Sublist Item 2</ListItem>
+      </List>
+    </ListItem>
+  </List>
+);
+
+export const overview = ({ ...args }: ListProps) => (
+  <>
+    <Flex flexDirection="column" marginBottom="spacingM" fullWidth>
+      <Flex marginBottom="spacingS">
+        <SectionHeading>Unordered List</SectionHeading>
+      </Flex>
+      <Flex>
+        <List {...args}>
+          <ListItem>List Item 1</ListItem>
+          <ListItem>List Item 2</ListItem>
+          <ListItem>
+            List Item with a&nbsp;
+            <TextLink>text link</TextLink>&nbsp;
+          </ListItem>
+          <ListItem>
+            <List>
+              <ListItem>Sublist Item 1</ListItem>
+              <ListItem>Sublist Item 2</ListItem>
+            </List>
+          </ListItem>
         </List>
-      </ListItem>
-    </List>
-  ));
+      </Flex>
+    </Flex>
+    <Flex flexDirection="column">
+      <Flex marginBottom="spacingS">
+        <SectionHeading>Ordered List</SectionHeading>
+      </Flex>
+      <Flex>
+        <List element="ol" {...args}>
+          <ListItem>List Item 1</ListItem>
+          <ListItem>List Item 2</ListItem>
+          <ListItem>
+            List Item with a&nbsp;
+            <TextLink>text link</TextLink>&nbsp;
+          </ListItem>
+          <ListItem>
+            <List element="ol">
+              <ListItem>Sublist Item 1</ListItem>
+              <ListItem>Sublist Item 2</ListItem>
+            </List>
+          </ListItem>
+        </List>
+      </Flex>
+    </Flex>
+  </>
+);

--- a/packages/forma-36-react-components/src/components/List/List.test.tsx
+++ b/packages/forma-36-react-components/src/components/List/List.test.tsx
@@ -15,6 +15,16 @@ it('renders the component', () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
+it('renders as ordered list', () => {
+  const { container } = render(
+    <List element="ol">
+      <ListItem>Item</ListItem>
+    </List>,
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
 it('renders the component with an additional class name', () => {
   const { container } = render(
     <List className="my-extra-class">

--- a/packages/forma-36-react-components/src/components/List/List.tsx
+++ b/packages/forma-36-react-components/src/components/List/List.tsx
@@ -3,7 +3,10 @@ import cn from 'classnames';
 
 import styles from './List.css';
 
+type ListType = 'ul' | 'ol';
+
 export interface ListProps {
+  element?: ListType;
   className?: string;
   children: React.ReactNode;
   style?: React.CSSProperties;
@@ -11,17 +14,22 @@ export interface ListProps {
 }
 
 export function List({
+  element: Tag = 'ul',
   className,
   children,
   testId = 'cf-ui-list',
   ...otherProps
 }: ListProps): React.ReactElement {
-  const classNames = cn(styles['List'], className);
+  const classNames = cn(
+    styles['List'],
+    { [styles['List--unordered']]: Tag === 'ul' },
+    className,
+  );
 
   return (
-    <ul {...otherProps} className={classNames} data-test-id={testId}>
+    <Tag {...otherProps} className={classNames} data-test-id={testId}>
       {children}
-    </ul>
+    </Tag>
   );
 }
 

--- a/packages/forma-36-react-components/src/components/List/ListItem/ListItem.css
+++ b/packages/forma-36-react-components/src/components/List/ListItem/ListItem.css
@@ -6,7 +6,6 @@
   font-size: var(--font-size-m);
   font-family: var(--font-stack-primary);
   line-height: var(--line-height-default);
-  list-style-type: disc;
 }
 
 .ListItem--nested-list {

--- a/packages/forma-36-react-components/src/components/List/README.mdx
+++ b/packages/forma-36-react-components/src/components/List/README.mdx
@@ -1,0 +1,37 @@
+List is component that helps with vertical indexing of content.
+Every list item begins with a bullet or a number.
+
+## Table of contents
+
+- [How to use List](#how-to-use-list)
+- [Component variations](#component-variations)
+- [Code example](#code-example)
+
+## How to use List
+
+- when displaying vertical data (text and images)
+- when displaying hierarchically indexed content
+
+## Component variations
+
+The List component can be configured in two different ways: to display bulleted (unordered) list or numbered (ordered) list.
+
+## Code example
+
+```jsx
+// import { List, ListItem } from '@contentful/forma-36-react-components';
+
+<List element="ul">
+  <ListItem>List Item 1</ListItem>
+  <ListItem>List Item 2</ListItem>
+  <ListItem>
+    List Item with <TextLink>text link</TextLink>
+  </ListItem>
+  <ListItem>
+    <List element="ol">
+      <ListItem>Sublist Item 1</ListItem>
+      <ListItem>Sublist Item 2</ListItem>
+    </List>
+  </ListItem>
+</List>
+```

--- a/packages/forma-36-react-components/src/components/List/__snapshots__/List.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/List/__snapshots__/List.test.tsx.snap
@@ -1,8 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders as ordered list 1`] = `
+<ol
+  class="List"
+  data-test-id="cf-ui-list"
+>
+  <li
+    class="ListItem"
+    data-test-id="cf-ui-list-item"
+  >
+    Item
+  </li>
+</ol>
+`;
+
 exports[`renders the component 1`] = `
 <ul
-  class="List"
+  class="List List--unordered"
   data-test-id="cf-ui-list"
 >
   <li
@@ -16,7 +30,7 @@ exports[`renders the component 1`] = `
 
 exports[`renders the component with an additional class name 1`] = `
 <ul
-  class="List my-extra-class"
+  class="List List--unordered my-extra-class"
   data-test-id="cf-ui-list"
 >
   <li


### PR DESCRIPTION
# Purpose of PR

Addresses https://github.com/contentful/forma-36/issues/423 by introducing the tag change in the List component.

<img width="1140" alt="Screenshot 2021-01-26 at 08 59 52" src="https://user-images.githubusercontent.com/9191638/105816756-f559ff00-5fb4-11eb-9f97-161ccbe03372.png">


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information

tagging @fabe for design review on the addition of the ordered list