### PR TITLE
fix: add labelText prop support to TextInput component

### DIFF
--- a/packages/forma-36-react-components/src/components/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Form/__snapshots__/Form.test.tsx.snap
@@ -34,7 +34,6 @@ exports[`renders the component 1`] = `
         class="TextInput TextInput--full"
       >
         <input
-          aria-label="nameInput"
           class="TextInput__input"
           data-test-id="cf-ui-text-input"
           id="nameInput"
@@ -92,7 +91,6 @@ exports[`renders the component with an additional class name 1`] = `
         class="TextInput TextInput--full"
       >
         <input
-          aria-label="nameInput"
           class="TextInput__input"
           data-test-id="cf-ui-text-input"
           id="nameInput"
@@ -150,7 +148,6 @@ exports[`renders the component with condensed spacing 1`] = `
         class="TextInput TextInput--full"
       >
         <input
-          aria-label="nameInput"
           class="TextInput__input"
           data-test-id="cf-ui-text-input"
           id="nameInput"

--- a/packages/forma-36-react-components/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -20,7 +20,6 @@ exports[`renders the component 1`] = `
     class="TextInput TextInput--full"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
@@ -51,7 +50,6 @@ exports[`renders the component with a copybutton 1`] = `
     class="TextInput TextInput--full TextInput--with-copy-button"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
@@ -123,7 +121,6 @@ exports[`renders the component with a placeholder text 1`] = `
     class="TextInput TextInput--full"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
@@ -155,7 +152,6 @@ exports[`renders the component with a rows defined 1`] = `
     class="TextInput TextInput--full"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
@@ -218,7 +214,6 @@ exports[`renders the component with a textlink 1`] = `
     class="TextInput TextInput--full"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
@@ -249,7 +244,6 @@ exports[`renders the component with a value 1`] = `
     class="TextInput TextInput--full"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
@@ -280,7 +274,6 @@ exports[`renders the component with additional prop 1`] = `
     class="TextInput TextInput--full"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="test"
       id="someComponent"
@@ -311,7 +304,6 @@ exports[`renders the component with an additional class name 1`] = `
     class="TextInput TextInput--full"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
@@ -372,7 +364,6 @@ exports[`renders the component with characters count 1`] = `
     class="TextInput TextInput--full"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
@@ -416,7 +407,6 @@ exports[`renders the component with help text 1`] = `
     class="TextInput TextInput--full"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
@@ -457,7 +447,6 @@ exports[`renders the component with max length of characters 1`] = `
     class="TextInput TextInput--full"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
@@ -489,7 +478,6 @@ exports[`renders the component with required text 1`] = `
     class="TextInput TextInput--full"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
@@ -520,7 +508,6 @@ exports[`renders the component with small width 1`] = `
     class="TextInput TextInput--full"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
@@ -551,7 +538,6 @@ exports[`renders the component with validation message 1`] = `
     class="TextInput TextInput--full TextInput--negative"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"
@@ -607,7 +593,6 @@ exports[`updates the value 1`] = `
     class="TextInput TextInput--full"
   >
     <input
-      aria-label="someComponent"
       class="TextInput__input"
       data-test-id="cf-ui-text-input"
       id="someComponent"

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.stories.tsx
@@ -26,6 +26,7 @@ export const Basic = (args: TextInputProps) => <TextInput {...args} />;
 
 Basic.args = {
   name: 'text-input',
+  labelText: 'text-input-label-text',
   id: 'text-input',
 };
 
