### PR TITLE
feat: enable passing props down to label in ControlledInput [Homer 25]

### DIFF
--- a/packages/components/inputs/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/components/inputs/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -49,7 +49,26 @@ exports[`renders the component 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -78,18 +97,6 @@ exports[`renders the component 1`] = `
   height: 0.75rem;
 }
 
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
-}
-
 .emotion-1 {
   display: inline-block;
   fill: #ffffff;
@@ -109,6 +116,7 @@ exports[`renders the component 1`] = `
   />
   <label
     class="emotion-2"
+    data-test-id="cf-ui-form-label"
   >
     <svg
       class="emotion-1"
@@ -174,7 +182,26 @@ exports[`renders the component with an additional class name 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -203,18 +230,6 @@ exports[`renders the component with an additional class name 1`] = `
   height: 0.75rem;
 }
 
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
-}
-
 .emotion-1 {
   display: inline-block;
   fill: #ffffff;
@@ -234,6 +249,7 @@ exports[`renders the component with an additional class name 1`] = `
   />
   <label
     class="emotion-2"
+    data-test-id="cf-ui-form-label"
   >
     <svg
       class="emotion-1"

--- a/packages/components/inputs/src/controlled-input/ControlledInput.tsx
+++ b/packages/components/inputs/src/controlled-input/ControlledInput.tsx
@@ -10,6 +10,8 @@ import React, {
 import { cx } from 'emotion';
 import { Done, Minus } from '@contentful/f36-icons';
 import type { IconProps } from '@contentful/f36-icons';
+import { Label } from '@contentful/f36-forms';
+import type { LabelProps } from '@contentful/f36-forms';
 
 import { styles } from './ControlledInput.styles';
 import { Box, BoxProps } from '@contentful/f36-core';
@@ -31,7 +33,7 @@ export interface ControlledInputProps extends Omit<BoxProps<'div'>, 'ref'> {
   canBlurOnEsc?: boolean;
   isIndeterminate?: boolean;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-  labelProps?: React.InputHTMLAttributes<HTMLLabelElement>;
+  labelProps?: LabelProps;
 }
 
 const _ControlledInput = (
@@ -137,12 +139,11 @@ const _ControlledInput = (
         onKeyDown={handleOnKeyDown}
       />
       {type === 'radio' ? (
-        // eslint-disable-next-line jsx-a11y/label-has-associated-control
-        <label {...labelProps} className={labelClassnames} htmlFor={id} />
+        <Label {...labelProps} className={labelClassnames} htmlFor={id} />
       ) : (
-        <label {...labelProps} className={labelClassnames} htmlFor={id}>
+        <Label {...labelProps} className={labelClassnames} htmlFor={id}>
           {isIndeterminate ? <Minus {...iconProps} /> : <Done {...iconProps} />}
-        </label>
+        </Label>
       )}
     </Box>
   );

--- a/packages/components/inputs/src/controlled-input/ControlledInput.tsx
+++ b/packages/components/inputs/src/controlled-input/ControlledInput.tsx
@@ -31,6 +31,7 @@ export interface ControlledInputProps extends Omit<BoxProps<'div'>, 'ref'> {
   canBlurOnEsc?: boolean;
   isIndeterminate?: boolean;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+  labelProps?: React.InputHTMLAttributes<HTMLLabelElement>;
 }
 
 const _ControlledInput = (
@@ -51,6 +52,7 @@ const _ControlledInput = (
     canBlurOnEsc = true,
     isIndeterminate,
     inputProps,
+    labelProps,
     ...otherProps
   }: ControlledInputProps,
   ref: React.Ref<HTMLDivElement>,
@@ -68,6 +70,14 @@ const _ControlledInput = (
   );
 
   const wrapperClassnames = cx(styles.container, className);
+  const labelClassnames = cx(
+    styles.ghost,
+    {
+      [styles.ghostRadioButton]: type === 'radio',
+      [styles.ghostCheckbox]: type === 'checkbox',
+    },
+    labelProps?.className,
+  );
 
   const handleOnKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
@@ -128,12 +138,9 @@ const _ControlledInput = (
       />
       {type === 'radio' ? (
         // eslint-disable-next-line jsx-a11y/label-has-associated-control
-        <label
-          className={cx(styles.ghost, styles.ghostRadioButton)}
-          htmlFor={id}
-        />
+        <label {...labelProps} className={labelClassnames} htmlFor={id} />
       ) : (
-        <label className={cx(styles.ghost, styles.ghostCheckbox)} htmlFor={id}>
+        <label {...labelProps} className={labelClassnames} htmlFor={id}>
           {isIndeterminate ? <Minus {...iconProps} /> : <Done {...iconProps} />}
         </label>
       )}

--- a/packages/components/inputs/src/controlled-input/__snapshots__/ControlledInput.test.tsx.snap
+++ b/packages/components/inputs/src/controlled-input/__snapshots__/ControlledInput.test.tsx.snap
@@ -49,7 +49,26 @@ exports[`renders the component with a value 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -78,18 +97,6 @@ exports[`renders the component with a value 1`] = `
   height: 0.75rem;
 }
 
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
-}
-
 .emotion-1 {
   display: inline-block;
   fill: #ffffff;
@@ -110,6 +117,7 @@ exports[`renders the component with a value 1`] = `
   />
   <label
     class="emotion-2"
+    data-test-id="cf-ui-form-label"
     for="ControlledInput"
   >
     <svg
@@ -176,7 +184,26 @@ exports[`renders the component with all required props 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -205,18 +232,6 @@ exports[`renders the component with all required props 1`] = `
   height: 0.75rem;
 }
 
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
-}
-
 .emotion-1 {
   display: inline-block;
   fill: #ffffff;
@@ -237,6 +252,7 @@ exports[`renders the component with all required props 1`] = `
   />
   <label
     class="emotion-2"
+    data-test-id="cf-ui-form-label"
     for="ControlledInput"
   >
     <svg
@@ -303,7 +319,26 @@ exports[`renders the component with an additional class name 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -332,18 +367,6 @@ exports[`renders the component with an additional class name 1`] = `
   height: 0.75rem;
 }
 
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
-}
-
 .emotion-1 {
   display: inline-block;
   fill: #ffffff;
@@ -364,6 +387,7 @@ exports[`renders the component with an additional class name 1`] = `
   />
   <label
     class="emotion-2"
+    data-test-id="cf-ui-form-label"
     for="ControlledInput"
   >
     <svg
@@ -430,7 +454,26 @@ exports[`renders the component with as checked 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -457,18 +500,6 @@ exports[`renders the component with as checked 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-1 {
@@ -492,6 +523,7 @@ exports[`renders the component with as checked 1`] = `
   />
   <label
     class="emotion-2"
+    data-test-id="cf-ui-form-label"
     for="ControlledInput"
   >
     <svg
@@ -510,7 +542,26 @@ exports[`renders the component with as checked 1`] = `
 `;
 
 exports[`renders the component with disabled prop 1`] = `
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -537,18 +588,6 @@ exports[`renders the component with disabled prop 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-0 {
@@ -621,6 +660,7 @@ exports[`renders the component with disabled prop 1`] = `
   />
   <label
     class="emotion-2"
+    data-test-id="cf-ui-form-label"
     for="ControlledInput"
   >
     <svg
@@ -687,7 +727,26 @@ exports[`renders the component with required prop 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -716,18 +775,6 @@ exports[`renders the component with required prop 1`] = `
   height: 0.75rem;
 }
 
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
-}
-
 .emotion-1 {
   display: inline-block;
   fill: #ffffff;
@@ -749,6 +796,7 @@ exports[`renders the component with required prop 1`] = `
   />
   <label
     class="emotion-2"
+    data-test-id="cf-ui-form-label"
     for="ControlledInput"
   >
     <svg

--- a/packages/components/inputs/src/radio-button/__snapshots__/RadioButton.test.tsx.snap
+++ b/packages/components/inputs/src/radio-button/__snapshots__/RadioButton.test.tsx.snap
@@ -41,7 +41,26 @@ exports[`renders the component 1`] = `
   background: #b4c3ca;
 }
 
+.emotion-2 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-1 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -71,18 +90,6 @@ exports[`renders the component 1`] = `
   height: 6px;
 }
 
-.emotion-2 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
-}
-
 <div
   class="emotion-2"
   data-test-id="cf-ui-radio-button"
@@ -95,6 +102,7 @@ exports[`renders the component 1`] = `
   />
   <label
     class="emotion-1"
+    data-test-id="cf-ui-form-label"
   />
 </div>
 `;
@@ -140,7 +148,26 @@ exports[`renders the component with an additional class name 1`] = `
   background: #b4c3ca;
 }
 
+.emotion-2 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-1 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -170,18 +197,6 @@ exports[`renders the component with an additional class name 1`] = `
   height: 6px;
 }
 
-.emotion-2 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
-}
-
 <div
   class="my-extra-class emotion-2"
   data-test-id="cf-ui-radio-button"
@@ -194,6 +209,7 @@ exports[`renders the component with an additional class name 1`] = `
   />
   <label
     class="emotion-1"
+    data-test-id="cf-ui-form-label"
   />
 </div>
 `;

--- a/packages/forma-36-react-components/src/components/CheckboxField/__snapshots__/CheckboxField.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/CheckboxField/__snapshots__/CheckboxField.test.tsx.snap
@@ -49,7 +49,26 @@ exports[`renders the component 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -76,18 +95,6 @@ exports[`renders the component 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-1 {
@@ -124,6 +131,7 @@ exports[`renders the component 1`] = `
     />
     <label
       class="emotion-2"
+      data-test-id="cf-ui-form-label"
       for="checkbox"
     >
       <svg

--- a/packages/forma-36-react-components/src/components/ControlledInputField/__snapshots__/ControlledInputField.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/ControlledInputField/__snapshots__/ControlledInputField.test.tsx.snap
@@ -49,7 +49,26 @@ exports[`renders the component 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -76,18 +95,6 @@ exports[`renders the component 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-1 {
@@ -124,6 +131,7 @@ exports[`renders the component 1`] = `
     />
     <label
       class="emotion-2"
+      data-test-id="cf-ui-form-label"
       for="checkbox"
     >
       <svg
@@ -200,7 +208,26 @@ exports[`renders the component as checked 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -227,18 +254,6 @@ exports[`renders the component as checked 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-1 {
@@ -276,6 +291,7 @@ exports[`renders the component as checked 1`] = `
     />
     <label
       class="emotion-2"
+      data-test-id="cf-ui-form-label"
       for="checkbox"
     >
       <svg
@@ -352,7 +368,26 @@ exports[`renders the component as required 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -379,18 +414,6 @@ exports[`renders the component as required 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-1 {
@@ -434,6 +457,7 @@ exports[`renders the component as required 1`] = `
     />
     <label
       class="emotion-2"
+      data-test-id="cf-ui-form-label"
       for="checkbox"
     >
       <svg
@@ -469,7 +493,26 @@ exports[`renders the component as required 1`] = `
 `;
 
 exports[`renders the component in a disabled state 1`] = `
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -496,18 +539,6 @@ exports[`renders the component in a disabled state 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-4 {
@@ -594,6 +625,7 @@ exports[`renders the component in a disabled state 1`] = `
     />
     <label
       class="emotion-2"
+      data-test-id="cf-ui-form-label"
       for="checkbox"
     >
       <svg
@@ -670,7 +702,26 @@ exports[`renders the component with a help text 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -697,18 +748,6 @@ exports[`renders the component with a help text 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-1 {
@@ -755,6 +794,7 @@ exports[`renders the component with a help text 1`] = `
     />
     <label
       class="emotion-2"
+      data-test-id="cf-ui-form-label"
       for="checkbox"
     >
       <svg
@@ -837,7 +877,26 @@ exports[`renders the component with a light label variation 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -864,18 +923,6 @@ exports[`renders the component with a light label variation 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-1 {
@@ -947,6 +994,7 @@ exports[`renders the component with a light label variation 1`] = `
     />
     <label
       class="emotion-2"
+      data-test-id="cf-ui-form-label"
       for="checkbox"
     >
       <svg
@@ -1049,7 +1097,26 @@ exports[`renders the component with a validation message 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -1076,18 +1143,6 @@ exports[`renders the component with a validation message 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-1 {
@@ -1159,6 +1214,7 @@ exports[`renders the component with a validation message 1`] = `
     />
     <label
       class="emotion-2"
+      data-test-id="cf-ui-form-label"
       for="checkbox"
     >
       <svg
@@ -1261,7 +1317,26 @@ exports[`renders the component with a value 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -1288,18 +1363,6 @@ exports[`renders the component with a value 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-1 {
@@ -1336,6 +1399,7 @@ exports[`renders the component with a value 1`] = `
     />
     <label
       class="emotion-2"
+      data-test-id="cf-ui-form-label"
       for="checkbox"
     >
       <svg
@@ -1412,7 +1476,26 @@ exports[`renders the component with an additional class name 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -1439,18 +1522,6 @@ exports[`renders the component with an additional class name 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-1 {
@@ -1487,6 +1558,7 @@ exports[`renders the component with an additional class name 1`] = `
     />
     <label
       class="emotion-2"
+      data-test-id="cf-ui-form-label"
       for="checkbox"
     >
       <svg

--- a/packages/forma-36-react-components/src/components/Form/FieldGroup/__snapshots__/FieldGroup.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Form/FieldGroup/__snapshots__/FieldGroup.test.tsx.snap
@@ -49,7 +49,26 @@ exports[`renders the component 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -76,18 +95,6 @@ exports[`renders the component 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-1 {
@@ -141,6 +148,7 @@ exports[`renders the component 1`] = `
         />
         <label
           class="emotion-2"
+          data-test-id="cf-ui-form-label"
           for="agree"
         >
           <svg
@@ -193,6 +201,7 @@ exports[`renders the component 1`] = `
         />
         <label
           class="emotion-2"
+          data-test-id="cf-ui-form-label"
           for="reallyAgree"
         >
           <svg
@@ -277,7 +286,26 @@ exports[`renders the component children in a row 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -304,18 +332,6 @@ exports[`renders the component children in a row 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-1 {
@@ -369,6 +385,7 @@ exports[`renders the component children in a row 1`] = `
         />
         <label
           class="emotion-2"
+          data-test-id="cf-ui-form-label"
           for="agree"
         >
           <svg
@@ -421,6 +438,7 @@ exports[`renders the component children in a row 1`] = `
         />
         <label
           class="emotion-2"
+          data-test-id="cf-ui-form-label"
           for="reallyAgree"
         >
           <svg
@@ -505,7 +523,26 @@ exports[`renders the component with an additional class name 1`] = `
   fill: #c3cfd5;
 }
 
+.emotion-3 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-2 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -532,18 +569,6 @@ exports[`renders the component with an additional class name 1`] = `
   min-width: 0.75rem;
   min-height: 0.75rem;
   height: 0.75rem;
-}
-
-.emotion-3 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
 }
 
 .emotion-1 {
@@ -597,6 +622,7 @@ exports[`renders the component with an additional class name 1`] = `
         />
         <label
           class="emotion-2"
+          data-test-id="cf-ui-form-label"
           for="agree"
         >
           <svg
@@ -649,6 +675,7 @@ exports[`renders the component with an additional class name 1`] = `
         />
         <label
           class="emotion-2"
+          data-test-id="cf-ui-form-label"
           for="reallyAgree"
         >
           <svg

--- a/packages/forma-36-react-components/src/components/RadioButtonField/__snapshots__/RadioButtonField.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/RadioButtonField/__snapshots__/RadioButtonField.test.tsx.snap
@@ -41,7 +41,26 @@ exports[`renders the component 1`] = `
   background: #b4c3ca;
 }
 
+.emotion-2 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-1 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -71,18 +90,6 @@ exports[`renders the component 1`] = `
   height: 6px;
 }
 
-.emotion-2 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
-}
-
 .emotion-3 {
   display: inline-block;
   color: #192532;
@@ -110,6 +117,7 @@ exports[`renders the component 1`] = `
     />
     <label
       class="emotion-1"
+      data-test-id="cf-ui-form-label"
       for="radio-button"
     />
   </div>
@@ -166,7 +174,26 @@ exports[`renders the component with an additional class name 1`] = `
   background: #b4c3ca;
 }
 
+.emotion-2 {
+  display: inline-block;
+  position: relative;
+  text-overflow: ellipsis;
+  line-height: 1.5rem;
+  margin: 0;
+  width: 1rem;
+  height: 1rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
 .emotion-1 {
+  display: inline-block;
+  color: #192532;
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  margin-bottom: calc(1rem * (8 / 16));
   background: #ffffff;
   width: 1rem;
   height: 1rem;
@@ -196,18 +223,6 @@ exports[`renders the component with an additional class name 1`] = `
   height: 6px;
 }
 
-.emotion-2 {
-  display: inline-block;
-  position: relative;
-  text-overflow: ellipsis;
-  line-height: 1.5rem;
-  margin: 0;
-  width: 1rem;
-  height: 1rem;
-  min-height: 1rem;
-  overflow: visible;
-}
-
 .emotion-3 {
   display: inline-block;
   color: #192532;
@@ -235,6 +250,7 @@ exports[`renders the component with an additional class name 1`] = `
     />
     <label
       class="emotion-1"
+      data-test-id="cf-ui-form-label"
       for="radio-button"
     />
   </div>


### PR DESCRIPTION
# Purpose of PR

For migrating ControlledInputField, we want to pass styles down to the label component. Thus, we add the prop `labelProps` in the same manner as `inputProps`.

[See related comment](https://github.com/contentful/forma-36/pull/954/files#r637008561)

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
