### PR TITLE
feat: v4 BaseInput

### DIFF
--- a/packages/components/inputs/src/base-input/BaseInput.styles.ts
+++ b/packages/components/inputs/src/base-input/BaseInput.styles.ts
@@ -1,12 +1,12 @@
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 
-export type GetStyleArguments = {
+export type StylesArguments = {
   isDisabled: boolean;
   isInvalid: boolean;
 };
 
-const getInputStyles = ({ isDisabled, isInvalid }: GetStyleArguments) => {
+const getInputStyles = ({ isDisabled, isInvalid }: StylesArguments) => {
   const invalidStyle = {
     borderColor: tokens.red600,
 
@@ -37,7 +37,6 @@ const getInputStyles = ({ isDisabled, isInvalid }: GetStyleArguments) => {
   const baseStyle = {
     outline: 'none',
     boxShadow: tokens.insetBoxShadowDefault,
-    boxSizing: 'border-box',
     backgroundColor: tokens.colorWhite,
     border: `1px solid ${tokens.gray300}`,
     borderRadius: tokens.borderRadiusMedium,
@@ -82,6 +81,6 @@ const getInputStyles = ({ isDisabled, isInvalid }: GetStyleArguments) => {
   return baseStyle;
 };
 
-export default ({ isDisabled, isInvalid }: GetStyleArguments) => ({
+export default ({ isDisabled, isInvalid }: StylesArguments) => ({
   input: css(getInputStyles({ isDisabled, isInvalid })),
 });

--- a/packages/components/inputs/src/base-input/BaseInput.styles.ts
+++ b/packages/components/inputs/src/base-input/BaseInput.styles.ts
@@ -1,0 +1,87 @@
+import { css } from 'emotion';
+import tokens from '@contentful/f36-tokens';
+
+export type GetStyleArguments = {
+  isDisabled: boolean;
+  isInvalid: boolean;
+};
+
+const getInputStyles = ({ isDisabled, isInvalid }: GetStyleArguments) => {
+  const invalidStyle = {
+    borderColor: tokens.red600,
+
+    '&:focus': {
+      boxShadow: tokens.glowNegative,
+    },
+
+    '&:active, &:active:hover': {
+      boxShadow: tokens.glowNegative,
+    },
+  };
+
+  const disabledStyle = {
+    cursor: 'not-allowed',
+    background: tokens.gray100,
+
+    '&:focus': {
+      borderColor: tokens.gray300,
+      boxShadow: 'none',
+    },
+
+    '&:active, &:active:hover': {
+      borderColor: tokens.gray300,
+      boxShadow: 'none',
+    },
+  };
+
+  const baseStyle = {
+    outline: 'none',
+    boxShadow: tokens.insetBoxShadowDefault,
+    boxSizing: 'border-box',
+    backgroundColor: tokens.colorWhite,
+    border: `1px solid ${tokens.gray300}`,
+    borderRadius: tokens.borderRadiusMedium,
+    maxHeight: `calc(1rem * (40 / ${tokens.fontBaseDefault}))`,
+    color: tokens.gray700,
+    fontFamily: tokens.fontStackPrimary,
+    fontSize: tokens.fontSizeM,
+    lineHeight: tokens.lineHeightM,
+    padding: '10px 12px',
+    margin: 0,
+
+    '&::placeholder': {
+      color: tokens.gray500,
+    },
+
+    '&:active, &:active:hover': {
+      borderColor: tokens.blue600,
+      boxShadow: tokens.glowPrimary,
+    },
+
+    '&:focus': {
+      zIndex: tokens.zIndexDefault,
+      borderColor: tokens.blue600,
+      boxShadow: tokens.glowPrimary,
+    },
+  };
+
+  if (isDisabled) {
+    return {
+      ...baseStyle,
+      ...disabledStyle,
+    };
+  }
+
+  if (isInvalid) {
+    return {
+      ...baseStyle,
+      ...invalidStyle,
+    };
+  }
+
+  return baseStyle;
+};
+
+export default ({ isDisabled, isInvalid }: GetStyleArguments) => ({
+  input: css(getInputStyles({ isDisabled, isInvalid })),
+});

--- a/packages/components/inputs/src/base-input/BaseInput.test.tsx
+++ b/packages/components/inputs/src/base-input/BaseInput.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { axe } from '@/scripts/test/axeHelper';
+
+import { BaseInput } from './BaseInput';
+
+describe('InputBase', function () {
+  it('renders the component with all required props', () => {
+    const { getByLabelText } = render(
+      <BaseInput id="InputBase" label="InputBase" />,
+    );
+
+    const input = getByLabelText('InputBase');
+    expect(input).toBeTruthy();
+  });
+
+  it('renders the component with an additional class name', () => {
+    const { container } = render(
+      <BaseInput className="my-extra-class" id="InputBase" label="InputBase" />,
+    );
+
+    expect(container.firstChild).toHaveClass('my-extra-class');
+  });
+
+  it('renders the component with disabled prop', () => {
+    const { getByLabelText } = render(
+      <BaseInput
+        className="my-extra-class"
+        id="InputBase"
+        label="InputBase"
+        isDisabled
+      />,
+    );
+
+    expect(getByLabelText('InputBase')).toBeDisabled();
+  });
+
+  it('renders the component with a value', () => {
+    const { getByLabelText } = render(
+      <BaseInput
+        className="my-extra-class"
+        id="InputBase"
+        label="InputBase"
+        value="someValue"
+      />,
+    );
+
+    expect(getByLabelText('InputBase').getAttribute('value')).toEqual(
+      'someValue',
+    );
+  });
+
+  it('renders textarea when as property is set in the component', () => {
+    const { container } = render(
+      <BaseInput
+        className="my-extra-class"
+        id="InputBase"
+        label="InputBase"
+        value="someValue"
+        as="textarea"
+      />,
+    );
+    // get textarea element from the DOM node
+    const textareaElement = container.querySelector('textarea');
+    expect(textareaElement).toBeInTheDocument();
+  });
+
+  it('can blur when clicking escape', () => {
+    const onBlur = jest.fn();
+    const { getByLabelText } = render(
+      <BaseInput
+        id="InputBase"
+        label="InputBase"
+        onBlur={onBlur}
+        type="text"
+      />,
+    );
+    const input = getByLabelText('InputBase');
+    fireEvent.keyDown(input, {
+      code: 'Escape',
+      target: { blur: onBlur },
+    });
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it('has no a11y issues', async () => {
+    const { container } = render(
+      <BaseInput id="InputBase" label="InputBase" />,
+    );
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/components/inputs/src/base-input/BaseInput.tsx
+++ b/packages/components/inputs/src/base-input/BaseInput.tsx
@@ -1,0 +1,152 @@
+import React, {
+  useEffect,
+  useCallback,
+  FocusEvent,
+  KeyboardEvent,
+  ChangeEvent,
+  useState,
+  ElementType,
+} from 'react';
+import { cx } from 'emotion';
+
+import {
+  usePrimitive,
+  PolymorphicComponentWithRef,
+  PolymorphicComponentProps,
+  PolymorphicComponent,
+} from '@contentful/f36-core';
+import getInputStyles from './BaseInput.styles';
+import { BaseInputInternalProps } from './types';
+
+const DEFAULT_TAG: ElementType = 'input';
+
+export type BaseInputProps<
+  E extends React.ElementType
+> = PolymorphicComponentProps<E, BaseInputInternalProps, 'disabled'>;
+
+const _BaseInput: PolymorphicComponentWithRef<
+  BaseInputInternalProps,
+  typeof DEFAULT_TAG
+> = (props, ref) => {
+  const {
+    as,
+    className,
+    isDisabled,
+    isReadOnly,
+    isInvalid,
+    id,
+    label,
+    name,
+    onBlur,
+    onChange,
+    onFocus,
+    onKeyDown,
+    testId = 'cf-ui-base-input',
+    type = 'text',
+    value,
+    placeholder,
+    willBlurOnEsc = true,
+    style,
+    ...otherProps
+  } = props;
+
+  const { Element, primitiveProps } = usePrimitive({
+    testId,
+    as,
+    className,
+    style,
+  });
+
+  const [valueState, setValueState] = useState<string | undefined>(value);
+
+  const styles = getInputStyles({ isDisabled, isInvalid });
+
+  const handleFocus = (e: FocusEvent) => {
+    e.persist();
+    if (isDisabled) {
+      (e.target as HTMLInputElement).select();
+    }
+  };
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      e.persist();
+      if (isDisabled || isReadOnly) return;
+
+      if (onChange) {
+        onChange(e);
+      }
+      setValueState(e.currentTarget.value);
+    },
+    [onChange, isDisabled, isReadOnly],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      e.persist();
+
+      if (onKeyDown) {
+        onKeyDown(e);
+      }
+
+      if (e.nativeEvent.code === 'Escape' && willBlurOnEsc) {
+        e.currentTarget.blur();
+      }
+    },
+    [willBlurOnEsc, onKeyDown],
+  );
+
+  useEffect(() => {
+    setValueState(value);
+  }, [value]);
+
+  if (as === 'textarea') {
+    return (
+      <Element
+        {...otherProps}
+        {...primitiveProps}
+        data-test-id={testId}
+        placeholder={placeholder}
+        className={cx(styles.input, className)}
+        value={valueState}
+        name={name}
+        type={type}
+        ref={ref}
+        aria-label={label}
+        id={id}
+        disabled={isDisabled}
+        onChange={handleChange}
+        onBlur={onBlur}
+        onKeyDown={handleKeyDown}
+        onFocus={handleFocus}
+      />
+    );
+  }
+
+  return (
+    <Element
+      {...otherProps}
+      {...primitiveProps}
+      data-test-id={testId}
+      placeholder={placeholder}
+      className={cx(styles.input, className)}
+      value={valueState}
+      name={name}
+      type={type}
+      ref={ref}
+      aria-label={label}
+      id={id}
+      disabled={isDisabled}
+      onChange={handleChange}
+      onBlur={onBlur}
+      onKeyDown={handleKeyDown}
+      onFocus={handleFocus}
+    />
+  );
+};
+
+export const BaseInput: PolymorphicComponent<
+  BaseInputInternalProps,
+  typeof DEFAULT_TAG,
+  'disabled'
+> = React.forwardRef(_BaseInput);

--- a/packages/components/inputs/src/base-input/README.mdx
+++ b/packages/components/inputs/src/base-input/README.mdx
@@ -1,0 +1,4 @@
+# @contentful/f36-baseinput
+
+This package is part of the pre-release. This means it is unsupported and subject to breaking changes without warning.
+Please use official, supported version of the library [forma-36](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components), [NPM](https://www.npmjs.com/package/@contentful/forma-36-react-components)

--- a/packages/components/inputs/src/base-input/index.ts
+++ b/packages/components/inputs/src/base-input/index.ts
@@ -1,0 +1,2 @@
+export { BaseInput } from './BaseInput';
+export type { BaseInputProps } from './BaseInput';

--- a/packages/components/inputs/src/base-input/types.ts
+++ b/packages/components/inputs/src/base-input/types.ts
@@ -1,0 +1,77 @@
+import { CommonProps } from '@contentful/f36-core';
+import {
+  EventHandler,
+  FocusEvent,
+  ChangeEventHandler,
+  KeyboardEventHandler,
+} from 'react';
+
+export interface BaseInputInternalProps extends CommonProps {
+  /**
+   * Sets the id of the input
+   */
+  id?: string;
+  /**
+   * Allows to render input | textarea tag
+   */
+  as?: 'input' | 'textarea'; // TODO: we can extend to select
+  /**
+   * Label value is set as aria-label attribute in the input
+   */
+  label: string;
+  /**
+   * Set the value of the input
+   */
+  value?: string;
+  /**
+   * Set the name of the input
+   */
+  name?: string;
+  /**
+   * Set the type of the input
+   * @default text
+   */
+  type?: 'text' | 'email' | 'file' | 'number' | 'password' | 'search' | 'url';
+  // we need to answer the question if we would need the sizes matching sizes of the buttons
+  // variant?: string;
+  /**
+   * Applies disabled styles
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Applies read-only styles
+   * @default false
+   */
+  isReadOnly?: boolean;
+  /**
+   * Applies invalid styles
+   * @default false
+   */
+  isInvalid?: boolean;
+  /**
+   * Property that set the placeholder value for input
+   */
+  placeholder?: string;
+  /**
+   * Boolean property that allows to blur on escape
+   * @default true
+   */
+  willBlurOnEsc?: boolean;
+  /**
+   * Allows to listen to an input’s change in value
+   */
+  onChange?: ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
+  /**
+   * Allows to listen to an event when a key is pressed
+   */
+  onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
+  /**
+   * Allows to listen to an event when an element loses focus
+   */
+  onBlur?: EventHandler<FocusEvent<HTMLTextAreaElement | HTMLInputElement>>;
+  /**
+   * Allows to listen to an event when an element get focused
+   */
+  onFocus?: EventHandler<FocusEvent<HTMLTextAreaElement | HTMLInputElement>>;
+}

--- a/packages/components/inputs/src/index.ts
+++ b/packages/components/inputs/src/index.ts
@@ -1,3 +1,4 @@
 export * from './controlled-input';
 export * from './checkbox';
 export * from './radio-button';
+export * from './base-input';

--- a/packages/components/inputs/stories/InputBase.stories.tsx
+++ b/packages/components/inputs/stories/InputBase.stories.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { BaseInput } from '../src';
+import { Flex } from '@contentful/f36-core';
+
+export default {
+  title: 'Form Elements/BaseInput',
+  component: BaseInput,
+  parameters: {
+    propTypes: [BaseInput['__docgenInfo']],
+  },
+  args: {
+    onBlur: undefined,
+    onChange: undefined,
+    onFocus: undefined,
+  },
+  argTypes: {
+    className: { control: { disable: true } },
+    testId: { control: { disable: true } },
+    style: { control: { disable: true } },
+  },
+};
+
+export const Basic = () => {
+  return (
+    <Flex flexDirection="column">
+      <Flex marginBottom="spacingM">
+        <BaseInput
+          name="someOtherOption"
+          label="this is my label"
+          placeholder="placeholder"
+          id="4"
+          type="text"
+          as="textarea"
+        />
+      </Flex>
+      <Flex marginBottom="spacingM">
+        <BaseInput
+          name="someOtherOption"
+          label="this is my label"
+          placeholder="placeholder"
+          id="3"
+          type="text"
+          as="input"
+        />
+      </Flex>
+
+      <Flex marginBottom="spacingM">
+        <BaseInput
+          name="someOtherOption"
+          label="this is my label"
+          placeholder="placeholder"
+          id="2"
+          type="text"
+          as="input"
+          isInvalid
+        />
+      </Flex>
+
+      <Flex marginBottom="spacingM">
+        <BaseInput
+          name="someOtherOption"
+          label="this is my label"
+          placeholder="placeholder"
+          id="1"
+          type="text"
+          as="input"
+          isDisabled
+        />
+      </Flex>
+    </Flex>
+  );
+};


### PR DESCRIPTION
Attempt to create `BaseInput` component that would drive the `TextInput`, `Textarea` + potentially `Select`.
We could extend `BaseInput` while working on `Select`. 
I am not sure to which extend this component could be a base for `Checkbox` and `Radio`, we could give it a try, but from the first glance we might want to have something separate for those 2 cases - there is additional logic to allow custom styling of those components (previous ControlledInput and ControlledInputField was only used by `Checkbox` and `Radio`)

This would be an internal component. It would be used by, for example, by `TextInput`. In there we would handle label, validation, and help messages + there will be a property `is Standalone` that would allow hiding label (the `aria-label` is always in the input though)

Open questions:
 - @domarku @fabe do we want to allow icons in inputs at the beginning (search for example would be the case that could use that)