### PR TITLE
fix: add focusContainerOnOpen prop on Dropdown

### DIFF
--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -256,6 +256,7 @@ export const Autocomplete = <T extends {}>({
         dispatch({ type: TOGGLED_LIST, payload: false });
       }}
       toggleElement={renderToggleElementFunction(toggleProps)}
+      focusContainerOnOpen={false}
       {...dropdownProps}
       isOpen={isOpen}
     >

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
@@ -148,6 +148,13 @@ export interface DropdownProps {
    * Autocomplete component for an actual example of this usage.
    */
   nonClosingRefs?: RefObject<HTMLElement>[];
+
+  /**
+   * Boolean to focus DropdownContainer on open
+   *
+   * Defaults to `true`
+   */
+  focusContainerOnOpen?: boolean;
 }
 
 export function Dropdown({
@@ -165,6 +172,7 @@ export function Dropdown({
   toggleElement,
   usePortal,
   nonClosingRefs,
+  focusContainerOnOpen = true,
   ...otherProps
 }: DropdownProps) {
   const [referenceElement, setReferenceElement] = useState<HTMLElement | null>(
@@ -283,6 +291,7 @@ export function Dropdown({
           ref={setPopperElement}
           style={popperStyles.popper}
           submenu
+          focusContainerOnOpen={focusContainerOnOpen}
           usePortal={usePortal}
           {...attributes.popper}
         >
@@ -315,6 +324,7 @@ export function Dropdown({
           ref={setPopperElement}
           style={popperStyles.popper}
           submenu={false}
+          focusContainerOnOpen={focusContainerOnOpen}
           testId={containerTestId}
           usePortal={usePortal}
           {...attributes.popper}

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -18,6 +18,7 @@ export interface DropdownContainerProps
   submenu?: boolean;
   testId?: string;
   usePortal?: boolean;
+  focusContainerOnOpen?: boolean;
 }
 
 export const DropdownContainer = forwardRef<
@@ -36,6 +37,7 @@ export const DropdownContainer = forwardRef<
     testId = 'cf-ui-dropdown-portal',
     usePortal = true,
     nonClosingRefs,
+    focusContainerOnOpen,
     ...props
   },
   refCallback,
@@ -58,12 +60,14 @@ export const DropdownContainer = forwardRef<
   });
 
   useEffect(() => {
-    dropdown.current?.focus();
+    if (focusContainerOnOpen) {
+      dropdown.current?.focus();
+    }
 
     if (getRef && dropdown.current) {
       getRef(dropdown.current);
     }
-  }, [getRef]);
+  }, [getRef, focusContainerOnOpen]);
 
   const dropdownComponent = (
     <div


### PR DESCRIPTION
# Purpose of PR

With the recent fixes for dropdown component to focus the dropdown container on open, that is interrupting input on autocomplete component as the focus moves out of input on focusing

This PR adds `focusContainerOnOpen` on open property to `Dropdown` and setting it to false on `Autocomplete` as autocomplete already handling mouse up and down, and doesn't need focus on content container

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
