### PR TITLE
feat: Machine Readable Formats for DateTime with DATE_ONLY or TIME_ONLY

### DIFF
--- a/packages/forma-36-react-components/src/components/DateTime/DateTime.test.tsx
+++ b/packages/forma-36-react-components/src/components/DateTime/DateTime.test.tsx
@@ -5,7 +5,7 @@ import { DateTime } from './DateTime';
 
 const exampleDate = new Date('2020-04-09T16:17:18.912Z');
 
-const monkeyPatch = (errorMessage: string) => {
+const silenceErrorsWithMessage = (errorMessage: string) => {
   // Throw expected error silently
   const originalFunction = console.error;
   const spy = jest.spyOn(console, 'error');
@@ -67,7 +67,7 @@ describe('DateTime', () => {
   it('does not allow for an unknown format', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const format = 'NOT_REAL' as any;
-    const restoreErrorPatch = monkeyPatch("Unknown date format 'NOT_REAL'");
+    const restoreErrorPatch = silenceErrorsWithMessage("Unknown date format 'NOT_REAL'");
     expect(() => {
       render(<DateTime date={exampleDate} format={format} />);
     }).toThrow(`Unknown date format 'NOT_REAL'`);

--- a/packages/forma-36-react-components/src/components/DateTime/DateTime.test.tsx
+++ b/packages/forma-36-react-components/src/components/DateTime/DateTime.test.tsx
@@ -67,7 +67,9 @@ describe('DateTime', () => {
   it('does not allow for an unknown format', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const format = 'NOT_REAL' as any;
-    const restoreErrorPatch = silenceErrorsWithMessage("Unknown date format 'NOT_REAL'");
+    const restoreErrorPatch = silenceErrorsWithMessage(
+      "Unknown date format 'NOT_REAL'",
+    );
     expect(() => {
       render(<DateTime date={exampleDate} format={format} />);
     }).toThrow(`Unknown date format 'NOT_REAL'`);

--- a/packages/forma-36-react-components/src/components/DateTime/DateTime.test.tsx
+++ b/packages/forma-36-react-components/src/components/DateTime/DateTime.test.tsx
@@ -51,9 +51,12 @@ describe('DateTime', () => {
   it('does not allow for an unknown format', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const format = 'NOT_REAL' as any;
-
+    // Throw error silently
+    const spy = jest.spyOn(console, 'error');
+    spy.mockImplementation(() => {});
     expect(() => {
       render(<DateTime date={exampleDate} format={format} />);
     }).toThrow(`Unknown date format 'NOT_REAL'`);
+    spy.mockRestore();
   });
 });

--- a/packages/forma-36-react-components/src/components/DateTime/DateTime.tsx
+++ b/packages/forma-36-react-components/src/components/DateTime/DateTime.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
-import { DateTimeFormat, formatDateTime } from './dateUtils';
+import {
+  DateTimeFormat,
+  formatDateTime,
+  formatMachineReadableDateTime,
+} from './dateUtils';
 import { CoercibleDate } from './types';
 
 export interface DateTimeProps {
@@ -35,10 +39,11 @@ export const DateTime: React.FC<DateTimeProps> = ({
     date = new Date(date);
   }
   const formatted = formatDateTime(date, format);
+  const machineReadable = formatMachineReadableDateTime(date, format);
 
   return (
     <time
-      dateTime={date.toISOString()}
+      dateTime={machineReadable}
       className={className}
       data-test-id={testId}
     >

--- a/packages/forma-36-react-components/src/components/DateTime/__snapshots__/DateTime.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/DateTime/__snapshots__/DateTime.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`DateTime allows for DATE_ONLY formatting 1`] = `
 <time
-  datetime="2020-04-09T16:17:18.912Z"
+  datetime="2020-04-09"
 >
   9 Apr 2020
 </time>
@@ -18,7 +18,7 @@ exports[`DateTime allows for FULL formatting 1`] = `
 
 exports[`DateTime allows for TIME_ONLY formatting 1`] = `
 <time
-  datetime="2020-04-09T16:17:18.912Z"
+  datetime="16:17:18.912"
 >
   9:17 am
 </time>
@@ -26,7 +26,7 @@ exports[`DateTime allows for TIME_ONLY formatting 1`] = `
 
 exports[`DateTime allows for WEEKDAY_DATE formatting 1`] = `
 <time
-  datetime="2020-04-09T16:17:18.912Z"
+  datetime="04-09"
 >
   Thu, 9 Apr
 </time>

--- a/packages/forma-36-react-components/src/components/DateTime/dateUtils.test.ts
+++ b/packages/forma-36-react-components/src/components/DateTime/dateUtils.test.ts
@@ -17,6 +17,24 @@ describe('formatAbsoluteDateTime', () => {
   });
 });
 
+describe('formatMachineReadableDateTime', () => {
+  it('formats with the expected values', () => {
+    const date = new Date('2020-02-29T09:31:46.345Z');
+    const formatToExpected: [dateUtils.DateTimeFormat, string][] = [
+      ['FULL', '2020-02-29T09:31:46.345Z'],
+      ['DATE_ONLY', '2020-02-29'],
+      ['TIME_ONLY', '09:31:46.345'],
+      ['WEEKDAY_DATE', '02-29'],
+    ];
+
+    formatToExpected.forEach(([format, expected]) => {
+      expect(dateUtils.formatMachineReadableDateTime(date, format)).toEqual(
+        expected,
+      );
+    });
+  });
+});
+
 describe('formatWeekdayDate', () => {
   it('formats with the expected values', () => {
     const dateToExpected = [['2020-08-12T23:45:00.000Z', 'Wed, 12 Aug']];

--- a/packages/forma-36-react-components/src/components/DateTime/dateUtils.ts
+++ b/packages/forma-36-react-components/src/components/DateTime/dateUtils.ts
@@ -1,5 +1,8 @@
 import dayjs from 'dayjs';
 import RelativeTime from 'dayjs/plugin/relativeTime';
+import utcPlugin from 'dayjs/plugin/utc';
+
+dayjs.extend(utcPlugin);
 dayjs.extend(RelativeTime);
 
 import { CoercibleDate } from './types';
@@ -9,6 +12,13 @@ const formatTokens = {
   DATE_ONLY: 'D MMM YYYY',
   TIME_ONLY: 'h:mm a',
   WEEKDAY_DATE: 'ddd[, ]D MMM',
+};
+
+const formatTokensMachineReadable = {
+  FULL: 'YYYY-MM-DDTHH:mm:ss.SSS[Z]',
+  DATE_ONLY: 'YYYY-MM-DD',
+  TIME_ONLY: 'HH:mm:ss.SSS',
+  WEEKDAY_DATE: 'MM-DD',
 };
 
 export type DateTimeFormat = keyof typeof formatTokens;
@@ -30,6 +40,25 @@ export const formatDateTime = (
     throw new TypeError(`Unknown date format '${token}'`);
   }
   return dayjs(date).format(formatTokens[token]);
+};
+
+/**
+ * @example
+ * > formatMachineReadableDateTime(date)
+ * 2019-08-13T10:00:00.000Z
+ *
+ * @example
+ * > formatMachineReadableDateTime(date, 'DATE_ONLY')
+ * 2019-08-13
+ */
+export const formatMachineReadableDateTime = (
+  date: CoercibleDate,
+  token: DateTimeFormat = 'FULL',
+): string => {
+  if (!formatTokens[token]) {
+    throw new TypeError(`Unknown date format '${token}'`);
+  }
+  return dayjs(date).utc().format(formatTokensMachineReadable[token]);
 };
 
 /**


### PR DESCRIPTION
# Purpose of PR

When one uses DateTime only showing the date or time, the `datetime` attribute should represent that, too.

I followed the respective [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#valid_datetime_values) regarding which formats are allowed.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
