### PR TITLE
chore(AssetCard): align possible entity status

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.tsx
@@ -11,7 +11,12 @@ import AssetCardSkeleton from './AssetCardSkeleton';
 import CardDragHandle, { CardDragHandlePropTypes } from '../CardDragHandle';
 import styles from './AssetCard.css';
 
-export type AssetState = 'archived' | 'changed' | 'draft' | 'published';
+export type AssetState =
+  | 'deleted'
+  | 'archived'
+  | 'changed'
+  | 'draft'
+  | 'published';
 
 export interface AssetCardProps extends BaseCardProps {
   /**

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
@@ -10,7 +10,12 @@ import CardDragHandle, { CardDragHandlePropTypes } from '../CardDragHandle';
 import Icon, { IconType } from '../../Icon';
 import styles from './EntryCard.css';
 
-export type EntryCardStatus = 'archived' | 'changed' | 'draft' | 'published';
+export type EntryCardStatus =
+  | 'deleted'
+  | 'archived'
+  | 'changed'
+  | 'draft'
+  | 'published';
 
 export type EntryCardSize = 'default' | 'small' | 'auto';
 


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Align possible entity statuses with [field-editor-helpers](https://github.com/contentful/field-editors/blob/master/packages/_shared/src/utils/entityHelpers.ts#L169-L186)

forma was missing the `deleted` status

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
