### PR TITLE
fix: pill typescript workaround for rest props in react

### DIFF
--- a/packages/forma-36-react-components/src/components/Pill/Pill.tsx
+++ b/packages/forma-36-react-components/src/components/Pill/Pill.tsx
@@ -5,7 +5,7 @@ import { Icon } from '../Icon';
 import { TabFocusTrap } from '../TabFocusTrap';
 import styles from './Pill.css';
 
-export interface PillProps {
+export interface PillProps extends React.HTMLAttributes<HTMLElement> {
   label: string;
   onClose?: () => void;
   onDrag?: () => void;
@@ -14,8 +14,6 @@ export interface PillProps {
   style?: React.CSSProperties;
   dragHandleComponent?: React.ReactNode;
   variant?: 'idle' | 'active' | 'deleted';
-  // All other props
-  [key:string]: any;
 }
 
 export function Pill({

--- a/packages/forma-36-react-components/src/components/Pill/Pill.tsx
+++ b/packages/forma-36-react-components/src/components/Pill/Pill.tsx
@@ -14,6 +14,8 @@ export interface PillProps {
   style?: React.CSSProperties;
   dragHandleComponent?: React.ReactNode;
   variant?: 'idle' | 'active' | 'deleted';
+  // All other props
+  [key:string]: any;
 }
 
 export function Pill({


### PR DESCRIPTION
# Purpose of PR
The Pill.tsx React component uses a rest props approach. This makes it unusable in TypeScript project where we want to provide a prop that is not defined in its PillProps interface. A way to fix this is adding a generic key value in the interface. I needed this to make drag-and-drop work for the Pill. Also there's no working drag-drop example in the docs of Forma-36, but that's another discussion. 

## PR Checklist

- [ x ] I have read the relevant `readme.md` file(s)
- [ x ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ x ] Tests are passing
- [ ]  Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ x ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ x ] Doesn't contain any sensitive information
