### PR TITLE
docs: we are Forma 36

### DIFF
--- a/packages/forma-36-react-components/CHANGELOG.md
+++ b/packages/forma-36-react-components/CHANGELOG.md
@@ -2507,7 +2507,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-- **LineChart:** LineChart removed from Forma36 ([8e9b74c](https://github.com/contentful/forma-36/commit/8e9b74c))
+- **LineChart:** LineChart removed from Forma 36 ([8e9b74c](https://github.com/contentful/forma-36/commit/8e9b74c))
 
 # [2.5.0](https://github.com/contentful/forma-36/compare/@contentful/forma-36-react-components@2.4.1...@contentful/forma-36-react-components@2.5.0) (2019-02-20)
 

--- a/packages/forma-36-react-components/src/components/Card/Card.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Card/Card.stories.tsx
@@ -83,7 +83,7 @@ export const WithLinkAndTarget: Story<CardProps> = (args) => {
   return (
     <Card {...args}>
       <Typography>
-        <Heading>Forma36</Heading>
+        <Heading>Forma 36</Heading>
         <Paragraph>
           Forma 36 is an open-source design system by Contentful created with
           the intent to reduce the overhead of creating UI by providing tools
@@ -103,7 +103,7 @@ export const overview: Story<CardProps> = (args) => {
       </Flex>
       <Card {...args}>
         <Typography>
-          <Heading>Forma36</Heading>
+          <Heading>Forma 36</Heading>
           <Paragraph>
             Forma 36 is an open-source design system by Contentful created with
             the intent to reduce the overhead of creating UI by providing tools
@@ -117,7 +117,7 @@ export const overview: Story<CardProps> = (args) => {
         <SectionHeading element="h3">Card selected</SectionHeading>
       </Flex>
       <Card selected>
-        <Heading>Forma36</Heading>
+        <Heading>Forma 36</Heading>
         <Paragraph>
           Forma 36 is an open-source design system by Contentful created with
           the intent to reduce the overhead of creating UI by providing tools
@@ -130,7 +130,7 @@ export const overview: Story<CardProps> = (args) => {
         <SectionHeading element="h3">Card with default padding</SectionHeading>
       </Flex>
       <Card padding="default">
-        <Heading>Forma36</Heading>
+        <Heading>Forma 36</Heading>
         <Paragraph>
           Forma 36 is an open-source design system by Contentful created with
           the intent to reduce the overhead of creating UI by providing tools
@@ -142,7 +142,7 @@ export const overview: Story<CardProps> = (args) => {
         <SectionHeading element="h3">Card with large padding</SectionHeading>
       </Flex>
       <Card padding="large">
-        <Heading>Forma36</Heading>
+        <Heading>Forma 36</Heading>
         <Paragraph>
           Forma 36 is an open-source design system by Contentful created with
           the intent to reduce the overhead of creating UI by providing tools
@@ -155,7 +155,7 @@ export const overview: Story<CardProps> = (args) => {
         <SectionHeading element="h3">Card without padding</SectionHeading>
       </Flex>
       <Card padding="none">
-        <Heading>Forma36</Heading>
+        <Heading>Forma 36</Heading>
         <Paragraph>
           Forma 36 is an open-source design system by Contentful created with
           the intent to reduce the overhead of creating UI by providing tools

--- a/packages/forma-36-react-components/src/components/DateTime/README.mdx
+++ b/packages/forma-36-react-components/src/components/DateTime/README.mdx
@@ -28,7 +28,7 @@ Displays an absolute date and/or time in a variety of formats that conforms to F
 
 ```ts
 import React from 'react';
-import { DateTime } from '@contentful/forma36-react-components';
+import { DateTime } from '@contentful/forma-36-react-components';
 
 export const MyComponent: React.FC<{ date: Date }> = ({ date }) => {
   return <DateTime date={date} />;
@@ -39,7 +39,7 @@ or with a different format
 
 ```ts
 import React from 'react';
-import { DateTime } from '@contentful/forma36-react-components';
+import { DateTime } from '@contentful/forma-36-react-components';
 
 export const ScheduledForWeekdate: React.FC<{ date: Date }> = ({ date }) => {
   return <DateTime date={date} format="WEEKDAY_DATE" />;
@@ -56,7 +56,7 @@ Provides a relative date string for resolutions ranging from seconds up through 
 
 ```ts
 import React from 'react';
-import { RelativeDate } from '@contentful/forma36-react-components';
+import { RelativeDate } from '@contentful/forma-36-react-components';
 
 export const EntryPublishedRelative: React.FC<{ publishedAt: Date }> = ({
   publishedAt,
@@ -69,7 +69,7 @@ With a different `baseDate`
 
 ```ts
 import React from 'react';
-import { RelativeDate } from '@contentful/forma36-react-components';
+import { RelativeDate } from '@contentful/forma-36-react-components';
 
 export const EntryLifetime: React.FC<{
   createdAt: Date;
@@ -96,7 +96,7 @@ Additional functions are available for strings in cases when the date and/or tim
 **Example**
 
 ```ts
-import { datetime } from '@contentful/forma36-react-components';
+import { datetime } from '@contentful/forma-36-react-components';
 
 const publishedTime = datetime.formatTime(date);
 ```

--- a/packages/forma-36-react-components/src/components/DateTime/RelativeDate/RelativeDate.tsx
+++ b/packages/forma-36-react-components/src/components/DateTime/RelativeDate/RelativeDate.tsx
@@ -18,7 +18,7 @@ export interface RelativeDateProps {
 /**
  * Expresses a historical or upcoming date as a relative date/date time
  *
- * Forma36 usage guidelines: https://f36.contentful.com/guidelines/date-and-time/
+ * Forma 36 usage guidelines: https://f36.contentful.com/guidelines/date-and-time/
  */
 export const RelativeDate: React.FC<RelativeDateProps> = ({
   date,

--- a/packages/forma-36-react-components/src/components/Spinner/README.mdx
+++ b/packages/forma-36-react-components/src/components/Spinner/README.mdx
@@ -31,4 +31,4 @@ It’s possible to use the Spinner with other elements. A very common pattern is
 </div>
 ```
 
-Another good example of the Spinner being used with other components is the loading state of [Forma36’s button](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components/src/components/Button).
+Another good example of the Spinner being used with other components is the loading state of [Forma 36’s button](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components/src/components/Button).

--- a/packages/forma-36-react-components/tools/rollup.umd.config.js
+++ b/packages/forma-36-react-components/tools/rollup.umd.config.js
@@ -24,7 +24,7 @@ function getConfig(environment) {
           'react-dom': 'ReactDOM',
         },
         format: 'umd',
-        name: 'Forma36',
+        name: 'Forma 36',
         exports: 'named',
       },
     ],

--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -361,7 +361,7 @@ module.exports = {
       resolve: `gatsby-plugin-algolia-docsearch`,
       options: {
         // The key is added here only give access to searching the public content of the website https://docsearch.algolia.com/docs/what-is-docsearch
-        // You can even check Forma36's configuration in DocSearch's repo https://github.com/algolia/docsearch-configs/blob/master/configs/contentful_forma-36.json
+        // You can even check Forma 36's configuration in DocSearch's repo https://github.com/algolia/docsearch-configs/blob/master/configs/contentful_forma-36.json
         apiKey: 'b7d2cac8e38b0903385db259b042c66c',
         indexName: 'contentful_forma-36',
         inputSelector: '#search',

--- a/packages/forma-36-website/src/components/DocSearch.jsx
+++ b/packages/forma-36-website/src/components/DocSearch.jsx
@@ -36,7 +36,7 @@ const DocSearch = () => {
 
     window.docsearch({
       // The key is added here only give access to searching the public content of the website https://docsearch.algolia.com/docs/what-is-docsearch
-      // You can even check Forma36's configuration in DocSearch's repo https://github.com/algolia/docsearch-configs/blob/master/configs/contentful_forma-36.json
+      // You can even check Forma 36's configuration in DocSearch's repo https://github.com/algolia/docsearch-configs/blob/master/configs/contentful_forma-36.json
       apiKey: 'b7d2cac8e38b0903385db259b042c66c',
       indexName: 'contentful_forma-36',
       inputSelector: '#search',


### PR DESCRIPTION
# Purpose of PR

👋

It happens quite often that people remove the space from the Forma 36 name and write it as "Forma36". This PR removes any last instances of such naming from our code. Hopefully this helps avoid confusion about how Forma 36 is written 🙂 

The only remaining question is if we should bother renaming the community Slack channel to `#forma-36` instead of `#forma36`.