### PR TITLE
style(tag): increase font-weight to correct changes made in #823

### DIFF
--- a/packages/forma-36-react-components/src/components/Tag/Tag.css
+++ b/packages/forma-36-react-components/src/components/Tag/Tag.css
@@ -7,7 +7,7 @@
 .Tag {
   display: inline-block;
   font-family: var(--font-stack-primary);
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-demi-bold);
   font-size: calc(1rem * (12 / var(--font-base-default)));
   line-height: 20px;
   max-height: 20px;


### PR DESCRIPTION
# Purpose of PR

The typography [changes](https://github.com/contentful/forma-36/pull/823/files#diff-825231766b7f9c91f84f3a1ed1959049497b3fcb75fcdeeceda45ad6d69cc997L3) introduced in #823 changed the token value used in the Tag component and made
the text thinner than it should be considering it's all caps and smaller text size. Reverting to
font-weight: 600.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
