### PR TITLE
fix: Include `...otherProps` in Pill types

### DIFF
--- a/packages/forma-36-react-components/src/components/Pill/Pill.tsx
+++ b/packages/forma-36-react-components/src/components/Pill/Pill.tsx
@@ -5,7 +5,7 @@ import { Icon } from '../Icon';
 import { TabFocusTrap } from '../TabFocusTrap';
 import styles from './Pill.css';
 
-export interface PillProps {
+export interface PillProps extends React.HTMLAttributes<HTMLElement> {
   label: string;
   onClose?: () => void;
   onDrag?: () => void;
@@ -14,8 +14,6 @@ export interface PillProps {
   style?: React.CSSProperties;
   dragHandleComponent?: React.ReactNode;
   variant?: 'idle' | 'active' | 'deleted';
-  // All other props
-  [key:string]: any;
 }
 
 export function Pill({

--- a/packages/forma-36-react-components/src/components/Pill/Pill.tsx
+++ b/packages/forma-36-react-components/src/components/Pill/Pill.tsx
@@ -14,6 +14,8 @@ export interface PillProps {
   style?: React.CSSProperties;
   dragHandleComponent?: React.ReactNode;
   variant?: 'idle' | 'active' | 'deleted';
+  // All other props
+  [key:string]: any;
 }
 
 export function Pill({


### PR DESCRIPTION
# Purpose of PR

#1031 Fix pill types to include `...otherProps`

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
