### PR TITLE
chore: make netlify use different segment in preview and branch deploys

### DIFF
--- a/packages/forma-36-website/gatsby-browser.js
+++ b/packages/forma-36-website/gatsby-browser.js
@@ -1,6 +1,5 @@
 const OSANO_KEY = process.env.GATSBY_OSANO_KEY;
 const OSANO_F36_WEBSITE_KEY = process.env.GATSBY_OSANO_F36_WEBSITE_KEY;
-const SEGMENT_KEY = process.env.GATSBY_SEGMENT_KEY;
 
 export const onClientEntry = () => {
   if (OSANO_KEY && OSANO_F36_WEBSITE_KEY) {
@@ -102,7 +101,14 @@ function handleConsent(newConsentOptions) {
  * Function to append Segment’ script to the head of the website and track the first page view
  */
 function initSegment() {
-  const segmentSnippet = `!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="4cYEEHVWGSFHTetV5XLulQLVpk9WjmvY";analytics.SNIPPET_VERSION="4.13.2";}}();`;
+  // We need to do this hack otherwise tracking events from our preview websites will be dispatched to the production Segment
+  const context = process.env.CONTEXT;
+  const SEGMENT_KEY =
+    context === 'deploy-preview' || context === 'branch-deploy'
+      ? process.env.GATSBY_SEGMENT_STAGGING_KEY
+      : process.env.GATSBY_SEGMENT_KEY;
+
+  const segmentSnippet = `!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="${SEGMENT_KEY}";analytics.SNIPPET_VERSION="4.13.2";}}();`;
 
   const script = document.createElement('script');
   script.addEventListener('error', () => {


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Well... apparently Netlify use `NODE_ENV=production` for both production and preview deployments
So we need to check `CONTEXT` in order to NOT send tracked events of our previews to Segment in production 👀 

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
