### PR TITLE
fix: fix styles for disable Radio button

### DIFF
--- a/packages/forma-36-react-components/src/components/ControlledInput/ControlledInput.css
+++ b/packages/forma-36-react-components/src/components/ControlledInput/ControlledInput.css
@@ -54,23 +54,23 @@
 
       &:disabled {
         & + .RadioButton__ghost {
-          border-color: var(--color-element-dark);
           background: var(--color-element-dark);
         }
 
         & + .RadioButton__ghost::before {
-          background: var(--color-element-darkest);
+          background: var(--color-text-lightest);
         }
       }
     }
 
     &:disabled {
       & + .RadioButton__ghost {
+        border-color: var(--color-element-dark);
         background: var(--color-element-dark);
       }
 
       & + .RadioButton__ghost::before {
-        background: var(--color-text-lightest);
+        background: var(--color-element-darkest);
       }
     }
   }

--- a/packages/forma-36-react-components/src/components/RadioButtonField/RadioButtonField.stories.tsx
+++ b/packages/forma-36-react-components/src/components/RadioButtonField/RadioButtonField.stories.tsx
@@ -95,6 +95,22 @@ export const overview = () => (
     </Flex>
     <Flex marginBottom="spacingS">
       <SectionHeading element="h3">
+        Radio button disabled checked
+      </SectionHeading>
+    </Flex>
+    <Flex marginBottom="spacingS">
+      <RadioButtonField
+        labelText="Label text"
+        helpText="This is a helptext"
+        disabled
+        checked
+        name="someOption"
+        value="no"
+        id="radioButton3"
+      />
+    </Flex>
+    <Flex marginBottom="spacingS">
+      <SectionHeading element="h3">
         Radio button with light label
       </SectionHeading>
     </Flex>


### PR DESCRIPTION
Hey F36!

Small fix for styles for disabled Radio buttons. 

**BEFORE:**

<img width="315" alt="Screenshot 2021-02-19 at 14 23 45" src="https://user-images.githubusercontent.com/4272331/108509880-1e249a00-72be-11eb-98c5-3d6ad7e253a9.png">

**AFTER:**
<img width="356" alt="Screenshot 2021-02-19 at 14 25 47" src="https://user-images.githubusercontent.com/4272331/108510096-6479f900-72be-11eb-8afd-6f8fe54c86c9.png">


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
