### PR TITLE
fix(accordion): make AccordionPanel height adjustable to content

### DIFF
--- a/packages/forma-36-react-components/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Accordion/Accordion.stories.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Accordion, AccordionProps } from './Accordion';
 import { AccordionItem } from './AccordionItem/AccordionItem';
 import { Flex } from '../Flex';
+import { Button } from '../Button';
 import { Paragraph, SectionHeading, Typography } from '../Typography';
 
 export default {
@@ -95,6 +96,31 @@ export const overview = ({ align, ...args }: AccordionProps) => (
     </Flex>
   </>
 );
+
+export const DynamicContent = ({ align, ...args }: AccordionProps) => {
+  const [content, updateContent] = useState(defaultText);
+
+  const addContent = () => {
+    updateContent(content + defaultText);
+  };
+
+  return (
+    <Flex flexDirection="column" fullWidth>
+      <Flex marginBottom="spacingS">
+        <Button onClick={addContent}>Add content</Button>
+      </Flex>
+      <Flex>
+        <Accordion align={align}>
+          <AccordionItem title={args['AccordionItem Title #1']}>
+            <Typography>
+              <Paragraph>{content}</Paragraph>
+            </Typography>
+          </AccordionItem>
+        </Accordion>
+      </Flex>
+    </Flex>
+  );
+};
 
 basic.args = {
   align: 'end',

--- a/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.css
+++ b/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.css
@@ -4,14 +4,13 @@
 .AccordionPanel {
   box-sizing: border-box;
   overflow: hidden;
-  padding: 0 var(--spacing-m);
   height: 0;
   transition: height var(--transition-duration-default)
       var(--transition-easing-default),
     padding var(--transition-duration-default) var(--transition-easing-default);
 }
 
-.AccordionPanel--expanded {
+.AccordionPanel__content {
+  width: 100%;
   padding: var(--spacing-xs) var(--spacing-m) var(--spacing-m);
-  height: auto;
 }

--- a/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
+++ b/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
@@ -1,6 +1,5 @@
 import React, { FC, useLayoutEffect, useRef } from 'react';
 import cn from 'classnames';
-import tokens from '@contentful/forma-36-tokens';
 
 import styles from './AccordionPanel.css';
 
@@ -26,29 +25,54 @@ export const AccordionPanel: FC<AccordionPanelProps> = ({
 }: AccordionPanelProps) => {
   const panelEl = useRef<HTMLDivElement>(null);
 
+  const getPanelContentHeight = () => {
+    const { current } = panelEl;
+
+    if (!current) {
+      // to keep the function return type as string only and
+      // not overcomplicate things with non-nullable checks
+      return '0px';
+    }
+
+    return `${current.scrollHeight / 16}rem`; // converting height pixels into rem
+  };
+
   useLayoutEffect(() => {
     const { current } = panelEl;
 
-    if (current) {
-      // height + padding-top + padding-bottom of the accordion’s panel final state
-      // we need this math because the height will depend on the accordion’s content
-      const panelHeight = `${current.scrollHeight / 16}rem`; // converting height pixels into rem
-      const finalHeight = `calc(${panelHeight} + ${tokens.spacingXs} + ${tokens.spacingM})`;
+    const handleTransitionEnd = () => {
+      if (current) {
+        current.style.height = 'auto';
+      }
+    };
 
+    if (current) {
       if (isExpanded) {
+        current.addEventListener('transitionend', handleTransitionEnd);
+
         requestAnimationFrame(function () {
           current.style.height = '0px';
 
           requestAnimationFrame(function () {
-            current.style.height = finalHeight;
+            current.style.height = getPanelContentHeight();
           });
         });
       } else {
         requestAnimationFrame(function () {
-          current.style.height = '0px';
+          current.style.height = getPanelContentHeight();
+
+          requestAnimationFrame(function () {
+            current.style.height = '0px';
+          });
         });
       }
     }
+
+    return () => {
+      if (current) {
+        current.removeEventListener('transitionend', handleTransitionEnd);
+      }
+    };
   }, [isExpanded]);
 
   return (
@@ -62,7 +86,7 @@ export const AccordionPanel: FC<AccordionPanelProps> = ({
       })}
       ref={panelEl}
     >
-      {children}
+      <div className={cn(styles['AccordionPanel__content'])}>{children}</div>
     </div>
   );
 };

--- a/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
+++ b/packages/forma-36-react-components/src/components/Accordion/AccordionPanel/AccordionPanel.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useLayoutEffect, useRef } from 'react';
 import cn from 'classnames';
+import tokens from '@contentful/forma-36-tokens';
 
 import styles from './AccordionPanel.css';
 
@@ -34,7 +35,7 @@ export const AccordionPanel: FC<AccordionPanelProps> = ({
       return '0px';
     }
 
-    return `${current.scrollHeight / 16}rem`; // converting height pixels into rem
+    return `${current.scrollHeight / parseInt(tokens.fontBaseDefault, 10)}rem`; // converting height pixels into rem
   };
 
   useLayoutEffect(() => {

--- a/packages/forma-36-react-components/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -45,7 +45,11 @@ exports[`renders the component 1`] = `
       id="accordion-panel--1"
       role="region"
     >
-      Accordion content
+      <div
+        class="AccordionPanel__content"
+      >
+        Accordion content
+      </div>
     </div>
   </li>
 </ul>
@@ -96,7 +100,11 @@ exports[`renders the component with an additional class name 1`] = `
       id="accordion-panel--2"
       role="region"
     >
-      Accordion content
+      <div
+        class="AccordionPanel__content"
+      >
+        Accordion content
+      </div>
     </div>
   </li>
 </ul>
@@ -147,7 +155,11 @@ exports[`renders the component with chevron on the left 1`] = `
       id="accordion-panel--3"
       role="region"
     >
-      Accordion content
+      <div
+        class="AccordionPanel__content"
+      >
+        Accordion content
+      </div>
     </div>
   </li>
 </ul>


### PR DESCRIPTION
# Purpose of PR
Make `AccordionPanel` height dynamically adjustable to its content. So whenever content size changes the height of `AccordionPanel` adapt to it.

Closes #962 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
