### PR TITLE
feat(autocomplete): add preventDefault for enter key

### DIFF
--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -151,6 +151,10 @@ export const Autocomplete = <T extends {}>({
     const lastIndex = items.length ? items.length - 1 : 0;
     const direction = getNavigationDirection(event);
 
+    if (isEnter) {
+      event.preventDefault();
+    }
+
     if (direction) {
       const newIndex = getNewIndex(
         highlightedItemIndex as number,


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

The purpose of this PR is to `preventDefault` when hitting Enter in the Autocomplete component.
Related discussion that led to this PR is [here](https://github.com/contentful/forma-36/pull/846).

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
