### PR TITLE
fix: introduce transparent variant of the button component

### DIFF
--- a/packages/components/button/src/Button.tsx
+++ b/packages/components/button/src/Button.tsx
@@ -97,7 +97,11 @@ const _Button = (props: ButtonProps, ref) => {
     >
       {icon && !isLoading && (
         <Flex as="span" marginRight={children ? 'spacing2Xs' : 'none'}>
-          <Icon className={styles.buttonIcon} as={icon} />
+          <Icon
+            className={styles.buttonIcon}
+            as={icon}
+            size={size === 'large' ? 'medium' : 'small'}
+          />
         </Flex>
       )}
       <span className={styles.buttonText}>{children}</span>

--- a/packages/components/button/src/styles.ts
+++ b/packages/components/button/src/styles.ts
@@ -35,8 +35,8 @@ const variantActiveStyles = (variant: ButtonVariant): CSSObject => {
     case 'transparent':
       return {
         ', &:hover': {
-          background: `none`,
-          borderColor: tokens.colorElementLight,
+          backgroundColor: tokens.colorElementLightest,
+          borderColor: tokens.colorElementLightest,
         },
       };
     default:
@@ -116,8 +116,8 @@ const variantToStyles = (variant: ButtonVariant): CSSObject => {
         },
         '&:active': variantActiveStyles(variant),
         '&:focus': {
-          background: `none`,
-          border: `1px solid ${tokens.colorElementLight}`,
+          backgroundColor: 'none',
+          boxShadow: tokens.glowMuted,
         },
       };
     default:

--- a/packages/components/button/src/styles.ts
+++ b/packages/components/button/src/styles.ts
@@ -32,6 +32,13 @@ const variantActiveStyles = (variant: ButtonVariant): CSSObject => {
           borderColor: tokens.colorRedDark,
         },
       };
+    case 'transparent':
+      return {
+        ', &:hover': {
+          background: `none`,
+          borderColor: tokens.colorBlueLight,
+        },
+      };
     default:
       return {};
   }
@@ -97,6 +104,22 @@ const variantToStyles = (variant: ButtonVariant): CSSObject => {
           boxShadow: tokens.glowNegative,
         },
       };
+    case 'transparent':
+      return {
+        color: tokens.colorTextBase,
+        background: `none`,
+        borderColor: `transparent`,
+        boxShadow: `none`,
+        '&:hover': {
+          backgroundColor: tokens.colorElementLightest,
+          color: tokens.colorTextDark,
+        },
+        '&:active': variantActiveStyles(variant),
+        '&:focus': {
+          background: `none`,
+          border: `1px solid ${tokens.colorBlueLight}`,
+        },
+      };
     default:
       return {};
   }
@@ -109,18 +132,21 @@ const sizeToStyles = (size: ButtonSize): CSSObject => {
         fontSize: tokens.fontSizeM,
         lineHeight: tokens.lineHeightCondensed,
         padding: `${tokens.spacing2Xs} ${tokens.spacingS}`,
+        minHeight: `32px`,
       };
     case 'medium':
       return {
         fontSize: tokens.fontSizeM,
         lineHeight: tokens.lineHeightCondensed,
         padding: `${tokens.spacingXs} ${tokens.spacingM}`,
+        minHeight: `40px`,
       };
     case 'large':
       return {
         fontSize: tokens.fontSizeXl,
         lineHeight: tokens.lineHeightXl,
         padding: `${tokens.spacingXs} ${tokens.spacingM}`,
+        minHeight: `48px`,
       };
     default:
       return {};

