### PR TITLE
fix: allow isDisabled property for CopyButton

### DIFF
--- a/packages/components/copybutton/src/CopyButton.styles.ts
+++ b/packages/components/copybutton/src/CopyButton.styles.ts
@@ -31,4 +31,18 @@ export const getStyles = () => ({
       boxShadow: tokens.glowMuted,
     },
   }),
+  copyButtonDisbaled: css({
+    cursor: 'not-allowed',
+    backgroundColor: tokens.gray100,
+
+    '&:focus': {
+      borderColor: tokens.gray300,
+      boxShadow: 'none',
+    },
+
+    '&:active, &:active:hover': {
+      borderColor: tokens.gray300,
+      boxShadow: 'none',
+    },
+  }),
 });

--- a/packages/components/copybutton/src/CopyButton.styles.ts
+++ b/packages/components/copybutton/src/CopyButton.styles.ts
@@ -31,7 +31,7 @@ export const getStyles = () => ({
       boxShadow: tokens.glowMuted,
     },
   }),
-  copyButtonDisbaled: css({
+  copyButtonDisabled: css({
     cursor: 'not-allowed',
     backgroundColor: tokens.gray100,
 

--- a/packages/components/copybutton/src/CopyButton.tsx
+++ b/packages/components/copybutton/src/CopyButton.tsx
@@ -93,7 +93,7 @@ function _CopyButton(props: CopyButtonProps, ref: React.Ref<HTMLDivElement>) {
             type="button"
             ref={button}
             className={cx(styles.copyButton, {
-              [styles.copyButtonDisbaled]: isDisabled,
+              [styles.copyButtonDisabled]: isDisabled,
             })}
             aria-label={`Copy ${value} to clipboard`}
             disabled={isDisabled}

--- a/packages/components/copybutton/src/CopyButton.tsx
+++ b/packages/components/copybutton/src/CopyButton.tsx
@@ -83,33 +83,25 @@ function _CopyButton(props: CopyButtonProps, ref: React.Ref<HTMLDivElement>) {
       className={cx(styles.wrapper, className)}
       {...otherProps}
     >
-      {isDisabled ? (
-        <button
-          type="button"
-          ref={button}
-          className={cx(styles.copyButton, styles.copyButtonDisbaled)}
-          aria-label={`Copy ${value} to clipboard`}
-          disabled={isDisabled}
+      <CopyToClipboard text={value} onCopy={handleOnCopy}>
+        <Tooltip
+          content={copied ? tooltipCopiedText : tooltipText}
+          {...tooltipProps}
+          isDisabled={isDisabled}
         >
-          <CopyIcon variant="muted" />
-        </button>
-      ) : (
-        <CopyToClipboard text={value} onCopy={handleOnCopy}>
-          <Tooltip
-            content={copied ? tooltipCopiedText : tooltipText}
-            {...tooltipProps}
+          <button
+            type="button"
+            ref={button}
+            className={cx(styles.copyButton, {
+              [styles.copyButtonDisbaled]: isDisabled,
+            })}
+            aria-label={`Copy ${value} to clipboard`}
+            disabled={isDisabled}
           >
-            <button
-              type="button"
-              ref={button}
-              className={cx(styles.copyButton)}
-              aria-label={`Copy ${value} to clipboard`}
-            >
-              <CopyIcon variant="muted" />
-            </button>
-          </Tooltip>
-        </CopyToClipboard>
-      )}
+            <CopyIcon variant="muted" />
+          </button>
+        </Tooltip>
+      </CopyToClipboard>
     </div>
   );
 }

--- a/packages/components/copybutton/src/CopyButton.tsx
+++ b/packages/components/copybutton/src/CopyButton.tsx
@@ -36,7 +36,7 @@ export interface CopyButtonProps extends CommonProps {
    */
   label?: string;
   /**
-   * Allows to disbale the copy button, when true, tooltip would not be shown
+   * Allows to disable the copy button, when true the tooltip would not be shown
    * @default false
    */
   isDisabled?: boolean;

--- a/packages/components/copybutton/src/CopyButton.tsx
+++ b/packages/components/copybutton/src/CopyButton.tsx
@@ -35,6 +35,11 @@ export interface CopyButtonProps extends CommonProps {
    * @default Copy {value} to clipboard
    */
   label?: string;
+  /**
+   * Allows to disbale the copy button, when true, tooltip would not be shown
+   * @default false
+   */
+  isDisabled?: boolean;
 }
 
 function _CopyButton(props: CopyButtonProps, ref: React.Ref<HTMLDivElement>) {
@@ -46,6 +51,7 @@ function _CopyButton(props: CopyButtonProps, ref: React.Ref<HTMLDivElement>) {
     tooltipText = 'Copy to clipboard',
     tooltipCopiedText = 'Copied!',
     tooltipProps,
+    isDisabled = false,
     ...otherProps
   } = props;
   const styles = getStyles();
@@ -77,21 +83,33 @@ function _CopyButton(props: CopyButtonProps, ref: React.Ref<HTMLDivElement>) {
       className={cx(styles.wrapper, className)}
       {...otherProps}
     >
-      <CopyToClipboard text={value} onCopy={handleOnCopy}>
-        <Tooltip
-          content={copied ? tooltipCopiedText : tooltipText}
-          {...tooltipProps}
+      {isDisabled ? (
+        <button
+          type="button"
+          ref={button}
+          className={cx(styles.copyButton, styles.copyButtonDisbaled)}
+          aria-label={`Copy ${value} to clipboard`}
+          disabled={isDisabled}
         >
-          <button
-            type="button"
-            ref={button}
-            className={cx(styles.copyButton)}
-            aria-label={`Copy ${value} to clipboard`}
+          <CopyIcon variant="muted" />
+        </button>
+      ) : (
+        <CopyToClipboard text={value} onCopy={handleOnCopy}>
+          <Tooltip
+            content={copied ? tooltipCopiedText : tooltipText}
+            {...tooltipProps}
           >
-            <CopyIcon variant="muted" />
-          </button>
-        </Tooltip>
-      </CopyToClipboard>
+            <button
+              type="button"
+              ref={button}
+              className={cx(styles.copyButton)}
+              aria-label={`Copy ${value} to clipboard`}
+            >
+              <CopyIcon variant="muted" />
+            </button>
+          </Tooltip>
+        </CopyToClipboard>
+      )}
     </div>
   );
 }

--- a/packages/components/tooltip/src/Tooltip.tsx
+++ b/packages/components/tooltip/src/Tooltip.tsx
@@ -88,6 +88,11 @@ export interface TooltipProps extends CommonProps {
    * Defaults to `false`
    */
   usePortal?: boolean;
+  /**
+   * Prevents from showing the tooltip
+   * @default false
+   */
+  isDisabled?: boolean;
 }
 
 export const Tooltip = ({
@@ -108,6 +113,7 @@ export const Tooltip = ({
   testId = 'cf-ui-tooltip',
   placement = 'auto',
   usePortal = false,
+  isDisabled = false,
   ...otherProps
 }: TooltipProps) => {
   const styles = getStyles();
@@ -166,7 +172,7 @@ export const Tooltip = ({
     ...popperStyles.popper,
   };
 
-  if (!content) {
+  if (!content || isDisabled) {
     return (
       <Box as={HtmlTag} className={targetWrapperClassName}>
         {children}

--- a/packages/components/tooltip/src/Tooltip.tsx
+++ b/packages/components/tooltip/src/Tooltip.tsx
@@ -89,7 +89,7 @@ export interface TooltipProps extends CommonProps {
    */
   usePortal?: boolean;
   /**
-   * Prevents from showing the tooltip
+   * Prevents showing the tooltip
    * @default false
    */
   isDisabled?: boolean;


### PR DESCRIPTION
We would need to allow CopyButton to be disbaled on order to make it work nicely with input, when it's disbaled.

When CopyButton is disabled, we should not show the tooltip.