### PR TITLE
feat: add 'featured' tagType to Tag

### DIFF
--- a/packages/components/datepicker/CHANGELOG.md
+++ b/packages/components/datepicker/CHANGELOG.md
@@ -7,10 +7,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @contentful/forma-36-react-datepicker
 
-
-
-
-
 # [0.4.0-alpha.27](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-datepicker@0.4.0-alpha.26...@contentful/forma-36-react-datepicker@0.4.0-alpha.27) (2021-03-18)
 
 **Note:** Version bump only for package @contentful/forma-36-react-datepicker

--- a/packages/components/timepicker/CHANGELOG.md
+++ b/packages/components/timepicker/CHANGELOG.md
@@ -7,10 +7,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @contentful/forma-36-react-timepicker
 
-
-
-
-
 # [0.5.0-alpha.28](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-timepicker@0.5.0-alpha.27...@contentful/forma-36-react-timepicker@0.5.0-alpha.28) (2021-03-18)
 
 **Note:** Version bump only for package @contentful/forma-36-react-timepicker

--- a/packages/forma-36-react-components/.size-limit
+++ b/packages/forma-36-react-components/.size-limit
@@ -12,7 +12,7 @@
   {
     "path": "dist/styles.css",
     "name": "gzipped css",
-    "limit": "95 KB",
+    "limit": "100 KB",
     "gzip": false
   }
 ]

--- a/packages/forma-36-react-components/CHANGELOG.md
+++ b/packages/forma-36-react-components/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [3.85.0](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-components@3.84.3...@contentful/forma-36-react-components@3.85.0) (2021-03-19)
 
-
 ### Features
 
-* add rel attribute to card component ([ca18a23](https://github.com/contentful/forma-36/commit/ca18a239e0c35e8f0685ae9573be040b185e9b96))
-
-
-
-
+- add rel attribute to card component ([ca18a23](https://github.com/contentful/forma-36/commit/ca18a239e0c35e8f0685ae9573be040b185e9b96))
 
 ## [3.84.3](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-components@3.84.2...@contentful/forma-36-react-components@3.84.3) (2021-03-18)
 

--- a/packages/forma-36-react-components/src/components/Tag/README.mdx
+++ b/packages/forma-36-react-components/src/components/Tag/README.mdx
@@ -193,6 +193,29 @@ Tags are used to label or highlight items in the interface.
 </>
 ```
 
+- **Featured** - used for featured entities that should be highlighted.
+
+```jsx
+<Table>
+  <TableHead>
+    <TableRow>
+      <TableCell>Space</TableCell>
+      <TableCell>Updated</TableCell>
+      <TableCell>Status</TableCell>
+    </TableRow>
+  </TableHead>
+  <TableBody>
+    <TableRow>
+      <TableCell>My space</TableCell>
+      <TableCell>Oct 29, 2020</TableCell>
+      <TableCell>
+        <Tag tagType="primary">trial</Tag>
+      </TableCell>
+    </TableRow>
+  </TableBody>
+</Table>
+```
+
 - **Muted** - this `tagType` is deprecated, please use `tagType` `secondary` instead
 
 ### Tag sizes

--- a/packages/forma-36-react-components/src/components/Tag/Tag.css
+++ b/packages/forma-36-react-components/src/components/Tag/Tag.css
@@ -52,6 +52,11 @@
   background-color: var(--color-primary);
 }
 
+.Tag--featured {
+  color: var(--color-purple-base);
+  background-color: var(--color-purple-lightest);
+}
+
 .Tag--small {
   padding: 3px var(--spacing-2xs);
   font-size: 0.625rem;

--- a/packages/forma-36-react-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Tag/Tag.stories.tsx
@@ -68,6 +68,11 @@ export const overview = () => (
       </Flex>
       <Flex marginBottom="spacingM" alignItems="center">
         <Flex marginRight="spacingS">
+          <Tag tagType="featured">featured</Tag>
+        </Flex>
+      </Flex>
+      <Flex marginBottom="spacingM" alignItems="center">
+        <Flex marginRight="spacingS">
           <Tag tagType="muted">muted</Tag>
           <Paragraph style={{ color: `${tokens.colorRedBase}` }}>
             {' '}

--- a/packages/forma-36-react-components/src/components/Tag/Tag.tsx
+++ b/packages/forma-36-react-components/src/components/Tag/Tag.tsx
@@ -10,6 +10,7 @@ export type TagType =
   | 'negative'
   | 'warning'
   | 'secondary'
+  | 'featured'
   | 'muted';
 
 type Status =
@@ -32,7 +33,7 @@ const statusTagTypeMap = {
 export interface TagProps {
   /**
    * prop, used for setting type of the component from
-   * TagTypes - primary, primary-filled, positive, negative, warning, secondary, muted */
+   * TagTypes - primary, primary-filled, positive, negative, warning, secondary, muted, featured */
   tagType?: TagType;
   /**
    * property to set size of the component */

--- a/packages/forma-36-react-components/src/components/Tag/Tag.tsx
+++ b/packages/forma-36-react-components/src/components/Tag/Tag.tsx
@@ -33,7 +33,7 @@ const statusTagTypeMap = {
 export interface TagProps {
   /**
    * prop, used for setting type of the component from
-   * TagTypes - primary, primary-filled, positive, negative, warning, secondary, muted, featured */
+   */
   tagType?: TagType;
   /**
    * property to set size of the component */

--- a/packages/forma-36-react-components/src/styles/settings/colors.css
+++ b/packages/forma-36-react-components/src/styles/settings/colors.css
@@ -11,3 +11,4 @@
 @import '@contentful/forma-36-tokens/dist/css/colors/colors-semantic.css';
 @import '@contentful/forma-36-tokens/dist/css/colors/colors-text.css';
 @import '@contentful/forma-36-tokens/dist/css/colors/colors-white.css';
+@import '@contentful/forma-36-tokens/dist/css/colors/colors-purple.css';


### PR DESCRIPTION
Adding `featured` tagType to Tag, as requested by @fabe 

<img width="975" alt="Screenshot 2021-03-24 at 13 35 51" src="https://user-images.githubusercontent.com/9191638/112311336-e2f2fd80-8ca5-11eb-84a9-0e12ab05a818.png">

