### PR TITLE
fix(switch.css): adds missing font-family: var(--font-stack-primary) declaration for Switch labels

### DIFF
--- a/packages/forma-36-react-components/src/components/Switch/Switch.css
+++ b/packages/forma-36-react-components/src/components/Switch/Switch.css
@@ -51,6 +51,7 @@
 }
 
 .Switch__label {
+  font-family: var(--font-stack-primary);
   color: var(--color-text-dark);
   display: flex;
   align-items: center;


### PR DESCRIPTION
# Purpose of PR

adds missing `font-family: var(--font-stack-primary)` declaration for Switch labels to `Switch.css`

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information

# Screenshots:

#### Switch labelText with unset font-family: 
<img width="355" alt="Screen Shot 2021-07-28 at 1 34 25 PM" src="https://user-images.githubusercontent.com/492573/127371224-7ce36067-a9a4-46e7-bed5-7f51d3e76acb.png">

#### `<Switch />` implementation:
<img width="1027" alt="Screen Shot 2021-07-28 at 1 35 11 PM" src="https://user-images.githubusercontent.com/492573/127371225-201067a7-e854-47db-90a8-e240072b6ca0.png">

#### Dependency declarations:
<img width="699" alt="Screen Shot 2021-07-28 at 1 35 30 PM" src="https://user-images.githubusercontent.com/492573/127371227-5bdb8a6d-c20f-4790-b61f-463109268e71.png">