### PR TITLE
v4 chore: upgrade to TypeScript v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "rimraf": "^3.0.2",
     "style-loader": "^2.0.0",
     "ts-jest": "^26.4.4",
-    "typescript": "3.9.7",
+    "typescript": "4.2.3",
     "webpack": "^4.39.3",
     "webpack-cli": "^3.3.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -25638,10 +25638,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
# Purpose of PR

Upgrades to TypeScript v4. I'd like to get this change in because I ran into a TS bug that's blocking #864, which got fixed in 4.1.5 🙂 