### PR TITLE
fix(Icon): add types for otherProps [HOMER-268]

### DIFF
--- a/packages/forma-36-react-components/src/components/Icon/Icon.test.tsx
+++ b/packages/forma-36-react-components/src/components/Icon/Icon.test.tsx
@@ -85,6 +85,18 @@ it('renders as a "white" icon', () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
+it('renders aria properties', () => {
+  const { container } = render(
+    <Icon
+      icon={'ArrowDown'}
+      aria-label="my label"
+      aria-labelledby="another label"
+    />,
+  );
+
+  expect(container.firstChild).toMatchSnapshot();
+});
+
 Object.keys(iconName).forEach((icon) => {
   it(`${icon} has no a11y issues`, async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/forma-36-react-components/src/components/Icon/Icon.tsx
+++ b/packages/forma-36-react-components/src/components/Icon/Icon.tsx
@@ -296,7 +296,7 @@ const iconComponents = {
 
 export type IconType = keyof typeof iconName;
 
-export interface IconProps {
+export interface IconProps extends React.SVGProps<SVGSVGElement> {
   size?: 'tiny' | 'small' | 'medium' | 'large';
   color?:
     | 'primary'
@@ -330,7 +330,8 @@ export function Icon({
     className,
   );
 
-  const Element = iconComponents[icon];
+  const Element: (props: React.SVGProps<SVGSVGElement>) => JSX.Element =
+    iconComponents[icon];
 
   return (
     <Element data-test-id={testId} className={classNames} {...otherProps} />

--- a/packages/forma-36-react-components/src/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -18,6 +18,26 @@ exports[`renders a large icon 1`] = `
 </svg>
 `;
 
+exports[`renders aria properties 1`] = `
+<svg
+  aria-label="my label"
+  aria-labelledby="another label"
+  class="Icon Icon--small Icon--primary"
+  data-test-id="cf-ui-icon"
+  height="1em"
+  viewBox="0 0 24 24"
+  width="1em"
+>
+  <path
+    d="M7 10l5 5 5-5z"
+  />
+  <path
+    d="M0 0h24v24H0z"
+    fill="none"
+  />
+</svg>
+`;
+
 exports[`renders as a "muted" icon 1`] = `
 <svg
   class="Icon Icon--large Icon--muted"


### PR DESCRIPTION
# Purpose of PR

When working with `<Icon>`, I realized that the prop types don't allow defining `aria-label`. This is due to incomplete types since `otherProps` is passed to the SVG element and thus supports general props for SVG elements.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
