### PR TITLE
docs: remove classNames from Skeleton component stories

### DIFF
--- a/packages/forma-36-react-components/src/components/Skeleton/SkeletonDisplayText/SkeletonDisplayText.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Skeleton/SkeletonDisplayText/SkeletonDisplayText.stories.tsx
@@ -12,9 +12,7 @@ export default {
   parameters: {
     propTypes: [SkeletonDisplayText['__docgenInfo']],
   },
-  argTypes: {
-    className: { control: { disable: true } },
-  },
+  argTypes: {},
 };
 
 export const Basic = (args: SkeletonDisplayTextProps) => (

--- a/packages/forma-36-react-components/src/components/Skeleton/SkeletonImage/SkeletonImage.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Skeleton/SkeletonImage/SkeletonImage.stories.tsx
@@ -9,9 +9,7 @@ export default {
   parameters: {
     propTypes: [SkeletonImage['__docgenInfo']],
   },
-  argTypes: {
-    className: { control: { disable: true } },
-  },
+  argTypes: {},
 };
 
 export const Basic = (args: SkeletonImageProps) => (

--- a/packages/forma-36-react-components/src/components/Skeleton/SkeletonRow/SkeletonRow.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Skeleton/SkeletonRow/SkeletonRow.stories.tsx
@@ -9,9 +9,7 @@ export default {
   parameters: {
     propTypes: [SkeletonRow['__docgenInfo']],
   },
-  argTypes: {
-    className: { control: { disable: true } },
-  },
+  argTypes: {},
 };
 
 export const Basic = (args: SkeletonRowProps) => (


### PR DESCRIPTION
Most of our skeleton components don't take classnames. This PR removes the `className` prop from stories for those components, to avoid confusion.

Closes #992 