### PR TITLE
feat(modallauncher): add closeAll method to ModalLauncher

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { ModalLauncher } from './ModalLauncher';
@@ -53,9 +53,46 @@ function DefaultStory() {
   );
 }
 
+function CloseAllStory() {
+  const openModal = useCallback((content) => {
+    ModalLauncher.open(({ isShown, onClose }) => (
+      <Modal title={content} isShown={isShown} onClose={() => onClose()}>
+        <Modal.Content>{content}</Modal.Content>
+        <Modal.Controls>
+          <Button buttonType="primary" onClick={() => openModal(`New modal`)}>
+            Open modal
+          </Button>
+          <Button
+            buttonType="muted"
+            onClick={() => {
+              onClose();
+            }}
+          >
+            Close one modal
+          </Button>
+          <Button buttonType="muted" onClick={ModalLauncher.closeAll}>
+            Close all
+          </Button>
+        </Modal.Controls>
+      </Modal>
+    ));
+  }, []);
+
+  useEffect(() => {
+    openModal(`Modal one`);
+  }, [openModal]);
+
+  return (
+    <React.Fragment>
+      <Button onClick={() => openModal(`New modal`)}>Open modal</Button>
+    </React.Fragment>
+  );
+}
+
 storiesOf('Components/Modal/ModalLauncher', module)
   .addParameters({
     propTypes: ModalLauncher['__docgenInfo'],
     component: ModalLauncher,
   })
-  .add('default', () => <DefaultStory />);
+  .add('default', () => <DefaultStory />)
+  .add('closeAll method', () => <CloseAllStory />);

--- a/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.tsx
@@ -9,9 +9,46 @@ interface ModalLauncherComponentRendererProps<T = any> {
 }
 
 interface ModalLauncherOpenOptions {
+  /**
+   * Unique id to be used as identifier for the modal contianer
+   */
   modalId?: string;
-  // ms before removing the component from the tree, defaults to 25ms.
+  /**
+   * ms before removing the component from the tree
+   * @default 300
+   */
   delay?: number;
+}
+
+interface CloseModalData {
+  delay: number;
+  render: (args: ModalLauncherComponentRendererProps<any>) => void;
+  currentConfig: ModalLauncherComponentRendererProps<any>;
+}
+
+const getRoot = (rootElId: string): HTMLElement => {
+  // Reuse the container if we find it
+  let rootDom = document.getElementById(rootElId);
+  if (rootDom !== null) {
+    return rootDom;
+  }
+
+  // Otherwise create it
+  rootDom = document.createElement('div');
+  rootDom.setAttribute('id', rootElId);
+  document.body.appendChild(rootDom);
+  return rootDom;
+};
+
+let openModalsIds: Map<string, CloseModalData> = new Map();
+function closeAll() {
+  openModalsIds.forEach(async ({ render, currentConfig, delay }, rootElId) => {
+    const config = { ...currentConfig, isShown: false };
+    render(config);
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, delay));
+    ReactDOM.unmountComponentAtNode(getRoot(rootElId));
+    openModalsIds.delete(rootElId);
+  });
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -25,25 +62,7 @@ function open<T = any>(
 
   // Allow components to specify if they wish to reuse the modal container
   const rootElId = `modals-root${options.modalId || Date.now()}`;
-  let rootDom: HTMLElement | null = null;
-
-  const getRoot = () => {
-    if (rootDom !== null) {
-      return rootDom;
-    }
-
-    // Reuse the container if we find it
-    rootDom = document.getElementById(rootElId);
-    if (rootDom !== null) {
-      return rootDom;
-    }
-
-    // Otherwise create it
-    rootDom = document.createElement('div');
-    rootDom.setAttribute('id', rootElId);
-    document.body.appendChild(rootDom);
-    return rootDom;
-  };
+  const rootDom = getRoot(rootElId);
 
   return new Promise((resolve) => {
     let currentConfig = { onClose, isShown: true };
@@ -52,7 +71,7 @@ function open<T = any>(
       onClose,
       isShown,
     }: ModalLauncherComponentRendererProps<T>) {
-      ReactDOM.render(componentRenderer({ onClose, isShown }), getRoot());
+      ReactDOM.render(componentRenderer({ onClose, isShown }), rootDom);
     }
 
     async function onClose(arg?: T) {
@@ -64,15 +83,22 @@ function open<T = any>(
       await new Promise((resolveDelay) =>
         setTimeout(resolveDelay, options.delay),
       );
-      ReactDOM.unmountComponentAtNode(getRoot());
-      getRoot().remove();
+      ReactDOM.unmountComponentAtNode(rootDom);
+      rootDom.remove();
+      openModalsIds.delete(rootElId);
       resolve(arg);
     }
 
     render(currentConfig);
+    openModalsIds.set(rootElId, {
+      render,
+      currentConfig,
+      delay: options.delay,
+    });
   });
 }
 
 export const ModalLauncher = {
   open,
+  closeAll,
 };

--- a/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.tsx
@@ -40,7 +40,7 @@ const getRoot = (rootElId: string): HTMLElement => {
   return rootDom;
 };
 
-let openModalsIds: Map<string, CloseModalData> = new Map();
+const openModalsIds: Map<string, CloseModalData> = new Map();
 function closeAll() {
   openModalsIds.forEach(async ({ render, currentConfig, delay }, rootElId) => {
     const config = { ...currentConfig, isShown: false };


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->
Add `closeAll` method to the `ModalLauncher`.
It works by storing all the root elements ids, on a Map, when the `open` method is called, and iterating over the map when the `closeAll` method is called to render with `{ isShown: false }`, and waiting for the set delay before removing the element from the tree, so it keeps the closing animation.
Also removes the value from the map in case the modal is closed through the onClosed.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
