### PR TITLE
chore: enable auto deploy of the v4 packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,7 @@ workflows:
             branches:
               only:
                 - master
+                - forma-v4
           requires:
             - lint-and-test
             - chromatic-deployment


### PR DESCRIPTION
Since we would like to start the adoption of the v4 in clients, we would like to deploy new packages from v4