### PR TITLE
fix(flex): typo in fullHeight prop preventing the height to take effect

### DIFF
--- a/packages/forma-36-react-components/src/components/Flex/Flex.tsx
+++ b/packages/forma-36-react-components/src/components/Flex/Flex.tsx
@@ -167,7 +167,7 @@ export const Flex = ({
   const classNames = cn(styles.Flex, className, {
     [styles.Flex__inline]: inlineFlex,
     [styles.Flex__fullWidth]: fullWidth,
-    [styles.Flex__fullHight]: fullHeight,
+    [styles.Flex__fullHeight]: fullHeight,
     [styles.Flex__noShrink]: noShrink,
   });
 


### PR DESCRIPTION
# Purpose of PR

Fix typo in Flex `fullHeight` prop