### PR TITLE
docs: add notes about figma account to the home page part 2

### DIFF
--- a/packages/forma-36-website/src/pages/index.mdx
+++ b/packages/forma-36-website/src/pages/index.mdx
@@ -35,9 +35,9 @@ import Resource from './../components/Home/Resource';
   <Resources>
     <Resource
       title="Prototype in Figma with Forma 36 components"
-      description="Open the F36 UI Kit in Figma and create a duplicate. You need a Figma account to do this. Publish it as a Team library and start prototyping."
-      linkText="View the F36 UI Kit on Figma"
-      linkHref="https://www.figma.com/file/xkNH4KddWvI5Zrkbi6CYZJ/F36-UI-Kit?node-id=0%3A601"
+      description="Copy the F36 UI Kit to Figma, publish it as a Team library and start prototyping. You need a Figma account to do this."
+      linkText="Copy F36 UI Kit to Figma"
+      linkHref="https://www.figma.com/file/xkNH4KddWvI5Zrkbi6CYZJ/F36-UI-Kit/duplicate"
       imageNode={<img src={uiKitImg} alt="Illustration for Forma 36 UI Kit" />}
     />
     <Resource

--- a/packages/forma-36-website/src/pages/index.mdx
+++ b/packages/forma-36-website/src/pages/index.mdx
@@ -35,7 +35,7 @@ import Resource from './../components/Home/Resource';
   <Resources>
     <Resource
       title="Prototype in Figma with Forma 36 components"
-      description="Open the F36 UI Kit in Figma and create a duplicate. Publish it as a Team library and start prototyping."
+      description="Open the F36 UI Kit in Figma and create a duplicate. You need a Figma account to do this. Publish it as a Team library and start prototyping."
       linkText="View the F36 UI Kit on Figma"
       linkHref="https://www.figma.com/file/xkNH4KddWvI5Zrkbi6CYZJ/F36-UI-Kit?node-id=0%3A601"
       imageNode={<img src={uiKitImg} alt="Illustration for Forma 36 UI Kit" />}


### PR DESCRIPTION
# Purpose of PR

Change the URL to automatically create a duplicate
Move the note about a necessary Figma account to the end

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
