### PR TITLE
fix(Modal): story improvement & allow scrolling in ModalCofirm []

### DIFF
--- a/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalConfirm/ModalConfirm.tsx
@@ -173,7 +173,7 @@ export function ModalConfirm({
     >
       {() => {
         return (
-          <div>
+          <React.Fragment>
             <Modal.Header title={title || ''} {...modalHeaderProps} />
             <Modal.Content {...modalContentProps}>{children}</Modal.Content>
             <Modal.Controls {...modalControlsProps}>
@@ -191,7 +191,7 @@ export function ModalConfirm({
                 </Fragment>
               )}
             </Modal.Controls>
-          </div>
+          </React.Fragment>
         );
       }}
     </Modal>

--- a/packages/forma-36-react-components/src/components/Modal/ModalConfirm/__snapshots__/ModalConfirm.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Modal/ModalConfirm/__snapshots__/ModalConfirm.test.tsx.snap
@@ -9,28 +9,26 @@ exports[`can accept custom labels 1`] = `
     data-test-id="cf-ui-modal-confirm"
     style="width: 520px;"
   >
-    <div>
-      <div
-        class="ModalHeader"
-        data-test-id="cf-ui-modal-header"
+    <div
+      class="ModalHeader"
+      data-test-id="cf-ui-modal-header"
+    >
+      <h1
+        class="ModalHeader__title"
       >
-        <h1
-          class="ModalHeader__title"
-        >
-          Are you sure?
-        </h1>
-      </div>
-      <div
-        class="ModalContent"
-        data-test-id="cf-ui-modal-content"
-      >
-        ModalConfirm
-      </div>
-      <div
-        class="ModalControls"
-        data-test-id="cf-ui-modal-controls"
-      />
+        Are you sure?
+      </h1>
     </div>
+    <div
+      class="ModalContent"
+      data-test-id="cf-ui-modal-content"
+    >
+      ModalConfirm
+    </div>
+    <div
+      class="ModalControls"
+      data-test-id="cf-ui-modal-controls"
+    />
   </div>
 </div>
 `;
@@ -44,28 +42,26 @@ exports[`renders the component 1`] = `
     data-test-id="cf-ui-modal-confirm"
     style="width: 520px;"
   >
-    <div>
-      <div
-        class="ModalHeader"
-        data-test-id="cf-ui-modal-header"
+    <div
+      class="ModalHeader"
+      data-test-id="cf-ui-modal-header"
+    >
+      <h1
+        class="ModalHeader__title"
       >
-        <h1
-          class="ModalHeader__title"
-        >
-          Are you sure?
-        </h1>
-      </div>
-      <div
-        class="ModalContent"
-        data-test-id="cf-ui-modal-content"
-      >
-        ModalConfirm
-      </div>
-      <div
-        class="ModalControls"
-        data-test-id="cf-ui-modal-controls"
-      />
+        Are you sure?
+      </h1>
     </div>
+    <div
+      class="ModalContent"
+      data-test-id="cf-ui-modal-content"
+    >
+      ModalConfirm
+    </div>
+    <div
+      class="ModalControls"
+      data-test-id="cf-ui-modal-controls"
+    />
   </div>
 </div>
 `;
@@ -79,28 +75,26 @@ exports[`renders the component with override header, content and controls 1`] = 
     data-test-id="cf-ui-modal-confirm"
     style="width: 520px;"
   >
-    <div>
-      <div
-        class="ModalHeader additional header class"
-        data-test-id="cf-ui-modal-header"
+    <div
+      class="ModalHeader additional header class"
+      data-test-id="cf-ui-modal-header"
+    >
+      <h1
+        class="ModalHeader__title ModalHeader__title--is-not-wrapped"
       >
-        <h1
-          class="ModalHeader__title ModalHeader__title--is-not-wrapped"
-        >
-          Are you sure?
-        </h1>
-      </div>
-      <div
-        class="ModalContent additional content class"
-        data-test-id="cf-ui-modal-content"
-      >
-        ModalConfirm
-      </div>
-      <div
-        class="ModalControls additional controls class"
-        data-test-id="cf-ui-modal-controls"
-      />
+        Are you sure?
+      </h1>
     </div>
+    <div
+      class="ModalContent additional content class"
+      data-test-id="cf-ui-modal-content"
+    >
+      ModalConfirm
+    </div>
+    <div
+      class="ModalControls additional controls class"
+      data-test-id="cf-ui-modal-controls"
+    />
   </div>
 </div>
 `;

--- a/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Modal/ModalLauncher/ModalLauncher.stories.tsx
@@ -80,6 +80,7 @@ function CloseAllStory() {
 
   useEffect(() => {
     openModal(`Modal one`);
+    return ModalLauncher.closeAll;
   }, [openModal]);
 
   return (


### PR DESCRIPTION
# Purpose of PR

## Topic 1:
A customer is complaining that a confirmation modal with some content doesn't render properly on smaller devices. The content overflows and makes it impossible to submit the dialog.
![image](https://user-images.githubusercontent.com/9327071/132239602-f0041a7a-24ac-4821-93db-7bb7672c9934.png)

This works for the normal modal while it doesn't work for the confirmation one because we render a `<div>` container breaking the intended scrolling behavior of the modal.

After the fix:
![Screenshot 2021-09-06 at 17 35 02](https://user-images.githubusercontent.com/9327071/132239797-b1ab5f20-819f-4f0b-adab-b6c37a59c827.png)

## Topic 2:
While investigating this bug and clicking through modals in the storybook, I was getting annoyed by the ModalLauncher stories always creating a modal on mount. I guess it's part of the story but at least I expect it to close them again if I switch to another story. With the unmount function I'm doing this now.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [o] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
