### PR TITLE
fix: website footer is getting hidden by promo banner

### DIFF
--- a/packages/forma-36-website/src/components/Container.js
+++ b/packages/forma-36-website/src/components/Container.js
@@ -22,14 +22,13 @@ import {
 import ComponentSource from './ComponentSource';
 import DocFormatter from './DocFormatter';
 import Footer from './Footer';
-import { heightOfHeader } from './Navigation';
 
 const styles = {
   container: css`
     width: 100%;
     display: flex;
     flex-direction: column;
-    height: calc(100vh - ${heightOfHeader}px);
+    height: 100%;
     overflow-y: auto;
   `,
 

--- a/packages/forma-36-website/src/components/Layout.js
+++ b/packages/forma-36-website/src/components/Layout.js
@@ -98,7 +98,7 @@ const Layout = (props) => {
 
 Layout.propTypes = {
   children: PropTypes.node,
-  location: PropTypes.object.isRequired,
+  location: PropTypes.object,
 };
 
 export default Layout;

--- a/packages/forma-36-website/src/components/Layout.js
+++ b/packages/forma-36-website/src/components/Layout.js
@@ -5,6 +5,7 @@ import { useStaticQuery, graphql } from 'gatsby';
 import '@contentful/forma-36-react-components/dist/styles.css';
 import '@contentful/forma-36-fcss/dist/styles.css';
 import { css } from '@emotion/core';
+
 import Header from './Header';
 import Promo from './Promo';
 import Container from './Container';
@@ -14,13 +15,10 @@ import './Layout.css';
 const styles = {
   main: css`
     display: flex;
-    flex: 2;
+    height: calc(100vh - 70px);
   `,
-  test: css`
-    display: flex;
-    flex-direction: column;
-    height: 100vh;
-    overflow-y: hidden;
+  withPromo: css`
+    height: calc(100vh - 107px);
   `,
 };
 
@@ -51,8 +49,10 @@ const Layout = (props) => {
     }
   `);
 
+  const withPromo = !!data.site.siteMetadata.promoText;
+
   return (
-    <div css={styles.test}>
+    <>
       <Helmet
         title={data.site.siteMetadata.title}
         meta={[
@@ -69,7 +69,7 @@ const Layout = (props) => {
         <html lang="en" />
       </Helmet>
 
-      {data.site.siteMetadata.promoText && (
+      {withPromo && (
         <Promo
           text={data.site.siteMetadata.promoText}
           linkHref={data.site.siteMetadata.promoLink}
@@ -80,7 +80,7 @@ const Layout = (props) => {
 
       <Header />
 
-      <div css={styles.main}>
+      <div css={[styles.main, withPromo && styles.withPromo]}>
         <Navigation
           menuItems={data.site.siteMetadata && data.site.siteMetadata.menuLinks}
           currentPath={props && props.location && props.location.pathname}
@@ -92,7 +92,7 @@ const Layout = (props) => {
           {props.children}
         </Container>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/packages/forma-36-website/src/components/Navigation.js
+++ b/packages/forma-36-website/src/components/Navigation.js
@@ -10,12 +10,11 @@ import { Icon, SectionHeading } from '@contentful/forma-36-react-components';
 
 import DocSearch from './DocSearch';
 
-export const heightOfHeader = 56;
-const heightOfDocSearch = 72;
-
 const styles = {
   sidemenu: css`
-    flex-basis: 380px;
+    display: flex;
+    flex-direction: column;
+    width: 30%;
     padding-top: ${tokens.spacingM};
     border-right: 1px solid ${tokens.colorElementMid};
   `,
@@ -25,7 +24,6 @@ const styles = {
     flex-direction: column;
     border-top: 1px solid ${tokens.colorElementMid};
     padding: ${tokens.spacingM} 0;
-    height: calc(100vh - ${heightOfHeader + heightOfDocSearch}px);
     overflow-y: auto;
     color: ${tokens.colorTextMid};
   `,

--- a/packages/forma-36-website/src/components/Navigation.js
+++ b/packages/forma-36-website/src/components/Navigation.js
@@ -147,7 +147,7 @@ const MenuListItem = ({ item, currentPath, isActive, hierarchyLevel }) => {
 MenuListItem.propTypes = {
   item: PropTypes.shape({ link: PropTypes.string, name: PropTypes.string })
     .isRequired,
-  currentPath: PropTypes.string.isRequired,
+  currentPath: PropTypes.string,
   isActive: PropTypes.bool,
   hierarchyLevel: PropTypes.number,
 };
@@ -176,7 +176,7 @@ const MenuList = ({ menuItems, currentPath, hierarchyLevel }) => {
 };
 
 const MenuListProps = {
-  currentPath: PropTypes.string.isRequired,
+  currentPath: PropTypes.string,
   menuItems: PropTypes.arrayOf(
     PropTypes.shape({ link: PropTypes.string, name: PropTypes.string }),
   ),


### PR DESCRIPTION
# Purpose of PR

When we add a promo banner to the website it pushes all the rest of content down and the sidemenu and content view bleed outside the screen, check how the scrollbars are in this screenshot:
![Screenshot 2021-08-04 at 12 38 33](https://user-images.githubusercontent.com/6597467/128167763-ecc53a6e-8379-445f-ae86-c07af8d504be.png)

This PR fixes it, basically the height of the "main" div will change based on if we have a promo banner or not
![Screenshot 2021-08-04 at 12 39 10](https://user-images.githubusercontent.com/6597467/128167894-7ac5a5e1-619f-4e60-92d8-d48194343b10.png)
![Screenshot 2021-08-04 at 12 39 20](https://user-images.githubusercontent.com/6597467/128167910-5b0c0a09-331a-4401-a244-c69fc7c3e28c.png)


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
