### PR TITLE
feat: Stack component

### DIFF
--- a/packages/core/src/Stack/Stack.tsx
+++ b/packages/core/src/Stack/Stack.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import {
+  PolymorphicComponentProps,
+  PolymorphicComponent,
+} from '../Primitive/Primitive';
+import { Grid } from '../Grid';
+import type { GridInternalProps } from '../Grid/Grid';
+import type { MarginProps, PaddingProps, Spacing } from '../types';
+
+function getValidChildren(children: React.ReactNode) {
+  return React.Children.toArray(children).filter((child) =>
+    React.isValidElement(child),
+  ) as React.ReactElement[];
+}
+export interface StackInternalProps extends MarginProps, PaddingProps {
+  /**
+   * Spacing between elements
+   * @default spacingM
+   */
+  gap?: Spacing;
+  /**
+   * Stack direction
+   * @default row
+   */
+  direction?: 'row' | 'column' | 'row-reverse' | 'column-reverse';
+
+  /**
+   * Child nodes to be rendered in the component */
+  children?: React.ReactNode;
+}
+
+export type StackProps<E extends React.ElementType> = PolymorphicComponentProps<
+  E,
+  StackInternalProps
+>;
+
+const DEFAULT_TAG = 'div';
+
+function Stack<E extends React.ElementType = typeof DEFAULT_TAG>(
+  {
+    children,
+    direction = 'row',
+    gap = 'spacingM',
+    divider,
+    ...otherProps
+  }: StackProps<E>,
+  ref: typeof otherProps.ref,
+) {
+  const validChildren = getValidChildren(children);
+
+  const gridProps: Partial<GridInternalProps> = {};
+
+  if (direction === 'row' || direction === 'row-reverse') {
+    gridProps.columns = validChildren.length;
+    gridProps.rows = 'none';
+    gridProps.rowGap = 'none';
+    gridProps.columnGap = gap;
+  } else if (direction === 'column' || direction === 'column-reverse') {
+    gridProps.rows = validChildren.length;
+    gridProps.rowGap = gap;
+    gridProps.columns = 'none';
+    gridProps.columnGap = 'none';
+  }
+
+  if (direction === 'row-reverse' || direction === 'column-reverse') {
+    validChildren.reverse();
+  }
+
+  return (
+    <Grid as={DEFAULT_TAG} inline {...gridProps} {...otherProps} ref={ref}>
+      {validChildren}
+    </Grid>
+  );
+}
+
+export const _Stack: PolymorphicComponent<
+  StackInternalProps,
+  typeof DEFAULT_TAG
+> = React.forwardRef(Stack);
+
+export { _Stack as Stack };

--- a/packages/core/src/Stack/index.ts
+++ b/packages/core/src/Stack/index.ts
@@ -1,0 +1,2 @@
+export { Stack } from './Stack';
+export type { StackProps } from './Stack';

--- a/packages/core/stories/Stack.stories.tsx
+++ b/packages/core/stories/Stack.stories.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Story } from '@storybook/react';
+
+import tokens from '@contentful/f36-tokens';
+import { Stack, _Stack, StackInternalProps } from '../src/Stack/Stack';
+import { Box } from '../src/Box';
+
+const styles = {
+  demoBox: {
+    backgroundColor: tokens.colorContrastLight,
+    width: '150px',
+    height: '80px',
+    color: tokens.colorWhite,
+  },
+};
+
+export default {
+  title: 'Layout/Stack',
+  component: Stack,
+  parameters: {
+    propTypes: [_Stack['__docgenInfo']],
+  },
+  argTypes: {
+    className: { control: { disable: true } },
+    testId: { control: { disable: true } },
+    as: { control: { disable: true } },
+    style: { control: { disable: true } },
+  },
+};
+
+const Template: Story<StackInternalProps> = (args) => (
+  <Stack {...args}>
+    <Box style={styles.demoBox}>Example element 1</Box>
+    <Box style={styles.demoBox}>Example element 2</Box>
+    <Box style={styles.demoBox}>Example element 3</Box>
+    <Box style={styles.demoBox}>Example element 4</Box>
+  </Stack>
+);
+
+export const Basic = Template.bind({});
+
+Basic.args = {
+  direction: 'row',
+  gap: 'spacingM',
+};


### PR DESCRIPTION
# Purpose of PR

The latest addition to a layout family in Forma V4 - Stack component.

It's very similar to https://chakra-ui.com/docs/layout/stack and allows to stack components vertically or horizontally with a spacing gap between them.

Internally, it's just a wrapper on top of `Grid` component that hides all complexity of Grid properties and provides a simple way to control the behavior with only two properties: `direction` and `gap`

Depends on https://github.com/contentful/forma-36/pull/878