### PR TITLE
fix(Autocomplete): add error handling possibility

### DIFF
--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.css
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.css
@@ -1,4 +1,6 @@
 @import 'settings/dimensions';
+@import 'settings/colors';
+@import 'settings/shadows';
 
 .autocompleteDropdown {
   display: block;
@@ -6,6 +8,14 @@
 
 .autocompleteInput {
   display: flex;
+}
+
+.autocompleteInputNegative input {
+  border-color: var(--color-negative);
+}
+
+.autocompleteInputNegative input:focus {
+  box-shadow: var(--glow-negative);
 }
 
 .autocompleteInput input::-webkit-search-cancel-button {
@@ -19,4 +29,9 @@
 .autocompleteInput .inputIconButton {
   position: relative;
   margin-left: calc(-1 * var(--spacing-xl));
+}
+
+.validationMessage {
+  position: absolute;
+  top: calc(40px + var(--spacing-s));
 }

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import { Autocomplete, AutocompleteProps } from './Autocomplete';
+import { Subheading } from './../Typography/Subheading/Subheading';
 
 export default {
   title: 'Components/Autocomplete',
@@ -132,7 +133,7 @@ export const MultiSelect = (args: AutocompleteProps<{}>) => {
           ))
         }
       </Autocomplete>
-      <h3>Shopping List:</h3>
+      <Subheading>Shopping List:</Subheading>
       <ul>
         {tagElements.map((tag: string, idx: number) => (
           <li key={`element-${tag}-${idx}`}>{tag}</li>

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -86,7 +86,6 @@ export const ErrorHandling = (args: AutocompleteProps<{}>) => {
       items={filteredItems}
       onChange={handleChange}
       selectedItem={selectedItem}
-      error={true}
       validationMessage="This field is required"
     >
       {(options: Item[]) =>

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.stories.tsx
@@ -64,6 +64,47 @@ Basic.args = {
   emptyListMessage: 'There are no items to choose from',
   noMatchesMessage: 'No matches',
 };
+
+export const ErrorHandling = (args: AutocompleteProps<{}>) => {
+  const [filteredItems, setFilteredItems] = useState(items);
+  const [selectedItem, setSelectedItem] = useState('');
+
+  const handleQueryChange = (query: string) => {
+    setFilteredItems(
+      query ? items.filter((item) => item.label.includes(query)) : items,
+    );
+  };
+
+  const handleChange = (item: Item) => {
+    setSelectedItem(item.label);
+  };
+
+  return (
+    <Autocomplete<Item>
+      {...args}
+      onQueryChange={handleQueryChange}
+      items={filteredItems}
+      onChange={handleChange}
+      selectedItem={selectedItem}
+      error={true}
+      validationMessage="This field is required"
+    >
+      {(options: Item[]) =>
+        options.map((option: Item) => (
+          <span key={option.value}>{option.label}</span>
+        ))
+      }
+    </Autocomplete>
+  );
+};
+
+ErrorHandling.args = {
+  placeholder: 'Find fruit',
+  width: 'full',
+  emptyListMessage: 'There are no items to choose from',
+  noMatchesMessage: 'No matches',
+};
+
 export const MultiSelect = (args: AutocompleteProps<{}>) => {
   const [filteredItems, setFilteredItems] = useState(items);
   const [tagElements, setTagElements] = useState([]);
@@ -92,10 +133,10 @@ export const MultiSelect = (args: AutocompleteProps<{}>) => {
           ))
         }
       </Autocomplete>
-      Shopping List:
+      <h3>Shopping List:</h3>
       <ul>
-        {tagElements.map((tag: string) => (
-          <li key={`element-${tag}`}>{tag}</li>
+        {tagElements.map((tag: string, idx: number) => (
+          <li key={`element-${tag}-${idx}`}>{tag}</li>
         ))}
       </ul>
     </>

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.test.tsx
@@ -31,6 +31,8 @@ describe('Autocomplete', () => {
     placeholder = '',
     width = 'large',
     selectedItem = '',
+    error = false,
+    validationMessage = '',
     dropdownProps = {
       isOpen: false,
       children: null,
@@ -49,6 +51,8 @@ describe('Autocomplete', () => {
         selectedItem={selectedItem}
         width={width}
         dropdownProps={dropdownProps}
+        error={error}
+        validationMessage={validationMessage}
       >
         {(options: Item[]) =>
           options.map((option) => (
@@ -87,6 +91,21 @@ describe('Autocomplete', () => {
       const { getByTestId } = build({ selectedItem: 'Coriander' });
       const input = getByTestId('autocomplete.input');
       expect(input).toHaveAttribute('value', 'Coriander');
+    });
+
+    it('shows an error state', () => {
+      const { getByTestId } = build({
+        error: true,
+        validationMessage: 'This field is required',
+      });
+      const validationMessageComponent = getByTestId(
+        'cf-ui-validation-message',
+      );
+      const autocompleteComp = getByTestId('cf-ui-dropdown');
+      expect(autocompleteComp.firstChild).toHaveClass(
+        'autocompleteInputNegative',
+      );
+      expect(validationMessageComponent).toBeDefined();
     });
 
     it('shows the dropdown', async () => {

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.test.tsx
@@ -31,7 +31,6 @@ describe('Autocomplete', () => {
     placeholder = '',
     width = 'large',
     selectedItem = '',
-    error = false,
     validationMessage = '',
     dropdownProps = {
       isOpen: false,
@@ -51,7 +50,6 @@ describe('Autocomplete', () => {
         selectedItem={selectedItem}
         width={width}
         dropdownProps={dropdownProps}
-        error={error}
         validationMessage={validationMessage}
       >
         {(options: Item[]) =>
@@ -95,7 +93,6 @@ describe('Autocomplete', () => {
 
     it('shows an error state', () => {
       const { getByTestId } = build({
-        error: true,
         validationMessage: 'This field is required',
       });
       const validationMessageComponent = getByTestId(

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useReducer, useRef, ChangeEvent } from 'react';
-import cn from 'classnames';
+import cx from 'classnames';
 
 import { TextInput } from '../TextInput';
 import {
@@ -51,7 +51,6 @@ export interface AutocompleteProps<T extends {}> {
   willClearQueryOnClose?: boolean;
   dropdownProps?: DropdownProps;
   renderToggleElement?: (props: RenderToggleElementProps) => React.ReactElement;
-  error?: boolean;
   validationMessage?: string;
 }
 
@@ -118,7 +117,6 @@ export const Autocomplete = <T extends {}>({
   willClearQueryOnClose,
   dropdownProps,
   renderToggleElement,
-  error,
   validationMessage,
 }: AutocompleteProps<T>) => {
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -198,9 +196,9 @@ export const Autocomplete = <T extends {}>({
     [children, items],
   );
 
-  const dropdownClassNames = cn(styles.autocompleteDropdown, className);
-  const autocompleteClassNames = cn(styles.autocompleteInput, {
-    [styles.autocompleteInputNegative]: error,
+  const dropdownClassNames = cx(styles.autocompleteDropdown, className);
+  const autocompleteClassNames = cx(styles.autocompleteInput, {
+    [styles.autocompleteInputNegative]: validationMessage,
   });
 
   function renderDefaultToggleElement(toggleProps: RenderToggleElementProps) {

--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -10,6 +10,7 @@ import {
 } from '../Dropdown';
 import { SkeletonBodyText, SkeletonContainer } from '../Skeleton';
 import { IconButton } from '../IconButton';
+import { ValidationMessage } from '../ValidationMessage';
 import { KEY_CODE } from './utils';
 import styles from './Autocomplete.css';
 
@@ -50,6 +51,8 @@ export interface AutocompleteProps<T extends {}> {
   willClearQueryOnClose?: boolean;
   dropdownProps?: DropdownProps;
   renderToggleElement?: (props: RenderToggleElementProps) => React.ReactElement;
+  error?: boolean;
+  validationMessage?: string;
 }
 
 interface State {
@@ -115,6 +118,8 @@ export const Autocomplete = <T extends {}>({
   willClearQueryOnClose,
   dropdownProps,
   renderToggleElement,
+  error,
+  validationMessage,
 }: AutocompleteProps<T>) => {
   const listRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -194,36 +199,46 @@ export const Autocomplete = <T extends {}>({
   );
 
   const dropdownClassNames = cn(styles.autocompleteDropdown, className);
+  const autocompleteClassNames = cn(styles.autocompleteInput, {
+    [styles.autocompleteInputNegative]: error,
+  });
 
   function renderDefaultToggleElement(toggleProps: RenderToggleElementProps) {
     return (
-      <div className={styles.autocompleteInput}>
-        <TextInput
-          value={toggleProps.selectedItem || toggleProps.query}
-          onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            toggleProps.onChange(e.target.value)
-          }
-          onFocus={toggleProps.onFocus}
-          onKeyDown={toggleProps.onKeyDown}
-          disabled={toggleProps.disabled}
-          placeholder={toggleProps.placeholder}
-          width={toggleProps.width}
-          inputRef={toggleProps.inputRef}
-          testId="autocomplete.input"
-          type="search"
-          autoComplete="off"
-          aria-label={toggleProps.name}
-        />
-        <IconButton
-          className={styles.inputIconButton}
-          tabIndex={-1}
-          disabled={toggleProps.disabled}
-          buttonType="muted"
-          iconProps={{ icon: toggleProps.query ? 'Close' : 'ChevronDown' }}
-          onClick={toggleProps.onToggle}
-          label={toggleProps.query ? 'Clear' : 'Show list'}
-        />
-      </div>
+      <>
+        <div className={autocompleteClassNames}>
+          <TextInput
+            value={toggleProps.selectedItem || toggleProps.query}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              toggleProps.onChange(e.target.value)
+            }
+            onFocus={toggleProps.onFocus}
+            onKeyDown={toggleProps.onKeyDown}
+            disabled={toggleProps.disabled}
+            placeholder={toggleProps.placeholder}
+            width={toggleProps.width}
+            inputRef={toggleProps.inputRef}
+            testId="autocomplete.input"
+            type="search"
+            autoComplete="off"
+            aria-label={toggleProps.name}
+          />
+          <IconButton
+            className={styles.inputIconButton}
+            tabIndex={-1}
+            disabled={toggleProps.disabled}
+            buttonType="muted"
+            iconProps={{ icon: toggleProps.query ? 'Close' : 'ChevronDown' }}
+            onClick={toggleProps.onToggle}
+            label={toggleProps.query ? 'Clear' : 'Show list'}
+          />
+        </div>
+        {validationMessage && (
+          <ValidationMessage className={styles.validationMessage}>
+            {validationMessage}
+          </ValidationMessage>
+        )}
+      </>
     );
   }
 

--- a/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
@@ -34,6 +34,8 @@ by either saving all selected items in an array of items or forwarding only the 
 
 ## Code examples
 
+Default Usage, set the selected item as value of the text input.
+
 ```jsx
 // import { Autocomplete } from '@contentful/forma-36-react-components';
 function AutocompleteExample() {
@@ -48,14 +50,11 @@ function AutocompleteExample() {
   const [filteredItems, setFilteredItems] = React.useState(items);
   const [selectedItem, setSelectedItem] = React.useState();
 
-  const handleQueryChange = React.useCallback(
-    (query) => {
-      setFilteredItems(
-        query ? items.filter((item) => item.label.includes(query)) : items,
-      );
-    },
-    [setFilteredItems],
-  );
+  const handleQueryChange = (query) => {
+    setFilteredItems(
+      query ? items.filter((item) => item.label.includes(query)) : items,
+    );
+  };
 
   const handleOnChange = (item) => {
     setSelectedItem(item.label);
@@ -78,6 +77,119 @@ function AutocompleteExample() {
         options.map((option) => <span key={option.value}>{option.label}</span>)
       }
     </Autocomplete>
+  );
+}
+```
+
+Usage for filling in a list of items.
+
+```jsx
+// import { Autocomplete } from '@contentful/forma-36-react-components';
+function AutocompleteExample() {
+  const items = [
+    { value: 1, label: 'Ananas' },
+    { value: 2, label: 'Apple' },
+    { value: 3, label: 'Banana' },
+    { value: 4, label: 'Lemon' },
+    { value: 5, label: 'Avocado' },
+  ];
+
+  const [filteredItems, setFilteredItems] = React.useState(items);
+  const [selectedItems, setSelectedItems] = React.useState([]);
+
+  const handleQueryChange = (query) => {
+    setFilteredItems(
+      query ? items.filter((item) => item.label.includes(query)) : items,
+    );
+  };
+
+  const handleOnChange = (item) => {
+    setSelectedItems((tagElements) => [...tagElements, item.label]);
+  };
+
+  return (
+    <>
+      <Autocomplete
+        items={filteredItems}
+        onQueryChange={handleQueryChange}
+        width={'full'}
+        placeholder={'search'}
+        emptyListMessage={'no result found'}
+        noMatchesMessage={'no matches'}
+        dropdownProps={{ isFullWidth: true }}
+        disabled={false}
+        onChange={handleOnChange}
+        maxHeight={100}
+      >
+        {(options) =>
+          options.map((option) => (
+            <span key={option.value}>{option.label}</span>
+          ))
+        }
+      </Autocomplete>
+      <h3>Shopping List</h3>
+      <ul>
+        {selectedItems.map((item, index) => (
+          <li key={`element-${item}-${index}`}>{item}</li>
+        ))}
+      </ul>
+    </>
+  );
+}
+```
+
+Example for showing error messages
+
+```jsx
+// import { Autocomplete } from '@contentful/forma-36-react-components';
+function AutocompleteExample() {
+  const items = [
+    { value: 1, label: 'Ananas' },
+    { value: 2, label: 'Apple' },
+    { value: 3, label: 'Banana' },
+    { value: 4, label: 'Lemon' },
+    { value: 5, label: 'Avocado' },
+  ];
+
+  const [filteredItems, setFilteredItems] = React.useState(items);
+  const [selectedItem, setSelectedItem] = React.useState();
+
+  const handleQueryChange = (query) => {
+    setFilteredItems(
+      query ? items.filter((item) => item.label.includes(query)) : items,
+    );
+  };
+
+  const handleOnChange = (item) => {
+    setSelectedItem(item.label);
+  };
+
+  return (
+    <div>
+      <span>Favorit Fruit *</span>
+      <Autocomplete
+        id="autocomplete"
+        items={filteredItems}
+        onQueryChange={handleQueryChange}
+        width={'full'}
+        placeholder={'search'}
+        emptyListMessage={'no result found'}
+        noMatchesMessage={'no matches'}
+        dropdownProps={{ isFullWidth: true }}
+        disabled={false}
+        onChange={handleOnChange}
+        selectedItem={selectedItem}
+        error={true}
+        validationMessage="This item is required"
+      >
+        {(options) =>
+          options.map((option) => (
+            <span key={option.value}>{option.label}</span>
+          ))
+        }
+      </Autocomplete>
+      <p style={{ marginTop: '45px' }}>* Required fields</p>
+    </div>
   );
 }
 ```

--- a/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/README.mdx
@@ -69,7 +69,6 @@ function AutocompleteExample() {
       emptyListMessage={'no result found'}
       noMatchesMessage={'no matches'}
       dropdownProps={{ isFullWidth: true }}
-      disabled={false}
       onChange={handleOnChange}
       selectedItem={selectedItem}
     >
@@ -117,7 +116,6 @@ function AutocompleteExample() {
         emptyListMessage={'no result found'}
         noMatchesMessage={'no matches'}
         dropdownProps={{ isFullWidth: true }}
-        disabled={false}
         onChange={handleOnChange}
         maxHeight={100}
       >
@@ -176,10 +174,8 @@ function AutocompleteExample() {
         emptyListMessage={'no result found'}
         noMatchesMessage={'no matches'}
         dropdownProps={{ isFullWidth: true }}
-        disabled={false}
         onChange={handleOnChange}
         selectedItem={selectedItem}
-        error={true}
         validationMessage="This item is required"
       >
         {(options) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7002,17 +7002,17 @@
     tsutils "^3.17.1"
 
 "@typescript-eslint/eslint-plugin@^4.12.0":
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.12.0.tgz#00d1b23b40b58031e6d7c04a5bc6c1a30a2e834a"
-  integrity sha512-wHKj6q8s70sO5i39H2g1gtpCXCvjVszzj6FFygneNFyIAxRvNSVz9GML7XpqrB9t7hNutXw+MHnLN/Ih6uyB8Q==
+  version "4.29.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.3.tgz#95cb8029a8bd8bd9c7f4ab95074a7cb2115adefa"
+  integrity sha512-tBgfA3K/3TsZY46ROGvoRxQr1wBkclbVqRQep97MjVHJzcRBURRY3sNFqLk0/Xr//BY5hM9H2p/kp+6qim85SA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.12.0"
-    "@typescript-eslint/scope-manager" "4.12.0"
-    debug "^4.1.1"
+    "@typescript-eslint/experimental-utils" "4.29.3"
+    "@typescript-eslint/scope-manager" "4.29.3"
+    debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
-    regexpp "^3.0.0"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+    regexpp "^3.1.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
 "@typescript-eslint/experimental-utils@2.34.0":
   version "2.34.0"
@@ -7024,39 +7024,15 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/experimental-utils@4.12.0":
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.12.0.tgz#372838e76db76c9a56959217b768a19f7129546b"
-  integrity sha512-MpXZXUAvHt99c9ScXijx7i061o5HEjXltO+sbYfZAAHxv3XankQkPaNi5myy0Yh0Tyea3Hdq1pi7Vsh0GJb0fA==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.12.0"
-    "@typescript-eslint/types" "4.12.0"
-    "@typescript-eslint/typescript-estree" "4.12.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
-"@typescript-eslint/experimental-utils@^4.0.1":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.0.tgz#19b1417602d0e1ef325b3312ee95f61220542df5"
-  integrity sha512-FpNVKykfeaIxlArLUP/yQfv/5/3rhl1ov6RWgud4OgbqWLkEq7lqgQU9iiavZRzpzCRQV4XddyFz3wFXdkiX9w==
+"@typescript-eslint/experimental-utils@4.29.3", "@typescript-eslint/experimental-utils@^4.0.1", "@typescript-eslint/experimental-utils@^4.24.0":
+  version "4.29.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.3.tgz#52e437a689ccdef73e83c5106b34240a706f15e1"
+  integrity sha512-ffIvbytTVWz+3keg+Sy94FG1QeOvmV9dP2YSdLFHw/ieLXWCa3U1TYu8IRCOpMv2/SPS8XqhM1+ou1YHsdzKrg==
   dependencies:
     "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.29.0"
-    "@typescript-eslint/types" "4.29.0"
-    "@typescript-eslint/typescript-estree" "4.29.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
-
-"@typescript-eslint/experimental-utils@^4.24.0":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz#0af2b17b0296b60c6b207f11062119fa9c5a8994"
-  integrity sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==
-  dependencies:
-    "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.29.1"
-    "@typescript-eslint/types" "4.29.1"
-    "@typescript-eslint/typescript-estree" "4.29.1"
+    "@typescript-eslint/scope-manager" "4.29.3"
+    "@typescript-eslint/types" "4.29.3"
+    "@typescript-eslint/typescript-estree" "4.29.3"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
@@ -7088,36 +7064,23 @@
     "@typescript-eslint/types" "4.12.0"
     "@typescript-eslint/visitor-keys" "4.12.0"
 
-"@typescript-eslint/scope-manager@4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.0.tgz#cf5474f87321bedf416ef65839b693bddd838599"
-  integrity sha512-HPq7XAaDMM3DpmuijxLV9Io8/6pQnliiXMQUcAdjpJJSR+fdmbD/zHCd7hMkjJn04UQtCQBtshgxClzg6NIS2w==
+"@typescript-eslint/scope-manager@4.29.3":
+  version "4.29.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.3.tgz#497dec66f3a22e459f6e306cf14021e40ec86e19"
+  integrity sha512-x+w8BLXO7iWPkG5mEy9bA1iFRnk36p/goVlYobVWHyDw69YmaH9q6eA+Fgl7kYHmFvWlebUTUfhtIg4zbbl8PA==
   dependencies:
-    "@typescript-eslint/types" "4.29.0"
-    "@typescript-eslint/visitor-keys" "4.29.0"
-
-"@typescript-eslint/scope-manager@4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz#f25da25bc6512812efa2ce5ebd36619d68e61358"
-  integrity sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==
-  dependencies:
-    "@typescript-eslint/types" "4.29.1"
-    "@typescript-eslint/visitor-keys" "4.29.1"
+    "@typescript-eslint/types" "4.29.3"
+    "@typescript-eslint/visitor-keys" "4.29.3"
 
 "@typescript-eslint/types@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.12.0.tgz#fb891fe7ccc9ea8b2bbd2780e36da45d0dc055e5"
   integrity sha512-N2RhGeheVLGtyy+CxRmxdsniB7sMSCfsnbh8K/+RUIXYYq3Ub5+sukRCjVE80QerrUBvuEvs4fDhz5AW/pcL6g==
 
-"@typescript-eslint/types@4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.0.tgz#c8f1a1e4441ea4aca9b3109241adbc145f7f8a4e"
-  integrity sha512-2YJM6XfWfi8pgU2HRhTp7WgRw78TCRO3dOmSpAvIQ8MOv4B46JD2chnhpNT7Jq8j0APlIbzO1Bach734xxUl4A==
-
-"@typescript-eslint/types@4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.1.tgz#94cce6cf7cc83451df03339cda99d326be2feaf5"
-  integrity sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==
+"@typescript-eslint/types@4.29.3":
+  version "4.29.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.3.tgz#d7980c49aef643d0af8954c9f14f656b7fd16017"
+  integrity sha512-s1eV1lKNgoIYLAl1JUba8NhULmf+jOmmeFO1G5MN/RBCyyzg4TIOfIOICVNC06lor+Xmy4FypIIhFiJXOknhIg==
 
 "@typescript-eslint/typescript-estree@2.34.0":
   version "2.34.0"
@@ -7146,26 +7109,13 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.0.tgz#af7ab547757b86c91bfdbc54ff86845410856256"
-  integrity sha512-8ZpNHDIOyqzzgZrQW9+xQ4k5hM62Xy2R4RPO3DQxMc5Rq5QkCdSpk/drka+DL9w6sXNzV5nrdlBmf8+x495QXQ==
+"@typescript-eslint/typescript-estree@4.29.3":
+  version "4.29.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.3.tgz#1bafad610015c4ded35c85a70b6222faad598b40"
+  integrity sha512-45oQJA0bxna4O5TMwz55/TpgjX1YrAPOI/rb6kPgmdnemRZx/dB0rsx+Ku8jpDvqTxcE1C/qEbVHbS3h0hflag==
   dependencies:
-    "@typescript-eslint/types" "4.29.0"
-    "@typescript-eslint/visitor-keys" "4.29.0"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/typescript-estree@4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz#7b32a25ff8e51f2671ccc6b26cdbee3b1e6c5e7f"
-  integrity sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==
-  dependencies:
-    "@typescript-eslint/types" "4.29.1"
-    "@typescript-eslint/visitor-keys" "4.29.1"
+    "@typescript-eslint/types" "4.29.3"
+    "@typescript-eslint/visitor-keys" "4.29.3"
     debug "^4.3.1"
     globby "^11.0.3"
     is-glob "^4.0.1"
@@ -7180,20 +7130,12 @@
     "@typescript-eslint/types" "4.12.0"
     eslint-visitor-keys "^2.0.0"
 
-"@typescript-eslint/visitor-keys@4.29.0":
-  version "4.29.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.0.tgz#1ff60f240def4d85ea68d4fd2e4e9759b7850c04"
-  integrity sha512-LoaofO1C/jAJYs0uEpYMXfHboGXzOJeV118X4OsZu9f7rG7Pr9B3+4HTU8+err81rADa4xfQmAxnRnPAI2jp+Q==
+"@typescript-eslint/visitor-keys@4.29.3":
+  version "4.29.3"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.3.tgz#c691760a00bd86bf8320d2a90a93d86d322f1abf"
+  integrity sha512-MGGfJvXT4asUTeVs0Q2m+sY63UsfnA+C/FDgBKV3itLBmM9H0u+URcneePtkd0at1YELmZK6HSolCqM4Fzs6yA==
   dependencies:
-    "@typescript-eslint/types" "4.29.0"
-    eslint-visitor-keys "^2.0.0"
-
-"@typescript-eslint/visitor-keys@4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz#0615be8b55721f5e854f3ee99f1a714f2d093e5d"
-  integrity sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==
-  dependencies:
-    "@typescript-eslint/types" "4.29.1"
+    "@typescript-eslint/types" "4.29.3"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.9.0":
@@ -28727,14 +28669,7 @@ tslib@~2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
   integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
-tsutils@^3.17.1:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.18.0.tgz#38add50a28ec97e988cb43c5b32e55d1ff4a222a"
-  integrity sha512-D9Tu8nE3E7D1Bsf/V29oMHceMf+gnVO+pDguk/A5YRo1cLpkiQ48ZnbbS57pvvHeY+OIeNQx1vf4ASPlEtRpcA==
-  dependencies:
-    tslib "^1.8.1"
-
-tsutils@^3.21.0:
+tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR
![image](https://user-images.githubusercontent.com/1789174/130990145-e362e6ed-1993-4d27-9af2-ea7bba9d73c0.png)

The Autocomplete component was not able to handle a possible error state e.g. if the component is required. Now it accepts a boolean prop named error as well as a validationMessage to display below the component.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added & updated
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
