### PR TITLE
fix(modal-controls): remove negative margin-top and fix padding

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/ModalContent/ModalContent.css
+++ b/packages/forma-36-react-components/src/components/Modal/ModalContent/ModalContent.css
@@ -4,7 +4,7 @@
 @import 'settings/transitions';
 
 .ModalContent {
-  padding: var(--spacing-m) var(--spacing-l) var(--spacing-l) var(--spacing-l);
+  padding: var(--spacing-m) var(--spacing-l);
   color: var(--color-text-mid);
   font-size: var(--font-size-m);
   font-family: var(--font-stack-primary);

--- a/packages/forma-36-react-components/src/components/Modal/ModalControls/ModalControls.css
+++ b/packages/forma-36-react-components/src/components/Modal/ModalControls/ModalControls.css
@@ -6,7 +6,6 @@
   display: flex;
   flex-direction: row;
   padding: 0 var(--spacing-l) var(--spacing-l) var(--spacing-l);
-  margin-top: calc(-1 * var(--spacing-xs));
 }
 
 .ModalControls--right {


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR
Removes negative margin top on ModalControls and fix padding on ModalContent to account for not having the negative margin anymore.

Closes #995 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
