### PR TITLE
fix(dropdown): fix "`focus` of `null`" error in Dropdown component

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
@@ -233,7 +233,7 @@ export function Dropdown({
     const toggleElementNode = document.querySelector(
       `[data-node-id="${toggleElementId}"]`,
     ) as HTMLElement;
-    toggleElementNode.focus();
+    toggleElementNode?.focus();
 
     if (onClose) {
       onClose();


### PR DESCRIPTION
# Purpose of PR

There is an issue sometimes, when `toggleElementNode` is `null`, it causes a TypeError. This check should fix it, at least avoid chasing an app.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
