### PR TITLE
fix(table): add z-index to table head

### DIFF
--- a/packages/forma-36-react-components/src/components/Table/TableHead/TableHead.css
+++ b/packages/forma-36-react-components/src/components/Table/TableHead/TableHead.css
@@ -1,4 +1,7 @@
+@import 'settings/z-index';
+
 .TableHead--sticky th {
   position: sticky;
   top: 0;
+  z-index: var(--z-index-default);
 }


### PR DESCRIPTION
# Purpose of PR

Fixes #793 by adding a `z-index` value to `th` elements when `isSticky` is used.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
