### PR TITLE
chore: don't run chromatic for external prs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,10 @@ workflows:
       - chromatic-deployment:
           requires:
             - lint-and-test
+          filters:
+            branches:
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              ignore: /pull\/[0-9]+/
       - release:
           filters:
             branches:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "lint": "yarn run lint:js && yarn run lint:packages",
     "lint:js": "eslint packages --ext .js,.jsx,.ts,.tsx",
     "lint:packages": "node scripts/lint-packages.js",
-    "postversion": "yarn run prettier",
     "prettier": "prettier --write '**/*.{jsx,js,ts,tsx,md,mdx}'",
     "prettier:check": "prettier --check '**/*.{jsx,js,ts,tsx,md,mdx}'",
     "semantic-release": "lerna exec --concurrency 1 -- npx --no-install semantic-release -e semantic-release-monorepo",
@@ -34,7 +33,8 @@
   "husky": {
     "hooks": {
       "pre-commit": "yarn pretty-quick --staged --pattern '**/*.*(js|jsx|ts|tsx|md|mdx)'",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+      "postversion": "yarn run prettier"
     }
   },
   "config": {

--- a/packages/components/datepicker/CHANGELOG.md
+++ b/packages/components/datepicker/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.4.0-alpha.31](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-datepicker@0.4.0-alpha.30...@contentful/forma-36-react-datepicker@0.4.0-alpha.31) (2021-04-01)
 
-
 ### Bug Fixes
 
-* equal left & right paddings in a dropdown button ([#902](https://github.com/contentful/forma-36/issues/902)) ([334c598](https://github.com/contentful/forma-36/commit/334c598fb27848e9df2d2996d67b6a0dcbbf77fd))
-
-
-
-
+- equal left & right paddings in a dropdown button ([#902](https://github.com/contentful/forma-36/issues/902)) ([334c598](https://github.com/contentful/forma-36/commit/334c598fb27848e9df2d2996d67b6a0dcbbf77fd))
 
 # [0.4.0-alpha.30](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-datepicker@0.4.0-alpha.29...@contentful/forma-36-react-datepicker@0.4.0-alpha.30) (2021-04-01)
 

--- a/packages/components/timepicker/CHANGELOG.md
+++ b/packages/components/timepicker/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [0.5.0-alpha.32](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-timepicker@0.5.0-alpha.31...@contentful/forma-36-react-timepicker@0.5.0-alpha.32) (2021-04-01)
 
-
 ### Bug Fixes
 
-* equal left & right paddings in a dropdown button ([#902](https://github.com/contentful/forma-36/issues/902)) ([334c598](https://github.com/contentful/forma-36/commit/334c598fb27848e9df2d2996d67b6a0dcbbf77fd))
-
-
-
-
+- equal left & right paddings in a dropdown button ([#902](https://github.com/contentful/forma-36/issues/902)) ([334c598](https://github.com/contentful/forma-36/commit/334c598fb27848e9df2d2996d67b6a0dcbbf77fd))
 
 # [0.5.0-alpha.31](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-timepicker@0.5.0-alpha.30...@contentful/forma-36-react-timepicker@0.5.0-alpha.31) (2021-04-01)
 

--- a/packages/forma-36-react-components/CHANGELOG.md
+++ b/packages/forma-36-react-components/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [3.86.2](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-components@3.86.1...@contentful/forma-36-react-components@3.86.2) (2021-04-01)
 
-
 ### Bug Fixes
 
-* equal left & right paddings in a dropdown button ([#902](https://github.com/contentful/forma-36/issues/902)) ([334c598](https://github.com/contentful/forma-36/commit/334c598fb27848e9df2d2996d67b6a0dcbbf77fd))
-
-
-
-
+- equal left & right paddings in a dropdown button ([#902](https://github.com/contentful/forma-36/issues/902)) ([334c598](https://github.com/contentful/forma-36/commit/334c598fb27848e9df2d2996d67b6a0dcbbf77fd))
 
 ## [3.86.1](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-components@3.86.0...@contentful/forma-36-react-components@3.86.1) (2021-04-01)
 


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Chromatic job is using a secret environment variable that isn't visible to forked PRs.

https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/ suggests to disable the step and allow running them only after collaborator executes a command:

```bash
git-push-fork-to-upstream-branch upstream <fork_username>:<fork_branch>
```