### PR TITLE
fix: fix inputs onChange, onBlur, onFocus types

### DIFF
--- a/packages/forma-36-react-components/src/components/ControlledInputField/ControlledInputField.tsx
+++ b/packages/forma-36-react-components/src/components/ControlledInputField/ControlledInputField.tsx
@@ -22,7 +22,7 @@ export interface ControlledInputFieldPropTypes {
   checked?: boolean;
   inputProps?: object;
   inputType?: 'radio' | 'checkbox';
-  onChange?: ChangeEventHandler;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
   className?: string;
   testId?: string;
   children?: ReactNode;

--- a/packages/forma-36-react-components/src/components/SelectField/SelectField.tsx
+++ b/packages/forma-36-react-components/src/components/SelectField/SelectField.tsx
@@ -24,8 +24,8 @@ export interface SelectFieldProps {
   selectProps?: Partial<SelectProps>;
   helpText?: string;
   required?: boolean;
-  onChange?: ChangeEventHandler;
-  onBlur?: FocusEventHandler;
+  onChange?: ChangeEventHandler<HTMLSelectElement>;
+  onBlur?: FocusEventHandler<HTMLSelectElement>;
   testId?: string;
   className?: string;
 }

--- a/packages/forma-36-react-components/src/components/TextField/TextField.tsx
+++ b/packages/forma-36-react-components/src/components/TextField/TextField.tsx
@@ -33,8 +33,8 @@ export interface TextFieldProps {
   textarea?: boolean;
   countCharacters?: boolean;
   onChange?: ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
-  onBlur?: FocusEventHandler;
-  onFocus?: FocusEventHandler;
+  onBlur?: FocusEventHandler<HTMLTextAreaElement | HTMLInputElement>;
+  onFocus?: FocusEventHandler<HTMLTextAreaElement | HTMLInputElement>;
 }
 
 export const TextField = ({

--- a/packages/forma-36-react-components/src/components/TextField/TextField.tsx
+++ b/packages/forma-36-react-components/src/components/TextField/TextField.tsx
@@ -32,7 +32,7 @@ export interface TextFieldProps {
   required?: boolean;
   textarea?: boolean;
   countCharacters?: boolean;
-  onChange?: ChangeEventHandler;
+  onChange?: ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
   onBlur?: FocusEventHandler;
   onFocus?: FocusEventHandler;
 }


### PR DESCRIPTION
# Purpose of PR

This PR narrows down types of some inputs handlers, specifically `onChange`, `onBlur`, `onFocus`.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
