### PR TITLE
fix(validation-message): use FlexInternalProps

### DIFF
--- a/packages/components/validation-message/src/ValidationMessage.tsx
+++ b/packages/components/validation-message/src/ValidationMessage.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef } from 'react';
 import tokens from '@contentful/f36-tokens';
 import { Flex } from '@contentful/f36-core';
 import type {
-  BoxInternalProps,
+  FlexInternalProps,
   PolymorphicComponent,
   PolymorphicComponentProps,
   PolymorphicComponentWithRef,
@@ -26,7 +26,7 @@ const styles = {
   }),
 };
 
-export type ValidationMessageInternalProps = BoxInternalProps;
+export type ValidationMessageInternalProps = FlexInternalProps;
 
 export type ValidationMessageProps = PolymorphicComponentProps<
   typeof DEFAULT_TAG,


### PR DESCRIPTION
We should use `FlexInternalProps` since we're using the `Flex` component.