### PR TITLE
fix: make children optional in Workbench sidebar and content

### DIFF
--- a/packages/forma-36-react-components/src/components/Workbench/Workbench.tsx
+++ b/packages/forma-36-react-components/src/components/Workbench/Workbench.tsx
@@ -90,7 +90,7 @@ export function WorkbenchHeader({
 WorkbenchHeader.displayName = 'Workbench.Header';
 
 export interface WorkbenchSidebarProps {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   className?: string;
   position?: 'left' | 'right';
   testId?: string;
@@ -120,7 +120,7 @@ export function WorkbenchSidebar({
 }
 
 export interface WorkbenchContentProps {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   type?: 'default' | 'text' | 'full';
   className?: string;
   testId?: string;


### PR DESCRIPTION
# Purpose of PR

Makes `children` property of `Workbench.Sidebar` and `Workbench.Content` optional. It's already a `React.ReactNode` type, so `undefined` is allowed. My change would allow to render them as self-enclosed: `<Workbench.Sidebar position="right" />`

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
