### PR TITLE
fix(autocomplete): dropdown button position

### DIFF
--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.css
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.css
@@ -16,7 +16,7 @@
   display: none;
 }
 
-.inputIconButton {
+.autocompleteInput .inputIconButton {
   position: relative;
   margin-left: calc(-1 * var(--spacing-xl));
 }


### PR DESCRIPTION
# Purpose of PR

Under some circumstances, the margin style of `.inputIconButton` class get's overwritten, which results in a wrongly placed dropdown indicator button.

This PR adds a more specific css class path to ensure the domination of the button class.

<img width="225" alt="Screenshot 2021-04-22 at 14 21 05" src="https://user-images.githubusercontent.com/156505/115713374-396f5c80-a376-11eb-9744-252c517f10e4.png">
<img width="333" alt="Screenshot 2021-04-22 at 14 21 21" src="https://user-images.githubusercontent.com/156505/115713377-3a07f300-a376-11eb-8c1a-31a6983541fe.png">


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
