### PR TITLE
docs(forms): create section for form components

### DIFF
--- a/packages/forma-36-react-components/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Checkbox/Checkbox.stories.tsx
@@ -5,7 +5,7 @@ import Flex from '../Flex/Flex';
 import SectionHeading from '../Typography/SectionHeading';
 
 export default {
-  title: 'Forms/Checkbox',
+  title: 'Form Elements/Checkbox',
   component: Checkbox,
   parameters: {
     propTypes: [Checkbox['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Checkbox/Checkbox.stories.tsx
@@ -5,7 +5,7 @@ import Flex from '../Flex/Flex';
 import SectionHeading from '../Typography/SectionHeading';
 
 export default {
-  title: 'Components/Checkbox',
+  title: 'Forms/Checkbox',
   component: Checkbox,
   parameters: {
     propTypes: [Checkbox['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/CheckboxField/CheckboxField.stories.tsx
+++ b/packages/forma-36-react-components/src/components/CheckboxField/CheckboxField.stories.tsx
@@ -6,7 +6,7 @@ import Flex from '../Flex/Flex';
 import SectionHeading from '../Typography/SectionHeading';
 
 export default {
-  title: 'Components/CheckboxField',
+  title: 'Forms/CheckboxField',
   component: CheckboxField,
   parameters: {
     propTypes: [CheckboxField['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/CheckboxField/CheckboxField.stories.tsx
+++ b/packages/forma-36-react-components/src/components/CheckboxField/CheckboxField.stories.tsx
@@ -6,7 +6,7 @@ import Flex from '../Flex/Flex';
 import SectionHeading from '../Typography/SectionHeading';
 
 export default {
-  title: 'Forms/CheckboxField',
+  title: 'Form Elements/CheckboxField',
   component: CheckboxField,
   parameters: {
     propTypes: [CheckboxField['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/Form/FieldGroup/FieldGroup.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Form/FieldGroup/FieldGroup.stories.tsx
@@ -4,7 +4,7 @@ import CheckboxField from '../../CheckboxField';
 import FieldGroup from './FieldGroup';
 
 export default {
-  title: 'Forms/FieldGroup',
+  title: 'Form Elements/FieldGroup',
   component: FieldGroup,
   parameters: {
     propTypes: [FieldGroup['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/Form/FieldGroup/FieldGroup.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Form/FieldGroup/FieldGroup.stories.tsx
@@ -4,7 +4,7 @@ import CheckboxField from '../../CheckboxField';
 import FieldGroup from './FieldGroup';
 
 export default {
-  title: 'Components/Form/FieldGroup',
+  title: 'Forms/FieldGroup',
   component: FieldGroup,
   parameters: {
     propTypes: [FieldGroup['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/Form/Form.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Form/Form.stories.tsx
@@ -8,7 +8,7 @@ import CheckboxField from '../CheckboxField';
 import notes from './README.mdx';
 
 export default {
-  title: 'Components/Form',
+  title: 'Forms/Form',
   component: Form,
   parameters: {
     propTypes: [Form['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/Form/Form.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Form/Form.stories.tsx
@@ -8,7 +8,7 @@ import CheckboxField from '../CheckboxField';
 import notes from './README.mdx';
 
 export default {
-  title: 'Forms/Form',
+  title: 'Form Elements/Form',
   component: Form,
   parameters: {
     propTypes: [Form['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/FormLabel/FormLabel.stories.tsx
+++ b/packages/forma-36-react-components/src/components/FormLabel/FormLabel.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import FormLabel, { FormLabelProps } from './FormLabel';
 
 export default {
-  title: 'Forms/FormLabel',
+  title: 'Form Elements/FormLabel',
   component: FormLabel,
   parameters: {
     propTypes: [FormLabel['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/FormLabel/FormLabel.stories.tsx
+++ b/packages/forma-36-react-components/src/components/FormLabel/FormLabel.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import FormLabel, { FormLabelProps } from './FormLabel';
 
 export default {
-  title: 'Components/Form/FormLabel',
+  title: 'Forms/FormLabel',
   component: FormLabel,
   parameters: {
     propTypes: [FormLabel['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/RadioButton/RadioButton.stories.tsx
+++ b/packages/forma-36-react-components/src/components/RadioButton/RadioButton.stories.tsx
@@ -5,7 +5,7 @@ import Flex from '../Flex/Flex';
 import SectionHeading from '../Typography/SectionHeading';
 
 export default {
-  title: 'Forms/RadioButton',
+  title: 'Form Elements/RadioButton',
   component: RadioButton,
   parameters: {
     propTypes: [RadioButton['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/RadioButton/RadioButton.stories.tsx
+++ b/packages/forma-36-react-components/src/components/RadioButton/RadioButton.stories.tsx
@@ -5,7 +5,7 @@ import Flex from '../Flex/Flex';
 import SectionHeading from '../Typography/SectionHeading';
 
 export default {
-  title: 'Components/RadioButton',
+  title: 'Forms/RadioButton',
   component: RadioButton,
   parameters: {
     propTypes: [RadioButton['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/RadioButtonField/RadioButtonField.stories.tsx
+++ b/packages/forma-36-react-components/src/components/RadioButtonField/RadioButtonField.stories.tsx
@@ -6,7 +6,7 @@ import Flex from '../Flex/Flex';
 import SectionHeading from '../Typography/SectionHeading';
 
 export default {
-  title: 'Components/RadioButtonField',
+  title: 'Forms/RadioButtonField',
   component: RadioButtonField,
   parameters: {
     propTypes: [RadioButtonField['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/RadioButtonField/RadioButtonField.stories.tsx
+++ b/packages/forma-36-react-components/src/components/RadioButtonField/RadioButtonField.stories.tsx
@@ -6,7 +6,7 @@ import Flex from '../Flex/Flex';
 import SectionHeading from '../Typography/SectionHeading';
 
 export default {
-  title: 'Forms/RadioButtonField',
+  title: 'Form Elements/RadioButtonField',
   component: RadioButtonField,
   parameters: {
     propTypes: [RadioButtonField['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/Select/Select.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Select/Select.stories.tsx
@@ -6,7 +6,7 @@ import Flex from '../Flex/Flex';
 import SectionHeading from '../Typography/SectionHeading';
 
 export default {
-  title: 'Components/Select',
+  title: 'Forms/Select',
   component: Select,
   parameters: {
     propTypes: [Select['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/Select/Select.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Select/Select.stories.tsx
@@ -6,7 +6,7 @@ import Flex from '../Flex/Flex';
 import SectionHeading from '../Typography/SectionHeading';
 
 export default {
-  title: 'Forms/Select',
+  title: 'Form Elements/Select',
   component: Select,
   parameters: {
     propTypes: [Select['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/SelectField/SelectField.stories.tsx
+++ b/packages/forma-36-react-components/src/components/SelectField/SelectField.stories.tsx
@@ -3,7 +3,7 @@ import SelectField, { SelectFieldProps } from './SelectField';
 import Option from '../Select/Option';
 
 export default {
-  title: 'Components/SelectField',
+  title: 'Forms/SelectField',
   component: SelectField,
   parameters: {
     propTypes: [SelectField['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/SelectField/SelectField.stories.tsx
+++ b/packages/forma-36-react-components/src/components/SelectField/SelectField.stories.tsx
@@ -3,7 +3,7 @@ import SelectField, { SelectFieldProps } from './SelectField';
 import Option from '../Select/Option';
 
 export default {
-  title: 'Forms/SelectField',
+  title: 'Form Elements/SelectField',
   component: SelectField,
   parameters: {
     propTypes: [SelectField['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/Switch/Switch.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Switch/Switch.stories.tsx
@@ -5,7 +5,7 @@ import SectionHeading from '../Typography/SectionHeading';
 import Flex from '../Flex/Flex';
 
 export default {
-  title: 'Forms/Switch',
+  title: 'Components/Switch',
   component: Switch,
   parameters: {
     propTypes: [Switch['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/Switch/Switch.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Switch/Switch.stories.tsx
@@ -5,7 +5,7 @@ import SectionHeading from '../Typography/SectionHeading';
 import Flex from '../Flex/Flex';
 
 export default {
-  title: 'Components/Switch',
+  title: 'Forms/Switch',
   component: Switch,
   parameters: {
     propTypes: [Switch['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/TextField/TextField.stories.tsx
+++ b/packages/forma-36-react-components/src/components/TextField/TextField.stories.tsx
@@ -5,7 +5,7 @@ import SectionHeading from '../Typography/SectionHeading';
 import Flex from '../Flex/Flex';
 
 export default {
-  title: 'Components/TextField',
+  title: 'Forms/TextField',
   component: TextField,
   parameters: {
     propTypes: [TextField['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/TextField/TextField.stories.tsx
+++ b/packages/forma-36-react-components/src/components/TextField/TextField.stories.tsx
@@ -5,7 +5,7 @@ import SectionHeading from '../Typography/SectionHeading';
 import Flex from '../Flex/Flex';
 
 export default {
-  title: 'Forms/TextField',
+  title: 'Form Elements/TextField',
   component: TextField,
   parameters: {
     propTypes: [TextField['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.stories.tsx
@@ -6,7 +6,7 @@ import SectionHeading from '../Typography/SectionHeading';
 import Flex from '../Flex/Flex';
 
 export default {
-  title: 'Components/TextInput',
+  title: 'Forms/TextInput',
   component: TextInput,
   parameters: {
     propTypes: [TextInput['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.stories.tsx
@@ -6,7 +6,7 @@ import SectionHeading from '../Typography/SectionHeading';
 import Flex from '../Flex/Flex';
 
 export default {
-  title: 'Forms/TextInput',
+  title: 'Form Elements/TextInput',
   component: TextInput,
   parameters: {
     propTypes: [TextInput['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Textarea/Textarea.stories.tsx
@@ -6,7 +6,7 @@ import SectionHeading from '../Typography/SectionHeading';
 import Flex from '../Flex/Flex';
 
 export default {
-  title: 'Forms/TextArea',
+  title: 'Form Elements/TextArea',
   component: Textarea,
   parameters: {
     propTypes: [Textarea['__docgenInfo']],

--- a/packages/forma-36-react-components/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Textarea/Textarea.stories.tsx
@@ -6,7 +6,7 @@ import SectionHeading from '../Typography/SectionHeading';
 import Flex from '../Flex/Flex';
 
 export default {
-  title: 'Components/TextArea',
+  title: 'Forms/TextArea',
   component: Textarea,
   parameters: {
     propTypes: [Textarea['__docgenInfo']],

--- a/scripts/.storybook/preview.js
+++ b/scripts/.storybook/preview.js
@@ -21,7 +21,7 @@ export const parameters = {
   options: {
     storySort: {
       method: 'alphabetical',
-      order: ['Documentation', 'Components', '(alpha)'],
+      order: ['Documentation', 'Forms', 'Components', '(alpha)'],
     },
   },
   // Creating DocPage from our old notes

--- a/scripts/.storybook/preview.js
+++ b/scripts/.storybook/preview.js
@@ -21,7 +21,7 @@ export const parameters = {
   options: {
     storySort: {
       method: 'alphabetical',
-      order: ['Documentation', 'Forms', 'Components', '(alpha)'],
+      order: ['Documentation', 'Form Elements', 'Components', '(alpha)'],
     },
   },
   // Creating DocPage from our old notes


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->
![Screenshot 2021-02-05 at 15 04 27](https://user-images.githubusercontent.com/6597467/107043645-94f06c00-67c3-11eb-9e21-4dde293b24a0.png)

With the intention to organize our usage examples, I propose to create a section for the components related to Forms
Since they are usually used in the same context, grouping these components makes it easier to find them

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
