### PR TITLE
fix: add keyboard support to dropdown elements [SPA-262]

### DIFF
--- a/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/AssetCard.test.tsx
@@ -56,6 +56,9 @@ it('renders the component with status', () => {
 });
 
 it('renders the component with actions', () => {
+  Date.now = jest.fn(() => 123456);
+  Math.random = jest.fn(() => 500);
+
   const { container } = render(
     <AssetCard
       dropdownListElements={

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
@@ -346,6 +346,7 @@ exports[`renders the component with actions 1`] = `
           aria-expanded="false"
           aria-haspopup="menu"
           class="IconButton IconButton--secondary"
+          data-node-id="dropdown-trigger-689829498989.8998"
           data-test-id="cf-ui-icon-button"
           type="button"
         >

--- a/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/AssetCard/__snapshots__/AssetCard.test.tsx.snap
@@ -346,7 +346,7 @@ exports[`renders the component with actions 1`] = `
           aria-expanded="false"
           aria-haspopup="menu"
           class="IconButton IconButton--secondary"
-          data-node-id="dropdown-trigger-689829498989.8998"
+          data-node-id="dropdown-trigger-61728000"
           data-test-id="cf-ui-icon-button"
           type="button"
         >

--- a/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/CardActions.test.tsx
@@ -5,6 +5,11 @@ import { axe } from '../../../utils/axeHelper';
 import { CardActions } from './CardActions';
 import { DropdownList, DropdownListItem } from '../../Dropdown';
 
+beforeAll(() => {
+  Date.now = jest.fn(() => 123456);
+  Math.random = jest.fn(() => 500);
+});
+
 it('renders the component using a single dropdown list', () => {
   const { container } = render(
     <CardActions>

--- a/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`renders the component as disabled 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="IconButton IconButton--disabled IconButton--secondary"
+    data-node-id="dropdown-trigger-1074726300328.2062"
     data-test-id="cf-ui-icon-button"
     disabled=""
     type="button"
@@ -51,6 +52,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="IconButton IconButton--secondary"
+    data-node-id="dropdown-trigger-205090004057.30914"
     data-test-id="cf-ui-icon-button"
     type="button"
   >
@@ -92,6 +94,7 @@ exports[`renders the component using a single dropdown list 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="IconButton IconButton--secondary"
+    data-node-id="dropdown-trigger-528737584095.7633"
     data-test-id="cf-ui-icon-button"
     type="button"
   >
@@ -133,6 +136,7 @@ exports[`renders the component with an additional class name 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="IconButton IconButton--secondary"
+    data-node-id="dropdown-trigger-527062413746.27783"
     data-test-id="cf-ui-icon-button"
     type="button"
   >
@@ -174,6 +178,7 @@ exports[`renders the component with published status 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="IconButton IconButton--secondary"
+    data-node-id="dropdown-trigger-832233668234.594"
     data-test-id="cf-ui-icon-button"
     type="button"
   >

--- a/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/CardActions/__snapshots__/CardActions.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`renders the component as disabled 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="IconButton IconButton--disabled IconButton--secondary"
-    data-node-id="dropdown-trigger-1074726300328.2062"
+    data-node-id="dropdown-trigger-61728000"
     data-test-id="cf-ui-icon-button"
     disabled=""
     type="button"
@@ -52,7 +52,7 @@ exports[`renders the component using a multiple dropdown lists 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="IconButton IconButton--secondary"
-    data-node-id="dropdown-trigger-205090004057.30914"
+    data-node-id="dropdown-trigger-61728000"
     data-test-id="cf-ui-icon-button"
     type="button"
   >
@@ -94,7 +94,7 @@ exports[`renders the component using a single dropdown list 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="IconButton IconButton--secondary"
-    data-node-id="dropdown-trigger-528737584095.7633"
+    data-node-id="dropdown-trigger-61728000"
     data-test-id="cf-ui-icon-button"
     type="button"
   >
@@ -136,7 +136,7 @@ exports[`renders the component with an additional class name 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="IconButton IconButton--secondary"
-    data-node-id="dropdown-trigger-527062413746.27783"
+    data-node-id="dropdown-trigger-61728000"
     data-test-id="cf-ui-icon-button"
     type="button"
   >
@@ -178,7 +178,7 @@ exports[`renders the component with published status 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="IconButton IconButton--secondary"
-    data-node-id="dropdown-trigger-832233668234.594"
+    data-node-id="dropdown-trigger-61728000"
     data-test-id="cf-ui-icon-button"
     type="button"
   >

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/EntryCard.test.tsx
@@ -39,6 +39,9 @@ it('renders the component with a thumbnail element', () => {
 });
 
 it('renders the component with dropdownListElements', () => {
+  Date.now = jest.fn(() => 123456);
+  Math.random = jest.fn(() => 500);
+
   const { container } = render(
     <EntryCard
       title="My Entry Card"

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
@@ -372,7 +372,7 @@ exports[`renders the component with dropdownListElements 1`] = `
           aria-expanded="false"
           aria-haspopup="menu"
           class="IconButton IconButton--secondary"
-          data-node-id="dropdown-trigger-1028323152347.9845"
+          data-node-id="dropdown-trigger-61728000"
           data-test-id="cf-ui-icon-button"
           type="button"
         >

--- a/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/EntryCard/__snapshots__/EntryCard.test.tsx.snap
@@ -372,6 +372,7 @@ exports[`renders the component with dropdownListElements 1`] = `
           aria-expanded="false"
           aria-haspopup="menu"
           class="IconButton IconButton--secondary"
+          data-node-id="dropdown-trigger-1028323152347.9845"
           data-test-id="cf-ui-icon-button"
           type="button"
         >

--- a/packages/forma-36-react-components/src/components/Card/InlineEntryCard/InlineEntryCard.test.tsx
+++ b/packages/forma-36-react-components/src/components/Card/InlineEntryCard/InlineEntryCard.test.tsx
@@ -34,6 +34,9 @@ it('renders the component with published status', () => {
 });
 
 it('renders the component with a dropdown', () => {
+  Date.now = jest.fn(() => 123456);
+  Math.random = jest.fn(() => 500);
+
   const { container } = render(
     <InlineEntryCard
       className="my-extra-class"

--- a/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`renders the component with a dropdown 1`] = `
       aria-expanded="false"
       aria-haspopup="menu"
       class="IconButton IconButton--secondary"
-      data-node-id="dropdown-trigger-651884820741.751"
+      data-node-id="dropdown-trigger-61728000"
       data-test-id="cf-ui-icon-button"
       type="button"
     >

--- a/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Card/InlineEntryCard/__snapshots__/InlineEntryCard.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`renders the component with a dropdown 1`] = `
       aria-expanded="false"
       aria-haspopup="menu"
       class="IconButton IconButton--secondary"
+      data-node-id="dropdown-trigger-651884820741.751"
       data-test-id="cf-ui-icon-button"
       type="button"
     >

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.test.tsx
@@ -8,6 +8,11 @@ import { Button } from '../Button';
 import { DropdownListItem } from './DropdownListItem/DropdownListItem';
 import { DropdownList } from './DropdownList/DropdownList';
 
+beforeAll(() => {
+  Date.now = jest.fn(() => 123456);
+  Math.random = jest.fn(() => 500);
+});
+
 it('renders the component', () => {
   const { container } = render(
     <Dropdown toggleElement={<Button onClick={() => {}}>Toggle</Button>}>

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,10 @@
-import React, { RefObject, useCallback, useEffect, useState } from 'react';
+import React, {
+  RefObject,
+  useCallback,
+  useEffect,
+  useState,
+  useRef,
+} from 'react';
 import cn from 'classnames';
 import { usePopper } from 'react-popper';
 import { Modifier, Placement, State as PopperState } from '@popperjs/core';
@@ -196,6 +202,8 @@ export function Dropdown({
   );
   const classNames = cn(styles['Dropdown'], className);
   const containerTestId = testId ? `${testId}-container` : testId;
+  const toggleElementIdSuffix = useRef(Math.random() * Date.now());
+  const toggleElementId = `dropdown-trigger-${toggleElementIdSuffix.current}`;
 
   useEffect(() => {
     setIsOpen(isOpenProp);
@@ -213,19 +221,26 @@ export function Dropdown({
     }
   };
 
-  const close = useCallback(() => {
-    setIsOpen(false);
+  const handleOnClose = useCallback(() => {
+    const toggleElementNode = document.querySelector(
+      `[data-node-id="${toggleElementId}"]`,
+    ) as HTMLElement;
+    toggleElementNode.focus();
 
     if (onClose) {
       onClose();
     }
-  }, [onClose, setIsOpen]);
+  }, [toggleElementId, onClose]);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    handleOnClose();
+  }, [handleOnClose, setIsOpen]);
 
   const handleEscapeKey = useCallback(
     (event: KeyboardEvent) => {
       if (event.code === 'Escape') {
         event.stopPropagation();
-
         close();
       }
     },
@@ -246,7 +261,9 @@ export function Dropdown({
       testId={testId}
       submenuToggleLabel={submenuToggleLabel}
       onEnter={() => setIsOpen(true)}
+      onClick={() => setIsOpen(true)}
       onLeave={() => setIsOpen(false)}
+      aria-expanded={isOpen}
       ref={setReferenceElement}
       {...otherProps}
     >
@@ -261,7 +278,7 @@ export function Dropdown({
           className={dropdownContainerClassName}
           getRef={getContainerRef}
           isOpen={isOpen}
-          onClose={onClose}
+          onClose={handleOnClose}
           openSubmenu={openSubmenu}
           ref={setPopperElement}
           style={popperStyles.popper}
@@ -284,6 +301,7 @@ export function Dropdown({
         React.cloneElement(toggleElement, {
           'aria-haspopup': 'menu',
           'aria-expanded': isOpen,
+          'data-node-id': toggleElementId,
         })}
 
       {isOpen && (
@@ -292,7 +310,7 @@ export function Dropdown({
           className={dropdownContainerClassName}
           getRef={getContainerRef}
           isOpen={isOpen}
-          onClose={onClose}
+          onClose={handleOnClose}
           openSubmenu={openSubmenu}
           ref={setPopperElement}
           style={popperStyles.popper}

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -58,9 +58,10 @@ export const DropdownContainer = forwardRef<
   });
 
   useEffect(() => {
+    dropdown.current?.focus();
+
     if (getRef && dropdown.current) {
       getRef(dropdown.current);
-      dropdown.current.focus();
     }
   }, [getRef]);
 

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -60,6 +60,7 @@ export const DropdownContainer = forwardRef<
   useEffect(() => {
     if (getRef && dropdown.current) {
       getRef(dropdown.current);
+      dropdown.current.focus();
     }
   }, [getRef]);
 
@@ -68,6 +69,9 @@ export const DropdownContainer = forwardRef<
       {...props}
       className={classNames}
       data-test-id={testId}
+      // tabIndex is Necessary to focus the container for keyboard accessibility
+      // eslint-disable-next-line
+      tabIndex={0}
       onMouseEnter={() => {
         if (openSubmenu) {
           openSubmenu(true);

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/__snapshots__/DropdownContainer.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/__snapshots__/DropdownContainer.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`renders the component as a submenu 1`] = `
 <div
   class="extraClassName DropdownContainer"
   data-test-id="cf-ui-dropdown-portal"
+  tabindex="0"
 >
   DropdownContainer
 </div>

--- a/packages/forma-36-react-components/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`renders the component 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="Button Button--primary Button--medium"
-    data-node-id="dropdown-trigger-419597958781.7941"
+    data-node-id="dropdown-trigger-61728000"
     data-test-id="cf-ui-button"
     type="button"
   >
@@ -36,7 +36,7 @@ exports[`renders the component as open 1`] = `
     aria-expanded="true"
     aria-haspopup="menu"
     class="Button Button--primary Button--medium"
-    data-node-id="dropdown-trigger-963772217587.9482"
+    data-node-id="dropdown-trigger-61728000"
     data-test-id="cf-ui-button"
     type="button"
   >
@@ -63,7 +63,7 @@ exports[`renders the component with a submenu 1`] = `
     aria-expanded="true"
     aria-haspopup="menu"
     class="Button Button--primary Button--medium"
-    data-node-id="dropdown-trigger-1055065286639.5449"
+    data-node-id="dropdown-trigger-61728000"
     data-test-id="cf-ui-button"
     type="button"
   >
@@ -90,7 +90,7 @@ exports[`renders the component with an additional class name 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="Button Button--primary Button--medium"
-    data-node-id="dropdown-trigger-1225761812343.7603"
+    data-node-id="dropdown-trigger-61728000"
     data-test-id="cf-ui-button"
     type="button"
   >

--- a/packages/forma-36-react-components/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`renders the component 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="Button Button--primary Button--medium"
+    data-node-id="dropdown-trigger-419597958781.7941"
     data-test-id="cf-ui-button"
     type="button"
   >
@@ -35,6 +36,7 @@ exports[`renders the component as open 1`] = `
     aria-expanded="true"
     aria-haspopup="menu"
     class="Button Button--primary Button--medium"
+    data-node-id="dropdown-trigger-963772217587.9482"
     data-test-id="cf-ui-button"
     type="button"
   >
@@ -61,6 +63,7 @@ exports[`renders the component with a submenu 1`] = `
     aria-expanded="true"
     aria-haspopup="menu"
     class="Button Button--primary Button--medium"
+    data-node-id="dropdown-trigger-1055065286639.5449"
     data-test-id="cf-ui-button"
     type="button"
   >
@@ -87,6 +90,7 @@ exports[`renders the component with an additional class name 1`] = `
     aria-expanded="false"
     aria-haspopup="menu"
     class="Button Button--primary Button--medium"
+    data-node-id="dropdown-trigger-1225761812343.7603"
     data-test-id="cf-ui-button"
     type="button"
   >

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.test.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.test.tsx
@@ -69,6 +69,9 @@ it('renders the component as an Asset with a lower-cased entityType', () => {
 });
 
 it('renders the component with dropdownListElements', () => {
+  Date.now = jest.fn(() => 123456);
+  Math.random = jest.fn(() => 500);
+
   const { container } = render(
     <EntityListItem
       title="Title"

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
@@ -1317,6 +1317,7 @@ exports[`renders the component with dropdownListElements 1`] = `
             aria-expanded="false"
             aria-haspopup="menu"
             class="IconButton IconButton--secondary"
+            data-node-id="dropdown-trigger-835746736795.7258"
             data-test-id="cf-ui-icon-button"
             type="button"
           >

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
@@ -1317,7 +1317,7 @@ exports[`renders the component with dropdownListElements 1`] = `
             aria-expanded="false"
             aria-haspopup="menu"
             class="IconButton IconButton--secondary"
-            data-node-id="dropdown-trigger-835746736795.7258"
+            data-node-id="dropdown-trigger-61728000"
             data-test-id="cf-ui-icon-button"
             type="button"
           >


### PR DESCRIPTION
# Purpose of PR

This PR fixes the issue of focus order on dropdown open and close
Previously the dropdown container won't be focused as the dropdown gets appended at the end of document body
Now dropdown container receives focus on open, and the toggle element receives the focus back on close
Same behaviour applied on submenus as well, it'll open when the `subToggleElement` is focused and clicked


https://user-images.githubusercontent.com/6163988/121927562-7d139080-cd3f-11eb-9ffd-b23020db2313.mov



## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information