### PR TITLE
docs: add space between buttons in the website

### DIFF
--- a/packages/forma-36-react-components/src/components/Button/README.mdx
+++ b/packages/forma-36-react-components/src/components/Button/README.mdx
@@ -36,34 +36,12 @@ Buttons communicate the action that will occur when the user clicks them. They c
 - **Naked** - (deprecated)
 
 ```jsx
-<>
-  <Flex flexDirection="row" marginBottom="spacingM">
-    <Grid
-      columnGap="spacingXs"
-      columns="repeat(4, auto)"
-      justifyContent="start"
-    >
-      <Button buttonType="primary">Primary</Button>
-      <Button buttonType="muted">Muted</Button>
-      <Button buttonType="positive">Positive</Button>
-      <Button buttonType="negative">Negative</Button>
-    </Grid>
-  </Flex>
-
-  <Grid
-    columnGap="spacingXs"
-    rowGap="spacingXs"
-    columns="repeat(2, auto)"
-    justifyContent="start"
-  >
-    <GridItem columnStart={1} columnEnd={53}>
-      <Tag tagType="warning">(deprecated)</Tag>
-    </GridItem>
-
-    <Button buttonType="warning">Warning</Button>
-    <Button buttonType="naked">Naked</Button>
-  </Grid>
-</>
+<Grid rowGap="spacingXs" rows="repeat(4, auto)" justifyContent="start">
+  <Button buttonType="primary">Primary</Button>
+  <Button buttonType="muted">Muted</Button>
+  <Button buttonType="positive">Positive</Button>
+  <Button buttonType="negative">Negative</Button>
+</Grid>
 ```
 
 Buttons can be used in couple of different variations, like active, disabled or loading. It's worthy mentioning is `indicateDropdown` property in the component,
@@ -77,13 +55,9 @@ Contentful buttons are available in 3 different sizes:
 
 ```jsx
 <Grid columnGap="spacingXs" columns="repeat(3, auto)" justifyContent="start">
-  <Button buttonType="positive" size="large">
-    Large
-  </Button>
-  <Button buttonType="positive">Default</Button>
-  <Button buttonType="positive" size="small">
-    Small
-  </Button>
+  <Button size="large">Large</Button>
+  <Button size="medium">Medium</Button>
+  <Button size="small">Small</Button>
 </Grid>
 ```
 

--- a/packages/forma-36-react-components/src/components/Button/README.mdx
+++ b/packages/forma-36-react-components/src/components/Button/README.mdx
@@ -4,7 +4,7 @@ type: 'component'
 status: 'stable'
 slug: /components/button/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components/src/components/Button'
-storybook: 'https://f36-storybook.contentful.com/?path=/story/components-button--button'
+storybook: 'https://f36-storybook.contentful.com/?path=/story/components-button--basic'
 ---
 
 Buttons communicate the action that will occur when the user clicks them. They communicate calls to action to the user and allow users to interact with pages in a variety of ways. They contain a text label to describe the action, and an icon if appropriate.
@@ -26,28 +26,57 @@ Buttons communicate the action that will occur when the user clicks them. They c
 
 ## Component variations
 
+### Types
+
 - **Primary** - Used for the most important actions in any scenario. Don’t use more than one primary button in a section or screen to avoid overwhelming users.
 - **Muted** - Used for a secondary actions, the most commonly used button type.
 - **Positive** - For use when the action has a positive connotation such as creating or publishing a new entity.
 - **Negative** - For destructive actions - when something can't be undone. For example, deleting entities.
-- **Naked** - Link button
+- **Warning** - (deprecated)
+- **Naked** - (deprecated)
 
 ```jsx
 <>
-  <Button buttonType="primary">Primary</Button>
-  <Button buttonType="negative">Negative</Button>
-  <Button buttonType="positive">Positive</Button>
-  <Button buttonType="muted">Muted</Button>
-  <Button buttonType="naked">Naked</Button>
+  <Flex flexDirection="row" marginBottom="spacingM">
+    <Grid
+      columnGap="spacingXs"
+      columns="repeat(4, auto)"
+      justifyContent="start"
+    >
+      <Button buttonType="primary">Primary</Button>
+      <Button buttonType="muted">Muted</Button>
+      <Button buttonType="positive">Positive</Button>
+      <Button buttonType="negative">Negative</Button>
+    </Grid>
+  </Flex>
+
+  <Grid
+    columnGap="spacingXs"
+    rowGap="spacingXs"
+    columns="repeat(2, auto)"
+    justifyContent="start"
+  >
+    <GridItem columnStart={1} columnEnd={53}>
+      <Tag tagType="warning">(deprecated)</Tag>
+    </GridItem>
+
+    <Button buttonType="warning">Warning</Button>
+    <Button buttonType="naked">Naked</Button>
+  </Grid>
 </>
 ```
 
-Buttons can be used in couple of different variations, like active, disabled or loading. Worth mentioning is `indicateDropdown` property in the component, which enables chevron icon on the right side of the button. Using `icon` property in the Button on the other hand, enables choosen icon on the left side of the button.
+Buttons can be used in couple of different variations, like active, disabled or loading. It's worthy mentioning is `indicateDropdown` property in the component,
+which enables the chevron icon on the right side of the button.
+
+Using `icon` property in the Button on the other hand, enables choosen icon on the left side of the button.
+
+### Sizes
 
 Contentful buttons are available in 3 different sizes:
 
 ```jsx
-<>
+<Grid columnGap="spacingXs" columns="repeat(3, auto)" justifyContent="start">
   <Button buttonType="positive" size="large">
     Large
   </Button>
@@ -55,17 +84,15 @@ Contentful buttons are available in 3 different sizes:
   <Button buttonType="positive" size="small">
     Small
   </Button>
-</>
+</Grid>
 ```
 
 ## Code examples
 
 ```jsx
-// import {Button} from '@contentful/forma-36-react-components';
+// import { Button } from '@contentful/forma-36-react-components';
 
-<Button buttonType="primary" data-test-id="create-content-type-empty-state">
-  Add content type
-</Button>
+<Button onClick={() => console.log('clicked!')}>Add content type</Button>
 ```
 
 Usage of the button with icon
@@ -73,8 +100,18 @@ Usage of the button with icon
 ```jsx
 // import {Button} from '@contentful/forma-36-react-components';
 
-<Button buttonType="primary" icon="Star">
-  Primary star
+<Button buttonType="muted" icon="Plus" onClick={() => console.log('clicked!')}>
+  Add content
+</Button>
+```
+
+Usage of the button with dropdown indication
+
+```jsx
+// import {Button} from '@contentful/forma-36-react-components';
+
+<Button indicateDropdown onClick={() => console.log('clicked!')}>
+  Add content
 </Button>
 ```
 


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Closes https://github.com/contentful/forma-36/issues/1046

This PR will update code examples for Buttons, this is how they look now:

![Screenshot 2021-08-09 at 17 02 57](https://user-images.githubusercontent.com/6597467/128729925-6584c4f9-98a0-4371-aa60-306cce3fc673.png)

![Screenshot 2021-08-09 at 17 03 04](https://user-images.githubusercontent.com/6597467/128729950-cf1b6a4b-0a92-47d5-81a2-d4dfc8253ca9.png)


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
