### PR TITLE
fix(copy-button): center icon alignment

### DIFF
--- a/packages/forma-36-react-components/src/components/CopyButton/CopyButton.css
+++ b/packages/forma-36-react-components/src/components/CopyButton/CopyButton.css
@@ -41,7 +41,7 @@
   composes: sr-only from './../../styles/settings/helpers.css';
 }
 
-.CopyButton__TabFocusTrap {
+.CopyButton .CopyButton__TabFocusTrap {
   width: 100%;
   height: 100%;
   display: flex;


### PR DESCRIPTION
Fix for CopyButton icon not being centered. The problem seems to be CSS specificity issues that show up in our production build but not in development, which is why the problem doesn't show in Storybook. The  `TabFocusTrap` component's default `display: inherit` value is overriding the CSS from CopyButton which sets it to `display: flex`.

I tried changing the class name order around and it didn't fix the problem 🤔 

Closes #904