@@ -46,6 +47,7 @@ export const ControlledTextInput = (args: TextInputProps) => {
 
 ControlledTextInput.args = {
   name: 'text-input',
+  labelText: 'text-input-label-text',
   id: 'text-input',
 };
 

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.test.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.test.tsx
@@ -111,7 +111,9 @@ it('renders the component as required', () => {
 });
 
 it('has no a11y issues', async () => {
-  const { container } = render(<TextInput id="someInput" name="userEmail" />);
+  const { container } = render(
+    <TextInput id="someInput" name="userEmail" labelText="userEmail" />,
+  );
   const results = await axe(container);
 
   expect(results).toHaveNoViolations();

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.test.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.test.tsx
@@ -5,14 +5,21 @@ import { axe } from '../../utils/axeHelper';
 import { TextInput } from './TextInput';
 
 it('renders the component with all required props', () => {
-  const { container } = render(<TextInput id="someInput" name="userEmail" />);
+  const { container } = render(
+    <TextInput id="someInput" name="userEmail" labelText="userEmail" />,
+  );
 
   expect(container.firstChild).toMatchSnapshot();
 });
 
 it('renders the component with an additional class name', () => {
   const { container } = render(
-    <TextInput id="someInput" name="userEmail" className="my-extra-class" />,
+    <TextInput
+      id="someInput"
+      name="userEmail"
+      labelText="userEmail"
+      className="my-extra-class"
+    />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -20,7 +27,12 @@ it('renders the component with an additional class name', () => {
 
 it('renders the component with disabled prop', () => {
   const { container } = render(
-    <TextInput id="someInput" name="userEmail" disabled />,
+    <TextInput
+      id="someInput"
+      name="userEmail"
+      labelText="userEmail"
+      disabled
+    />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -28,7 +40,7 @@ it('renders the component with disabled prop', () => {
 
 it('renders the component with error prop', () => {
   const { container } = render(
-    <TextInput id="someInput" name="userEmail" error />,
+    <TextInput id="someInput" name="userEmail" labelText="userEmail" error />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -36,7 +48,12 @@ it('renders the component with error prop', () => {
 
 it('renders the component with value prop', () => {
   const { container } = render(
-    <TextInput id="someInput" name="userEmail" value="123" />,
+    <TextInput
+      id="someInput"
+      name="userEmail"
+      labelText="userEmail"
+      value="123"
+    />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -44,7 +61,12 @@ it('renders the component with value prop', () => {
 
 it('renders the component with onChange prop', () => {
   const { container } = render(
-    <TextInput id="someInput" name="userEmail" onChange={() => {}} />,
+    <TextInput
+      id="someInput"
+      name="userEmail"
+      labelText="userEmail"
+      onChange={() => {}}
+    />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -52,7 +74,12 @@ it('renders the component with onChange prop', () => {
 
 it('renders the component with onBlur prop', () => {
   const { container } = render(
-    <TextInput id="someInput" name="userEmail" onBlur={() => {}} />,
+    <TextInput
+      id="someInput"
+      name="userEmail"
+      labelText="userEmail"
+      onBlur={() => {}}
+    />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -60,7 +87,12 @@ it('renders the component with onBlur prop', () => {
 
 it('renders the component with the copy button', () => {
   const { container } = render(
-    <TextInput id="someInput" name="userEmail" withCopyButton />,
+    <TextInput
+      id="someInput"
+      name="userEmail"
+      labelText="userEmail"
+      withCopyButton
+    />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -68,7 +100,12 @@ it('renders the component with the copy button', () => {
 
 it('renders the component with small width', () => {
   const { container } = render(
-    <TextInput id="someInput" name="userEmail" width="small" />,
+    <TextInput
+      id="someInput"
+      name="userEmail"
+      labelText="userEmail"
+      width="small"
+    />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -76,7 +113,12 @@ it('renders the component with small width', () => {
 
 it('renders the component with maxLength', () => {
   const { container } = render(
-    <TextInput id="someInput" name="userEmail" maxLength={10} />,
+    <TextInput
+      id="someInput"
+      name="userEmail"
+      labelText="userEmail"
+      maxLength={10}
+    />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -87,6 +129,7 @@ it('renders the component with a placeholder text', () => {
     <TextInput
       id="someInput"
       name="userEmail"
+      labelText="userEmail"
       placeholder="placeholder text"
     />,
   );
@@ -96,7 +139,12 @@ it('renders the component with a placeholder text', () => {
 
 it('renders the component with a test id', () => {
   const { container } = render(
-    <TextInput id="someInput" name="userEmail" testId="someTestId" />,
+    <TextInput
+      id="someInput"
+      name="userEmail"
+      labelText="userEmail"
+      testId="someTestId"
+    />,
   );
 
   expect(container.firstChild).toMatchSnapshot();
@@ -104,7 +152,13 @@ it('renders the component with a test id', () => {
 
 it('renders the component as required', () => {
   const { container } = render(
-    <TextInput id="someInput" name="userEmail" testId="someTestId" required />,
+    <TextInput
+      id="someInput"
+      name="userEmail"
+      labelText="userEmail"
+      testId="someTestId"
+      required
+    />,
   );
 
   expect(container.firstChild).toMatchSnapshot();

--- a/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
+++ b/packages/forma-36-react-components/src/components/TextInput/TextInput.tsx
@@ -26,6 +26,7 @@ export type TextInputProps = {
     | 'date'
     | 'time';
   name?: string;
+  labelText?: string;
   id?: string;
   className?: string;
   withCopyButton?: boolean;
@@ -47,6 +48,7 @@ export const TextInput = ({
   isReadOnly = false,
   maxLength,
   name,
+  labelText,
   onBlur,
   onChange,
   onCopy,
@@ -113,7 +115,7 @@ export const TextInput = ({
     <div className={classNames}>
       <input
         onKeyDown={handleKeyDown}
-        aria-label={name}
+        aria-label={labelText}
         className={styles['TextInput__input']}
         id={id}
         name={name}


### PR DESCRIPTION
# Purpose of PR

fixes #894

Addressed originally in #971 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
