### PR TITLE
fix: correct esm entry file

### DIFF
--- a/packages/forma-36-react-components/package.json
+++ b/packages/forma-36-react-components/package.json
@@ -3,7 +3,7 @@
   "description": "Contentful UI Component Library",
   "version": "3.82.1",
   "main": "dist/index.js",
-  "module": "dist/forma-36-react-components.esm.js",
+  "module": "dist/esm/index.js",
   "style": "dist/styles.css",
   "license": "MIT",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# Purpose of PR

Correct the `module` field of `package.json` to point to the correct esm file.