### PR TITLE
chore: make chromatic not required for release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
           name: Test
           command: yarn test
 
-  chromatic-deployment:
+  build-storybook:
     docker:
       - image: circleci/node:14.15.0-browsers
     resource_class: xlarge
@@ -57,7 +57,6 @@ jobs:
           pattern: ^(packages)|(.js|jsx|ts|tsx|css|scss)$
       - yarn_install
       - run: yarn run storybook:build
-      - run: yarn run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --exit-zero-on-changes
 
   release:
     docker:
@@ -82,7 +81,7 @@ workflows:
   commit-check:
     jobs:
       - lint-and-test
-      - chromatic-deployment:
+      - build-storybook:
           requires:
             - lint-and-test
           filters:
@@ -96,4 +95,4 @@ workflows:
                 - master
           requires:
             - lint-and-test
-            - chromatic-deployment
+            - build-storybook

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
           name: Test
           command: yarn test
 
-  build-storybook:
+  chromatic-deployment:
     docker:
       - image: circleci/node:14.15.0-browsers
     resource_class: xlarge
@@ -57,6 +57,7 @@ jobs:
           pattern: ^(packages)|(.js|jsx|ts|tsx|css|scss)$
       - yarn_install
       - run: yarn run storybook:build
+      - run: yarn run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --exit-zero-on-changes
 
   release:
     docker:
@@ -81,7 +82,7 @@ workflows:
   commit-check:
     jobs:
       - lint-and-test
-      - build-storybook:
+      - chromatic-deployment:
           requires:
             - lint-and-test
           filters:
@@ -95,4 +96,3 @@ workflows:
                 - master
           requires:
             - lint-and-test
-            - build-storybook


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

make chromatic not required for release job until we fix the access issue

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
