### PR TITLE
chore: small improvements to storybook and plop template

### DIFF
--- a/scripts/.storybook/preview.js
+++ b/scripts/.storybook/preview.js
@@ -32,17 +32,9 @@ export const parameters = {
       ],
     },
   },
-  // Creating DocPage from our old notes
-  docs: {
-    extractComponentDescription: (component, { notes }) => {
-      if (notes) {
-        return typeof notes === 'string' ? notes : notes.markdown || notes.text;
-      }
-      return null;
-    },
-  },
   controls: {
     expanded: true,
     hideNoControlsWarning: true,
+    sort: 'requiredFirst',
   },
 };

--- a/scripts/plop-templates/package/src/Component.tsx.hbs
+++ b/scripts/plop-templates/package/src/Component.tsx.hbs
@@ -1,15 +1,13 @@
-import { cx } from 'emotion';
 import React from 'react';
+import { cx } from 'emotion';
 import { CommonProps } from '@contentful/f36-core';
 import { styles } from './{{componentName}}.styles'
 
 export interface {{componentName}}Props extends CommonProps {
-  testId?: string;
-  className?: string;
   children: React.ReactNode;
 };
 
-function {{componentName}}(props: {{componentName}}Props, ref: React.Ref<HTMLDivElement>) {
+function _{{componentName}}(props: {{componentName}}Props, ref: React.Ref<HTMLDivElement>) {
   return (
     <div
       data-test-id={props.testId}
@@ -27,5 +25,4 @@ function {{componentName}}(props: {{componentName}}Props, ref: React.Ref<HTMLDiv
 /**
  * TODO: Add description of component here.
  */
-const _{{componentName}} = React.forwardRef({{componentName}});
-export { _{{componentName}} as {{componentName~}} };
+export const {{componentName}} = React.forwardRef(_{{componentName}});


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

- Remove the old hack to create docs from our old "note" files
- Set storybook to render mandatory props on top of the prop table
- in the plop template for Component
  - change the place of the `_{{ComponentName}}` pattern
  - move the React import to the first line :P
  - remove `testId` and `className` from the props type because they are inherited from CommonProps

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
