### PR TITLE
feat: extend Options props to supported native props like disabled []

### DIFF
--- a/packages/forma-36-react-components/src/components/Select/Option.tsx
+++ b/packages/forma-36-react-components/src/components/Select/Option.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { HTMLProps } from 'react';
 
-export interface OptionProps {
+export interface OptionProps extends HTMLProps<HTMLOptionElement> {
   value: string;
   children: React.ReactNode;
   testId?: string;

--- a/packages/forma-36-react-components/src/components/Select/README.mdx
+++ b/packages/forma-36-react-components/src/components/Select/README.mdx
@@ -53,6 +53,21 @@ Keep in mind that Select should not be used without the label. We provide [Selec
 </Select>
 ```
 
+### Select with placeholder
+
+```tsx
+// import { Select } from '@contentful/forma-36-react-components';
+
+<Select name="optionSelect" id="optionSelect">
+  <Option value="" disabled selected>
+    Please select an option...
+  </Option>
+  <Option value="optionOne">Option One</Option>
+  <Option value="optionTwo">Option Two</Option>
+  <Option value="optionThree">Option Three</Option>
+</Select>
+```
+
 ### Select with error
 
 ```tsx

--- a/packages/forma-36-react-components/src/components/Select/Select.test.tsx
+++ b/packages/forma-36-react-components/src/components/Select/Select.test.tsx
@@ -33,6 +33,20 @@ it('renders the component in disabled state', () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
+it('renders the component with placeholder', () => {
+  const { container } = render(
+    <Select name="optionSelect" id="optionSelect">
+      <Option value="" disabled selected>
+        Please select an option...
+      </Option>
+      <Option value="optionOne">Option One</Option>
+      <Option value="optionTwo">Option Two</Option>
+      <Option value="optionThree">Option Three</Option>
+    </Select>,
+  );
+  expect(container.firstChild).toMatchSnapshot();
+});
+
 it('renders the component with error', () => {
   const { container } = render(
     <Select hasError name="optionSelect" id="optionSelect">

--- a/packages/forma-36-react-components/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -193,3 +193,54 @@ exports[`renders the component with error 1`] = `
   </svg>
 </div>
 `;
+
+exports[`renders the component with placeholder 1`] = `
+<div
+  class="Select__wrapper Select--full"
+>
+  <select
+    aria-label="optionSelect"
+    class="Select"
+    data-test-id="cf-ui-select"
+    id="optionSelect"
+    name="optionSelect"
+  >
+    <option
+      data-test-id="cf-ui-select-option"
+      disabled=""
+      value=""
+    >
+      Please select an option...
+    </option>
+    <option
+      data-test-id="cf-ui-select-option"
+      value="optionOne"
+    >
+      Option One
+    </option>
+    <option
+      data-test-id="cf-ui-select-option"
+      value="optionTwo"
+    >
+      Option Two
+    </option>
+    <option
+      data-test-id="cf-ui-select-option"
+      value="optionThree"
+    >
+      Option Three
+    </option>
+  </select>
+  <svg
+    class="Icon Icon--small Icon--muted Select__icon"
+    data-test-id="cf-ui-icon"
+    height="1em"
+    viewBox="0 0 24 24"
+    width="1em"
+  >
+    <path
+      d="M5.29289 8.29289C5.68342 7.90237 6.31658 7.90237 6.70711 8.29289L12 13.5858L17.2929 8.29289C17.6834 7.90237 18.3166 7.90237 18.7071 8.29289C19.0976 8.68342 19.0976 9.31658 18.7071 9.70711L12.7071 15.7071C12.3166 16.0976 11.6834 16.0976 11.2929 15.7071L5.29289 9.70711C4.90237 9.31658 4.90237 8.68342 5.29289 8.29289Z"
+    />
+  </svg>
+</div>
+`;


### PR DESCRIPTION
# Purpose of PR

In our use case at Team Homer, we needed a select element with a placeholder. It's a common pattern to add an option with an empty string, and selected and disabled set to true. Due to missing props definitions this raised typescript errors.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
