### PR TITLE
docs(list): fix list component docs

### DIFF
--- a/packages/components/list/List.mdx
+++ b/packages/components/list/List.mdx
@@ -32,14 +32,14 @@ The List component can be configured in two different ways: to display bulleted 
 ```tsx
 // import { List, ListItem } from '@contentful/f36-components';
 
-<List element="ul">
+<List as="ul">
   <ListItem>List Item 1</ListItem>
   <ListItem>List Item 2</ListItem>
   <ListItem>
     List Item with <TextLink>text link</TextLink>
   </ListItem>
   <ListItem>
-    <List element="ol">
+    <List as="ol">
       <ListItem>Sublist Item 1</ListItem>
       <ListItem>Sublist Item 2</ListItem>
     </List>


### PR DESCRIPTION
A small PR to update List component docs

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
