### PR TITLE
fix: equal left & right paddings in a dropdown button

### DIFF
--- a/packages/components/datepicker/CHANGELOG.md
+++ b/packages/components/datepicker/CHANGELOG.md
@@ -7,10 +7,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @contentful/forma-36-react-datepicker
 
-
-
-
-
 # [0.4.0-alpha.29](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-datepicker@0.4.0-alpha.28...@contentful/forma-36-react-datepicker@0.4.0-alpha.29) (2021-03-24)
 
 ### Features

--- a/packages/components/timepicker/CHANGELOG.md
+++ b/packages/components/timepicker/CHANGELOG.md
@@ -7,10 +7,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @contentful/forma-36-react-timepicker
 
-
-
-
-
 # [0.5.0-alpha.30](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-timepicker@0.5.0-alpha.29...@contentful/forma-36-react-timepicker@0.5.0-alpha.30) (2021-03-24)
 
 ### Features

--- a/packages/forma-36-react-components/CHANGELOG.md
+++ b/packages/forma-36-react-components/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [3.86.1](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-components@3.86.0...@contentful/forma-36-react-components@3.86.1) (2021-04-01)
 
-
 ### Bug Fixes
 
-* **copy-button:** center icon alignment ([#905](https://github.com/contentful/forma-36/issues/905)) ([0d1e7c4](https://github.com/contentful/forma-36/commit/0d1e7c44b866bcf216573e1461d8b7c72ebae7e6)), closes [#904](https://github.com/contentful/forma-36/issues/904)
-
-
-
-
+- **copy-button:** center icon alignment ([#905](https://github.com/contentful/forma-36/issues/905)) ([0d1e7c4](https://github.com/contentful/forma-36/commit/0d1e7c44b866bcf216573e1461d8b7c72ebae7e6)), closes [#904](https://github.com/contentful/forma-36/issues/904)
 
 # [3.86.0](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-components@3.85.0...@contentful/forma-36-react-components@3.86.0) (2021-03-24)
 

--- a/packages/forma-36-react-components/src/components/Button/Button.css
+++ b/packages/forma-36-react-components/src/components/Button/Button.css
@@ -232,12 +232,6 @@
   justify-content: center;
 }
 
-.Button--is-dropdown {
-  & .Button__inner-wrapper {
-    padding-right: calc(1rem * (8 / var(--font-base-default)));
-  }
-}
-
 .Button__label {
   margin: 0 calc(1rem * (4 / var(--font-base-default)));
   font-size: calc(1rem * (14 / var(--font-base-default)));

--- a/packages/forma-36-react-components/src/components/Button/Button.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.tsx
@@ -80,7 +80,6 @@ export const Button = ({
       [styles['Button--disabled']]: disabled,
       [styles['Button--full-width']]: isFullWidth,
       [styles['Button--is-active']]: isActive,
-      [styles['Button--is-dropdown']]: indicateDropdown,
     },
   );
 

--- a/packages/forma-36-react-components/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -250,7 +250,7 @@ exports[`renders the component with an additional class name 1`] = `
 
 exports[`renders the component with dropdown indicator 1`] = `
 <button
-  class="Button Button--primary Button--medium Button--is-dropdown"
+  class="Button Button--primary Button--medium"
   data-test-id="cf-ui-button"
   type="button"
 >


### PR DESCRIPTION
# Purpose of PR

A medium or large button with `indicateDropdown` being `true` has a too small right-padding. The paddings should be the same on both sides. Right now this is only the case for a small button since its CSS styles have a higher specificity than ".is--dropdown".

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information

Before:
![Screenshot 2021-03-30 at 13 47 10](https://user-images.githubusercontent.com/9327071/112995504-94dd6e80-916b-11eb-80d5-40156ca2ae74.png)
![Screenshot 2021-03-30 at 13 47 25](https://user-images.githubusercontent.com/9327071/112995507-960e9b80-916b-11eb-9342-d8e9b21de796.png)
![Screenshot 2021-03-30 at 13 47 40](https://user-images.githubusercontent.com/9327071/112995509-960e9b80-916b-11eb-8fdc-476b70d0750a.png)

After:
![Screenshot 2021-03-30 at 13 48 03](https://user-images.githubusercontent.com/9327071/112995659-bc343b80-916b-11eb-90ec-a07c2f579e28.png)
![Screenshot 2021-03-30 at 13 47 49](https://user-images.githubusercontent.com/9327071/112995650-bb9ba500-916b-11eb-9511-e64525827b59.png)
