### PR TITLE
feat: add customBody prop to EntryCard

### DIFF
--- a/packages/components/datepicker/CHANGELOG.md
+++ b/packages/components/datepicker/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.4.0-alpha.31](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-datepicker@0.4.0-alpha.30...@contentful/forma-36-react-datepicker@0.4.0-alpha.31) (2021-04-01)
 
-
 ### Bug Fixes
 
-* equal left & right paddings in a dropdown button ([#902](https://github.com/contentful/forma-36/issues/902)) ([334c598](https://github.com/contentful/forma-36/commit/334c598fb27848e9df2d2996d67b6a0dcbbf77fd))
-
-
-
-
+- equal left & right paddings in a dropdown button ([#902](https://github.com/contentful/forma-36/issues/902)) ([334c598](https://github.com/contentful/forma-36/commit/334c598fb27848e9df2d2996d67b6a0dcbbf77fd))
 
 # [0.4.0-alpha.30](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-datepicker@0.4.0-alpha.29...@contentful/forma-36-react-datepicker@0.4.0-alpha.30) (2021-04-01)
 

--- a/packages/components/timepicker/CHANGELOG.md
+++ b/packages/components/timepicker/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.5.0-alpha.32](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-timepicker@0.5.0-alpha.31...@contentful/forma-36-react-timepicker@0.5.0-alpha.32) (2021-04-01)
 
-
 ### Bug Fixes
 
-* equal left & right paddings in a dropdown button ([#902](https://github.com/contentful/forma-36/issues/902)) ([334c598](https://github.com/contentful/forma-36/commit/334c598fb27848e9df2d2996d67b6a0dcbbf77fd))
-
-
-
-
+- equal left & right paddings in a dropdown button ([#902](https://github.com/contentful/forma-36/issues/902)) ([334c598](https://github.com/contentful/forma-36/commit/334c598fb27848e9df2d2996d67b6a0dcbbf77fd))
 
 # [0.5.0-alpha.31](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-timepicker@0.5.0-alpha.30...@contentful/forma-36-react-timepicker@0.5.0-alpha.31) (2021-04-01)
 

--- a/packages/forma-36-react-components/CHANGELOG.md
+++ b/packages/forma-36-react-components/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [3.86.2](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-components@3.86.1...@contentful/forma-36-react-components@3.86.2) (2021-04-01)
 
-
 ### Bug Fixes
 
-* equal left & right paddings in a dropdown button ([#902](https://github.com/contentful/forma-36/issues/902)) ([334c598](https://github.com/contentful/forma-36/commit/334c598fb27848e9df2d2996d67b6a0dcbbf77fd))
-
-
-
-
+- equal left & right paddings in a dropdown button ([#902](https://github.com/contentful/forma-36/issues/902)) ([334c598](https://github.com/contentful/forma-36/commit/334c598fb27848e9df2d2996d67b6a0dcbbf77fd))
 
 ## [3.86.1](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-components@3.86.0...@contentful/forma-36-react-components@3.86.1) (2021-04-01)
 

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
@@ -75,11 +75,11 @@ WithThumbnailElement.args = {
   ...Basic.args,
 };
 
-export const WithContentElement = (args: EntryCardPropTypes) => (
+export const WithCustomBody = (args: EntryCardPropTypes) => (
   <EntryCard
     {...args}
     size="auto"
-    contentElement={
+    customBody={
       <Flex
         alignItems="center"
         flexDirection="column"
@@ -95,7 +95,7 @@ export const WithContentElement = (args: EntryCardPropTypes) => (
   />
 );
 
-WithContentElement.args = {
+WithCustomBody.args = {
   ...Basic.args,
 };
 

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.stories.tsx
@@ -75,6 +75,30 @@ WithThumbnailElement.args = {
   ...Basic.args,
 };
 
+export const WithContentElement = (args: EntryCardPropTypes) => (
+  <EntryCard
+    {...args}
+    size="auto"
+    contentElement={
+      <Flex
+        alignItems="center"
+        flexDirection="column"
+        style={{ width: '100%' }}
+      >
+        <img
+          src="https://via.placeholder.com/300x200"
+          alt="Joy Division - Closer album cover"
+        />
+        <div>Joy Division - Closer</div>
+      </Flex>
+    }
+  />
+);
+
+WithContentElement.args = {
+  ...Basic.args,
+};
+
 export const Overview = () => (
   <div>
     <Flex marginBottom="spacingS" marginTop="spacingM">

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.test.tsx
@@ -128,3 +128,15 @@ it('has no a11y issues', async () => {
 
   expect(results).toHaveNoViolations();
 });
+
+it('renders the component with custom content', () => {
+  const { container } = render(
+    <EntryCard
+      status="published"
+      contentType="My Content Type"
+      contentElement={<div>This is custom content</div>}
+    />,
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.test.tsx
@@ -134,7 +134,7 @@ it('renders the component with custom content', () => {
     <EntryCard
       status="published"
       contentType="My Content Type"
-      contentElement={<div>This is custom content</div>}
+      customBody={<div>This is custom content</div>}
     />,
   );
 

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
@@ -80,9 +80,9 @@ export interface EntryCardPropTypes extends BaseCardProps {
    */
   size?: EntryCardSize;
   /**
-   * Render custom content for the entry. This will override the props title, description and thumbnailElement
+   * Render custom body for the entry. This will override the props title, description and thumbnailElement
    */
-  contentElement?: React.ReactNode;
+  customBody?: React.ReactNode;
 }
 
 export function EntryCard({
@@ -102,7 +102,7 @@ export function EntryCard({
   cardDragHandleComponent,
   cardDragHandleProps,
   withDragHandle,
-  contentElement,
+  customBody,
   ...otherProps
 }: EntryCardPropTypes): React.ReactElement {
   const renderTitle = useCallback((_size: EntryCardSize, title?: string) => {
@@ -258,7 +258,7 @@ export function EntryCard({
                 )}
               </div>
               <div className={styles.EntryCard__content}>
-                {contentElement ?? (
+                {customBody ?? (
                   <React.Fragment>
                     <div className={styles.EntryCard__body}>
                       {renderTitle(size, title)}

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.tsx
@@ -79,6 +79,10 @@ export interface EntryCardPropTypes extends BaseCardProps {
    * Changes the height of the component. When small will also ensure thumbnail and description aren't rendered
    */
   size?: EntryCardSize;
+  /**
+   * Render custom content for the entry. This will override the props title, description and thumbnailElement
+   */
+  contentElement?: React.ReactNode;
 }
 
 export function EntryCard({
@@ -98,6 +102,7 @@ export function EntryCard({
   cardDragHandleComponent,
   cardDragHandleProps,
   withDragHandle,
+  contentElement,
   ...otherProps
 }: EntryCardPropTypes): React.ReactElement {
   const renderTitle = useCallback((_size: EntryCardSize, title?: string) => {
@@ -253,11 +258,15 @@ export function EntryCard({
                 )}
               </div>
               <div className={styles.EntryCard__content}>
-                <div className={styles.EntryCard__body}>
-                  {renderTitle(size, title)}
-                  {renderDescription(size, description)}
-                </div>
-                {renderThumbnail(size, thumbnailElement)}
+                {contentElement ?? (
+                  <React.Fragment>
+                    <div className={styles.EntryCard__body}>
+                      {renderTitle(size, title)}
+                      {renderDescription(size, description)}
+                    </div>
+                    {renderThumbnail(size, thumbnailElement)}
+                  </React.Fragment>
+                )}
               </div>
             </React.Fragment>
           </div>

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
@@ -341,6 +341,41 @@ exports[`renders the component with an additional class name 1`] = `
 </div>
 `;
 
+exports[`renders the component with custom content 1`] = `
+<div
+  class="Card EntryCard EntryCard--size-default Card--padding-none"
+  data-test-id="cf-ui-entry-card"
+>
+  <div
+    class="EntryCard__wrapper"
+  >
+    <div
+      class="EntryCard__header"
+    >
+      <div
+        class="EntryCard__content-type"
+        data-test-id="content-type"
+      >
+        My Content Type
+      </div>
+      <div
+        class="Tag Tag--positive"
+        data-test-id="cf-ui-tag"
+      >
+        published
+      </div>
+    </div>
+    <div
+      class="EntryCard__content"
+    >
+      <div>
+        This is custom content
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renders the component with dropdownListElements 1`] = `
 <div
   class="Card EntryCard EntryCard--size-default Card--padding-none"


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->
Adds `contentElement` prop to EntryCard. This is useful when you want to fully customize the look of an entry beyond the structured design allowed by `title`, `description` and `thumbnailElement` props.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
