### PR TITLE
fix: workbench sidebar label

### DIFF
--- a/packages/forma-36-react-components/src/components/Workbench/Workbench.tsx
+++ b/packages/forma-36-react-components/src/components/Workbench/Workbench.tsx
@@ -105,7 +105,7 @@ export function WorkbenchSidebar({
   className,
   position,
   testId = 'cf-ui-workbench-sidebar',
-  labelText = position === 'left' ? 'Primary sidebar' : 'Secondary sidebar',
+  labelText = position === 'right' ? 'Primary sidebar' : 'Secondary sidebar',
   ...otherProps
 }: WorkbenchSidebarProps) {
   return (

--- a/packages/forma-36-react-components/src/components/Workbench/__snapshots__/Workbench.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Workbench/__snapshots__/Workbench.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`renders the component (complex) 1`] = `
     class="Workbench__content-wrapper"
   >
     <aside
-      aria-label="Primary sidebar"
+      aria-label="Secondary sidebar"
       class="Workbench__sidebar Workbench__sidebar--left"
       data-test-id="cf-ui-workbench-sidebar-left"
     >
@@ -82,7 +82,7 @@ exports[`renders the component (complex) 1`] = `
       </div>
     </main>
     <aside
-      aria-label="Secondary sidebar"
+      aria-label="Primary sidebar"
       class="Workbench__sidebar Workbench__sidebar--right"
       data-test-id="cf-ui-workbench-sidebar-right"
     >


### PR DESCRIPTION
# Purpose of PR

Based on the current webapp status, most of the single sidebars are used on the right side which makes it primary by default.

