### PR TITLE
feat: adds title attribute to typography components

### DIFF
--- a/packages/forma-36-react-components/src/components/Typography/DisplayText/DisplayText.tsx
+++ b/packages/forma-36-react-components/src/components/Typography/DisplayText/DisplayText.tsx
@@ -11,6 +11,7 @@ export interface DisplayTextProps {
   children?: React.ReactNode;
   style?: React.CSSProperties;
   testId?: string;
+  title?: string;
 }
 
 export function DisplayText({

--- a/packages/forma-36-react-components/src/components/Typography/DisplayText/DisplayText.tsx
+++ b/packages/forma-36-react-components/src/components/Typography/DisplayText/DisplayText.tsx
@@ -1,17 +1,13 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import cn from 'classnames';
 import styles from './DisplayText.css';
 
 import { TypographyContext } from '../Typography/Typography';
 
-export interface DisplayTextProps {
+export interface DisplayTextProps extends HTMLAttributes<HTMLElement> {
   element?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
   size?: 'default' | 'large' | 'huge';
-  className?: string;
-  children?: React.ReactNode;
-  style?: React.CSSProperties;
   testId?: string;
-  title?: string;
 }
 
 export function DisplayText({

--- a/packages/forma-36-react-components/src/components/Typography/Heading/Heading.tsx
+++ b/packages/forma-36-react-components/src/components/Typography/Heading/Heading.tsx
@@ -1,16 +1,12 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import cn from 'classnames';
 import styles from './Heading.css';
 
 import { TypographyContext } from '../Typography/Typography';
 
-export interface HeadingProps {
+export interface HeadingProps extends HTMLAttributes<HTMLElement> {
   element?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
-  style?: React.CSSProperties;
-  className?: string;
-  children?: React.ReactNode;
   testId?: string;
-  title?: string;
 }
 
 export function Heading({

--- a/packages/forma-36-react-components/src/components/Typography/Heading/Heading.tsx
+++ b/packages/forma-36-react-components/src/components/Typography/Heading/Heading.tsx
@@ -10,6 +10,7 @@ export interface HeadingProps {
   className?: string;
   children?: React.ReactNode;
   testId?: string;
+  title?: string;
 }
 
 export function Heading({

--- a/packages/forma-36-react-components/src/components/Typography/Paragraph/Paragraph.tsx
+++ b/packages/forma-36-react-components/src/components/Typography/Paragraph/Paragraph.tsx
@@ -1,16 +1,12 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import cn from 'classnames';
 import styles from './Paragraph.css';
 
 import { TypographyContext } from '../Typography/Typography';
 
-export interface ParagraphProps {
+export interface ParagraphProps extends HTMLAttributes<HTMLElement> {
   element?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
-  className?: string;
-  children?: React.ReactNode;
   testId?: string;
-  style?: React.CSSProperties;
-  title?: string;
 }
 
 export function Paragraph({

--- a/packages/forma-36-react-components/src/components/Typography/Paragraph/Paragraph.tsx
+++ b/packages/forma-36-react-components/src/components/Typography/Paragraph/Paragraph.tsx
@@ -10,6 +10,7 @@ export interface ParagraphProps {
   children?: React.ReactNode;
   testId?: string;
   style?: React.CSSProperties;
+  title?: string;
 }
 
 export function Paragraph({

--- a/packages/forma-36-react-components/src/components/Typography/SectionHeading/SectionHeading.tsx
+++ b/packages/forma-36-react-components/src/components/Typography/SectionHeading/SectionHeading.tsx
@@ -10,6 +10,7 @@ export interface SectionHeadingProps {
   children?: React.ReactNode | string;
   testId?: string;
   style?: React.CSSProperties;
+  title?: string;
 }
 
 export function SectionHeading({

--- a/packages/forma-36-react-components/src/components/Typography/SectionHeading/SectionHeading.tsx
+++ b/packages/forma-36-react-components/src/components/Typography/SectionHeading/SectionHeading.tsx
@@ -1,16 +1,12 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import cn from 'classnames';
 import styles from './SectionHeading.css';
 
 import { TypographyContext } from '../Typography/Typography';
 
-export interface SectionHeadingProps {
+export interface SectionHeadingProps extends HTMLAttributes<HTMLElement> {
   element?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
-  className?: string;
-  children?: React.ReactNode | string;
   testId?: string;
-  style?: React.CSSProperties;
-  title?: string;
 }
 
 export function SectionHeading({

--- a/packages/forma-36-react-components/src/components/Typography/Subheading/Subheading.tsx
+++ b/packages/forma-36-react-components/src/components/Typography/Subheading/Subheading.tsx
@@ -10,6 +10,7 @@ export interface SubheadingProps {
   children?: React.ReactNode;
   testId?: string;
   style?: React.CSSProperties;
+  title?: string;
 }
 
 export function Subheading({

--- a/packages/forma-36-react-components/src/components/Typography/Subheading/Subheading.tsx
+++ b/packages/forma-36-react-components/src/components/Typography/Subheading/Subheading.tsx
@@ -1,16 +1,12 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import cn from 'classnames';
 import styles from './Subheading.css';
 
 import { TypographyContext } from '../Typography/Typography';
 
-export interface SubheadingProps {
+export interface SubheadingProps extends HTMLAttributes<HTMLElement> {
   element?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
-  className?: string;
-  children?: React.ReactNode;
   testId?: string;
-  style?: React.CSSProperties;
-  title?: string;
 }
 
 export function Subheading({

--- a/packages/forma-36-react-components/src/components/Typography/Typography/Typography.tsx
+++ b/packages/forma-36-react-components/src/components/Typography/Typography/Typography.tsx
@@ -8,6 +8,7 @@ export interface TypographyProps {
   children?: React.ReactNode;
   style?: React.CSSProperties;
   testId?: string;
+  title?: string;
 }
 
 const defaultConfiguration = {

--- a/packages/forma-36-react-components/src/components/Typography/Typography/Typography.tsx
+++ b/packages/forma-36-react-components/src/components/Typography/Typography/Typography.tsx
@@ -1,14 +1,10 @@
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
 import cn from 'classnames';
 
 import styles from './Typography.css';
 
-export interface TypographyProps {
-  className?: string;
-  children?: React.ReactNode;
-  style?: React.CSSProperties;
+export interface TypographyProps extends HTMLAttributes<HTMLElement> {
   testId?: string;
-  title?: string;
 }
 
 const defaultConfiguration = {


### PR DESCRIPTION
# Purpose of PR

This PR adds `title` attribute to all Typography components. 

`title` is a global HTML attribute and can be used on any HTML tag. There are multiple usages of it in our Contentful web app. To make Typescript happy we should have it listed in the props.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
