### PR TITLE
style(button spinner): reduce the size of the new spinner in buttons

### DIFF
--- a/packages/forma-36-react-components/src/components/Button/Button.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.tsx
@@ -137,7 +137,7 @@ export const Button = ({
         >
           <Spinner
             className={styles.Button__spinner}
-            customSize={18}
+            customSize={12}
             color={
               buttonType === 'muted' ||
               buttonType === 'warning' ||

--- a/packages/forma-36-react-components/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -175,7 +175,7 @@ exports[`renders the component in loading state 1`] = `
     <svg
       class="Spinner Button__spinner Spinner--default Spinner--white"
       data-test-id="cf-ui-spinner"
-      style="height: 18px; width: 18px;"
+      style="height: 12px; width: 12px;"
       viewBox="0 0 60 51"
       xmlns="http://www.w3.org/2000/svg"
     >


### PR DESCRIPTION
# Purpose of PR

The current size of the spinner in buttons is not related to any value in the button — padding, label or line-height.
I suggest we reduce the size so that it sits on the baseline of the label and is closer in size to an ellipsis.

**Current**
![1-current](https://user-images.githubusercontent.com/7631029/110692449-9c51cd80-81e6-11eb-89c5-0d24ad83d965.gif)

**Proposed change**
![2-suggested](https://user-images.githubusercontent.com/7631029/110692466-a378db80-81e6-11eb-8786-bf0bb7578625.gif)


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