--- a/packages/components/button/src/styles.ts
+++ b/packages/components/button/src/styles.ts
@@ -36,7 +36,7 @@ const variantActiveStyles = (variant: ButtonVariant): CSSObject => {
       return {
         ', &:hover': {
           background: `none`,
-          borderColor: tokens.colorBlueLight,
+          borderColor: tokens.colorElementLight,
         },
       };
     default:
@@ -117,7 +117,7 @@ const variantToStyles = (variant: ButtonVariant): CSSObject => {
         '&:active': variantActiveStyles(variant),
         '&:focus': {
           background: `none`,
-          border: `1px solid ${tokens.colorBlueLight}`,
+          border: `1px solid ${tokens.colorElementLight}`,
         },
       };
     default:

--- a/packages/components/button/src/types.ts
+++ b/packages/components/button/src/types.ts
@@ -2,7 +2,9 @@ import { ComponentVariant } from '@contentful/f36-core';
 
 export type ButtonSize = 'small' | 'medium' | 'large';
 
-export type ButtonVariant = Exclude<ComponentVariant, 'warning'>;
+export type ButtonVariant =
+  | Exclude<ComponentVariant, 'warning'>
+  | 'transparent';
 
 export type ButtonStylesProps = {
   variant: ButtonVariant;

--- a/packages/components/button/stories/Button.stories.tsx
+++ b/packages/components/button/stories/Button.stories.tsx
@@ -36,6 +36,18 @@ basic.args = {
   children: 'Button CTA',
 };
 
+export const test: Story<any> = ({ icon, children, ...args }) => (
+  <Button icon={icons[icon]} {...args}>
+    {children}
+  </Button>
+);
+
+test.args = {
+  size: 'medium',
+  variant: 'transparent',
+  icon: 'Close',
+};
+
 export const Overview = (args) => {
   return (
     <>
@@ -78,17 +90,17 @@ export const Overview = (args) => {
         </Box>
         <Flex flexDirection="row" marginBottom="spacingM">
           <Box marginRight="spacingXs">
-            <Button variant="primary" size="small">
+            <Button variant="primary" size="small" icon={icons.Plus}>
               Small
             </Button>
           </Box>
           <Box marginRight="spacingXs">
-            <Button variant="primary" size="medium">
+            <Button variant="primary" size="medium" icon={icons.Plus}>
               Medium (default)
             </Button>
           </Box>
           <Box marginRight="spacingXs">
-            <Button variant="primary" size="large">
+            <Button variant="primary" size="large" icon={icons.Plus}>
               Large
             </Button>
           </Box>
@@ -214,6 +226,20 @@ export const Overview = (args) => {
         <Flex flexDirection="row" marginBottom="spacingM">
           <Box marginRight="spacingXs">
             <Button
+              variant="transparent"
+              icon={icons.Close}
+              aria-label="Close"
+            />
+          </Box>
+          <Box marginRight="spacingXs">
+            <Button
+              variant="transparent"
+              icon={icons.MoreHorizontal}
+              aria-label="More"
+            />
+          </Box>
+          <Box marginRight="spacingXs">
+            <Button
               variant="secondary"
               icon={icons.Download}
               aria-label="Download"
@@ -234,6 +260,32 @@ export const Overview = (args) => {
           </Box>
           <Box marginRight="spacingXs">
             <Button variant="primary" icon={icons.Plus} aria-label="Add" />
+          </Box>
+        </Flex>
+        <Flex flexDirection="row" marginBottom="spacingM">
+          <Box marginRight="spacingXs">
+            <Button
+              variant="primary"
+              icon={icons.Plus}
+              aria-label="Plus"
+              size="small"
+            />
+          </Box>
+          <Box marginRight="spacingXs">
+            <Button
+              variant="primary"
+              icon={icons.Plus}
+              aria-label="Plus"
+              size="medium"
+            />
+          </Box>
+          <Box marginRight="spacingXs">
+            <Button
+              variant="primary"
+              icon={icons.Plus}
+              aria-label="Plus"
+              size="large"
+            />
           </Box>
         </Flex>
       </Flex>

--- a/packages/components/button/stories/Button.stories.tsx
+++ b/packages/components/button/stories/Button.stories.tsx
@@ -36,18 +36,6 @@ basic.args = {
   children: 'Button CTA',
 };
 
-export const test: Story<any> = ({ icon, children, ...args }) => (
-  <Button icon={icons[icon]} {...args}>
-    {children}
-  </Button>
-);
-
-test.args = {
-  size: 'medium',
-  variant: 'transparent',
-  icon: 'Close',
-};
-
 export const Overview = (args) => {
   return (
     <>

--- a/packages/components/button/stories/Button.stories.tsx
+++ b/packages/components/button/stories/Button.stories.tsx
@@ -65,13 +65,12 @@ export const Overview = (args) => {
             </Button>
           </Box>
           <Box marginRight="spacingXs">
-            <Button disabled variant="primary">
-              Disabled
+            <Button variant="transparent" icon={icons[args.icon]}>
+              Transparent
             </Button>
           </Box>
         </Flex>
       </Flex>
-
       <Flex flexDirection="column" marginBottom="spacingL">
         <Box marginBottom="spacingS">
           <SectionHeading as="h3">Button sizes</SectionHeading>
@@ -120,6 +119,11 @@ export const Overview = (args) => {
               Negative isActive
             </Button>
           </Box>
+          <Box marginRight="spacingXs">
+            <Button variant="transparent" isActive>
+              Transparent
+            </Button>
+          </Box>
         </Flex>
       </Flex>
 
@@ -146,6 +150,11 @@ export const Overview = (args) => {
           <Box marginRight="spacingXs">
             <Button variant="negative" disabled>
               Negative disabled
+            </Button>
+          </Box>
+          <Box marginRight="spacingXs">
+            <Button variant="transparent" disabled>
+              Transparent
             </Button>
           </Box>
         </Flex>
@@ -176,6 +185,11 @@ export const Overview = (args) => {
               Negative with dropdown
             </Button>
           </Box>
+          <Box marginRight="spacingXs">
+            <Button variant="transparent" isDropdown>
+              Transparent
+            </Button>
+          </Box>
         </Flex>
       </Flex>
 
@@ -202,6 +216,11 @@ export const Overview = (args) => {
           <Box marginRight="spacingXs">
             <Button variant="negative" isLoading>
               Negative isLoading
+            </Button>
+          </Box>
+          <Box marginRight="spacingXs">
+            <Button variant="transparent" isLoading>
+              Transparent
             </Button>
           </Box>
         </Flex>


### PR DESCRIPTION
In order to be able to merge IconButton into the Button in v4, we need to introduce a transparent variant of the component.
I made small adjustments for icon sizes and display couple more examples in the storybook.

Next PR - create a separate component for the divided version:

![Screenshot 2021-07-08 at 12 51 48](https://user-images.githubusercontent.com/4272331/124929389-bff41b80-e000-11eb-81a7-3b7389b6eb25.png)
