### PR TITLE
fix: text link semantics and alignment

### DIFF
--- a/packages/forma-36-react-components/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -187,7 +187,7 @@ exports[`renders the component with a textlink 1`] = `
         class="TabFocusTrap"
         tabindex="-1"
       >
-        <div
+        <span
           class="TextLink__icon-wrapper"
         >
           <svg
@@ -205,7 +205,7 @@ exports[`renders the component with a textlink 1`] = `
               d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z"
             />
           </svg>
-        </div>
+        </span>
         Unlock to edit
       </span>
     </button>

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.css
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.css
@@ -9,7 +9,7 @@
 
 .TextLink,
 .TextLink:link {
-  display: inline;
+  display: inline-flex;
   align-items: center;
   box-sizing: border-box;
   border: 0;
@@ -29,6 +29,7 @@
   & > span {
     outline: 0;
     display: inherit;
+    align-items: inherit;
   }
 
   &:hover,

--- a/packages/forma-36-react-components/src/components/TextLink/TextLink.tsx
+++ b/packages/forma-36-react-components/src/components/TextLink/TextLink.tsx
@@ -58,7 +58,7 @@ export function TextLink({
       if (!icon) return undefined;
 
       return (
-        <div
+        <span
           className={
             iconPosition === 'right'
               ? styles['TextLink__icon-wrapper--right']
@@ -70,7 +70,7 @@ export function TextLink({
             color={linkType}
             className={styles.TextLink__icon}
           />
-        </div>
+        </span>
       );
     },
     [iconPosition],

--- a/packages/forma-36-react-components/src/components/TextLink/__snapshots__/TextLink.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/TextLink/__snapshots__/TextLink.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`renders with an icon 1`] = `
     class="TabFocusTrap"
     tabindex="-1"
   >
-    <div
+    <span
       class="TextLink__icon-wrapper"
     >
       <svg
@@ -224,7 +224,7 @@ exports[`renders with an icon 1`] = `
           fill="none"
         />
       </svg>
-    </div>
+    </span>
     Text Link
   </span>
 </button>
@@ -241,7 +241,7 @@ exports[`renders with an icon aligned right to the text 1`] = `
     tabindex="-1"
   >
     Text Link
-    <div
+    <span
       class="TextLink__icon-wrapper--right"
     >
       <svg
@@ -259,7 +259,7 @@ exports[`renders with an icon aligned right to the text 1`] = `
           fill="none"
         />
       </svg>
-    </div>
+    </span>
   </span>
 </button>
 `;


### PR DESCRIPTION
# Purpose of PR
Resolves
<img width="596" alt="Screenshot 2021-08-23 at 13 29 06" src="https://user-images.githubusercontent.com/6163988/130440088-8af98d2d-de7b-49ba-8bb3-8d56ea3862a1.png">

- Use `span` instead of `div` to resolve semantic warnings
- Align text and icon center
## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
