### PR TITLE
ci: align github actions setup with field-editors repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    target-branch: master
+    labels:
+      - dependencies
+      - dependabot
+    commit-message:
+      prefix: chore
+    registries:
+      - npm-registry-registry-npmjs-org

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,16 @@
+package:$1:
+  - packages/([^/]+)/.*
+
+component:$1:
+  - packages/components/([^/]+)/.*
+
+tools:
+  - .circleci/**/*
+  - .scripts/**/*
+  - .github/**/*
+
+styles:
+  - package/**/*.css
+
+tests:
+  - packages/**/*.spec.{js,tsx,ts}

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,16 @@
+titleAndCommits: true
+anyCommit: true
+allowMergeCommits: false
+types:
+  - feat
+  - fix
+  - improvement
+  - docs
+  - style
+  - refactor
+  - perf
+  - test
+  - build
+  - ci
+  - chore
+  - revert

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,12 @@
+name: Auto approve
+
+on: pull_request_target
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/auto-approve-action@v2.1.0
+        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,10 @@
+name: 'Pull Request Labeler'
+on: [pull_request]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: DataDog/labeler@glob-all
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Aligns Github actions configuration with the rest of open-source repositories:

* Updated dependabot configuration
* Auto-approve for dependabot PRs
* Automatic labels for PRs with component names that are touched in this PR
* Semantic titles validation