### PR TITLE
feat: follow guidelines for f36-inputs [HOMER-37]

### DIFF
--- a/packages/components/inputs/README.mdx
+++ b/packages/components/inputs/README.mdx
@@ -1,3 +1,12 @@
 # @contentful/f36-inputs
 
 This package is part of [forma-36](https://github.com/contentful/forma-36). See the repo for more details.
+
+## Components
+
+- ControlledInput
+- RadioButton
+- Checkbox
+- TextInput
+- TextareaInput
+- Select

--- a/packages/components/inputs/src/checkbox/Checkbox.test.tsx
+++ b/packages/components/inputs/src/checkbox/Checkbox.test.tsx
@@ -5,21 +5,21 @@ import { axe } from '@/scripts/test/axeHelper';
 import { Checkbox } from './Checkbox';
 
 it('renders the component', () => {
-  const { container } = render(<Checkbox labelText="checkbox" />);
+  const { container } = render(<Checkbox label="checkbox" />);
 
   expect(container.firstChild).toMatchSnapshot();
 });
 
 it('renders the component with an additional class name', () => {
   const { container } = render(
-    <Checkbox labelText="checkbox" className="my-extra-class" />,
+    <Checkbox label="checkbox" className="my-extra-class" />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
 });
 
 it('has no a11y issues', async () => {
-  const { container } = render(<Checkbox labelText="checkbox" />);
+  const { container } = render(<Checkbox label="checkbox" />);
   const results = await axe(container);
 
   expect(results).toHaveNoViolations();

--- a/packages/components/inputs/src/checkbox/Checkbox.tsx
+++ b/packages/components/inputs/src/checkbox/Checkbox.tsx
@@ -6,8 +6,8 @@ import { ControlledInput, ControlledInputProps } from '..';
 export interface CheckboxProps extends ControlledInputProps {}
 
 export const Checkbox = ({
-  disabled = false,
-  required = false,
+  isDisabled = false,
+  isRequired = false,
   testId = 'cf-ui-checkbox',
   type = 'checkbox',
   willBlurOnEsc = true,
@@ -15,8 +15,8 @@ export const Checkbox = ({
 }: CheckboxProps) => {
   return (
     <ControlledInput
-      disabled={disabled}
-      required={required}
+      isDisabled={isDisabled}
+      isRequired={isRequired}
       data-test-id={testId}
       type={type}
       willBlurOnEsc={willBlurOnEsc}

--- a/packages/components/inputs/src/checkbox/Checkbox.tsx
+++ b/packages/components/inputs/src/checkbox/Checkbox.tsx
@@ -5,10 +5,18 @@ import { ControlledInput, ControlledInputProps } from '..';
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CheckboxProps extends ControlledInputProps {}
 
-export const Checkbox = ({
-  testId = 'cf-ui-checkbox',
-  type = 'checkbox',
-  ...otherProps
-}: CheckboxProps) => {
-  return <ControlledInput testId={testId} type={type} {...otherProps} />;
+export const _Checkbox = (
+  { testId = 'cf-ui-checkbox', ...otherProps }: CheckboxProps,
+  ref: React.Ref<HTMLDivElement>,
+) => {
+  return (
+    <ControlledInput
+      testId={testId}
+      type="checkbox"
+      ref={ref}
+      {...otherProps}
+    />
+  );
 };
+
+export const Checkbox = React.forwardRef(_Checkbox);

--- a/packages/components/inputs/src/checkbox/Checkbox.tsx
+++ b/packages/components/inputs/src/checkbox/Checkbox.tsx
@@ -6,21 +6,9 @@ import { ControlledInput, ControlledInputProps } from '..';
 export interface CheckboxProps extends ControlledInputProps {}
 
 export const Checkbox = ({
-  isDisabled = false,
-  isRequired = false,
   testId = 'cf-ui-checkbox',
   type = 'checkbox',
-  willBlurOnEsc = true,
   ...otherProps
 }: CheckboxProps) => {
-  return (
-    <ControlledInput
-      isDisabled={isDisabled}
-      isRequired={isRequired}
-      data-test-id={testId}
-      type={type}
-      willBlurOnEsc={willBlurOnEsc}
-      {...otherProps}
-    />
-  );
+  return <ControlledInput testId={testId} type={type} {...otherProps} />;
 };

--- a/packages/components/inputs/src/checkbox/README.mdx
+++ b/packages/components/inputs/src/checkbox/README.mdx
@@ -7,4 +7,110 @@ github: 'https://github.com/contentful/forma-36/tree/master/packages/components/
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-checkbox--overview'
 ---
 
-Detailed documentation will be provided soon. For now, please have a look into the storybook for implementation details.
+Checkbox is used to show a checkbox form element. Under the hood, it uses `ControlledInput` with `type='checkbox'` .
+
+## Table of contents
+
+- [Table of contents](#table-of-contents)
+- [How to use Checkbox](#how-to-use-checkbox)
+- [Component variations](#component-variations)
+- [Content recommendations](#content-recommendations)
+- [Accessibility](#accessibility)
+- [Props](#props)
+
+## How to use Checkbox
+
+- You only need to define a suitable `label` to get a basic checkbox.
+- All common states (disabled, required, checked, indeterminate) are functionally and visually supported.
+- Control the current input value by setting `isChecked`.
+- Listen to native element events via `onChange`, `onBlur`, `onFocus`. More event handler can be attached by defining them via `inputProps`.
+
+## Component variations
+
+- **default**
+
+```jsx
+<div>
+  <Checkbox label="Subscribe to newsletter" name="newsletter-subscribe" />
+</div>
+```
+
+- **checked**
+
+```jsx
+<div>
+  <Checkbox
+    label="Subscribe to newsletter"
+    name="newsletter-subscribe"
+    isChecked
+  />
+</div>
+```
+
+- **indeterminate**
+
+```jsx
+<div>
+  <Checkbox
+    label="Subscribe to newsletter"
+    name="newsletter-subscribe"
+    isIndeterminate
+  />
+</div>
+```
+
+- **disabled**
+
+```jsx
+<div>
+  <Checkbox
+    label="Subscribe to newsletter"
+    name="newsletter-subscribe"
+    isDisabled
+  />
+</div>
+```
+
+- **disabled indeterminate**
+
+```jsx
+<div>
+  <Checkbox
+    label="Subscribe to newsletter"
+    name="newsletter-subscribe"
+    isIndeterminate
+    isDisabled
+  />
+</div>
+```
+
+- **disabled checked**
+
+```jsx
+<div>
+  <Checkbox
+    label="Subscribe to newsletter"
+    name="newsletter-subscribe"
+    isChecked
+    isDisabled
+  />
+</div>
+```
+
+## Content recommendations
+
+- Try to use labels with short, scannable text.
+
+## Accessibility
+
+- The `label` will be rendered as `aria-label` of the input node.
+- Use a unique `id`.
+- A explicit label node is rendered for showing a custom check mark. According to [w3](https://www.w3.org/WAI/tutorials/forms/labels/#associating-labels-implicitly), explicit labels provide a better support for assistive technologies.
+
+## Props
+
+```jsx
+import { Props } from '@contentful/f36-docs-utils';
+
+<Props of="Checkbox" />;
+```

--- a/packages/components/inputs/src/checkbox/README.mdx
+++ b/packages/components/inputs/src/checkbox/README.mdx
@@ -23,78 +23,78 @@ Checkbox is used to show a checkbox form element. Under the hood, it uses `Contr
 - You only need to define a suitable `label` to get a basic checkbox.
 - All common states (disabled, required, checked, indeterminate) are functionally and visually supported.
 - Control the current input value by setting `isChecked`.
-- Listen to native element events via `onChange`, `onBlur`, `onFocus`. More event handler can be attached by defining them via `inputProps`.
+- Listen to native element events via `onChange`, `onBlur`, `onFocus`. More event handlers can be attached by defining them via `inputProps`.
 
 ## Component variations
 
 - **default**
 
 ```jsx
-<div>
+<>
   <Checkbox label="Subscribe to newsletter" name="newsletter-subscribe" />
-</div>
+</>
 ```
 
 - **checked**
 
 ```jsx
-<div>
+<>
   <Checkbox
     label="Subscribe to newsletter"
     name="newsletter-subscribe"
     isChecked
   />
-</div>
+</>
 ```
 
 - **indeterminate**
 
 ```jsx
-<div>
+<>
   <Checkbox
     label="Subscribe to newsletter"
     name="newsletter-subscribe"
     isIndeterminate
   />
-</div>
+</>
 ```
 
 - **disabled**
 
 ```jsx
-<div>
+<>
   <Checkbox
     label="Subscribe to newsletter"
     name="newsletter-subscribe"
     isDisabled
   />
-</div>
+</>
 ```
 
 - **disabled indeterminate**
 
 ```jsx
-<div>
+<>
   <Checkbox
     label="Subscribe to newsletter"
     name="newsletter-subscribe"
     isIndeterminate
     isDisabled
   />
-</div>
+</>
 ```
 
 - **disabled checked**
 
 ```jsx
-<div>
+<>
   <Checkbox
     label="Subscribe to newsletter"
     name="newsletter-subscribe"
     isChecked
     isDisabled
   />
-</div>
+</>
 ```
 
 ## Content recommendations

--- a/packages/components/inputs/src/controlled-input/ControlledInput.test.tsx
+++ b/packages/components/inputs/src/controlled-input/ControlledInput.test.tsx
@@ -6,7 +6,7 @@ import { ControlledInput } from './ControlledInput';
 
 it('renders the component with all required props', () => {
   const { container } = render(
-    <ControlledInput id="ControlledInput" labelText="ControlledInput" />,
+    <ControlledInput id="ControlledInput" label="ControlledInput" />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -17,7 +17,7 @@ it('renders the component with an additional class name', () => {
     <ControlledInput
       className="my-extra-class"
       id="ControlledInput"
-      labelText="ControlledInput"
+      label="ControlledInput"
     />,
   );
 
@@ -29,8 +29,8 @@ it('renders the component with required prop', () => {
     <ControlledInput
       className="my-extra-class"
       id="ControlledInput"
-      labelText="ControlledInput"
-      required
+      label="ControlledInput"
+      isRequired
     />,
   );
 
@@ -42,8 +42,8 @@ it('renders the component with disabled prop', () => {
     <ControlledInput
       className="my-extra-class"
       id="ControlledInput"
-      labelText="ControlledInput"
-      disabled
+      label="ControlledInput"
+      isDisabled
     />,
   );
 
@@ -55,8 +55,8 @@ it('renders the component with as checked', () => {
     <ControlledInput
       className="my-extra-class"
       id="ControlledInput"
-      labelText="ControlledInput"
-      checked
+      label="ControlledInput"
+      isChecked
     />,
   );
 
@@ -68,7 +68,7 @@ it('renders the component with a value', () => {
     <ControlledInput
       className="my-extra-class"
       id="ControlledInput"
-      labelText="ControlledInput"
+      label="ControlledInput"
       value="someValue"
     />,
   );
@@ -78,7 +78,7 @@ it('renders the component with a value', () => {
 
 it('has no a11y issues', async () => {
   const { container } = render(
-    <ControlledInput id="ControlledInput" labelText="ControlledInput" />,
+    <ControlledInput id="ControlledInput" label="ControlledInput" />,
   );
   const results = await axe(container);
 

--- a/packages/components/inputs/src/controlled-input/ControlledInput.test.tsx
+++ b/packages/components/inputs/src/controlled-input/ControlledInput.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { axe } from '@/scripts/test/axeHelper';
 
 import { ControlledInput } from './ControlledInput';
@@ -83,4 +83,23 @@ it('has no a11y issues', async () => {
   const results = await axe(container);
 
   expect(results).toHaveNoViolations();
+});
+
+it('can blur when clicking escape', () => {
+  const onBlur = jest.fn();
+  const { getByRole } = render(
+    <ControlledInput
+      id="ControlledInput"
+      label="ControlledInput"
+      onBlur={onBlur}
+      canBlurOnEsc
+      type="checkbox"
+    />,
+  );
+  const input = getByRole('checkbox');
+  fireEvent.keyDown(input, {
+    code: 'Escape',
+    target: { blur: onBlur },
+  });
+  expect(onBlur).toHaveBeenCalled();
 });

--- a/packages/components/inputs/src/controlled-input/ControlledInput.tsx
+++ b/packages/components/inputs/src/controlled-input/ControlledInput.tsx
@@ -28,7 +28,7 @@ export interface ControlledInputProps extends Omit<BoxProps<'div'>, 'ref'> {
   type?: 'checkbox' | 'radio';
   className?: string;
   testId?: string;
-  willBlurOnEsc?: boolean;
+  canBlurOnEsc?: boolean;
   isIndeterminate?: boolean;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
@@ -48,7 +48,7 @@ const _ControlledInput = (
     testId = 'cf-ui-controlled-input',
     type = 'checkbox',
     value,
-    willBlurOnEsc = true,
+    canBlurOnEsc = true,
     isIndeterminate,
     inputProps,
     ...otherProps
@@ -72,12 +72,11 @@ const _ControlledInput = (
   const handleOnKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
       e.persist();
-
-      if (e.nativeEvent.code === 'Escape' && willBlurOnEsc) {
+      if (e.nativeEvent.code === 'Escape' && canBlurOnEsc) {
         e.currentTarget.blur();
       }
     },
-    [willBlurOnEsc],
+    [canBlurOnEsc],
   );
 
   useEffect(() => {

--- a/packages/components/inputs/src/controlled-input/ControlledInput.tsx
+++ b/packages/components/inputs/src/controlled-input/ControlledInput.tsx
@@ -16,40 +16,40 @@ import { Box, BoxProps } from '@contentful/f36-core';
 
 export interface ControlledInputProps extends Omit<BoxProps<'div'>, 'ref'> {
   id?: string;
-  required?: boolean;
-  labelText: string;
-  checked?: boolean;
+  isRequired?: boolean;
+  label: string;
+  isChecked?: boolean;
   onChange?: EventHandler<ChangeEvent<HTMLInputElement>>;
   name?: string;
   onBlur?: EventHandler<FocusEvent<HTMLInputElement>>;
   onFocus?: EventHandler<FocusEvent<HTMLInputElement>>;
   value?: string;
-  disabled?: boolean;
+  isDisabled?: boolean;
   type?: 'checkbox' | 'radio';
   className?: string;
   testId?: string;
   willBlurOnEsc?: boolean;
-  indeterminate?: boolean;
+  isIndeterminate?: boolean;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
 const _ControlledInput = (
   {
-    checked,
+    isChecked,
     className,
-    disabled = false,
+    isDisabled = false,
     id,
-    labelText,
+    label,
     name,
     onBlur,
     onChange,
     onFocus,
-    required = false,
+    isRequired = false,
     testId = 'cf-ui-controlled-input',
     type = 'checkbox',
     value,
     willBlurOnEsc = true,
-    indeterminate,
+    isIndeterminate,
     inputProps,
     ...otherProps
   }: ControlledInputProps,
@@ -57,15 +57,19 @@ const _ControlledInput = (
 ) => {
   const inputRef = useRef(null);
 
-  const inputClassnames = cx(styles.input, {
-    [styles.inputRadioButton]: type === 'radio',
-    [styles.inputCheckbox]: type === 'checkbox',
-    [styles.inputDisabled]: disabled,
-  });
+  const inputClassnames = cx(
+    styles.input,
+    {
+      [styles.inputRadioButton]: type === 'radio',
+      [styles.inputCheckbox]: type === 'checkbox',
+      [styles.inputDisabled]: isDisabled,
+    },
+    inputProps?.className,
+  );
 
   const wrapperClassnames = cx(styles.container, className);
 
-  const handleKeyDown = useCallback(
+  const handleOnKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
       e.persist();
 
@@ -77,28 +81,29 @@ const _ControlledInput = (
   );
 
   useEffect(() => {
-    inputRef.current.indeterminate = indeterminate;
-  }, [indeterminate]);
+    inputRef.current.indeterminate = isIndeterminate;
+  }, [isIndeterminate]);
 
   const iconProps: IconProps = {
     size: 'medium',
-    variant: disabled ? 'secondary' : 'white',
+    variant: isDisabled ? 'secondary' : 'white',
   };
 
   return (
     <Box
       as="div"
       display="inline-block"
-      className={wrapperClassnames}
       ref={ref}
       testId={testId}
       {...otherProps}
+      className={wrapperClassnames}
     >
       <input
+        {...inputProps}
         className={inputClassnames}
         value={value}
         name={name}
-        checked={checked}
+        checked={isChecked}
         type={type}
         ref={inputRef}
         onChange={(e) => {
@@ -116,12 +121,11 @@ const _ControlledInput = (
             onFocus(e);
           }
         }}
-        aria-label={labelText}
+        aria-label={label}
         id={id}
-        required={required}
-        disabled={disabled}
-        onKeyDown={handleKeyDown}
-        {...inputProps}
+        required={isRequired}
+        disabled={isDisabled}
+        onKeyDown={handleOnKeyDown}
       />
       {type === 'radio' ? (
         // eslint-disable-next-line jsx-a11y/label-has-associated-control
@@ -131,7 +135,7 @@ const _ControlledInput = (
         />
       ) : (
         <label className={cx(styles.ghost, styles.ghostCheckbox)} htmlFor={id}>
-          {indeterminate ? <Minus {...iconProps} /> : <Done {...iconProps} />}
+          {isIndeterminate ? <Minus {...iconProps} /> : <Done {...iconProps} />}
         </label>
       )}
     </Box>

--- a/packages/components/inputs/src/controlled-input/README.mdx
+++ b/packages/components/inputs/src/controlled-input/README.mdx
@@ -7,4 +7,73 @@ github: 'https://github.com/contentful/forma-36/tree/master/packages/components/
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-controlled-input--overview'
 ---
 
-Detailed documentation will be provided soon. For now, please have a look into the storybook for implementation details.
+ControlledInput is used to show a controlled checkbox or radio button.
+
+## Table of contents
+
+- [Table of contents](#table-of-contents)
+- [How to use ControlledInput](#how-to-use-controlledinput)
+- [Component variations](#component-variations)
+- [Content recommendations](#content-recommendations)
+- [Accessibility](#accessibility)
+- [Props](#props)
+
+## How to use ControlledInput
+
+- You only need to define a suitable `label` to get a basic controlled input.
+- Create a checkbox or radio button by defining the `type`.
+- All common states (disabled, required, checked, indeterminate) are functionally and visually supported.
+- Control the current input value by setting `isChecked`.
+- Listen to native element events via `onChange`, `onBlur`, `onFocus`. More event handler can be attached by defining them via `inputProps`.
+
+## Component variations
+
+- **Checkbox** - render a basic checkbox node. Visit the documentation of Checkbox to see all variations.
+
+```jsx
+<div>
+  <ControlledInput
+    type="checkbox"
+    label="Subscribe to newsletter"
+    name="newsletter-subscribe"
+  />
+</div>
+```
+
+- **Radio button** - render a basic radio button node. Visit the documentation of RadioButton to see all variations.
+
+```jsx
+<div>
+  <ControlledInput
+    type="radio"
+    label="Which pill?"
+    name="pill-decision"
+    value="Blue pill"
+  />
+  <ControlledInput
+    type="radio"
+    label="Which pill?"
+    name="pill-decision"
+    value="Red pill"
+  />
+</div>
+```
+
+## Content recommendations
+
+- Try to use labels with short, scannable text.
+- Prefer using the components Checkbox or RadioButton instead of directly using the ControlledInput.
+
+## Accessibility
+
+- The `label` will be rendered as `aria-label` of the input node.
+- Use a unique `id`.
+- A explicit label node is rendered for showing a custom check mark. According to [w3](https://www.w3.org/WAI/tutorials/forms/labels/#associating-labels-implicitly), explicit labels provide a better support for assistive technologies.
+
+## Props
+
+```jsx
+import { Props } from '@contentful/f36-docs-utils';
+
+<Props of="ControlledInput" />;
+```

--- a/packages/components/inputs/src/controlled-input/README.mdx
+++ b/packages/components/inputs/src/controlled-input/README.mdx
@@ -24,26 +24,26 @@ ControlledInput is used to show a controlled checkbox or radio button.
 - Create a checkbox or radio button by defining the `type`.
 - All common states (disabled, required, checked, indeterminate) are functionally and visually supported.
 - Control the current input value by setting `isChecked`.
-- Listen to native element events via `onChange`, `onBlur`, `onFocus`. More event handler can be attached by defining them via `inputProps`.
+- Listen to native element events via `onChange`, `onBlur`, `onFocus`. More event handlers can be attached by defining them via `inputProps`.
 
 ## Component variations
 
 - **Checkbox** - render a basic checkbox node. Visit the documentation of Checkbox to see all variations.
 
 ```jsx
-<div>
+<>
   <ControlledInput
     type="checkbox"
     label="Subscribe to newsletter"
     name="newsletter-subscribe"
   />
-</div>
+</>
 ```
 
 - **Radio button** - render a basic radio button node. Visit the documentation of RadioButton to see all variations.
 
 ```jsx
-<div>
+<>
   <ControlledInput
     type="radio"
     label="Which pill?"
@@ -56,7 +56,7 @@ ControlledInput is used to show a controlled checkbox or radio button.
     name="pill-decision"
     value="Red pill"
   />
-</div>
+</>
 ```
 
 ## Content recommendations

--- a/packages/components/inputs/src/radio-button/README.mdx
+++ b/packages/components/inputs/src/radio-button/README.mdx
@@ -23,48 +23,48 @@ RadioButton is used to show a radio button form element. Under the hood, it uses
 - You only need to define a suitable `label` to get a basic checkbox.
 - All common states (disabled, required, checked) are functionally and visually supported.
 - Control the current input value by setting `isChecked`.
-- Listen to native element events via `onChange`, `onBlur`, `onFocus`. More event handler can be attached by defining them via `inputProps`.
+- Listen to native element events via `onChange`, `onBlur`, `onFocus`. More event handlers can be attached by defining them via `inputProps`.
 
 ## Component variations
 
 - **default**
 
 ```jsx
-<div>
+<>
   <RadioButton label="Which pill?" name="pill-decision" value="Blue pill" />
-</div>
+</>
 ```
 
 - **checked**
 
 ```jsx
-<div>
+<>
   <RadioButton
     label="Which pill?"
     name="pill-decision"
     value="Blue pill"
     isChecked
   />
-</div>
+</>
 ```
 
 - **disabled**
 
 ```jsx
-<div>
+<>
   <RadioButton
     label="Which pill?"
     name="pill-decision"
     value="Blue pill"
     isDisabled
   />
-</div>
+</>
 ```
 
 - **disabled checked**
 
 ```jsx
-<div>
+<>
   <RadioButton
     label="Which pill?"
     name="pill-decision"
@@ -72,7 +72,7 @@ RadioButton is used to show a radio button form element. Under the hood, it uses
     isChecked
     isDisabled
   />
-</div>
+</>
 ```
 
 ## Content recommendations

--- a/packages/components/inputs/src/radio-button/README.mdx
+++ b/packages/components/inputs/src/radio-button/README.mdx
@@ -7,4 +7,88 @@ github: 'https://github.com/contentful/forma-36/tree/master/packages/components/
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-radiobutton--default'
 ---
 
-Detailed documentation will be provided soon. For now, please have a look into the storybook for implementation details.
+RadioButton is used to show a radio button form element. Under the hood, it uses `ControlledInput` with `type='radio'` .
+
+## Table of contents
+
+- [Table of contents](#table-of-contents)
+- [How to use RadioButton](#how-to-use-radiobutton)
+- [Component variations](#component-variations)
+- [Content recommendations](#content-recommendations)
+- [Accessibility](#accessibility)
+- [Props](#props)
+
+## How to use RadioButton
+
+- You only need to define a suitable `label` to get a basic checkbox.
+- All common states (disabled, required, checked) are functionally and visually supported.
+- Control the current input value by setting `isChecked`.
+- Listen to native element events via `onChange`, `onBlur`, `onFocus`. More event handler can be attached by defining them via `inputProps`.
+
+## Component variations
+
+- **default**
+
+```jsx
+<div>
+  <RadioButton label="Which pill?" name="pill-decision" value="Blue pill" />
+</div>
+```
+
+- **checked**
+
+```jsx
+<div>
+  <RadioButton
+    label="Which pill?"
+    name="pill-decision"
+    value="Blue pill"
+    isChecked
+  />
+</div>
+```
+
+- **disabled**
+
+```jsx
+<div>
+  <RadioButton
+    label="Which pill?"
+    name="pill-decision"
+    value="Blue pill"
+    isDisabled
+  />
+</div>
+```
+
+- **disabled checked**
+
+```jsx
+<div>
+  <RadioButton
+    label="Which pill?"
+    name="pill-decision"
+    value="Blue pill"
+    isChecked
+    isDisabled
+  />
+</div>
+```
+
+## Content recommendations
+
+- Try to use labels with short, scannable text.
+
+## Accessibility
+
+- The `label` will be rendered as `aria-label` of the input node.
+- Use a unique `id`.
+- A explicit label node is rendered for showing a custom check mark. According to [w3](https://www.w3.org/WAI/tutorials/forms/labels/#associating-labels-implicitly), explicit labels provide a better support for assistive technologies.
+
+## Props
+
+```jsx
+import { Props } from '@contentful/f36-docs-utils';
+
+<Props of="RadioButton" />;
+```

--- a/packages/components/inputs/src/radio-button/RadioButton.test.tsx
+++ b/packages/components/inputs/src/radio-button/RadioButton.test.tsx
@@ -5,21 +5,21 @@ import { axe } from '@/scripts/test/axeHelper';
 import { RadioButton } from './RadioButton';
 
 it('renders the component', () => {
-  const { container } = render(<RadioButton labelText="radio-button" />);
+  const { container } = render(<RadioButton label="radio-button" />);
 
   expect(container.firstChild).toMatchSnapshot();
 });
 
 it('renders the component with an additional class name', () => {
   const { container } = render(
-    <RadioButton labelText="radio-button" className="my-extra-class" />,
+    <RadioButton label="radio-button" className="my-extra-class" />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
 });
 
 it('has no a11y issues', async () => {
-  const { container } = render(<RadioButton labelText="radio-button" />);
+  const { container } = render(<RadioButton label="radio-button" />);
   const results = await axe(container);
 
   expect(results).toHaveNoViolations();

--- a/packages/components/inputs/src/radio-button/RadioButton.tsx
+++ b/packages/components/inputs/src/radio-button/RadioButton.tsx
@@ -5,10 +5,13 @@ import { ControlledInput, ControlledInputProps } from '..';
 export interface RadioButtonProps
   extends Omit<ControlledInputProps, 'isIndeterminate'> {}
 
-export const RadioButton = ({
-  testId = 'cf-ui-radio-button',
-  type = 'radio',
-  ...otherProps
-}: RadioButtonProps) => {
-  return <ControlledInput testId={testId} type={type} {...otherProps} />;
+const _RadioButton = (
+  { testId = 'cf-ui-radio-button', ...otherProps }: RadioButtonProps,
+  ref: React.Ref<HTMLDivElement>,
+) => {
+  return (
+    <ControlledInput testId={testId} type="radio" ref={ref} {...otherProps} />
+  );
 };
+
+export const RadioButton = React.forwardRef(_RadioButton);

--- a/packages/components/inputs/src/radio-button/RadioButton.tsx
+++ b/packages/components/inputs/src/radio-button/RadioButton.tsx
@@ -2,24 +2,13 @@ import React from 'react';
 import { ControlledInput, ControlledInputProps } from '..';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface RadioButtonProps extends ControlledInputProps {}
+export interface RadioButtonProps
+  extends Omit<ControlledInputProps, 'isIndeterminate'> {}
 
 export const RadioButton = ({
-  isDisabled = false,
-  isRequired = false,
   testId = 'cf-ui-radio-button',
   type = 'radio',
-  willBlurOnEsc = true,
   ...otherProps
 }: RadioButtonProps) => {
-  return (
-    <ControlledInput
-      isDisabled={isDisabled}
-      isRequired={isRequired}
-      data-test-id={testId}
-      type={type}
-      willBlurOnEsc={willBlurOnEsc}
-      {...otherProps}
-    />
-  );
+  return <ControlledInput testId={testId} type={type} {...otherProps} />;
 };

--- a/packages/components/inputs/src/radio-button/RadioButton.tsx
+++ b/packages/components/inputs/src/radio-button/RadioButton.tsx
@@ -5,8 +5,8 @@ import { ControlledInput, ControlledInputProps } from '..';
 export interface RadioButtonProps extends ControlledInputProps {}
 
 export const RadioButton = ({
-  disabled = false,
-  required = false,
+  isDisabled = false,
+  isRequired = false,
   testId = 'cf-ui-radio-button',
   type = 'radio',
   willBlurOnEsc = true,
@@ -14,12 +14,12 @@ export const RadioButton = ({
 }: RadioButtonProps) => {
   return (
     <ControlledInput
-      {...otherProps}
-      disabled={disabled}
-      required={required}
+      isDisabled={isDisabled}
+      isRequired={isRequired}
       data-test-id={testId}
       type={type}
       willBlurOnEsc={willBlurOnEsc}
+      {...otherProps}
     />
   );
 };

--- a/packages/components/inputs/stories/Checkbox.stories.tsx
+++ b/packages/components/inputs/stories/Checkbox.stories.tsx
@@ -27,14 +27,14 @@ export const overview = () => (
     <Flex marginBottom="spacingS" marginTop="spacingM">
       <SectionHeading as="h3">Checkbox default</SectionHeading>
     </Flex>
-    <Checkbox id="Checkbox" labelText="some label text" name="some-name" />
+    <Checkbox id="Checkbox" label="some label text" name="some-name" />
     <Flex marginBottom="spacingS" marginTop="spacingM">
       <SectionHeading as="h3">Checkbox checked</SectionHeading>
     </Flex>
     <Checkbox
       id="Checkbox"
-      checked
-      labelText="some label text"
+      isChecked
+      label="some label text"
       name="some-name"
     />
     <Flex marginBottom="spacingS" marginTop="spacingM">
@@ -42,8 +42,8 @@ export const overview = () => (
     </Flex>
     <Checkbox
       id="Checkbox"
-      indeterminate
-      labelText="multiple selection"
+      isIndeterminate
+      label="multiple selection"
       name="some-name"
     />
     <Flex marginBottom="spacingS" marginTop="spacingM">
@@ -51,8 +51,8 @@ export const overview = () => (
     </Flex>
     <Checkbox
       id="Checkbox"
-      disabled
-      labelText="some label text"
+      isDisabled
+      label="some label text"
       name="some-name"
     />
     <Flex marginBottom="spacingS" marginTop="spacingM">
@@ -60,9 +60,9 @@ export const overview = () => (
     </Flex>
     <Checkbox
       id="Checkbox"
-      disabled
-      indeterminate
-      labelText="multiple selection"
+      isDisabled
+      isIndeterminate
+      label="multiple selection"
       name="some-name"
     />
     <Flex marginBottom="spacingS" marginTop="spacingM">
@@ -70,9 +70,9 @@ export const overview = () => (
     </Flex>
     <Checkbox
       id="Checkbox"
-      disabled
-      checked
-      labelText="some label text"
+      isDisabled
+      isChecked
+      label="some label text"
       name="some-name"
     />
   </>

--- a/packages/components/inputs/stories/RadioButton.stories.tsx
+++ b/packages/components/inputs/stories/RadioButton.stories.tsx
@@ -28,7 +28,7 @@ export const overview = () => (
       <Flex marginBottom="spacingS">
         <SectionHeading as="h3">Radio button default</SectionHeading>
       </Flex>
-      <RadioButton id="Checkbox" labelText="some label text" name="some-name" />
+      <RadioButton id="Checkbox" label="some label text" name="some-name" />
     </Flex>
     <Flex flexDirection="column" marginBottom="spacingM">
       <Flex marginBottom="spacingS">
@@ -36,8 +36,8 @@ export const overview = () => (
       </Flex>
       <RadioButton
         id="Checkbox"
-        checked
-        labelText="some label text"
+        isChecked
+        label="some label text"
         name="some-name"
       />
     </Flex>
@@ -47,8 +47,8 @@ export const overview = () => (
       </Flex>
       <RadioButton
         id="Checkbox"
-        labelText="some label text"
-        disabled
+        label="some label text"
+        isDisabled
         name="some-name"
       />
     </Flex>

--- a/packages/forma-36-react-components/README.md
+++ b/packages/forma-36-react-components/README.md
@@ -101,7 +101,7 @@ We follow the principle that a component should only be responsible for its own 
 We recommend the following naming convention for PropTypes to make them as clear as possible:
 
 - Number - use a prefix or suffix to imply that the prop accepts a number. E.g. `numItems`, `itemCount`, `itemIndex`
-- Boolean - use the prefix 'is'/'can'/'has'/'will'. E.g. `isVisible`, `canExpand`, `hasImage`
+- Boolean - use the prefix 'is'/'can'/'has'. E.g. `isVisible`, `canExpand`, `hasImage`
 - Array - use a plural noun. E.g. `items`
 - Object - use a noun. E.g. `item`
 - Node - use the suffix 'Node'. E.g. `containerNode`

--- a/packages/forma-36-react-components/README.md
+++ b/packages/forma-36-react-components/README.md
@@ -101,7 +101,7 @@ We follow the principle that a component should only be responsible for its own 
 We recommend the following naming convention for PropTypes to make them as clear as possible:
 
 - Number - use a prefix or suffix to imply that the prop accepts a number. E.g. `numItems`, `itemCount`, `itemIndex`
-- Boolean - use the prefix 'is'/'can'/'has'. E.g. `isVisible`, `canExpand`, `hasImage`
+- Boolean - use the prefix 'is'/'can'/'has'/'will'. E.g. `isVisible`, `canExpand`, `hasImage`
 - Array - use a plural noun. E.g. `items`
 - Object - use a noun. E.g. `item`
 - Node - use the suffix 'Node'. E.g. `containerNode`

--- a/packages/forma-36-react-components/src/components/ControlledInputField/ControlledInputField.tsx
+++ b/packages/forma-36-react-components/src/components/ControlledInputField/ControlledInputField.tsx
@@ -57,12 +57,12 @@ export const ControlledInputField = ({
     <div data-test-id={testId} className={classNames} {...otherProps}>
       <ControlledInput
         id={id}
-        labelText={labelText}
+        label={labelText}
         type={inputType}
         name={name}
-        required={required}
-        checked={checked}
-        disabled={disabled}
+        isRequired={required}
+        isChecked={checked}
+        isDisabled={disabled}
         value={value}
         onChange={onChange}
         className={styles.ControlledInputField__input}


### PR DESCRIPTION
# Purpose of PR

Following up on the new created f36-inputs package, we want to have all components in this package documented and sticking to our guidelines.

Used Guidelines:
https://contentful.atlassian.net/wiki/spaces/PROD/pages/2821095662/F36+Code+Styleguide
https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#development

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
