### PR TITLE
feat(autocomplete): add event to onChange

### DIFF
--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { KeyboardEvent, MouseEvent } from 'react';
 import { render, fireEvent, within, screen } from '@testing-library/react';
 
 import { KEY_CODE } from './utils';
@@ -18,7 +18,7 @@ const items: Item[] = [
 ];
 
 describe('Autocomplete', () => {
-  let onChangeFn: (value: Item) => void;
+  let onChangeFn: (value: Item, event: MouseEvent | KeyboardEvent) => void;
   let onQueryChangeFn: (query: string) => void;
 
   const build = ({
@@ -161,17 +161,24 @@ describe('Autocomplete', () => {
     });
 
     it('calls the onChange and onQueryChange callbacks when the selecting an item with the enter key', () => {
+      const mockedKeyEvent = expect.objectContaining({
+        keyCode: KEY_CODE.ENTER,
+      });
       fireEvent.keyDown(input, { keyCode: KEY_CODE.ENTER });
-      expect(onChangeFn).toHaveBeenCalledWith(items[0]);
+      expect(onChangeFn).toHaveBeenCalledWith(items[0], mockedKeyEvent);
       expect(onQueryChangeFn).toHaveBeenCalledWith('');
     });
 
     it('calls the onChange and onQueryChange callbacks when selecting an item with a mouse click', () => {
+      const mockedMouseEvent = expect.objectContaining({
+        movementX: expect.any(Function),
+        movementY: expect.any(Function),
+      });
       const button = within(options[1]).getByTestId(
         'cf-ui-dropdown-list-item-button',
       );
       fireEvent.click(button); // select the second item
-      expect(onChangeFn).toHaveBeenCalledWith(items[1]);
+      expect(onChangeFn).toHaveBeenCalledWith(items[1], mockedMouseEvent);
       expect(onQueryChangeFn).toHaveBeenCalledWith('');
     });
 

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,11 @@
-import React, { useMemo, useReducer, useRef, ChangeEvent } from 'react';
+import React, {
+  useMemo,
+  useReducer,
+  useRef,
+  ChangeEvent,
+  KeyboardEvent,
+  MouseEvent,
+} from 'react';
 
 import TextInput from '../TextInput';
 import Dropdown, { DropdownProps } from '../Dropdown';
@@ -21,7 +28,7 @@ interface RenderToggleElementProps {
   query?: string;
   onChange: (value: string) => void;
   onFocus: () => void;
-  onKeyDown: (event: React.KeyboardEvent) => void;
+  onKeyDown: (event: KeyboardEvent) => void;
   onToggle: () => void;
   disabled?: boolean;
   placeholder?: string;
@@ -33,7 +40,7 @@ interface RenderToggleElementProps {
 export interface AutocompleteProps<T extends {}> {
   children: (items: T[]) => React.ReactNode[];
   items: T[];
-  onChange: (item: T) => void;
+  onChange: (item: T, event: KeyboardEvent | MouseEvent) => void;
   onQueryChange: (query: string) => void;
   disabled?: boolean;
   placeholder?: string;
@@ -130,10 +137,10 @@ export const Autocomplete = <T extends {}>({
     dispatch({ type: TOGGLED_LIST, payload: isOpen });
   };
 
-  const selectItem = (item: T) => {
+  const selectItem = (item: T, event: KeyboardEvent | MouseEvent) => {
     dispatch({ type: ITEM_SELECTED, payload: initialState });
     onQueryChange('');
-    onChange(item);
+    onChange(item, event);
   };
 
   const updateQuery = (value: string) => {
@@ -141,7 +148,7 @@ export const Autocomplete = <T extends {}>({
     onQueryChange(value);
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent) => {
+  const handleKeyDown = (event: KeyboardEvent) => {
     const isEnter = event.keyCode === KEY_CODE.ENTER;
     const isTab =
       event.keyCode === KEY_CODE.TAB ||
@@ -163,7 +170,7 @@ export const Autocomplete = <T extends {}>({
       dispatch({ type: NAVIGATED_ITEMS, payload: newIndex });
     } else if (isEnter && hasUserSelection) {
       const selected = items[highlightedItemIndex as number];
-      selectItem(selected);
+      selectItem(selected, event);
     } else if (isTab) {
       toggleList(false);
     }
@@ -273,7 +280,7 @@ export const Autocomplete = <T extends {}>({
                   key={index}
                   isActive={isActive}
                   data-selected={isActive} // this should be coming from the component library
-                  onClick={() => selectItem(option)}
+                  onClick={(e) => selectItem(option, e)}
                   testId="autocomplete.dropdown-list-item"
                 >
                   {child}
@@ -309,7 +316,7 @@ function OptionSkeleton() {
   );
 }
 
-function getNavigationDirection(event: React.KeyboardEvent): Direction | null {
+function getNavigationDirection(event: KeyboardEvent): Direction | null {
   if (event.keyCode === KEY_CODE.ARROW_DOWN) {
     return Direction.DOWN;
   }


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR


<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

The purpose of this PR is to pass on the `onChange` event from the `Autocomplete` component.
The specific use case that made it necessary is the need to `preventDefault` in some cases.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
