### PR TITLE
fix: Restore Margins on EmptyState in Product [HOMER-23]

### DIFF
--- a/packages/forma-36-react-components/src/components/EmptyState/EmptyState.css
+++ b/packages/forma-36-react-components/src/components/EmptyState/EmptyState.css
@@ -18,7 +18,7 @@
   background-position: center;
 }
 
-.EmptyState_element {
+.EmptyState .EmptyState_element {
   max-width: calc(1rem * (500 / var(--font-base-default)));
   margin-bottom: var(--spacing-m);
 }


### PR DESCRIPTION
# Purpose of PR
In Launch app we discovered broken margins when using the `EmptyState`. While we have `margin-bottom` for paragraph and heading in the storybook, the according to rules are overwritten if using F36 in another place (like the Launch app). @mshaaban0 pointed out that this issue is known and advised me to improve the selector specificity for this particular case.


# Screenshots
Storybook | Launch
------------ | -------------
<img width="534" alt="Screenshot 2021-04-27 at 14 29 48" src="https://user-images.githubusercontent.com/9327071/116242080-d9a5f680-a765-11eb-8976-8360e720da22.png"> | <img width="495" alt="Screenshot 2021-04-27 at 14 34 21" src="https://user-images.githubusercontent.com/9327071/116242100-e0cd0480-a765-11eb-9157-cfb64c36655e.png">
<img width="308" alt="Screenshot 2021-04-27 at 14 35 19" src="https://user-images.githubusercontent.com/9327071/116242165-f17d7a80-a765-11eb-97de-bcfe2b002152.png"> | <img width="302" alt="Screenshot 2021-04-27 at 14 34 56" src="https://user-images.githubusercontent.com/9327071/116242155-ee828a00-a765-11eb-952f-25dfdea006d6.png">
 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
