### PR TITLE
fix(dropdown-container): force window not to scroll on dropdown focus

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.tsx
@@ -60,12 +60,14 @@ export const DropdownContainer = forwardRef<
   });
 
   useEffect(() => {
-    if (focusContainerOnOpen) {
-      dropdown.current?.focus();
-    }
-
     if (getRef && dropdown.current) {
       getRef(dropdown.current);
+    }
+
+    if (focusContainerOnOpen) {
+      dropdown.current?.focus({
+        preventScroll: true,
+      });
     }
   }, [getRef, focusContainerOnOpen]);
 


### PR DESCRIPTION
# Purpose of PR

Closes #1075 by preventing Dropdown from scrolling to the focused dropdown on open.