### PR TITLE
fix: remove muted Badge variant

### DIFF
--- a/packages/components/badge/src/getBadgeStyles.ts
+++ b/packages/components/badge/src/getBadgeStyles.ts
@@ -30,11 +30,6 @@ const variantToStyles = ({ variant }: { variant: BadgeVariant }): CSSObject => {
         color: tokens.gray700,
         backgroundColor: tokens.gray200,
       };
-    case 'muted':
-      return {
-        color: tokens.gray600,
-        backgroundColor: tokens.gray200,
-      };
     case 'primary-filled':
       return {
         color: tokens.colorWhite,

--- a/packages/components/badge/src/types.ts
+++ b/packages/components/badge/src/types.ts
@@ -6,6 +6,5 @@ export type BadgeVariant =
   | 'primary'
   | 'secondary'
   | 'warning'
-  | 'muted'
   | 'primary-filled'
   | 'featured';

--- a/packages/components/badge/stories/Badge.stories.tsx
+++ b/packages/components/badge/stories/Badge.stories.tsx
@@ -103,20 +103,5 @@ export const overview = () => (
         </Badge>
       </Flex>
     </Flex>
-    <Flex marginBottom="spacingM" alignItems="center">
-      <Flex marginRight="spacingS">
-        <Badge variant="muted">muted</Badge>
-      </Flex>
-      <Flex marginRight="spacingS">
-        <Badge variant="muted" size="small">
-          muted
-        </Badge>
-      </Flex>
-      <div style={{ color: tokens.colorRedBase, fontSize: tokens.fontSizeM }}>
-        {' '}
-        - this tagType is deprecated, please use <strong>secondary</strong>{' '}
-        instead
-      </div>
-    </Flex>
   </>
 );

--- a/packages/components/badge/stories/Badge.stories.tsx
+++ b/packages/components/badge/stories/Badge.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import tokens from '@contentful/f36-tokens';
 import { Flex } from '@contentful/f36-core';
 import { SectionHeading } from '@contentful/f36-typography';
 


### PR DESCRIPTION
Remove the muted variant from Badge component (it is already deprecated in v3)

i will add an option to migrate it with the codemod.