### PR TITLE
refactor: adjustments to core utility types

### DIFF
--- a/packages/components/badge/src/Badge.tsx
+++ b/packages/components/badge/src/Badge.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { cx } from 'emotion';
 import { Box } from '@contentful/f36-core';
-import type {
-  CommonProps,
-  PolymorphicComponentProps,
-} from '@contentful/f36-core';
+import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 
 import type { BadgeSize, BadgeVariant } from './types';
 import { getBadgeStyles } from './getBadgeStyles';
@@ -24,7 +21,7 @@ export interface BadgeInternalProps extends CommonProps {
   children: React.ReactNode;
 }
 
-export type BadgeProps = PolymorphicComponentProps<'div', BadgeInternalProps>;
+export type BadgeProps = PropsWithHTMLElement<BadgeInternalProps, 'div'>;
 
 export const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
   (props, ref) => {

--- a/packages/components/button/src/Button.tsx
+++ b/packages/components/button/src/Button.tsx
@@ -3,8 +3,7 @@ import { cx } from 'emotion';
 import {
   Flex,
   Box,
-  PolymorphicComponentWithRef,
-  PolymorphicComponentProps,
+  PolymorphicProps,
   PolymorphicComponent,
 } from '@contentful/f36-core';
 import { Spinner } from '@contentful/f36-spinner';
@@ -12,16 +11,16 @@ import { Spinner } from '@contentful/f36-spinner';
 import type { ButtonInternalProps } from './types';
 import { getStyles } from './styles';
 
-const DEFAULT_TAG: React.ElementType = 'button';
+const DEFAULT_TAG = 'button';
 
 export type ButtonProps<
-  E extends React.ElementType
-> = PolymorphicComponentProps<E, ButtonInternalProps, 'disabled'>;
+  E extends React.ElementType = typeof DEFAULT_TAG
+> = PolymorphicProps<ButtonInternalProps, E, 'disabled'>;
 
-const _Button: PolymorphicComponentWithRef<
-  ButtonInternalProps,
-  typeof DEFAULT_TAG
-> = (props, ref) => {
+function _Button<E extends React.ElementType = typeof DEFAULT_TAG>(
+  props: ButtonProps<E>,
+  ref: React.Ref<any>,
+) {
   const styles = getStyles();
   const {
     as = DEFAULT_TAG,
@@ -107,7 +106,7 @@ const _Button: PolymorphicComponentWithRef<
       {commonContent}
     </button>
   );
-};
+}
 
 /**
  * @description: Buttons communicate the action that will occur when the user clicks it

--- a/packages/components/button/src/Button.tsx
+++ b/packages/components/button/src/Button.tsx
@@ -1,7 +1,6 @@
-import React, { ElementType } from 'react';
+import React from 'react';
 import { cx } from 'emotion';
 import {
-  usePrimitive,
   Flex,
   Box,
   PolymorphicComponentWithRef,
@@ -13,7 +12,7 @@ import { Spinner } from '@contentful/f36-spinner';
 import type { ButtonInternalProps } from './types';
 import { getStyles } from './styles';
 
-const DEFAULT_TAG: ElementType = 'button';
+const DEFAULT_TAG: React.ElementType = 'button';
 
 export type ButtonProps<
   E extends React.ElementType
@@ -40,13 +39,6 @@ const _Button: PolymorphicComponentWithRef<
     style,
     ...otherProps
   } = props;
-
-  const { Element, primitiveProps } = usePrimitive({
-    testId,
-    as,
-    className,
-    style,
-  });
 
   const rootClassNames = cx(
     styles.button({
@@ -90,30 +82,30 @@ const _Button: PolymorphicComponentWithRef<
     </>
   );
 
+  const commonProps = {
+    ['data-test-id']: testId,
+    className: rootClassNames,
+    ref: ref,
+    style,
+  };
+
   if (as === 'a') {
     return (
-      <Element
-        {...otherProps}
-        {...primitiveProps}
-        className={rootClassNames}
-        ref={ref}
-      >
+      <a {...otherProps} {...commonProps}>
         {commonContent}
-      </Element>
+      </a>
     );
   }
 
   return (
-    <Element
+    <button
       type="button"
       {...otherProps}
-      {...primitiveProps}
+      {...commonProps}
       disabled={isDisabled}
-      className={rootClassNames}
-      ref={ref}
     >
       {commonContent}
-    </Element>
+    </button>
   );
 };
 

--- a/packages/components/datetime/src/DateTime.tsx
+++ b/packages/components/datetime/src/DateTime.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
-import { CommonProps } from '@contentful/f36-core';
+import { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 
 import type { DateType, DateFormat } from '../types';
 import { formatDateAndTime, formatMachineReadableDateTime } from './utils';
 
-export interface DateTimeProps
-  extends CommonProps,
-    React.AllHTMLAttributes<HTMLTimeElement> {
+interface DateTimeOwnProps extends CommonProps {
   /**
    * The date that will be displayed. It accepts a JS Date, an ISO8601 Timestamp string, or Unix Epoch Milliseconds number
    */
@@ -18,6 +16,8 @@ export interface DateTimeProps
    **/
   format?: DateFormat;
 }
