### PR TITLE
💡 Proposal: remove build from lint and test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,39 @@ commands:
       - run: git show -m HEAD --name-only --pretty="" | egrep -q '<< parameters.pattern >>' || circleci step halt
 
 jobs:
+  build:
+    docker:
+      - image: circleci/node:14.15.0-browsers
+    resource_class: xlarge
+    working_directory: ~/circleci-f36-build
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/circleci-f36-build
+      - yarn_install
+      - run:
+          name: Lerna build
+          command: yarn build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - packages/components/**/dist
+            - packages/core/dist
+            - packages/f36-docs-utils/dist
+            - packages/forma-36-fcss/dist
+            - packages/forma-36-react-components/dist
+            - packages/forma-36-tokens/dist
+            - packages/forma-36-website/public
+
   analyze_code:
     docker:
       - image: circleci/node:14.15.0-browsers
     resource_class: xlarge
+    working_directory: ~/circleci-f36-build
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/circleci-f36-build
       - yarn_install
       - run:
           name: Prettier
@@ -45,8 +72,11 @@ jobs:
     docker:
       - image: circleci/node:14.15.0-browsers
     resource_class: xlarge
+    working_directory: ~/circleci-f36-build
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/circleci-f36-build
       - yarn_install
       - run:
           name: Test
@@ -56,8 +86,11 @@ jobs:
     docker:
       - image: circleci/node:14.15.0-browsers
     resource_class: xlarge
+    working_directory: ~/circleci-f36-build
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/circleci-f36-build
       - check-changed-files-or-halt:
           pattern: ^(packages)|(.js|jsx|ts|tsx|css|scss)$
       - yarn_install
@@ -71,8 +104,11 @@ jobs:
   release:
     docker:
       - image: circleci/node:14.15.0-browsers
+    working_directory: ~/circleci-f36-build
     steps:
       - checkout
+      - attach_workspace:
+          at: ~/circleci-f36-build
       - yarn_install
       - add_ssh_keys:
           fingerprints:
@@ -90,10 +126,16 @@ workflows:
   version: 2
   f36-build:
     jobs:
-      - analyze_code
-      - test
+      - build
+      - analyze_code:
+          requires:
+            - build
+      - test:
+          requires:
+            - build
       - deploy_chromatic:
           requires:
+            - build
             - analyze_code
             - test
           filters:
@@ -102,6 +144,7 @@ workflows:
               ignore: /pull\/[0-9]+/
       - release:
           requires:
+            - build
             - analyze_code
             - test
           filters:


### PR DESCRIPTION
# Purpose of PR

This is a proposal to improve our pipeline, but I'm not sure if it's worth it
It ended up saving up ~20s 🤷‍♂️ 

how it is now:
![Screenshot 2021-08-26 at 11 26 15](https://user-images.githubusercontent.com/6597467/130956213-4530ed90-9ce8-41b1-835e-4c789be25bbe.png)

how it will be if this proposal is accepted:
![Screenshot 2021-08-26 at 11 48 26](https://user-images.githubusercontent.com/6597467/130956266-c3f5d343-e5fb-403f-bb4d-3ebe687dc3c1.png)

### What is this doing?

- create a new `build` job that runs `yarn build` and then saves the built files in a circle workspace, so these files can be used by the other jobs. This way we don't need to run `yarn build` in every job. This not always more efficient because the other jobs still need to download those files etc.
- it splits tests and code analysis(prettier, lint, and tsc) into separated jobs so they can run in parallel. We could separate it even more.... maybe 

So... What do you think? 👍  or 👎 

## CircleCI Workspace

I'm really not good with circle ci things so if you wanna know more, this is [the documentation](https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs) I read to try to implement this.

This is what makes a job save files into a workspace to be used later
```yml
working_directory: ~/circleci-f36-build
- persist_to_workspace:
          root: .
          paths:
            - packages/components/**/dist
            - packages/core/dist
            - packages/f36-docs-utils/dist
            - packages/forma-36-fcss/dist
            - packages/forma-36-react-components/dist
            - packages/forma-36-tokens/dist
            - packages/forma-36-website/public
```

this is what tells a job to consume the saved files
```yml
working_directory: ~/circleci-f36-build
steps:
    - attach_workspace:
          at: ~/circleci-f36-build
```



## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
