### PR TITLE
feat(EditorToolbarButton): custom Tooltip placement

### DIFF
--- a/packages/forma-36-react-components/src/components/EditorToolbar/EditorToolbarButton/EditorToolbarButton.tsx
+++ b/packages/forma-36-react-components/src/components/EditorToolbar/EditorToolbarButton/EditorToolbarButton.tsx
@@ -3,7 +3,7 @@ import cn from 'classnames';
 import type { MouseEventHandler } from 'react';
 
 import { IconButton } from '../../IconButton';
-import { Tooltip } from '../../Tooltip';
+import { Tooltip, TooltipPlace } from '../../Tooltip';
 import styles from './EditorToolbarButton.css';
 import type { IconButtonProps } from '../../IconButton';
 import type { IconType } from '../../Icon';
@@ -12,6 +12,7 @@ export interface EditorToolbarButtonProps {
   label: string;
   icon: IconType;
   tooltip?: string;
+  tooltipPlace?: TooltipPlace;
   iconButtonProps?: Partial<IconButtonProps>;
   isActive?: boolean;
   disabled?: boolean;
@@ -27,6 +28,7 @@ export function EditorToolbarButton({
   testId = 'cf-ui-editor-toolbar-button',
   icon,
   tooltip,
+  tooltipPlace,
   iconButtonProps,
   isActive = false,
   disabled = false,
@@ -40,7 +42,10 @@ export function EditorToolbarButton({
 
   return (
     <React.Fragment>
-      <Tooltip content={!disabled ? tooltip : undefined}>
+      <Tooltip
+        content={!disabled ? tooltip : undefined}
+        place={tooltipPlace || 'bottom'}
+      >
         <IconButton
           {...{ iconProps: { icon } }}
           testId={testId}

--- a/packages/forma-36-react-components/src/components/EditorToolbar/EditorToolbarButton/EditorToolbarButton.tsx
+++ b/packages/forma-36-react-components/src/components/EditorToolbar/EditorToolbarButton/EditorToolbarButton.tsx
@@ -42,10 +42,7 @@ export function EditorToolbarButton({
 
   return (
     <React.Fragment>
-      <Tooltip
-        content={!disabled ? tooltip : undefined}
-        place={tooltipPlace || 'bottom'}
-      >
+      <Tooltip content={!disabled ? tooltip : undefined} place={tooltipPlace}>
         <IconButton
           {...{ iconProps: { icon } }}
           testId={testId}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR
Adds support for custom Tooltip placement of the `<EditorToolbarButton>` component ~while defaulting to `bottom` to make the behavior in the current web app consistent~.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
