### PR TITLE
v4 chore(deps): switch function specific lodash packages to lodash-es

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -160,7 +160,7 @@ module.exports = {
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
   transformIgnorePatterns: [
-    '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx|mjs)$',
+    '[/\\\\]node_modules[/\\\\](?!lodash-es).+\\.(js|jsx|ts|tsx|mjs)$',
   ],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them

--- a/packages/components/timepicker/package.json
+++ b/packages/components/timepicker/package.json
@@ -35,7 +35,7 @@
     "@testing-library/react": "11.2.2",
     "@types/is-hotkey": "^0.1.1",
     "@types/jest": "25.2.3",
-    "@types/lodash.orderby": "^4.6.6"
+    "@types/lodash-es": "^4.17.4"
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
@@ -43,6 +43,6 @@
     "date-fns": "^2.9.0",
     "emotion": "^10.0.17",
     "is-hotkey": "^0.1.6",
-    "lodash.orderby": "^4.6.0"
+    "lodash-es": "^4.17.21"
   }
 }

--- a/packages/components/timepicker/src/Timepicker.tsx
+++ b/packages/components/timepicker/src/Timepicker.tsx
@@ -10,7 +10,7 @@ import React, {
   ChangeEvent,
 } from 'react';
 import isHotkey from 'is-hotkey';
-import orderBy from 'lodash.orderby';
+import { orderBy } from 'lodash-es';
 import {
   format,
   addHours,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5154,10 +5154,10 @@
     "@types/interpret" "*"
     "@types/node" "*"
 
-"@types/lodash.orderby@^4.6.6":
-  version "4.6.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.orderby/-/lodash.orderby-4.6.6.tgz#126543bb597477dc9b27d748b5822244f577915c"
-  integrity sha512-wQzu6xK+bSwhu45OeMI7fjywiIZiiaBzJB8W3fwnF1SJXHoOXRLutrSnVmq4yHPOM036qsy8lx9wHQcAbXNjJw==
+"@types/lodash-es@^4.17.4":
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.4.tgz#b2e440d2bf8a93584a9fd798452ec497986c9b97"
+  integrity sha512-BBz79DCJbD2CVYZH67MBeHZRX++HF+5p8Mo5MzjZi64Wac39S3diedJYHZtScbRVf4DjZyN6LzA0SB0zy+HSSQ==
   dependencies:
     "@types/lodash" "*"
 
@@ -17212,7 +17212,7 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash-es@^4.17.15:
+lodash-es@^4.17.15, lodash-es@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
@@ -17354,11 +17354,6 @@ lodash.merge@^4.4.0, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.orderby@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.orderby/-/lodash.orderby-4.6.0.tgz#e697f04ce5d78522f54d9338b32b81a3393e4eb3"
-  integrity sha1-5pfwTOXXhSL1TZM4syuBozk+TrM=
 
 lodash.pick@^4.2.1:
   version "4.4.0"


### PR DESCRIPTION
The old function specific lodash packages aren't supported anymore and haven't been updated in years. We could switch to lodash or lodash-es, I went with the latter to hopefully get a smaller build without having to change our tooling.
