### PR TITLE
refactor: inline all component variants [BAU-59]

### DIFF
--- a/packages/components/badge/src/types.ts
+++ b/packages/components/badge/src/types.ts
@@ -1,9 +1,11 @@
-import type { ComponentVariant } from '@contentful/f36-core';
-
 export type BadgeSize = 'default' | 'small';
 
 export type BadgeVariant =
-  | ComponentVariant
+  | 'negative'
+  | 'positive'
+  | 'primary'
+  | 'secondary'
+  | 'warning'
   | 'muted'
   | 'primary-filled'
   | 'featured';

--- a/packages/components/button/src/types.ts
+++ b/packages/components/button/src/types.ts
@@ -1,9 +1,11 @@
-import { ComponentVariant } from '@contentful/f36-core';
-
 export type ButtonSize = 'small' | 'medium' | 'large';
 
 export type ButtonVariant =
-  | Exclude<ComponentVariant, 'warning'>
+  | 'negative'
+  | 'positive'
+  | 'primary'
+  | 'secondary'
+  | 'warning'
   | 'transparent';
 
 export type ButtonStylesProps = {

--- a/packages/components/button/src/types.ts
+++ b/packages/components/button/src/types.ts
@@ -5,7 +5,6 @@ export type ButtonVariant =
   | 'positive'
   | 'primary'
   | 'secondary'
-  | 'warning'
   | 'transparent';
 
 export type ButtonStylesProps = {

--- a/packages/components/icon/src/Icon.tsx
+++ b/packages/components/icon/src/Icon.tsx
@@ -4,7 +4,6 @@ import tokens from '@contentful/f36-tokens';
 import { Box } from '@contentful/f36-core';
 import type {
   BoxProps,
-  ComponentVariant,
   PolymorphicComponent,
   PolymorphicComponentProps,
   PolymorphicComponentWithRef,
@@ -24,7 +23,15 @@ export type IconComponent = ExoticComponent<any> | ComponentType<any>;
 
 export type IconSize = 'large' | 'medium' | 'small' | 'tiny';
 
-export type IconVariant = Simplify<ComponentVariant | 'muted' | 'white'>;
+export type IconVariant = Simplify<
+  | 'negative'
+  | 'positive'
+  | 'primary'
+  | 'secondary'
+  | 'warning'
+  | 'muted'
+  | 'white'
+>;
 
 const sizes: { [key in IconSize]: { [key in 'height' | 'width']: string } } = {
   large: {

--- a/packages/components/icon/src/Icon.tsx
+++ b/packages/components/icon/src/Icon.tsx
@@ -7,7 +7,6 @@ import type {
   PolymorphicComponent,
   PolymorphicComponentProps,
   PolymorphicComponentWithRef,
-  Simplify,
 } from '@contentful/f36-core';
 import type {
   ComponentType,
@@ -23,15 +22,14 @@ export type IconComponent = ExoticComponent<any> | ComponentType<any>;
 
 export type IconSize = 'large' | 'medium' | 'small' | 'tiny';
 
-export type IconVariant = Simplify<
+export type IconVariant =
   | 'negative'
   | 'positive'
   | 'primary'
   | 'secondary'
   | 'warning'
   | 'muted'
-  | 'white'
->;
+  | 'white';
 
 const sizes: { [key in IconSize]: { [key in 'height' | 'width']: string } } = {
   large: {

--- a/packages/components/note/src/Note.tsx
+++ b/packages/components/note/src/Note.tsx
@@ -1,7 +1,7 @@
 import { cx } from 'emotion';
 import React from 'react';
 import { Box } from '@contentful/f36-core';
-import type { CommonProps, ComponentVariant } from '@contentful/f36-core';
+import type { CommonProps } from '@contentful/f36-core';
 import { Button } from '@contentful/f36-button';
 import { Heading, Text } from '@contentful/f36-typography';
 import {
@@ -21,7 +21,7 @@ const icons = {
   warning: Warning,
 };
 
-export type NoteVariant = Exclude<ComponentVariant, 'secondary'>;
+export type NoteVariant = 'negative' | 'positive' | 'primary' | 'warning';
 export interface NoteProps extends CommonProps {
   /**
    * Determines style variation of Note component

--- a/packages/components/spinner/src/Spinner.tsx
+++ b/packages/components/spinner/src/Spinner.tsx
@@ -4,8 +4,6 @@ import tokens from '@contentful/f36-tokens';
 import { Box } from '@contentful/f36-core';
 import type {
   BoxInternalProps,
-  ComponentVariant,
-  PickUnion,
   PolymorphicComponent,
   PolymorphicComponentProps,
   PolymorphicComponentWithRef,
@@ -14,9 +12,7 @@ import type {
 
 const DEFAULT_TAG = 'div';
 
-export type SpinnerVariant = Simplify<
-  PickUnion<ComponentVariant, 'primary'> | 'default' | 'white'
->;
+export type SpinnerVariant = Simplify<'primary' | 'default' | 'white'>;
 
 export type SpinnerSize = 'large' | 'medium' | 'small';
 

--- a/packages/components/spinner/src/Spinner.tsx
+++ b/packages/components/spinner/src/Spinner.tsx
@@ -7,12 +7,11 @@ import type {
   PolymorphicComponent,
   PolymorphicComponentProps,
   PolymorphicComponentWithRef,
-  Simplify,
 } from '@contentful/f36-core';
 
 const DEFAULT_TAG = 'div';
 
-export type SpinnerVariant = Simplify<'primary' | 'default' | 'white'>;
+export type SpinnerVariant = 'primary' | 'default' | 'white';
 
 export type SpinnerSize = 'large' | 'medium' | 'small';
 

--- a/packages/components/text-link/src/types.ts
+++ b/packages/components/text-link/src/types.ts
@@ -1,6 +1,7 @@
-import { ComponentVariant } from '@contentful/f36-core';
-
 export type TextLinkVariant =
-  | Exclude<ComponentVariant, 'warning'>
+  | 'negative'
+  | 'positive'
+  | 'primary'
+  | 'secondary'
   | 'muted'
   | 'white';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,6 @@
 export * from './Primitive';
 export type {
   CommonProps,
-  ComponentVariant,
   EntityStatus,
   MarginProps,
   PaddingProps,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,6 @@ export type {
   MarginProps,
   PaddingProps,
   PickUnion,
-  Simplify,
   Spacing,
 } from './types';
 export * from './Flex';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -71,5 +71,3 @@ export type PickUnion<UnionType, Keys> = Exclude<
   UnionType,
   Exclude<UnionType, Keys>
 >;
-
-export type Simplify<T> = { [KeyType in keyof T]: T[KeyType] };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,16 +15,6 @@ export type CommonProps = {
 };
 
 /**
- * Forma 36 component variants
- */
-export type ComponentVariant =
-  | 'negative'
-  | 'positive'
-  | 'primary'
-  | 'secondary'
-  | 'warning';
-
-/**
  * Contentful entity status
  */
 export type EntityStatus =


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Inline all component variants instead of picking and excluding from the shared type.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