+
+export type DateTimeProps = PropsWithHTMLElement<DateTimeOwnProps, 'time'>;
 
 const _DateTime = (
   {

--- a/packages/components/datetime/src/RelativeDateTime.tsx
+++ b/packages/components/datetime/src/RelativeDateTime.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CommonProps } from '@contentful/f36-core';
+import { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 
 import dayjs from 'dayjs';
 import utcPlugin from 'dayjs/plugin/utc';
@@ -16,9 +16,7 @@ import {
   formatRelativeToCurrentWeekDateTime,
 } from './utils';
 
-export interface RelativeDateTimeProps
-  extends CommonProps,
-    React.AllHTMLAttributes<HTMLTimeElement> {
+interface RelativeDateTimeInternalProps extends CommonProps {
   /**
    * The date that will be displayed. It accepts a JS Date, an ISO8601 Timestamp string, or Unix Epoch Milliseconds number
    */
@@ -36,6 +34,11 @@ export interface RelativeDateTimeProps
    */
   isRelativeToCurrentWeek?: boolean;
 }
+
+export type RelativeDateTimeProps = PropsWithHTMLElement<
+  RelativeDateTimeInternalProps,
+  'time'
+>;
 
 const _RelativeDateTime = (
   {

--- a/packages/components/drag-handle/src/DragHandle.tsx
+++ b/packages/components/drag-handle/src/DragHandle.tsx
@@ -6,16 +6,10 @@ import React, {
   MouseEventHandler,
 } from 'react';
 import { cx } from 'emotion';
-import type {
-  PolymorphicComponentProps,
-  PolymorphicComponentWithRef,
-  PolymorphicComponent,
-} from '@contentful/f36-core';
+import type { PropsWithHTMLElement } from '@contentful/f36-core';
 import type { CommonProps } from '@contentful/f36-core';
 import { DragIcon } from '@contentful/f36-icons';
 import { getStyles } from './DragHandle.styles';
-
-const DEFAULT_TAG: React.ElementType = 'button';
 
 export type DragHandleInternalProps = CommonProps & {
   /**
@@ -38,98 +32,98 @@ export type DragHandleInternalProps = CommonProps & {
   label: string;
 };
 
-export type DragHandleProps<
-  E extends React.ElementType
-> = PolymorphicComponentProps<E, DragHandleInternalProps>;
-
-const _DragHandle: PolymorphicComponentWithRef<
+export type DragHandleProps = PropsWithHTMLElement<
   DragHandleInternalProps,
-  typeof DEFAULT_TAG
-> = (
-  {
-    className,
-    isActive,
-    isFocused: isFocusedProp,
-    isHovered: isHoveredProp,
-    label,
-    onBlur,
-    onFocus,
-    onMouseEnter,
-    onMouseLeave,
-    testId = 'cf-ui-drag-handle',
-    style,
-    as: Element = DEFAULT_TAG,
-    ...otherProps
+  'button'
+>;
+
+export const DragHandle = forwardRef<HTMLButtonElement, DragHandleProps>(
+  (
+    {
+      className,
+      isActive,
+      isFocused: isFocusedProp,
+      isHovered: isHoveredProp,
+      label,
+      onBlur,
+      onFocus,
+      onMouseEnter,
+      onMouseLeave,
+      testId = 'cf-ui-drag-handle',
+      style,
+      ...otherProps
+    },
+    forwardedRef,
+  ) => {
+    const styles = getStyles();
+    const [isFocused, setisFocused] = useState(isFocusedProp);
+    const [isHovered, setisHovered] = useState(isHoveredProp);
+
+    const handleFocus = useCallback<FocusEventHandler<HTMLButtonElement>>(
+      (event) => {
+        setisFocused(true);
+
+        if (onFocus) {
+          onFocus(event);
+        }
+      },
+      [onFocus],
+    );
+
+    const handleBlur = useCallback<FocusEventHandler<HTMLButtonElement>>(
+      (event) => {
+        setisFocused(false);
+
+        if (onBlur) {
+          onBlur(event);
+        }
+      },
+      [onBlur],
+    );
+
+    const handleMouseEnter = useCallback<MouseEventHandler<HTMLButtonElement>>(
+      (event) => {
+        setisHovered(true);
+
+        if (onMouseEnter) {
+          onMouseEnter(event);
+        }
+      },
+      [onMouseEnter],
+    );
+
+    const handleMouseLeave = useCallback<MouseEventHandler<HTMLButtonElement>>(
+      (event) => {
+        setisHovered(false);
+
+        if (onMouseLeave) {
+          onMouseLeave(event);
+        }
+      },
+      [onMouseLeave],
+    );
+
+    return (
+      <button
+        type="button"
+        {...otherProps}
+        className={cx(
+          styles.root({ isActive, isFocused, isHovered }),
+          className,
+        )}
+        onBlur={handleBlur}
+        onFocus={handleFocus}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        data-test-id={testId}
+        ref={forwardedRef}
+        style={style}
+      >
+        <DragIcon variant="muted" />
+        <span className={styles.label}>{label}</span>
+      </button>
+    );
   },
-  forwardedRef,
-) => {
-  const styles = getStyles();
-  const [isFocused, setisFocused] = useState(isFocusedProp);
-  const [isHovered, setisHovered] = useState(isHoveredProp);
+);
 
-  const handleFocus = useCallback<FocusEventHandler>(
-    (event) => {
-      setisFocused(true);
-
-      if (onFocus) {
-        onFocus(event);
-      }
-    },
-    [onFocus],
-  );
-
-  const handleBlur = useCallback<FocusEventHandler>(
-    (event) => {
-      setisFocused(false);
-
-      if (onBlur) {
-        onBlur(event);
-      }
-    },
-    [onBlur],
-  );
-
-  const handleMouseEnter = useCallback<MouseEventHandler>(
-    (event) => {
-      setisHovered(true);
-
-      if (onMouseEnter) {
-        onMouseEnter(event);
-      }
-    },
-    [onMouseEnter],
-  );
-
-  const handleMouseLeave = useCallback<MouseEventHandler>(
-    (event) => {
-      setisHovered(false);
-
-      if (onMouseLeave) {
-        onMouseLeave(event);
-      }
-    },
-    [onMouseLeave],
-  );
-
-  return (
-    <Element
-      {...otherProps}
-      className={cx(styles.root({ isActive, isFocused, isHovered }), className)}
-      onBlur={handleBlur}
-      onFocus={handleFocus}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      data-test-id={testId}
-      ref={forwardedRef}
-      style={style}
-    >
-      <DragIcon variant="muted" />
-      <span className={styles.label}>{label}</span>
-    </Element>
-  );
-};
-
-export const DragHandle: PolymorphicComponent<
-  DragHandleInternalProps,
-  typeof DEFAULT_TAG
-> = forwardRef(_DragHandle);
+DragHandle.displayName = 'DragHandle';

--- a/packages/components/drag-handle/src/DragHandle.tsx
+++ b/packages/components/drag-handle/src/DragHandle.tsx
@@ -6,7 +6,6 @@ import React, {
   MouseEventHandler,
 } from 'react';
 import { cx } from 'emotion';
-import { usePrimitive } from '@contentful/f36-core';
 import type {
   PolymorphicComponentProps,
   PolymorphicComponentWithRef,
@@ -16,7 +15,7 @@ import type { CommonProps } from '@contentful/f36-core';
 import { DragIcon } from '@contentful/f36-icons';
 import { getStyles } from './DragHandle.styles';
 
-const DEFAULT_TAG = 'button';
+const DEFAULT_TAG: React.ElementType = 'button';
 
 export type DragHandleInternalProps = CommonProps & {
   /**
@@ -58,12 +57,13 @@ const _DragHandle: PolymorphicComponentWithRef<
     onMouseEnter,
     onMouseLeave,
     testId = 'cf-ui-drag-handle',
+    style,
+    as: Element = DEFAULT_TAG,
     ...otherProps
   },
   forwardedRef,
 ) => {
   const styles = getStyles();
-  const { primitiveProps: commonProps, Element } = usePrimitive(otherProps);
   const [isFocused, setisFocused] = useState(isFocusedProp);
   const [isHovered, setisHovered] = useState(isHoveredProp);
 
@@ -113,15 +113,15 @@ const _DragHandle: PolymorphicComponentWithRef<
 
   return (
     <Element
-      as={DEFAULT_TAG}
-      {...commonProps}
+      {...otherProps}
       className={cx(styles.root({ isActive, isFocused, isHovered }), className)}
       onBlur={handleBlur}
       onFocus={handleFocus}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      testId={testId}
+      data-test-id={testId}
       ref={forwardedRef}
+      style={style}
     >
       <DragIcon variant="muted" />
       <span className={styles.label}>{label}</span>

--- a/packages/components/empty-state/src/EmptyState.tsx
+++ b/packages/components/empty-state/src/EmptyState.tsx
@@ -2,10 +2,7 @@ import { cx } from 'emotion';
 import React, { forwardRef } from 'react';
 import { getStyles } from './EmptyState.styles';
 import { Box } from '@contentful/f36-core';
-import type {
-  CommonProps,
-  PolymorphicComponentProps,
-} from '@contentful/f36-core';
+import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 import type { HeadingElement } from '@contentful/f36-typography';
 import { Heading, Paragraph } from '@contentful/f36-typography';
 
@@ -32,9 +29,9 @@ export interface EmptyStateInternalProps extends CommonProps {
   descriptionProps?: TextElementProps;
 }
 
-export type EmptyStateProps = PolymorphicComponentProps<
-  'article',
-  EmptyStateInternalProps
+export type EmptyStateProps = PropsWithHTMLElement<
+  EmptyStateInternalProps,
+  'article'
 >;
 
 interface TextElementProps {

--- a/packages/components/forms/src/base-input/BaseInput.tsx
+++ b/packages/components/forms/src/base-input/BaseInput.tsx
@@ -5,30 +5,27 @@ import React, {
   KeyboardEvent,
   ChangeEvent,
   useState,
-  ElementType,
 } from 'react';
 import { cx } from 'emotion';
 
 import {
-  usePrimitive,
-  PolymorphicComponentWithRef,
-  PolymorphicComponentProps,
+  PolymorphicProps,
   PolymorphicComponent,
   Box,
 } from '@contentful/f36-core';
 import getInputStyles from './BaseInput.styles';
 import { BaseInputInternalProps } from './types';
 
-const DEFAULT_TAG: ElementType = 'input';
+const DEFAULT_TAG = 'input';
 
 export type BaseInputProps<
-  E extends React.ElementType
-> = PolymorphicComponentProps<E, BaseInputInternalProps, 'disabled'>;
+  E extends React.ElementType = typeof DEFAULT_TAG
+> = PolymorphicProps<BaseInputInternalProps, E, 'disabled'>;
 
-const _BaseInput: PolymorphicComponentWithRef<
-  BaseInputInternalProps,
-  typeof DEFAULT_TAG
-> = (props, ref) => {
+function _BaseInput<E extends React.ElementType = typeof DEFAULT_TAG>(
+  props: BaseInputProps<E>,
+  ref: React.Ref<any>,
+) {
   const {
     as = DEFAULT_TAG,
     className,
@@ -53,13 +50,6 @@ const _BaseInput: PolymorphicComponentWithRef<
   } = props;
   const [valueState, setValueState] = useState<string | undefined>(value);
   const styles = getInputStyles({ isDisabled, isInvalid });
-
-  const { Element, primitiveProps } = usePrimitive({
-    testId,
-    as,
-    className,
-    style,
-  });
 
   const handleFocus = (e: FocusEvent) => {
     e.persist();
@@ -110,11 +100,13 @@ const _BaseInput: PolymorphicComponentWithRef<
     </Box>
   );
 
+  const Element = as as React.ElementType;
+
   const inputContent = (iconClassName?: string) => (
     <Element
       {...otherProps}
-      {...primitiveProps}
       data-test-id={testId}
+      style={style}
       placeholder={placeholder}
       className={cx(styles.input, iconClassName, className)}
       value={valueState}
@@ -145,7 +137,7 @@ const _BaseInput: PolymorphicComponentWithRef<
   }
 
   return inputContent();
-};
+}
 
 export const BaseInput: PolymorphicComponent<
   BaseInputInternalProps,

--- a/packages/components/helptext/src/HelpText.tsx
+++ b/packages/components/helptext/src/HelpText.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
-import { CommonProps, PolymorphicComponentProps } from '@contentful/f36-core';
+import { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 import { Text } from '@contentful/f36-typography';
 
 export type HelpTextInternalProps = CommonProps & {
   children: React.ReactNode;
 };
 
-export type HelpTextProps = PolymorphicComponentProps<
-  'p',
-  HelpTextInternalProps
->;
+export type HelpTextProps = PropsWithHTMLElement<HelpTextInternalProps, 'p'>;
 
 /**
  * `HelpText` is a styled copy block with guidance, placed in the context of form components.

--- a/packages/components/icon/src/Icon.tsx
+++ b/packages/components/icon/src/Icon.tsx
@@ -5,8 +5,7 @@ import { Box } from '@contentful/f36-core';
 import type {
   CommonProps,
   PolymorphicComponent,
-  PolymorphicComponentProps,
-  PolymorphicComponentWithRef,
+  PolymorphicProps,
 } from '@contentful/f36-core';
 import type {
   ComponentType,
@@ -82,9 +81,9 @@ export type IconInternalProps = CommonProps & {
 
 export type IconProps<
   E extends React.ElementType = IconComponent
-> = PolymorphicComponentProps<
-  E,
+> = PolymorphicProps<
   IconInternalProps,
+  E,
   'as' | 'children' | 'width' | 'height'
 >;
 
@@ -103,10 +102,7 @@ const useAriaHidden = (
   };
 };
 
-export const _Icon: PolymorphicComponentWithRef<
-  IconInternalProps,
-  typeof DEFAULT_TAG
-> = (
+export function _Icon<E extends React.ElementType = IconComponent>(
   {
     as,
     children,
@@ -117,9 +113,9 @@ export const _Icon: PolymorphicComponentWithRef<
     trimmed,
     viewBox = '0 0 24 24',
     ...otherProps
-  },
-  forwardedRef,
-) => {
+  }: IconProps<E>,
+  forwardedRef: React.Ref<any>,
+) {
   const shared = {
     className: cx(
       css({
@@ -137,13 +133,12 @@ export const _Icon: PolymorphicComponentWithRef<
 
   if (as) {
     return (
-      // @ts-expect-error mute polymorphic error
       <Box
         display="inline-block"
         {...ariaHiddenProps}
         {...otherProps}
         {...shared}
-        as={as}
+        as={as as React.ElementType}
       />
     );
   }
@@ -160,7 +155,7 @@ export const _Icon: PolymorphicComponentWithRef<
       {children}
     </Box>
   );
-};
+}
 
 export const Icon: PolymorphicComponent<
   IconInternalProps,

--- a/packages/components/list/src/List.tsx
+++ b/packages/components/list/src/List.tsx
@@ -1,37 +1,57 @@
 import { cx, css } from 'emotion';
 import React from 'react';
 
-import { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
+import {
+  CommonProps,
+  PolymorphicProps,
+  PolymorphicComponent,
+} from '@contentful/f36-core';
+
+const DEFAULT_TAG = 'ul';
+
 export interface ListInternalProps extends CommonProps {
   as?: 'ul' | 'ol';
   children?: React.ReactNode;
 }
 
-export type ListProps = PropsWithHTMLElement<ListInternalProps, 'ul'>;
+export type ListProps<
+  E extends React.ElementType = typeof DEFAULT_TAG
+> = PolymorphicProps<ListInternalProps, E>;
 
 /**
  * List is component that helps with vertical indexing of content.
  * Every list item begins with a bullet or a number.
  */
-export const List = React.forwardRef<HTMLUListElement, ListProps>(
-  ({ as, className, children, testId = 'cf-ui-list', ...otherProps }, ref) => {
-    return (
-      <ul
-        data-test-id={testId}
-        className={cx(
-          css({
-            margin: 0,
-            listStyleType: as === 'ul' ? 'disc' : 'decimal',
-          }),
-          className,
-        )}
-        ref={ref}
-        {...otherProps}
-      >
-        {children}
-      </ul>
-    );
-  },
-);
+function _List<E extends React.ElementType = typeof DEFAULT_TAG>(
+  {
+    as,
+    className,
+    children,
+    testId = 'cf-ui-list',
+    ...otherProps
+  }: ListProps<E>,
+  ref: React.Ref<any>,
+) {
+  const Element: React.ElementType = as || DEFAULT_TAG;
 
-List.displayName = 'List';
+  return (
+    <Element
+      data-test-id={testId}
+      className={cx(
+        css({
+          margin: 0,
+        }),
+        className,
+      )}
+      ref={ref}
+      {...otherProps}
+    >
+      {children}
+    </Element>
+  );
+}
+
+export const List: PolymorphicComponent<
+  ListInternalProps,
+  typeof DEFAULT_TAG
+> = React.forwardRef(_List);

--- a/packages/components/list/src/List.tsx
+++ b/packages/components/list/src/List.tsx
@@ -1,64 +1,37 @@
 import { cx, css } from 'emotion';
 import React from 'react';
 
-import {
-  Box,
-  CommonProps,
-  PolymorphicComponent,
-  PolymorphicComponentProps,
-  PolymorphicComponentWithRef,
-} from '@contentful/f36-core';
-
-const DEFAULT_TAG = 'ul';
-
-export type ListElement = 'ul' | 'ol';
+import { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 export interface ListInternalProps extends CommonProps {
-  as?: ListElement;
+  as?: 'ul' | 'ol';
   children?: React.ReactNode;
 }
 
-export type ListProps = PolymorphicComponentProps<
-  typeof DEFAULT_TAG,
-  ListInternalProps
->;
-
-const _List: PolymorphicComponentWithRef<
-  ListInternalProps,
-  typeof DEFAULT_TAG
-> = (
-  {
-    as: Tag = DEFAULT_TAG,
-    className,
-    children,
-    testId = 'cf-ui-list',
-    ...otherProps
-  },
-  ref,
-) => {
-  return (
-    <Box
-      as={DEFAULT_TAG}
-      testId={testId}
-      className={cx(
-        css({
-          margin: 0,
-          listStyleType: Tag === 'ul' ? 'disc' : 'decimal',
-        }),
-        className,
-      )}
-      ref={ref}
-      {...otherProps}
-    >
-      {children}
-    </Box>
-  );
-};
+export type ListProps = PropsWithHTMLElement<ListInternalProps, 'ul'>;
 
 /**
  * List is component that helps with vertical indexing of content.
  * Every list item begins with a bullet or a number.
  */
-export const List: PolymorphicComponent<
-  ListInternalProps,
-  typeof DEFAULT_TAG
-> = React.forwardRef(_List);
+export const List = React.forwardRef<HTMLUListElement, ListProps>(
+  ({ as, className, children, testId = 'cf-ui-list', ...otherProps }, ref) => {
+    return (
+      <ul
+        data-test-id={testId}
+        className={cx(
+          css({
+            margin: 0,
+            listStyleType: as === 'ul' ? 'disc' : 'decimal',
+          }),
+          className,
+        )}
+        ref={ref}
+        {...otherProps}
+      >
+        {children}
+      </ul>
+    );
+  },
+);
+
+List.displayName = 'List';

--- a/packages/components/list/src/ListItem/ListItem.tsx
+++ b/packages/components/list/src/ListItem/ListItem.tsx
@@ -1,18 +1,15 @@
 import { cx, css } from 'emotion';
 import React from 'react';
 import tokens from '@contentful/f36-tokens';
-import type {
-  CommonProps,
-  PolymorphicComponentProps,
-} from '@contentful/f36-core';
+import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 
 import { List } from '../List';
 
-export type ListItemProps = PolymorphicComponentProps<
-  'li',
+export type ListItemProps = PropsWithHTMLElement<
   CommonProps & {
     children?: React.ReactNode;
-  }
+  },
+  'li'
 >;
 
 export function ListItem({

--- a/packages/components/list/stories/List.stories.tsx
+++ b/packages/components/list/stories/List.stories.tsx
@@ -29,7 +29,7 @@ export const Default: Story<ListProps> = (args) => {
       <List.Item>List Item 1</List.Item>
       <List.Item>List Item 2</List.Item>
       <List.Item>
-        <List>
+        <List {...args}>
           <List.Item>Sublist Item 1</List.Item>
           <List.Item>Sublist Item 2</List.Item>
         </List>
@@ -44,11 +44,11 @@ export const overview = ({ ...args }: ListProps) => (
       <SectionHeading marginBottom="spacingS">Unordered List</SectionHeading>
 
       <Flex>
-        <List {...args}>
+        <List {...args} as="ul">
           <List.Item>List Item 1</List.Item>
           <List.Item>List Item 2</List.Item>
           <List.Item>
-            <List>
+            <List {...args} as="ul">
               <List.Item>Sublist Item 1</List.Item>
               <List.Item>Sublist Item 2</List.Item>
             </List>
@@ -60,11 +60,11 @@ export const overview = ({ ...args }: ListProps) => (
       <SectionHeading marginBottom="spacingS">Ordered List</SectionHeading>
 
       <Flex>
-        <List as="ol" {...args}>
+        <List {...args} as="ol">
           <List.Item>List Item 1</List.Item>
           <List.Item>List Item 2</List.Item>
           <List.Item>
-            <List as="ol">
+            <List {...args} as="ol">
               <List.Item>Sublist Item 1</List.Item>
               <List.Item>Sublist Item 2</List.Item>
             </List>

--- a/packages/components/modal/src/ModalContent/ModalContent.tsx
+++ b/packages/components/modal/src/ModalContent/ModalContent.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { cx } from 'emotion';
-import type { PrimitiveProps } from '@contentful/f36-core';
+import type { PropsWithHTMLElement, CommonProps } from '@contentful/f36-core';
 import { Box } from '@contentful/f36-core';
 import { getModalContentStyles } from './ModalContent.styles';
 
-export interface ModalContentProps extends PrimitiveProps<'div'> {
+interface ModalContentInternalProps extends CommonProps {
   children: React.ReactNode;
-  as?: 'div';
 }
+
+export type ModalContentProps = PropsWithHTMLElement<
+  ModalContentInternalProps,
+  'div'
+>;
 
 export function ModalContent({
   testId = 'cf-ui-modal-content',

--- a/packages/components/modal/src/ModalControls/ModalControls.tsx
+++ b/packages/components/modal/src/ModalControls/ModalControls.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 
-import type { PrimitiveProps } from '@contentful/f36-core';
+import type { PropsWithHTMLElement, CommonProps } from '@contentful/f36-core';
 import { Flex } from '@contentful/f36-core';
 import { ButtonGroup } from '@contentful/f36-button';
 
-export interface ModalControlsProps extends PrimitiveProps<'div'> {
-  as?: 'div';
+interface ModalControlsInternalProps extends CommonProps {
   children: React.ReactElement[] | React.ReactElement;
 }
+
+export type ModalControlsProps = PropsWithHTMLElement<
+  ModalControlsInternalProps,
+  'div'
+>;
 
 export function ModalControls({
   testId = 'cf-ui-modal-controls',

--- a/packages/components/modal/src/ModalHeader/ModalHeader.tsx
+++ b/packages/components/modal/src/ModalHeader/ModalHeader.tsx
@@ -2,17 +2,21 @@ import React from 'react';
 import { cx } from 'emotion';
 import { CloseIcon } from '@contentful/f36-icons';
 import { Flex } from '@contentful/f36-core';
-import type { PrimitiveProps } from '@contentful/f36-core';
+import type { PropsWithHTMLElement, CommonProps } from '@contentful/f36-core';
 import { Button } from '@contentful/f36-button';
 import { Subheading } from '@contentful/f36-typography';
 
 import { getModalHeaderStyles } from './ModalHeader.styles';
 
-export interface ModalHeaderProps extends PrimitiveProps<'div'> {
+interface ModalHeaderInternalProps extends CommonProps {
   title: string;
   onClose?: Function;
-  as?: 'div';
 }
+
+export type ModalHeaderProps = PropsWithHTMLElement<
+  ModalHeaderInternalProps,
+  'div'
+>;
 
 export function ModalHeader({
   onClose,

--- a/packages/components/modal/stories/ModalLauncher.stories.tsx
+++ b/packages/components/modal/stories/ModalLauncher.stories.tsx
@@ -65,7 +65,7 @@ export const CloseAllStory = () => {
       <Modal title={content} isShown={isShown} onClose={() => onClose()}>
         <Modal.Content>{content}</Modal.Content>
         <Modal.Controls>
-          <Button buttonType="primary" onClick={() => openModal(`New modal`)}>
+          <Button variant="primary" onClick={() => openModal(`New modal`)}>
             Open modal
           </Button>
           <Button
@@ -76,7 +76,7 @@ export const CloseAllStory = () => {
           >
             Close one modal
           </Button>
-          <Button buttonType="muted" onClick={ModalLauncher.closeAll}>
+          <Button variant="secondary" onClick={ModalLauncher.closeAll}>
             Close all
           </Button>
         </Modal.Controls>

--- a/packages/components/note/src/Note.tsx
+++ b/packages/components/note/src/Note.tsx
@@ -99,7 +99,7 @@ export const Note = React.forwardRef<HTMLElement, NoteProps>((props, ref) => {
           icon={<CloseIcon className={styles.closeIcon} />}
           onClick={onClose}
           testId={`${testId}-close`}
-          label="Dismiss"
+          aria-label="Dismiss"
           className={styles.close}
         />
       )}

--- a/packages/components/note/src/Note.tsx
+++ b/packages/components/note/src/Note.tsx
@@ -1,10 +1,7 @@
 import { cx } from 'emotion';
 import React from 'react';
 import { Flex } from '@contentful/f36-core';
-import type {
-  CommonProps,
-  PolymorphicComponentProps,
-} from '@contentful/f36-core';
+import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 import { Button } from '@contentful/f36-button';
 import { Heading, Text } from '@contentful/f36-typography';
 import {
@@ -48,9 +45,9 @@ export type NoteInternalProps = CommonProps & {
   /**
    * Callback for handling closing
    */
-  onClose?: Function;
+  onClose?: React.MouseEventHandler<HTMLButtonElement>;
 };
-export type NoteProps = PolymorphicComponentProps<'article', NoteInternalProps>;
+export type NoteProps = PropsWithHTMLElement<NoteInternalProps, 'article'>;
 
 /**
  * @description: Note provides context and information about a situation or action.

--- a/packages/components/pill/src/Pill.tsx
+++ b/packages/components/pill/src/Pill.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { cx } from 'emotion';
-import type {
-  CommonProps,
-  PolymorphicComponentProps,
-} from '@contentful/f36-core';
-import { Box } from '@contentful/f36-core';
+import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 import { DragIcon, CloseIcon } from '@contentful/f36-icons';
 import { Button } from '@contentful/f36-button';
 import { PillVariants } from './types';
@@ -34,7 +30,7 @@ export type PillInternalProps = CommonProps & {
   variant?: PillVariants;
 };
 
-export type PillProps = PolymorphicComponentProps<'div', PillInternalProps>;
+export type PillProps = PropsWithHTMLElement<PillInternalProps, 'div'>;
 
 export const Pill = React.forwardRef<HTMLDivElement, PillProps>(
   (props, ref) => {
@@ -52,8 +48,7 @@ export const Pill = React.forwardRef<HTMLDivElement, PillProps>(
     const styles = getPillStyles(variant);
 
     return (
-      <Box
-        as="div"
+      <div
         className={cx(styles.pill, className)}
         data-test-id={testId}
         onDrag={onDrag}
@@ -81,7 +76,7 @@ export const Pill = React.forwardRef<HTMLDivElement, PillProps>(
             className={styles.closeButton}
           />
         )}
-      </Box>
+      </div>
     );
   },
 );

--- a/packages/components/popover/src/PopoverContent/PopoverContent.tsx
+++ b/packages/components/popover/src/PopoverContent/PopoverContent.tsx
@@ -1,13 +1,18 @@
-import React, { AllHTMLAttributes } from 'react';
+import React from 'react';
 import { cx } from 'emotion';
-import { CommonProps } from '@contentful/f36-core';
+import { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 import { usePopoverContext } from '../PopoverContext';
 import { Portal } from '@contentful/f36-utils';
 import { getPopoverContentStyles } from './PopoverContent.styles';
 
-export interface PopoverContentProps
-  extends AllHTMLAttributes<HTMLDivElement>,
-    CommonProps {}
+interface PopoverContentInternalProps extends CommonProps {
+  children?: React.ReactNode;
+}
+
+export type PopoverContentProps = PropsWithHTMLElement<
+  PopoverContentInternalProps,
+  'div'
+>;
 
 const _PopoverContent = (props: PopoverContentProps, ref) => {
   const {

--- a/packages/components/spinner/src/Spinner.tsx
+++ b/packages/components/spinner/src/Spinner.tsx
@@ -2,10 +2,7 @@ import { cx, css } from 'emotion';
 import React, { forwardRef } from 'react';
 import tokens from '@contentful/f36-tokens';
 import { Box } from '@contentful/f36-core';
-import type {
-  CommonProps,
-  PolymorphicComponentProps,
-} from '@contentful/f36-core';
+import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 import type { SpinnerSize, SpinnerVariant } from './types';
 import { getStyles } from './Spinner.styles';
 
@@ -33,10 +30,7 @@ export type SpinnerInternalProps = CommonProps & {
   size?: SpinnerSize;
 };
 
-export type SpinnerProps = PolymorphicComponentProps<
-  'div',
-  SpinnerInternalProps
->;
+export type SpinnerProps = PropsWithHTMLElement<SpinnerInternalProps, 'div'>;
 
 export const Spinner = forwardRef<HTMLDivElement, SpinnerProps>(
   (

--- a/packages/components/table/src/Table.tsx
+++ b/packages/components/table/src/Table.tsx
@@ -1,7 +1,7 @@
 import { cx, css } from 'emotion';
 import React, { forwardRef } from 'react';
 import { Box, CommonProps } from '@contentful/f36-core';
-import type { PolymorphicComponentProps } from '@contentful/f36-core';
+import type { PropsWithHTMLElement } from '@contentful/f36-core';
 import tokens from '@contentful/f36-tokens';
 
 const getStyles = () => {
@@ -32,7 +32,7 @@ export type TableInternalProps = CommonProps & {
   layout?: 'inline' | 'embedded';
 };
 
-export type TableProps = PolymorphicComponentProps<'table', TableInternalProps>;
+export type TableProps = PropsWithHTMLElement<TableInternalProps, 'table'>;
 
 export const Table = forwardRef<HTMLTableElement, TableProps>(
   (

--- a/packages/components/table/src/TableBody.tsx
+++ b/packages/components/table/src/TableBody.tsx
@@ -1,18 +1,15 @@
 import React, { forwardRef } from 'react';
 import type { ReactElement } from 'react';
 import { Box } from '@contentful/f36-core';
-import type {
-  CommonProps,
-  PolymorphicComponentProps,
-} from '@contentful/f36-core';
+import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 
 export type TableBodyInternalProps = CommonProps & {
   children: ReactElement | ReactElement[];
 };
 
-export type TableBodyProps = PolymorphicComponentProps<
-  'tbody',
-  TableBodyInternalProps
+export type TableBodyProps = PropsWithHTMLElement<
+  TableBodyInternalProps,
+  'tbody'
 >;
 
 export const TableBody = forwardRef<HTMLTableSectionElement, TableBodyProps>(

--- a/packages/components/table/src/TableCell.tsx
+++ b/packages/components/table/src/TableCell.tsx
@@ -2,10 +2,7 @@ import { css, cx } from 'emotion';
 import React, { forwardRef } from 'react';
 import tokens from '@contentful/f36-tokens';
 import { Box } from '@contentful/f36-core';
-import type {
-  CommonProps,
-  PolymorphicComponentProps,
-} from '@contentful/f36-core';
+import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 
 import { TableCellContext } from './tableCellContext';
 
@@ -23,9 +20,9 @@ export type TableCellInternalProps = CommonProps & {
   children?: React.ReactNode;
 };
 
-export type TableCellProps = PolymorphicComponentProps<
-  'th' | 'td',
-  TableCellInternalProps
+export type TableCellProps = PropsWithHTMLElement<
+  TableCellInternalProps,
+  'th' | 'td'
 >;
 
 export const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(

--- a/packages/components/table/src/TableHead.tsx
+++ b/packages/components/table/src/TableHead.tsx
@@ -1,10 +1,7 @@
 import { css, cx } from 'emotion';
 import React, { forwardRef } from 'react';
 import { Box } from '@contentful/f36-core';
-import type {
-  CommonProps,
-  PolymorphicComponentProps,
-} from '@contentful/f36-core';
+import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 import tokens from '@contentful/f36-tokens';
 
 import { TableCellContext, contextOptions } from './';
@@ -15,9 +12,9 @@ export type TableHeadInternalProps = CommonProps & {
   children: React.ReactNode;
 };
 
-export type TableHeadProps = PolymorphicComponentProps<
-  'thead',
-  TableHeadInternalProps
+export type TableHeadProps = PropsWithHTMLElement<
+  TableHeadInternalProps,
+  'thead'
 >;
 
 export const TableHead = forwardRef<HTMLTableSectionElement, TableHeadProps>(

--- a/packages/components/table/src/TableRow.tsx
+++ b/packages/components/table/src/TableRow.tsx
@@ -2,10 +2,7 @@ import { css, cx } from 'emotion';
 import React, { forwardRef } from 'react';
 import tokens from '@contentful/f36-tokens';
 import { Box } from '@contentful/f36-core';
-import type {
-  CommonProps,
-  PolymorphicComponentProps,
-} from '@contentful/f36-core';
+import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 
 const getStyles = () => {
   return {
@@ -33,10 +30,7 @@ export type TableRowInternalProps = CommonProps & {
   children: React.ReactNode;
 };
 
-export type TableRowProps = PolymorphicComponentProps<
-  'tr',
-  TableRowInternalProps
->;
+export type TableRowProps = PropsWithHTMLElement<TableRowInternalProps, 'tr'>;
 
 export const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
   (

--- a/packages/components/text-link/TextLink.mdx
+++ b/packages/components/text-link/TextLink.mdx
@@ -87,3 +87,9 @@ Text links communicate actions and highlight linked resources to users.
 
 - Avoid using extra styling that that make link looks just like regular text.
 - If you use `TextLink` for linking to third party content and use `target="_blank"` prop, it is recommended to set `rel="noreferrer noopener"`. [More details about external links security](https://web.dev/external-anchors-use-rel-noopener/)
+
+## Props of DateTime
+
+import { Props } from '@contentful/f36-docs-utils';
+
+<Props of="TextLink" />

--- a/packages/components/text-link/TextLink.mdx
+++ b/packages/components/text-link/TextLink.mdx
@@ -88,7 +88,7 @@ Text links communicate actions and highlight linked resources to users.
 - Avoid using extra styling that that make link looks just like regular text.
 - If you use `TextLink` for linking to third party content and use `target="_blank"` prop, it is recommended to set `rel="noreferrer noopener"`. [More details about external links security](https://web.dev/external-anchors-use-rel-noopener/)
 
-## Props of DateTime
+## Props of TextLink
 
 import { Props } from '@contentful/f36-docs-utils';
 

--- a/packages/components/text-link/src/TextLink.tsx
+++ b/packages/components/text-link/src/TextLink.tsx
@@ -3,9 +3,8 @@ import { cx } from 'emotion';
 import {
   Flex,
   CommonProps,
-  PolymorphicComponentWithRef,
-  PolymorphicComponentProps,
-  PolymorphicComponent,
+  PolymorphicProps,
+  PolymorphicComponentI,
 } from '@contentful/f36-core';
 import { styles } from './TextLink.styles';
 import { TextLinkVariant } from './types';
@@ -40,15 +39,14 @@ interface TextLinkInternalProps extends CommonProps {
   as?: 'a' | 'button';
 }
 
-type ElementPropsToOmit = 'type' | 'disabled';
 export type TextLinkProps<
   E extends React.ElementType = typeof DEFAULT_TAG
-> = PolymorphicComponentProps<E, TextLinkInternalProps, ElementPropsToOmit>;
+> = PolymorphicProps<TextLinkInternalProps, E, 'disabled'>;
 
-const TextLink: PolymorphicComponentWithRef<
-  TextLinkInternalProps,
-  typeof DEFAULT_TAG
-> = (props, ref) => {
+function _TextLink<E extends React.ElementType = typeof DEFAULT_TAG>(
+  props: TextLinkProps<E>,
+  ref,
+) {
   const {
     children,
     className,
@@ -124,11 +122,10 @@ const TextLink: PolymorphicComponentWithRef<
       {commonContent}
     </a>
   );
-};
+}
 
-const _TextLink: PolymorphicComponent<
+export const TextLink: PolymorphicComponentI<
   TextLinkInternalProps,
   typeof DEFAULT_TAG,
   'disabled'
-> = React.forwardRef(TextLink);
-export { _TextLink as TextLink };
+> = React.forwardRef(_TextLink);

--- a/packages/components/text-link/src/TextLink.tsx
+++ b/packages/components/text-link/src/TextLink.tsx
@@ -4,7 +4,7 @@ import {
   Flex,
   CommonProps,
   PolymorphicProps,
-  PolymorphicComponentI,
+  PolymorphicComponent,
 } from '@contentful/f36-core';
 import { styles } from './TextLink.styles';
 import { TextLinkVariant } from './types';
@@ -45,7 +45,7 @@ export type TextLinkProps<
 
 function _TextLink<E extends React.ElementType = typeof DEFAULT_TAG>(
   props: TextLinkProps<E>,
-  ref,
+  ref: React.Ref<any>,
 ) {
   const {
     children,
@@ -124,7 +124,7 @@ function _TextLink<E extends React.ElementType = typeof DEFAULT_TAG>(
   );
 }
 
-export const TextLink: PolymorphicComponentI<
+export const TextLink: PolymorphicComponent<
   TextLinkInternalProps,
   typeof DEFAULT_TAG,
   'disabled'

--- a/packages/components/typography/src/DisplayText.tsx
+++ b/packages/components/typography/src/DisplayText.tsx
@@ -4,8 +4,7 @@ import {
   CommonProps,
   MarginProps,
   PolymorphicComponent,
-  PolymorphicComponentProps,
-  PolymorphicComponentWithRef,
+  PolymorphicProps,
 } from '@contentful/f36-core';
 import { Text } from './Text';
 import type { HeadingElement } from './Heading';
@@ -19,16 +18,19 @@ export interface DisplayTextInternalProps extends CommonProps, MarginProps {
 }
 
 export type DisplayTextProps<
-  E extends React.ElementType
-> = PolymorphicComponentProps<E, DisplayTextInternalProps>;
+  E extends React.ElementType = typeof DEFAULT_TAG
+> = PolymorphicProps<DisplayTextInternalProps, E>;
 
-const _DisplayText: PolymorphicComponentWithRef<
-  DisplayTextInternalProps,
-  typeof DEFAULT_TAG
-> = (
-  { children, size = 'default', testId = 'cf-ui-display-text', ...otherProps },
-  ref,
-) => {
+function _DisplayText<E extends React.ElementType = typeof DEFAULT_TAG>(
+  {
+    children,
+    size = 'default',
+    testId = 'cf-ui-display-text',
+    as,
+    ...otherProps
+  }: DisplayTextProps<E>,
+  ref: React.Ref<any>,
+) {
   let fontSize: FontSizeTokens = 'fontSize2Xl';
   let lineHeight: LineHeightTokens = 'lineHeight2Xl';
 
@@ -55,7 +57,7 @@ const _DisplayText: PolymorphicComponentWithRef<
       {children}
     </Text>
   );
-};
+}
 
 export const DisplayText: PolymorphicComponent<
   DisplayTextInternalProps,

--- a/packages/components/typography/src/Heading.tsx
+++ b/packages/components/typography/src/Heading.tsx
@@ -3,10 +3,11 @@ import {
   CommonProps,
   MarginProps,
   PolymorphicComponent,
-  PolymorphicComponentProps,
-  PolymorphicComponentWithRef,
+  PolymorphicProps,
 } from '@contentful/f36-core';
 import { Text } from './Text';
+
+const DEFAULT_TAG = 'h1';
 
 export type HeadingElement = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
@@ -17,15 +18,13 @@ export interface HeadingInternalProps extends CommonProps, MarginProps {
 }
 
 export type HeadingProps<
-  E extends React.ElementType
-> = PolymorphicComponentProps<E, HeadingInternalProps>;
+  E extends React.ElementType = typeof DEFAULT_TAG
+> = PolymorphicProps<HeadingInternalProps, E>;
 
-const DEFAULT_TAG = 'h1';
-
-const _Heading: PolymorphicComponentWithRef<
-  HeadingInternalProps,
-  typeof DEFAULT_TAG
-> = ({ children, testId = 'cf-ui-heading', ...otherProps }, ref) => {
+function _Heading<E extends React.ElementType = typeof DEFAULT_TAG>(
+  { children, testId = 'cf-ui-heading', ...otherProps }: HeadingProps<E>,
+  ref: React.Ref<any>,
+) {
   return (
     <Text
       as={DEFAULT_TAG}
@@ -41,7 +40,7 @@ const _Heading: PolymorphicComponentWithRef<
       {children}
     </Text>
   );
-};
+}
 
 export const Heading: PolymorphicComponent<
   HeadingInternalProps,

--- a/packages/components/typography/src/Paragraph.tsx
+++ b/packages/components/typography/src/Paragraph.tsx
@@ -1,46 +1,34 @@
 import React from 'react';
 import {
-  PolymorphicComponent,
-  PolymorphicComponentWithRef,
-  PolymorphicComponentProps,
+  PropsWithHTMLElement,
   CommonProps,
   MarginProps,
 } from '@contentful/f36-core';
 import { Text } from './Text';
 
-const DEFAULT_TAG = 'p';
-
 export type ParagraphInternalProps = CommonProps &
   MarginProps & {
     children: React.ReactNode;
-    as?: typeof DEFAULT_TAG;
     isTruncated?: boolean;
   };
 
-export type ParagraphProps = PolymorphicComponentProps<
-  'p',
-  ParagraphInternalProps
->;
+export type ParagraphProps = PropsWithHTMLElement<ParagraphInternalProps, 'p'>;
 
-const _Paragraph: PolymorphicComponentWithRef<
-  ParagraphInternalProps,
-  typeof DEFAULT_TAG
-> = ({ children, testId = 'cf-ui-paragraph', ...otherProps }, ref) => {
-  return (
-    <Text
-      as={DEFAULT_TAG}
-      testId={testId}
-      marginBottom="spacingM"
-      lineHeight="lineHeightM"
-      {...otherProps}
-      ref={ref}
-    >
-      {children}
-    </Text>
-  );
-};
+export const Paragraph = React.forwardRef<HTMLParagraphElement, ParagraphProps>(
+  ({ children, testId = 'cf-ui-paragraph', ...otherProps }, ref) => {
+    return (
+      <Text
+        as="p"
+        testId={testId}
+        marginBottom="spacingM"
+        lineHeight="lineHeightM"
+        {...otherProps}
+        ref={ref}
+      >
+        {children}
+      </Text>
+    );
+  },
+);
 
-export const Paragraph: PolymorphicComponent<
-  ParagraphInternalProps,
-  typeof DEFAULT_TAG
-> = React.forwardRef(_Paragraph);
+Paragraph.displayName = 'Paragraph';

--- a/packages/components/typography/src/SectionHeading.tsx
+++ b/packages/components/typography/src/SectionHeading.tsx
@@ -5,8 +5,7 @@ import {
   CommonProps,
   MarginProps,
   PolymorphicComponent,
-  PolymorphicComponentWithRef,
-  PolymorphicComponentProps,
+  PolymorphicProps,
 } from '@contentful/f36-core';
 import type { HeadingElement } from './Heading';
 import { Text } from './Text';
@@ -19,16 +18,18 @@ export interface SectionHeadingInternalProps extends CommonProps, MarginProps {
 }
 
 export type SectionHeadingProps<
-  E extends React.ElementType
-> = PolymorphicComponentProps<E, SectionHeadingInternalProps>;
+  E extends React.ElementType = typeof DEFAULT_TAG
+> = PolymorphicProps<SectionHeadingInternalProps, E>;
 
-const _SectionHeading: PolymorphicComponentWithRef<
-  SectionHeadingInternalProps,
-  typeof DEFAULT_TAG
-> = (
-  { children, className, testId = 'cf-ui-section-heading', ...otherProps },
-  ref,
-) => {
+function _SectionHeading<E extends React.ElementType = typeof DEFAULT_TAG>(
+  {
+    children,
+    className,
+    testId = 'cf-ui-section-heading',
+    ...otherProps
+  }: SectionHeadingProps<E>,
+  ref: React.Ref<any>,
+) {
   return (
     <Text
       as={DEFAULT_TAG}
@@ -51,7 +52,7 @@ const _SectionHeading: PolymorphicComponentWithRef<
       {children}
     </Text>
   );
-};
+}
 
 export const SectionHeading: PolymorphicComponent<
   SectionHeadingInternalProps,

--- a/packages/components/typography/src/Subheading.tsx
+++ b/packages/components/typography/src/Subheading.tsx
@@ -3,8 +3,7 @@ import {
   CommonProps,
   MarginProps,
   PolymorphicComponent,
-  PolymorphicComponentProps,
-  PolymorphicComponentWithRef,
+  PolymorphicProps,
 } from '@contentful/f36-core';
 import type { HeadingElement } from './Heading';
 import { Text } from './Text';
@@ -17,13 +16,13 @@ export interface SubheadingInternalProps extends CommonProps, MarginProps {
 }
 
 export type SubheadingProps<
-  E extends React.ElementType
-> = PolymorphicComponentProps<E, SubheadingInternalProps>;
+  E extends React.ElementType = typeof DEFAULT_TAG
+> = PolymorphicProps<SubheadingInternalProps, E>;
 
-const _Subheading: PolymorphicComponentWithRef<
-  SubheadingInternalProps,
-  typeof DEFAULT_TAG
-> = ({ children, testId = 'cf-ui-subheading', ...otherProps }, ref) => {
+function _Subheading<E extends React.ElementType = typeof DEFAULT_TAG>(
+  { children, testId = 'cf-ui-subheading', ...otherProps }: SubheadingProps<E>,
+  ref: React.Ref<any>,
+) {
   return (
     <Text
       as={DEFAULT_TAG}
@@ -39,7 +38,7 @@ const _Subheading: PolymorphicComponentWithRef<
       {children}
     </Text>
   );
-};
+}
 
 export const Subheading: PolymorphicComponent<
   SubheadingInternalProps,

--- a/packages/components/typography/src/Text.tsx
+++ b/packages/components/typography/src/Text.tsx
@@ -50,6 +50,7 @@ function _Text<E extends React.ElementType = typeof DEFAULT_TAG>(
     isTruncated,
     as,
     className,
+    margin = 'none',
     ...otherProps
   }: TextProps<E>,
   ref: React.Ref<any>,
@@ -62,7 +63,6 @@ function _Text<E extends React.ElementType = typeof DEFAULT_TAG>(
       as={Element}
       className={cx(
         css({
-          margin: 0,
           padding: 0,
           fontFamily: tokens[fontStack],
           fontWeight: tokens[fontWeight],
@@ -73,6 +73,7 @@ function _Text<E extends React.ElementType = typeof DEFAULT_TAG>(
         isTruncated ? truncatedStyle() : null,
         className,
       )}
+      margin={margin}
       ref={ref}
     >
       {children}

--- a/packages/components/typography/src/Text.tsx
+++ b/packages/components/typography/src/Text.tsx
@@ -26,7 +26,7 @@ export interface TextInternalProps extends CommonProps, MarginProps {
   isTruncated?: boolean;
 }
 
-const DEFAULT_TAG = 'span';
+const DEFAULT_TAG: React.ElementType = 'span';
 
 function truncatedStyle() {
   return css({

--- a/packages/components/typography/src/Text.tsx
+++ b/packages/components/typography/src/Text.tsx
@@ -9,11 +9,10 @@ import tokens, {
 import { css, cx } from 'emotion';
 import {
   PolymorphicComponent,
-  PolymorphicComponentWithRef,
   CommonProps,
   MarginProps,
-  PolymorphicComponentProps,
-  useBox,
+  PolymorphicProps,
+  Box,
 } from '@contentful/f36-core';
 
 export interface TextInternalProps extends CommonProps, MarginProps {
@@ -26,7 +25,7 @@ export interface TextInternalProps extends CommonProps, MarginProps {
   isTruncated?: boolean;
 }
 
-const DEFAULT_TAG: React.ElementType = 'span';
+const DEFAULT_TAG = 'span';
 
 function truncatedStyle() {
   return css({
@@ -36,15 +35,11 @@ function truncatedStyle() {
   });
 }
 
-export type TextProps<E extends React.ElementType> = PolymorphicComponentProps<
-  E,
-  TextInternalProps
->;
+export type TextProps<
+  E extends React.ElementType = typeof DEFAULT_TAG
+> = PolymorphicProps<TextInternalProps, E>;
 
-const _Text: PolymorphicComponentWithRef<
-  TextInternalProps,
-  typeof DEFAULT_TAG
-> = (
+function _Text<E extends React.ElementType = typeof DEFAULT_TAG>(
   {
     fontSize = 'fontSizeM',
     fontStack = 'fontStackPrimary',
@@ -53,18 +48,18 @@ const _Text: PolymorphicComponentWithRef<
     lineHeight,
     children,
     isTruncated,
-    as = DEFAULT_TAG,
-    ...otherProps
-  },
-  ref,
-) => {
-  const { boxProps, Element } = useBox({
-    ...otherProps,
     as,
-  });
+    className,
+    ...otherProps
+  }: TextProps<E>,
+  ref: React.Ref<any>,
+) {
+  const Element: React.ElementType = as || DEFAULT_TAG;
+
   return (
-    <Element
-      {...boxProps}
+    <Box
+      {...otherProps}
+      as={Element}
       className={cx(
         css({
           margin: 0,
@@ -76,14 +71,14 @@ const _Text: PolymorphicComponentWithRef<
           lineHeight: tokens[lineHeight],
         }),
         isTruncated ? truncatedStyle() : null,
-        boxProps.className,
+        className,
       )}
       ref={ref}
     >
       {children}
-    </Element>
+    </Box>
   );
-};
+}
 
 export const Text: PolymorphicComponent<
   TextInternalProps,

--- a/packages/components/validation-message/src/ValidationMessage.tsx
+++ b/packages/components/validation-message/src/ValidationMessage.tsx
@@ -1,9 +1,6 @@
 import React, { forwardRef } from 'react';
 import { Flex } from '@contentful/f36-core';
-import type {
-  CommonProps,
-  PolymorphicComponentProps,
-} from '@contentful/f36-core';
+import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 import { ErrorCircleOutlineIcon } from '@contentful/f36-icons';
 import { Text } from '@contentful/f36-typography';
 
@@ -11,9 +8,9 @@ export type ValidationMessageInternalProps = CommonProps & {
   children: React.ReactNode;
 };
 
-export type ValidationMessageProps = PolymorphicComponentProps<
-  'div',
-  ValidationMessageInternalProps
+export type ValidationMessageProps = PropsWithHTMLElement<
+  ValidationMessageInternalProps,
+  'div'
 >;
 
 export const ValidationMessage = forwardRef<

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -4,14 +4,9 @@ import { css, cx } from 'emotion';
 import type { MarginProps, PaddingProps, CommonProps } from '../types';
 import { getSpacingStyles } from '../utils/getSpacingStyles';
 
-const DEFAULT_TAG = 'div';
+const DEFAULT_TAG: React.ElementType = 'div';
 
-import {
-  usePrimitive,
-  PolymorphicComponentProps,
-  PolymorphicComponentWithRef,
-  PolymorphicComponent,
-} from '../Primitive/Primitive';
+import { PolymorphicProps, PolymorphicComponent } from '../Primitive/Primitive';
 
 export interface BoxInternalProps
   extends CommonProps,
@@ -22,18 +17,12 @@ export interface BoxInternalProps
    */
   display?: CSS.Property.Display;
   children?: React.ReactNode;
+  as?: React.ElementType<any>;
 }
 
-export type BoxProps<E extends React.ElementType> = PolymorphicComponentProps<
-  E,
-  BoxInternalProps
->;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function useBox(props: BoxInternalProps & { as?: any }) {
+export function useBox(props: Omit<BoxInternalProps, 'children'>) {
   const {
     display,
-    children,
     className,
     margin,
     marginBottom,
@@ -45,7 +34,9 @@ export function useBox(props: BoxInternalProps & { as?: any }) {
     paddingLeft,
     paddingRight,
     paddingTop,
-    ...otherProps
+    testId,
+    as: Element = DEFAULT_TAG,
+    style,
   } = props;
   const boxProps = {
     className: cx(
@@ -68,19 +59,24 @@ export function useBox(props: BoxInternalProps & { as?: any }) {
       }),
       className,
     ),
-    ...otherProps,
+    ['data-test-id']: testId,
+    style,
   };
-  const { Element, primitiveProps } = usePrimitive(boxProps);
+
   return {
-    boxProps: primitiveProps,
+    boxProps: boxProps,
     Element,
   };
 }
 
-const _Box: PolymorphicComponentWithRef<
-  BoxInternalProps,
-  typeof DEFAULT_TAG
-> = (props, ref) => {
+export type BoxProps<
+  E extends React.ElementType = typeof DEFAULT_TAG
+> = PolymorphicProps<BoxInternalProps, E>;
+
+function _Box<E extends React.ElementType = typeof DEFAULT_TAG>(
+  props: BoxProps<E>,
+  ref: React.Ref<any>,
+) {
   const { boxProps, Element } = useBox(props);
 
   return (
@@ -88,7 +84,7 @@ const _Box: PolymorphicComponentWithRef<
       {props.children}
     </Element>
   );
-};
+}
 
 export const Box: PolymorphicComponent<
   BoxInternalProps,

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -20,7 +20,13 @@ export interface BoxInternalProps
   as?: React.ElementType<any>;
 }
 
-export function useBox(props: Omit<BoxInternalProps, 'children'>) {
+export type BoxProps<
+  E extends React.ElementType = typeof DEFAULT_TAG
+> = PolymorphicProps<BoxInternalProps, E>;
+
+export function useBox<E extends React.ElementType = typeof DEFAULT_TAG>(
+  props: BoxProps<E>,
+) {
   const {
     display,
     className,
@@ -36,7 +42,7 @@ export function useBox(props: Omit<BoxInternalProps, 'children'>) {
     paddingTop,
     testId,
     as: Element = DEFAULT_TAG,
-    style,
+    ...otherProps
   } = props;
   const boxProps = {
     className: cx(
@@ -60,7 +66,7 @@ export function useBox(props: Omit<BoxInternalProps, 'children'>) {
       className,
     ),
     ['data-test-id']: testId,
-    style,
+    ...otherProps,
   };
 
   return {
@@ -69,15 +75,11 @@ export function useBox(props: Omit<BoxInternalProps, 'children'>) {
   };
 }
 
-export type BoxProps<
-  E extends React.ElementType = typeof DEFAULT_TAG
-> = PolymorphicProps<BoxInternalProps, E>;
-
 function _Box<E extends React.ElementType = typeof DEFAULT_TAG>(
   props: BoxProps<E>,
   ref: React.Ref<any>,
 ) {
-  const { boxProps, Element } = useBox(props);
+  const { boxProps, Element } = useBox<E>(props);
 
   return (
     <Element {...boxProps} ref={ref}>

--- a/packages/core/src/Flex/Flex.tsx
+++ b/packages/core/src/Flex/Flex.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
 import { css, cx } from 'emotion';
-import {
-  PolymorphicComponentProps,
-  PolymorphicComponentWithRef,
-  PolymorphicComponent,
-} from '../Primitive/Primitive';
+import { PolymorphicProps, PolymorphicComponent } from '../Primitive/Primitive';
 import { useBox } from '../Box';
 import type { MarginProps, PaddingProps, CommonProps } from '../types';
 import type * as CSS from 'csstype';
@@ -77,17 +73,13 @@ export interface FlexInternalProps
   order?: CSS.Property.Order;
 }
 
-export type FlexProps<E extends React.ElementType> = PolymorphicComponentProps<
-  E,
-  FlexInternalProps
->;
+export type FlexProps<
+  E extends React.ElementType = typeof DEFAULT_TAG
+> = PolymorphicProps<FlexInternalProps, E>;
 
 const DEFAULT_TAG = 'div';
 
-const _Flex: PolymorphicComponentWithRef<
-  FlexInternalProps,
-  typeof DEFAULT_TAG
-> = (
+function _Flex<E extends React.ElementType = typeof DEFAULT_TAG>(
   {
     isInline,
     alignItems,
@@ -107,14 +99,17 @@ const _Flex: PolymorphicComponentWithRef<
     justifySelf,
     order,
     children,
+    as,
     ...otherProps
-  },
-  ref,
-) => {
-  const { boxProps, Element } = useBox(otherProps);
+  }: FlexProps<E>,
+  ref: React.Ref<any>,
+) {
+  const { boxProps, Element } = useBox<React.ElementType>({
+    otherProps,
+    as: as || DEFAULT_TAG,
+  });
   return (
     <Element
-      as={DEFAULT_TAG}
       {...boxProps}
       className={cx(
         css({
@@ -143,7 +138,7 @@ const _Flex: PolymorphicComponentWithRef<
       {children}
     </Element>
   );
-};
+}
 
 export const Flex: PolymorphicComponent<
   FlexInternalProps,

--- a/packages/core/src/Flex/Flex.tsx
+++ b/packages/core/src/Flex/Flex.tsx
@@ -105,7 +105,7 @@ function _Flex<E extends React.ElementType = typeof DEFAULT_TAG>(
   ref: React.Ref<any>,
 ) {
   const { boxProps, Element } = useBox<React.ElementType>({
-    otherProps,
+    ...otherProps,
     as: as || DEFAULT_TAG,
   });
   return (

--- a/packages/core/src/Grid/Grid.tsx
+++ b/packages/core/src/Grid/Grid.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
 import { css, cx } from 'emotion';
-import {
-  PolymorphicComponentProps,
-  PolymorphicComponentWithRef,
-  PolymorphicComponent,
-} from '../Primitive/Primitive';
+import { PolymorphicProps, PolymorphicComponent } from '../Primitive/Primitive';
 import { useBox } from '../Box';
 import type * as CSS from 'csstype';
 import type { MarginProps, PaddingProps, CommonProps, Spacing } from '../types';
@@ -43,17 +39,13 @@ export interface GridInternalProps
   alignContent?: CSS.Property.AlignContent;
 }
 
-export type GridProps<E extends React.ElementType> = PolymorphicComponentProps<
-  E,
-  GridInternalProps
->;
-
 const DEFAULT_TAG = 'div';
 
-const _Grid: PolymorphicComponentWithRef<
-  GridInternalProps,
-  typeof DEFAULT_TAG
-> = (
+export type GridProps<
+  E extends React.ElementType = typeof DEFAULT_TAG
+> = PolymorphicProps<GridInternalProps, E>;
+
+function _Grid<E extends React.ElementType = typeof DEFAULT_TAG>(
   {
     alignContent,
     children,
@@ -64,10 +56,11 @@ const _Grid: PolymorphicComponentWithRef<
     justifyContent,
     rowGap = 'none',
     rows = 'auto',
+    as,
     ...otherProps
-  },
-  ref,
-) => {
+  }: GridProps<E>,
+  ref: React.Ref<any>,
+) {
   const handleGridTemplate = (value?: string | number) => {
     if (typeof value === 'number') {
       return `repeat(${value}, minmax(0, 1fr))`;
@@ -75,11 +68,13 @@ const _Grid: PolymorphicComponentWithRef<
     return value;
   };
 
-  const { boxProps, Element } = useBox(otherProps);
+  const { boxProps, Element } = useBox<React.ElementType>({
+    ...otherProps,
+    as: as || DEFAULT_TAG,
+  });
 
   return (
     <Element
-      as={DEFAULT_TAG}
       {...boxProps}
       className={cx(
         css({
@@ -99,7 +94,7 @@ const _Grid: PolymorphicComponentWithRef<
       {children}
     </Element>
   );
-};
+}
 
 export const Grid: PolymorphicComponent<
   GridInternalProps,

--- a/packages/core/src/Grid/GridItem/GridItem.tsx
+++ b/packages/core/src/Grid/GridItem/GridItem.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { css, cx } from 'emotion';
 import {
-  PolymorphicComponentProps,
-  PolymorphicComponentWithRef,
+  PolymorphicProps,
   PolymorphicComponent,
 } from '../../Primitive/Primitive';
 import { useBox } from '../../Box';
@@ -39,13 +38,10 @@ export interface GridItemInternalProps
 }
 
 export type GridItemProps<
-  E extends React.ElementType
-> = PolymorphicComponentProps<E, GridItemInternalProps>;
+  E extends React.ElementType = typeof DEFAULT_TAG
+> = PolymorphicProps<GridItemInternalProps, E>;
 
-const _GridItem: PolymorphicComponentWithRef<
-  GridItemInternalProps,
-  typeof DEFAULT_TAG
-> = (
+function _GridItem<E extends React.ElementType = typeof DEFAULT_TAG>(
   {
     children,
     columnStart,
@@ -55,9 +51,9 @@ const _GridItem: PolymorphicComponentWithRef<
     area,
     order,
     ...otherProps
-  },
-  ref,
-) => {
+  }: GridItemProps<E>,
+  ref: React.Ref<any>,
+) {
   const calculatedArea = area
     ? area
     : [
@@ -84,7 +80,7 @@ const _GridItem: PolymorphicComponentWithRef<
       {children}
     </Element>
   );
-};
+}
 
 export const GridItem: PolymorphicComponent<
   GridItemInternalProps,

--- a/packages/core/src/Grid/GridItem/GridItem.tsx
+++ b/packages/core/src/Grid/GridItem/GridItem.tsx
@@ -71,7 +71,6 @@ const _GridItem: PolymorphicComponentWithRef<
 
   return (
     <Element
-      as={DEFAULT_TAG}
       {...boxProps}
       className={cx(
         css({

--- a/packages/core/src/Primitive/Primitive.tsx
+++ b/packages/core/src/Primitive/Primitive.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type { CommonProps } from '../types';
-import isPropValid from '@emotion/is-prop-valid';
 
 type PrimitiveOwnProps<E extends React.ElementType = React.ElementType> = {
   as?: E;
@@ -35,29 +34,6 @@ export type PolymorphicComponentWithRef<
   props: PolymorphicComponentProps<E, P>,
   ref: typeof props.ref,
 ) => React.ReactElement | null;
-
-const defaultElement = 'div';
-
-export function usePrimitive(props: PrimitiveOwnProps) {
-  const {
-    as: Element = defaultElement,
-    testId = undefined,
-    ...otherProps
-  } = props;
-  const validProps: Partial<PrimitiveOwnProps> = {};
-  for (const key in otherProps) {
-    if (isPropValid(key)) {
-      validProps[key] = otherProps[key];
-    } else {
-      console.warn('Invalid prop', key);
-    }
-  }
-
-  return {
-    primitiveProps: { ['data-test-id']: testId, ...validProps, as: undefined },
-    Element,
-  };
-}
 
 // -----------------------------------------------------------------
 

--- a/packages/core/src/Primitive/Primitive.tsx
+++ b/packages/core/src/Primitive/Primitive.tsx
@@ -1,41 +1,4 @@
 import React from 'react';
-import type { CommonProps } from '../types';
-
-type PrimitiveOwnProps<E extends React.ElementType = React.ElementType> = {
-  as?: E;
-} & CommonProps;
-
-type PrimitiveProps<
-  E extends React.ElementType,
-  PropsToOmit extends keyof React.ComponentProps<any> = undefined
-> = PrimitiveOwnProps<E> &
-  Omit<React.ComponentProps<E>, keyof PrimitiveOwnProps | PropsToOmit>;
-
-export type PolymorphicComponentProps<
-  E extends React.ElementType,
-  P,
-  PropsToOmit extends keyof React.ComponentProps<any> = undefined
-> = P & PrimitiveProps<E, PropsToOmit>;
-
-export type PolymorphicComponent<
-  P,
-  D extends React.ElementType = 'div',
-  PropsToOmit extends keyof React.ComponentProps<any> = undefined
-> = (<E extends React.ElementType = D>(
-  props: PolymorphicComponentProps<E, P, PropsToOmit>,
-) => React.ReactElement | null) & {
-  displayName?: string;
-};
-
-export type PolymorphicComponentWithRef<
-  P,
-  D extends React.ElementType = 'div'
-> = <E extends React.ElementType = D>(
-  props: PolymorphicComponentProps<E, P>,
-  ref: typeof props.ref,
-) => React.ReactElement | null;
-
-// -----------------------------------------------------------------
 
 type Overwrite<T, U> = Omit<T, keyof U> & U;
 
@@ -78,7 +41,7 @@ type PolymorphicPropsWithRef<
   E
 >;
 
-export type PolymorphicComponentI<
+export type PolymorphicComponent<
   P,
   D extends React.ElementType,
   OmitAdditionalProps extends keyof any = never

--- a/packages/core/src/Primitive/Primitive.tsx
+++ b/packages/core/src/Primitive/Primitive.tsx
@@ -58,3 +58,56 @@ export function usePrimitive(props: PrimitiveOwnProps) {
     Element,
   };
 }
+
+// -----------------------------------------------------------------
+
+type Overwrite<T, U> = Omit<T, keyof U> & U;
+
+type PropsWithAs<P, E extends React.ElementType> = P & { as?: E };
+
+/**
+ * Use for wrapping/mirroring a HTML Element.
+ *
+ * Example with wrapping button:
+ *
+ * interface ButtonOwnProps {
+ *  customProp: string
+ * }
+ * type ButtonProps = PropsWithHTMLElement<ButtonOwnProps, 'button'>
+ *
+ * export function Button(props: ButtonProps) {
+ *  const { customProp, ...otherProps } = props;
+ *
+ *  return <button {...otherProps} />;
+ * }
+ */
+export type PropsWithHTMLElement<
+  P,
+  E extends React.ElementType,
+  OmitAdditionalProps extends keyof any = never
+> = Overwrite<Omit<React.ComponentPropsWithoutRef<E>, OmitAdditionalProps>, P>;
+
+export type PolymorphicProps<
+  P,
+  E extends React.ElementType,
+  OmitAdditionalProps extends keyof any = never
+> = PropsWithAs<PropsWithHTMLElement<P, E, OmitAdditionalProps>, E>;
+
+type PolymorphicPropsWithRef<
+  P,
+  E extends React.ElementType,
+  OmitAdditionalProps extends keyof any = never
+> = PropsWithAs<
+  Overwrite<Omit<React.ComponentPropsWithRef<E>, OmitAdditionalProps>, P>,
+  E
+>;
+
+export type PolymorphicComponentI<
+  P,
+  D extends React.ElementType,
+  OmitAdditionalProps extends keyof any = never
+> = (<E extends React.ElementType = D>(
+  props: PolymorphicPropsWithRef<P, E, OmitAdditionalProps>,
+) => React.ReactElement | null) & {
+  displayName?: string;
+};

--- a/packages/core/src/Primitive/index.ts
+++ b/packages/core/src/Primitive/index.ts
@@ -1,4 +1,3 @@
-export { usePrimitive } from './Primitive';
 export type {
   PolymorphicComponentProps,
   PolymorphicComponent,

--- a/packages/core/src/Primitive/index.ts
+++ b/packages/core/src/Primitive/index.ts
@@ -3,4 +3,7 @@ export type {
   PolymorphicComponentProps,
   PolymorphicComponent,
   PolymorphicComponentWithRef,
+  PropsWithHTMLElement,
+  PolymorphicProps,
+  PolymorphicComponentI,
 } from './Primitive';

--- a/packages/core/src/Primitive/index.ts
+++ b/packages/core/src/Primitive/index.ts
@@ -1,8 +1,5 @@
 export type {
-  PolymorphicComponentProps,
   PolymorphicComponent,
-  PolymorphicComponentWithRef,
   PropsWithHTMLElement,
   PolymorphicProps,
-  PolymorphicComponentI,
 } from './Primitive';

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.stories.tsx
@@ -36,7 +36,6 @@ export const Default: Story = ({ submenuToggleLabel, ...args }) => {
         <Button
           size="small"
           variant="transparent"
-          isDropdown
           onClick={() => setOpen(!isOpen)}
         >
           Choose more options and settings
@@ -84,7 +83,6 @@ export const Scrollable: Story = (args) => {
         <Button
           size="small"
           variant="transparent"
-          isDropdown
           onClick={() => setOpen(!isOpen)}
         >
           toggle
@@ -128,7 +126,7 @@ export const DynamicContent: Story = (args) => {
       isOpen={isOpen}
       onClose={onClose}
       toggleElement={
-        <Button size="small" variant="transparent" onClick={onClick} isDropdown>
+        <Button size="small" variant="transparent" onClick={onClick}>
           Choose more options and settings
         </Button>
       }
@@ -152,7 +150,6 @@ export const WithFullWidth: Story = (args) => {
         <Button
           size="small"
           variant="transparent"
-          isDropdown
           onClick={() => setOpen(!isOpen)}
         >
           Open dropdown
@@ -192,7 +189,7 @@ export const Overview: Story = () => (
         usePortal
         position="bottom-left"
         toggleElement={
-          <Button size="small" variant="transparent" isDropdown>
+          <Button size="small" variant="transparent">
             Choose more options and settings
           </Button>
         }
@@ -232,7 +229,7 @@ export const Overview: Story = () => (
       isOpen
       isFullWidth
       toggleElement={
-        <Button size="small" variant="transparent" isDropdown>
+        <Button size="small" variant="transparent">
           Open dropdown
         </Button>
       }

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
@@ -76,7 +76,7 @@ export interface EntityListItemProps {
   /**
    * Props to pass down to the default CardDragHandle component (does not work with cardDragHandleComponent prop)
    */
-  cardDragHandleProps?: Partial<DragHandleProps<'button'>>;
+  cardDragHandleProps?: Partial<DragHandleProps>;
   /**
    * An entity can either be an Entry, an Asset or a Release. This prop will apply styling based on if the entity is an asset, a release or an entry
    *
@@ -266,12 +266,13 @@ export function EntityListItem({
                   position="bottom-right"
                   toggleElement={
                     <Button
-                      disabled={isActionsDisabled}
+                      isDisabled={isActionsDisabled}
                       icon={<MoreHorizontalIcon />}
-                      label="Actions"
                       onClick={handleActionClick}
                       variant="transparent"
-                    />
+                    >
+                      Actions
+                    </Button>
                   }
                   usePortal
                 >

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/EntityListItem.tsx
@@ -270,9 +270,8 @@ export function EntityListItem({
                       icon={<MoreHorizontalIcon />}
                       onClick={handleActionClick}
                       variant="transparent"
-                    >
-                      Actions
-                    </Button>
+                      aria-label="Actions"
+                    />
                   }
                   usePortal
                 >

--- a/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/EntityList/EntityListItem/__snapshots__/EntityListItem.test.tsx.snap
@@ -1005,9 +1005,10 @@ exports[`renders the component with a drag handle 1`] = `
   class="EntityListItem"
   data-test-id="cf-ui-entity-list-item"
 >
-  <div
+  <button
     class="emotion-2 EntityListItem__dragHandle"
-    testid="cf-ui-drag-handle"
+    data-test-id="cf-ui-drag-handle"
+    type="button"
   >
     <svg
       aria-hidden="true"
@@ -1028,7 +1029,7 @@ exports[`renders the component with a drag handle 1`] = `
     >
       Reorder entry
     </span>
-  </div>
+  </button>
   <article
     class="EntityListItem__inner"
   >
@@ -1778,10 +1779,10 @@ exports[`renders the component with dropdownListElements 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="menu"
+            aria-label="Actions"
             class="emotion-4"
             data-node-id="dropdown-trigger-61728000"
             data-test-id="cf-ui-button"
-            label="Actions"
             type="button"
           >
             <span

--- a/packages/forma-36-react-components/src/components/Workbench/__snapshots__/Workbench.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Workbench/__snapshots__/Workbench.test.tsx.snap
@@ -9,8 +9,8 @@ exports[`renders the component (complex) 1`] = `
 }
 
 .emotion-1 {
-  margin-bottom: 0;
   margin: 0;
+  margin-bottom: 0;
   padding: 0;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
   font-weight: 600;
@@ -175,8 +175,8 @@ exports[`renders the component (simple) 1`] = `
 }
 
 .emotion-1 {
-  margin-bottom: 0;
   margin: 0;
+  margin-bottom: 0;
   padding: 0;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
   font-weight: 600;

--- a/packages/forma-36-react-components/src/components/Workbench/__snapshots__/Workbench.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Workbench/__snapshots__/Workbench.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`renders the component (complex) 1`] = `
 }
 
 .emotion-1 {
+  margin-bottom: 0;
   margin: 0;
   padding: 0;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
@@ -16,7 +17,6 @@ exports[`renders the component (complex) 1`] = `
   color: #111B2B;
   font-size: 1.25rem;
   line-height: 2rem;
-  margin-bottom: 0;
 }
 
 .emotion-3 {
@@ -175,6 +175,7 @@ exports[`renders the component (simple) 1`] = `
 }
 
 .emotion-1 {
+  margin-bottom: 0;
   margin: 0;
   padding: 0;
   font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
@@ -182,7 +183,6 @@ exports[`renders the component (simple) 1`] = `
   color: #111B2B;
   font-size: 1.25rem;
   line-height: 2rem;
-  margin-bottom: 0;
 }
 
 .emotion-3 {


### PR DESCRIPTION
# Purpose of PR
It's unclear now when/how to use types for polymorphic components or for components that are not polymorphic but need to extend their own props with the default HTML element one.
That's why we ended up having slightly different approaches in our codebase:
- To extend own props we use [PolymorphicComponentProps with unchangeable as prop](https://github.com/contentful/forma-36/blob/c9991a83905b9ebac727946a69a941065ae20afb/packages/components/note/src/Note.tsx#L52)., It seems confusing, because we give `as` prop but fixing it to only one value.
- With the [DragHandle](https://github.com/contentful/forma-36/blob/673e7b39d637afe6d7afa8d1147aa2e24b838525/packages/components/drag-handle/src/DragHandle.tsx#L116) and [List](https://github.com/contentful/forma-36/blob/7e4dc05b740bfc47dbc52c40224dec424d6af841/packages/components/list/src/List.tsx#L31) components I didn't get the idea at all.
- We also for some reason include `CommonProps` initially [to Polymorphic component types](https://github.com/contentful/forma-36/blob/bf0fc7d5b9aa74009825588d822befe018c055ad/packages/core/src/Primitive/Primitive.tsx#L5) and then extending it in component one more time (ex. [Note](https://github.com/contentful/forma-36/blob/c9991a83905b9ebac727946a69a941065ae20afb/packages/components/note/src/Note.tsx#L29), [Button](https://github.com/contentful/forma-36/blob/ca7a3f7775bc2ee64ec80eb1fe09ddf7a9e91836/packages/components/button/src/types.ts#L20))
- The other question is why in some cases we use [usePrimitive](https://github.com/contentful/forma-36/blob/bf0fc7d5b9aa74009825588d822befe018c055ad/packages/core/src/Primitive/Primitive.tsx#L41) helper and in some we are not? What the purpose of this function? And do we need to use it everywhere where we have polymorphic component?

### The PR itself is just a proposal how everything described above can be done in a slightly different way. Just to simplify and bring a bit more clarity
New types working fine with storybook knobs generation and our website docs `<Props of="Component" />`

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
