### PR TITLE
chore: expose chromatic token in package json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,12 @@ jobs:
       - check-changed-files-or-halt:
           pattern: ^(packages)|(.js|jsx|ts|tsx|css|scss)$
       - yarn_install
-      - run: yarn run storybook:build
-      - run: yarn run chromatic --project-token=${CHROMATIC_PROJECT_TOKEN} --exit-zero-on-changes
+      - run:
+          name: Storybook
+          command: yarn run storybook:build
+      - run:
+          name: Chromatic
+          command: yarn run chromatic
 
   release:
     docker:
@@ -79,7 +83,7 @@ jobs:
 
 workflows:
   version: 2
-  commit-check:
+  f36-build:
     jobs:
       - lint-and-test
       - chromatic-deployment:
@@ -96,4 +100,3 @@ workflows:
                 - master
           requires:
             - lint-and-test
-            - chromatic-deployment

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "lerna run build --stream",
-    "chromatic": "chromatic --storybook-build-dir ./dist-storybook",
+    "chromatic": "chromatic --project-token=vn1cd01txe --exit-zero-on-changes --storybook-build-dir ./dist-storybook",
     "commit": "git-cz",
     "commitmsg": "validate-commit-msg",
     "generate": "plop --plopfile scripts/plopfile.js",


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

- exposes chromatic's token in package.json so it does not fail in forked PRs anymore.[ This is recommended for open source projects](https://www.chromatic.com/docs/circleci#run-chromatic-on-external-forks-of-open-source-projects)
- make chromatic-deployment not required to release f36 packages
- rename circle-ci workflow from `commit-check` to `f36-build`

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
