### PR TITLE
docs: update Forma36 storybook link on Forma36 website

### DIFF
--- a/packages/forma-36-website/src/pages/index.jsx
+++ b/packages/forma-36-website/src/pages/index.jsx
@@ -47,7 +47,7 @@ const IndexPage = () => (
           title="Get started with our React components"
           description="Build your application or extension using the Forma 36 React component library"
           linkText="View all components in Storybook"
-          linkHref="https://f36.contentful.com/storybook"
+          linkHref="https://f36-storybook.contentful.com/"
           imageNode={
             <img
               src={componentsImg}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR
Currently on the F36 website [View all components in Storybook] points to https://f36.contentful.com/storybook. But, all the storybook links in the components point to https://f36-storybook.contentful.com/. I feel https://f36-storybook.contentful.com/ appropriate.

More explanation here 👇
https://loom.com/share/87b97f3782d34b06b49683ab8f391e53
<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
