### PR TITLE
feat(switch): add sizes to Switch input component

### DIFF
--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.styles.ts
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.styles.ts
@@ -2,31 +2,49 @@ import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 import type { BaseCheckboxInternalProps } from './types';
 
+const sizeToStyle = (size) => {
+  if (size === 'small') {
+    return {
+      height: tokens.spacingM,
+      width: tokens.spacingXl,
+    };
+  }
+
+  return {
+    height: '20px',
+    width: '40px',
+  };
+};
+
 const getStyles = ({
   isDisabled,
   type,
-}: Pick<BaseCheckboxInternalProps, 'isDisabled' | 'type'>) => ({
+  size,
+}: Pick<BaseCheckboxInternalProps, 'isDisabled' | 'type' | 'size'>) => ({
   wrapper: css({
     alignItems: 'center',
     display: 'inline-flex',
     position: 'relative',
     margin: '0',
   }),
-  input: css({
-    cursor: isDisabled ? 'not-allowed' : 'pointer',
-    height: tokens.spacingM,
-    margin: 0,
-    opacity: 0,
-    position: 'absolute',
-    width: type === 'switch' ? tokens.spacingXl : tokens.spacingM,
-    zIndex: tokens.zIndexDefault,
-    '&:focus': {
-      outline: 'none',
-      '& + span': {
-        boxShadow: tokens.glowPrimary,
+  input: css([
+    {
+      cursor: isDisabled ? 'not-allowed' : 'pointer',
+      height: tokens.spacingM,
+      margin: 0,
+      opacity: 0,
+      position: 'absolute',
+      width: tokens.spacingM,
+      zIndex: tokens.zIndexDefault,
+      '&:focus': {
+        outline: 'none',
+        '& + span': {
+          boxShadow: tokens.glowPrimary,
+        },
       },
     },
-  }),
+    type === 'switch' && sizeToStyle(size),
+  ]),
 });
 
 export default getStyles;

--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
@@ -36,11 +36,12 @@ function _BaseCheckbox(
     willBlurOnEsc = true,
     testId = 'cf-ui-base-checkbox',
     className = '',
-    defaultChecked = false,
+    defaultChecked = undefined,
     name,
     inputProps = {},
     children,
     'aria-label': ariaLabel,
+    size = 'medium',
     ...otherProps
   } = props;
   const inputRef = useForwardedRef<HTMLInputElement>(ref);
@@ -50,7 +51,7 @@ function _BaseCheckbox(
     inputRef.current.indeterminate = isIndeterminate;
   }, [isIndeterminate, inputRef]);
 
-  const styles = getStyles({ isDisabled, type });
+  const styles = getStyles({ isDisabled, type, size });
 
   const handleFocus = useCallback(
     (e) => {
@@ -123,6 +124,7 @@ function _BaseCheckbox(
         type={type}
         isDisabled={isDisabled}
         isIndeterminate={isIndeterminate}
+        size={size}
       />
       {children}
     </Text>

--- a/packages/components/forms/src/base-checkbox/GhostCheckbox.styles.ts
+++ b/packages/components/forms/src/base-checkbox/GhostCheckbox.styles.ts
@@ -3,7 +3,7 @@ import type { CSSObject } from '@emotion/serialize';
 import type { GhostCheckboxProps } from './GhostCheckbox';
 import tokens from '@contentful/f36-tokens';
 
-type stylesArgs = Pick<GhostCheckboxProps, 'isDisabled'>;
+type stylesArgs = Pick<GhostCheckboxProps, 'isDisabled' | 'size'>;
 
 const getBaseGhostStyles = ({ isDisabled }): CSSObject => ({
   alignItems: 'center',
@@ -65,36 +65,58 @@ const getRadioStyles = ({ isDisabled }) => {
   return css(baseStyle);
 };
 
-const getSwitchStyles = ({ isDisabled }) => {
+const getSwitchStyles = ({ isDisabled, size }) => {
+  const sizeStyle =
+    size === 'small'
+      ? {
+          height: tokens.spacingM,
+          width: tokens.spacingXl,
+          '&:before': {
+            height: tokens.spacingS,
+            width: tokens.spacingS,
+          },
+          'input:checked + &:before': {
+            transform: `translateX(${tokens.spacingM})`,
+          },
+        }
+      : {
+          height: '20px',
+          width: '40px',
+          '&:before': {
+            height: tokens.spacingM,
+            width: tokens.spacingM,
+          },
+          'input:checked + &:before': {
+            transform: `translateX(20px)`,
+          },
+        };
+
   const baseStyle: CSSObject = {
     ...getBaseGhostStyles({ isDisabled }),
     background: tokens.gray600,
     borderColor: tokens.gray600,
     borderRadius: tokens.borderRadiusSmall,
+    justifyContent: 'space-around',
     position: 'relative',
-    width: tokens.spacingXl,
     '&:before': {
       background: tokens.colorWhite,
       borderRadius: `calc(${tokens.borderRadiusSmall}/2)`,
       content: '""',
-      height: tokens.spacingS,
       left: 0,
       position: 'absolute',
       transition: `transform ${tokens.transitionEasingDefault} ${tokens.transitionDurationDefault}`,
-      width: tokens.spacingS,
     },
     'input:checked + &': {
       background: tokens.blue600,
       borderColor: tokens.blue600,
-      '&:before': {
-        transform: `translateX(${tokens.spacingM})`,
-      },
     },
   };
 
   const disabledStyle: CSSObject = {
-    background: tokens.gray200,
-    borderColor: tokens.gray200,
+    '&, input:checked + &': {
+      background: tokens.gray200,
+      borderColor: tokens.gray200,
+    },
     '&:before': {
       background: tokens.gray400,
     },
@@ -103,15 +125,15 @@ const getSwitchStyles = ({ isDisabled }) => {
     },
   };
 
-  return css([baseStyle, isDisabled && disabledStyle]);
+  return css([baseStyle, sizeStyle, isDisabled && disabledStyle]);
 };
 
 const getStyles = (args: stylesArgs) => {
-  const { isDisabled } = args;
+  const { isDisabled, size } = args;
   return {
     radio: getRadioStyles({ isDisabled }),
     checkbox: getCheckboxStyles({ isDisabled }),
-    switch: getSwitchStyles({ isDisabled }),
+    switch: getSwitchStyles({ isDisabled, size }),
   };
 };
 

--- a/packages/components/forms/src/base-checkbox/GhostCheckbox.tsx
+++ b/packages/components/forms/src/base-checkbox/GhostCheckbox.tsx
@@ -5,12 +5,12 @@ import getStyles from './GhostCheckbox.styles';
 
 export type GhostCheckboxProps = Pick<
   BaseCheckboxInternalProps,
-  'type' | 'isIndeterminate' | 'isDisabled'
+  'type' | 'isIndeterminate' | 'isDisabled' | 'size'
 >;
 
 export const GhostCheckbox = (props: GhostCheckboxProps) => {
-  const { type, isIndeterminate, isDisabled } = props;
-  const styles = getStyles({ isDisabled });
+  const { type, isIndeterminate, isDisabled, size = 'medium' } = props;
+  const styles = getStyles({ isDisabled, size });
 
   if (type === 'switch') {
     return (

--- a/packages/components/forms/src/base-checkbox/types.ts
+++ b/packages/components/forms/src/base-checkbox/types.ts
@@ -36,4 +36,9 @@ export interface BaseCheckboxInternalProps
    * Value to be set as aria-label if not passing a children
    */
   'aria-label'?: string;
+  /**
+   * Size of the input, only valid for switch input
+   * @default medium
+   */
+  size?: 'small' | 'medium';
 }

--- a/packages/components/forms/src/checkbox/Checkbox.tsx
+++ b/packages/components/forms/src/checkbox/Checkbox.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BaseCheckbox, BaseCheckboxProps } from '../base-checkbox';
 import { useFormControl } from '../form-control/FormControlContext';
 
-export type CheckboxProps = Omit<BaseCheckboxProps, 'type'>;
+export type CheckboxProps = Omit<BaseCheckboxProps, 'type' | 'size'>;
 
 const _Checkbox = (props: CheckboxProps, ref: React.Ref<HTMLInputElement>) => {
   const {

--- a/packages/components/forms/src/radio/Radio.tsx
+++ b/packages/components/forms/src/radio/Radio.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { BaseCheckbox, BaseCheckboxProps } from '../base-checkbox';
 import { useFormControl } from '../form-control/FormControlContext';
 
-export type RadioProps = Omit<BaseCheckboxProps, 'type' | 'isIndeterminate'>;
+export type RadioProps = Omit<
+  BaseCheckboxProps,
+  'type' | 'isIndeterminate' | 'size'
+>;
 
 const _Radio = (props: RadioProps, ref: React.Ref<HTMLInputElement>) => {
   const {

--- a/packages/components/forms/stories/Switch.stories.tsx
+++ b/packages/components/forms/stories/Switch.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { SectionHeading } from '@contentful/f36-typography';
 import { Switch, SwitchProps } from '../src';
-import { Flex } from '@contentful/f36-core';
+import { Flex, Box } from '@contentful/f36-core';
 
 export default {
   title: 'Form Elements/Switch',
@@ -18,38 +18,73 @@ export const Basic = (args: SwitchProps) => (
 
 Basic.args = {
   children: 'Some label text',
+  size: 'medium',
 };
 
 export const overview = () => (
   <>
-    <SectionHeading as="h3" marginBottom="spacingS">
+    <SectionHeading as="h3" marginBottom="spacingM">
       Switch default
     </SectionHeading>
 
-    <Flex marginBottom="spacingS">
-      <Switch name="switch1" value="no" id="switch1">
-        Label text
-      </Switch>
+    <Flex flexDirection="column" marginBottom="spacingS">
+      <Box marginBottom="spacingS">
+        <Switch size="small" name="small-switch1" value="no" id="small-switch1">
+          Label text
+        </Switch>
+      </Box>
+      <Box marginBottom="spacingS">
+        <Switch name="switch1" value="no" id="switch1">
+          Label text
+        </Switch>
+      </Box>
     </Flex>
 
-    <SectionHeading as="h3" marginBottom="spacingS">
+    <SectionHeading as="h3" marginBottom="spacingM">
       Switch disabled
     </SectionHeading>
 
-    <Flex marginBottom="spacingS">
-      <Switch isDisabled name="switch2" value="no" id="switch2">
-        Label text
-      </Switch>
+    <Flex flexDirection="column" marginBottom="spacingS">
+      <Box marginBottom="spacingS">
+        <Switch
+          size="small"
+          isDisabled
+          name="small-switch2"
+          value="no"
+          id="small-switch2"
+        >
+          Label text
+        </Switch>
+      </Box>
+      <Box marginBottom="spacingS">
+        <Switch isDisabled name="switch2" value="no" id="switch2">
+          Label text
+        </Switch>
+      </Box>
     </Flex>
 
-    <SectionHeading as="h3" marginBottom="spacingS">
+    <SectionHeading as="h3" marginBottom="spacingM">
       Switch disabled checked
     </SectionHeading>
 
-    <Flex marginBottom="spacingS">
-      <Switch isDisabled isChecked name="switch3" value="no" id="switch3">
-        Label text
-      </Switch>
+    <Flex flexDirection="column" marginBottom="spacingS">
+      <Box marginBottom="spacingS">
+        <Switch
+          size="small"
+          isDisabled
+          isChecked
+          name="small-switch3"
+          value="no"
+          id="small-switch3"
+        >
+          Label text
+        </Switch>
+      </Box>
+      <Box marginBottom="spacingS">
+        <Switch isDisabled isChecked name="switch3" value="no" id="switch3">
+          Label text
+        </Switch>
+      </Box>
     </Flex>
   </>
 );


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->
Adds the `size` prop to render the switch component smaller or on medium(default) size.

![image](https://user-images.githubusercontent.com/1071799/132223818-706dcf9a-8461-40bd-bb4e-e7f63fbb0454.png)


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
