### PR TITLE
feat: improve Workbench a11y support

### DIFF
--- a/packages/forma-36-react-components/src/components/Workbench/Workbench.tsx
+++ b/packages/forma-36-react-components/src/components/Workbench/Workbench.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { HTMLProps } from 'react';
 import cn from 'classnames';
 import type { ReactElement } from 'react';
 
@@ -26,7 +26,7 @@ export function WorkbenchHeader({
   title,
 }: WorkbenchHeaderProps) {
   return (
-    <div
+    <header
       className={cn(styles['Workbench__header'], className)}
       data-test-id={testId}
     >
@@ -58,7 +58,10 @@ export function WorkbenchHeader({
           className={styles['Workbench__header-title']}
         >
           {typeof title === 'string' ? (
-            <Heading className={styles['Workbench__header-title__heading']}>
+            <Heading
+              element="h1"
+              className={styles['Workbench__header-title__heading']}
+            >
               {title}
             </Heading>
           ) : (
@@ -72,9 +75,9 @@ export function WorkbenchHeader({
           className={styles['Workbench__header-description']}
         >
           {typeof description === 'string' ? (
-            <span className={styles['Workbench__header-description__text']}>
+            <p className={styles['Workbench__header-description__text']}>
               {description}
-            </span>
+            </p>
           ) : (
             description
           )}
@@ -83,17 +86,18 @@ export function WorkbenchHeader({
       {actions ? (
         <div className={styles['Workbench__header-actions']}>{actions}</div>
       ) : null}
-    </div>
+    </header>
   );
 }
 
 WorkbenchHeader.displayName = 'Workbench.Header';
 
-export interface WorkbenchSidebarProps {
+export interface WorkbenchSidebarProps extends HTMLProps<HTMLElement> {
   children?: React.ReactNode;
   className?: string;
   position?: 'left' | 'right';
   testId?: string;
+  labelText?: string;
 }
 
 export function WorkbenchSidebar({
@@ -101,9 +105,11 @@ export function WorkbenchSidebar({
   className,
   position,
   testId = 'cf-ui-workbench-sidebar',
+  labelText = position === 'left' ? 'Primary sidebar' : 'Secondary sidebar',
+  ...otherProps
 }: WorkbenchSidebarProps) {
   return (
-    <div
+    <aside
       data-test-id={`${testId}${position ? `-${position}` : ''}`}
       className={cn(
         styles['Workbench__sidebar'],
@@ -113,17 +119,20 @@ export function WorkbenchSidebar({
         },
         className,
       )}
+      aria-label={labelText}
+      {...otherProps}
     >
       {children}
-    </div>
+    </aside>
   );
 }
 
-export interface WorkbenchContentProps {
+export interface WorkbenchContentProps extends HTMLProps<HTMLElement> {
   children?: React.ReactNode;
   type?: 'default' | 'text' | 'full';
   className?: string;
   testId?: string;
+  labelText?: string;
 }
 
 export function WorkbenchContent({
@@ -131,11 +140,13 @@ export function WorkbenchContent({
   className,
   testId = 'cf-ui-workbench-content',
   type = 'default',
+  labelText = 'Main content',
 }: WorkbenchContentProps) {
   return (
-    <div
+    <main
       className={cn(styles['Workbench__content'], className)}
       data-test-id={testId}
+      aria-label={labelText}
     >
       <div
         className={cn(styles['Workbench__content-inner'], {
@@ -146,7 +157,7 @@ export function WorkbenchContent({
       >
         {children}
       </div>
-    </div>
+    </main>
   );
 }
 

--- a/packages/forma-36-react-components/src/components/Workbench/__snapshots__/Workbench.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Workbench/__snapshots__/Workbench.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`renders the component (complex) 1`] = `
   class="Workbench"
   data-test-id="cf-ui-workbench"
 >
-  <div
+  <header
     class="Workbench__header"
     data-test-id="cf-ui-workbench-header"
   >
@@ -59,17 +59,19 @@ exports[`renders the component (complex) 1`] = `
         </span>
       </button>
     </div>
-  </div>
+  </header>
   <div
     class="Workbench__content-wrapper"
   >
-    <div
+    <aside
+      aria-label="Primary sidebar"
       class="Workbench__sidebar Workbench__sidebar--left"
       data-test-id="cf-ui-workbench-sidebar-left"
     >
       Left sidebar
-    </div>
-    <div
+    </aside>
+    <main
+      aria-label="Main content"
       class="Workbench__content"
       data-test-id="cf-ui-workbench-content"
     >
@@ -78,13 +80,14 @@ exports[`renders the component (complex) 1`] = `
       >
         Workbench
       </div>
-    </div>
-    <div
+    </main>
+    <aside
+      aria-label="Secondary sidebar"
       class="Workbench__sidebar Workbench__sidebar--right"
       data-test-id="cf-ui-workbench-sidebar-right"
     >
       Right sidebar
-    </div>
+    </aside>
   </div>
 </div>
 `;
@@ -94,7 +97,7 @@ exports[`renders the component (simple) 1`] = `
   class="Workbench"
   data-test-id="cf-ui-workbench"
 >
-  <div
+  <header
     class="Workbench__header"
     data-test-id="cf-ui-workbench-header"
   >
@@ -148,11 +151,12 @@ exports[`renders the component (simple) 1`] = `
         </span>
       </button>
     </div>
-  </div>
+  </header>
   <div
     class="Workbench__content-wrapper"
   >
-    <div
+    <main
+      aria-label="Main content"
       class="Workbench__content"
       data-test-id="cf-ui-workbench-content"
     >
@@ -161,7 +165,7 @@ exports[`renders the component (simple) 1`] = `
       >
         Workbench
       </div>
-    </div>
+    </main>
   </div>
 </div>
 `;


### PR DESCRIPTION
# Purpose of PR

Currently workbench is structured with divs only, this should be changed to use semantic html main aside  and header

We need to expose aria-label for these tags as well so screen reader users can determine the purpose of these tags

For more info see landmarks and page regions docs  https://www.w3.org/TR/WCAG20-TECHS/ARIA11.html

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
