### PR TITLE
refactor:(select) use defaultValue and value props instead of isSelected

### DIFF
--- a/packages/components/forms/src/checkbox/Checkbox.tsx
+++ b/packages/components/forms/src/checkbox/Checkbox.tsx
@@ -29,7 +29,7 @@ const _Checkbox = (props: CheckboxProps, ref: React.Ref<HTMLInputElement>) => {
     name,
   });
 
-  const formProps = useFormControl({
+  const { isReadOnly, ...formProps } = useFormControl({
     id,
     isDisabled,
     isInvalid,

--- a/packages/components/forms/src/checkbox/Checkbox.tsx
+++ b/packages/components/forms/src/checkbox/Checkbox.tsx
@@ -29,6 +29,7 @@ const _Checkbox = (props: CheckboxProps, ref: React.Ref<HTMLInputElement>) => {
     name,
   });
 
+  // Removes the isReadOnly property that comes from FormControl context.
   const { isReadOnly, ...formProps } = useFormControl({
     id,
     isDisabled,

--- a/packages/components/forms/src/radio/Radio.tsx
+++ b/packages/components/forms/src/radio/Radio.tsx
@@ -29,7 +29,7 @@ const _Radio = (props: RadioProps, ref: React.Ref<HTMLInputElement>) => {
     name,
   });
 
-  const formProps = useFormControl({
+  const { isReadOnly, ...formProps } = useFormControl({
     id,
     isDisabled,
     isInvalid,

--- a/packages/components/forms/src/radio/Radio.tsx
+++ b/packages/components/forms/src/radio/Radio.tsx
@@ -29,6 +29,7 @@ const _Radio = (props: RadioProps, ref: React.Ref<HTMLInputElement>) => {
     name,
   });
 
+  // Removes the isReadOnly property that comes from FormControl context.
   const { isReadOnly, ...formProps } = useFormControl({
     id,
     isDisabled,

--- a/packages/components/forms/src/select/Select.mdx
+++ b/packages/components/forms/src/select/Select.mdx
@@ -8,8 +8,8 @@ storybook: 'https://f36-storybook.contentful.com/?path=/story/form-elements-sele
 typescript: ./Select.tsx,./SelectOption.tsx
 ---
 
-Select allows users to make a single selection from an options menu.
-Keep in mind that Select should not be used without the label. We provide [SelectField](https://f36.contentful.com/components/select-field/) component, which contains label, help or error message if needed.
+Select allows users to make a single selection from an options menu.  
+Keep in mind that Select should not be used without the label.
 
 ## Table of contents
 
@@ -26,6 +26,43 @@ Keep in mind that Select should not be used without the label. We provide [Selec
 - Order the list of options in a logical way, so it make sense for the user
 - Don't use Select for a very long list of options, instead for those cases use [Autocomplete](https://f36.contentful.com/components/autocomplete/)
 - if you use Select component add your custom label to it or use our [SelectField](https://f36.contentful.com/components/select-field/) instead
+
+### Using as a controlled select
+
+To use the Select as controlled, you need to provide the value of one of the options as the value prop for the Select, and the onChange handler.
+
+```tsx static=true
+const ExampleControlled = () => {
+  const [selectValue, setSelectValue] = useState("optionOne");
+  const handleOnChange = (event) => setSelectedValue(event.target.value);
+
+  return (
+<Select
+  id="optionSelect-controlled"
+  name="optionSelect-controlled"
+  value={selectValue}
+  onChange={handleOnChange}
+>
+  <Select.Option value="optionOne">Option 1</Select.Option>
+  <Select.Option value="optionTwo">Long Option 2</Select.Option>
+</Select>
+```
+
+### Using as an uncontrolled select
+
+To use the Select as uncontrolled, you shouldn't pass the value prop, if you want to have an option selected by default, you can instead use the defaultValue prop.
+
+```tsx static=true
+<Select
+  id="optionSelect-controlled"
+  name="optionSelect-controlled"
+  defaultValue={'optionOne'}
+>
+  <Select.Option value="optionOne">Option 1</Select.Option> // This option would
+  be selected by default
+  <Select.Option value="optionTwo">Long Option 2</Select.Option>
+</Select>
+```
 
 ### Select vs dropdown
 
@@ -59,14 +96,12 @@ Keep in mind that Select should not be used without the label. We provide [Selec
 ```tsx
 // import { Select } from '@contentful/f36-components';
 
-<Select name="optionSelect" id="optionSelect">
-  <Select.Option value="" isDisabled isSelected>
+<Select name="optionSelect" id="optionSelect" defaultValue="">
+  <Select.Option value="" isDisabled>
     Please select an option...
   </Select.Option>
   <Select.Option value="optionOne">Option One</Select.Option>
-  <Select.Option value="optionTwo" isSelected>
-    Option Two
-  </Select.Option>
+  <Select.Option value="optionTwo">Option Two</Select.Option>
   <Select.Option value="optionThree" isDisabled>
     Option Three
   </Select.Option>

--- a/packages/components/forms/src/select/Select.test.tsx
+++ b/packages/components/forms/src/select/Select.test.tsx
@@ -36,14 +36,17 @@ it('should dispatch onChange', () => {
 
 it('has no a11y issues', async () => {
   const { container } = render(
-    <Select id="optionSelect" name="optionSelect" aria-label="Select">
+    <Select
+      id="optionSelect"
+      name="optionSelect"
+      aria-label="Select"
+      defaultValue="optionThree"
+    >
       <Select.Option value="optionOne">Option 1</Select.Option>
       <Select.Option value="optionTwo" isDisabled>
         Disabled option
       </Select.Option>
-      <Select.Option value="optionThree" isSelected>
-        Selected option
-      </Select.Option>
+      <Select.Option value="optionThree">Selected option</Select.Option>
     </Select>,
   );
   const results = await axe(container);

--- a/packages/components/forms/src/select/Select.tsx
+++ b/packages/components/forms/src/select/Select.tsx
@@ -21,6 +21,8 @@ export type SelectInternalProps = CommonProps & {
   children: ReactNode;
   willBlurOnEsc?: boolean;
   size?: SelectSize;
+  value?: string;
+  defaultValue?: string;
 };
 
 export type SelectProps = PropsWithHTMLElement<
@@ -41,6 +43,8 @@ const _Select = (
     willBlurOnEsc = true,
     onKeyDown,
     size = 'medium',
+    value = undefined,
+    defaultValue = undefined,
     ...otherProps
   }: SelectProps,
   ref: React.Ref<HTMLSelectElement>,
@@ -78,6 +82,8 @@ const _Select = (
         aria-required={formProps.isRequired ? 'true' : undefined}
         aria-invalid={formProps.isInvalid ? true : undefined}
         disabled={formProps.isDisabled}
+        defaultValue={defaultValue}
+        value={value}
         ref={ref}
       >
         {children}

--- a/packages/components/forms/src/select/Select.tsx
+++ b/packages/components/forms/src/select/Select.tsx
@@ -56,7 +56,11 @@ const _Select = (
     id,
   });
 
-  const styles = getSelectStyles({ isDisabled, isInvalid, size });
+  const styles = getSelectStyles({
+    isDisabled: formProps.isDisabled,
+    isInvalid: formProps.isInvalid,
+    size,
+  });
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLSelectElement>) => {

--- a/packages/components/forms/src/select/SelectOption.tsx
+++ b/packages/components/forms/src/select/SelectOption.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 
 export type OptionInternalProps = CommonProps & {
-  isSelected?: boolean;
   isDisabled?: boolean;
 };
 
@@ -14,16 +13,8 @@ export type OptionProps = PropsWithHTMLElement<
 
 export const Option = ({
   testId = 'cf-ui-select-option',
-  isSelected,
   isDisabled,
   ...otherProps
 }: OptionProps) => {
-  return (
-    <option
-      data-test-id={testId}
-      {...otherProps}
-      selected={isSelected}
-      disabled={isDisabled}
-    />
-  );
+  return <option data-test-id={testId} {...otherProps} disabled={isDisabled} />;
 };

--- a/packages/components/forms/src/switch/Switch.tsx
+++ b/packages/components/forms/src/switch/Switch.tsx
@@ -15,7 +15,7 @@ const _Switch = (props: SwitchProps, ref: React.Ref<HTMLInputElement>) => {
     ...otherProps
   } = props;
 
-  const formProps = useFormControl({
+  const { isReadOnly, ...formProps } = useFormControl({
     id,
     isDisabled,
     isInvalid,

--- a/packages/components/forms/src/switch/Switch.tsx
+++ b/packages/components/forms/src/switch/Switch.tsx
@@ -15,6 +15,7 @@ const _Switch = (props: SwitchProps, ref: React.Ref<HTMLInputElement>) => {
     ...otherProps
   } = props;
 
+  // Removes the isReadOnly property that comes from FormControl context.
   const { isReadOnly, ...formProps } = useFormControl({
     id,
     isDisabled,

--- a/packages/components/forms/stories/Form.stories.tsx
+++ b/packages/components/forms/stories/Form.stories.tsx
@@ -61,10 +61,14 @@ export const OverviewWithSmallInputs = (args: FormControlInternalProps) => {
       </FormControl>
       <FormControl {...args}>
         <FormControl.Label>Choose your favorite fruit</FormControl.Label>
-        <Select id="optionSelect" name="optionSelect" {...args} size="small">
-          <Select.Option value="optionOne" isSelected>
-            Apple
-          </Select.Option>
+        <Select
+          id="optionSelect"
+          name="optionSelect"
+          {...args}
+          size="small"
+          defaultValue="optionOne"
+        >
+          <Select.Option value="optionOne">Apple</Select.Option>
           <Select.Option value="optionOne">Peach</Select.Option>
           <Select.Option value="optionOne">Pineapple</Select.Option>
           <Select.Option value="optionTwo">Banana</Select.Option>

--- a/packages/components/forms/stories/FormControl.stories.tsx
+++ b/packages/components/forms/stories/FormControl.stories.tsx
@@ -46,8 +46,8 @@ export const Basic = (args: FormControlInternalProps) => {
 
       <FormControl {...args}>
         <FormControl.Label>City</FormControl.Label>
-        <Select>
-          <Select.Option value="" isDisabled isSelected>
+        <Select defaultValue="">
+          <Select.Option value="" isDisabled>
             Please, select your city
           </Select.Option>
           <Select.Option value="berlin">Berlin</Select.Option>

--- a/packages/components/forms/stories/Select.stories.tsx
+++ b/packages/components/forms/stories/Select.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Select, SelectProps } from '../src';
 import { Flex } from '@contentful/f36-core';
 import { SectionHeading } from '@contentful/f36-typography';
+import { action } from '@storybook/addon-actions';
 
 export default {
   title: 'Form Elements/Select',
@@ -10,11 +11,14 @@ export default {
 };
 
 export const Basic = (args: SelectProps) => (
-  <Select id="optionSelect" name="optionSelect" {...args}>
+  <Select
+    id="optionSelect"
+    name="optionSelect"
+    {...args}
+    defaultValue="optionTwo"
+  >
     <Select.Option value="optionOne">Option 1</Select.Option>
-    <Select.Option value="optionTwo" isSelected>
-      Option 2
-    </Select.Option>
+    <Select.Option value="optionTwo">Option 2</Select.Option>
     <Select.Option value="optionThree" isDisabled>
       Disabled option
     </Select.Option>
@@ -25,114 +29,155 @@ Basic.args = {
   size: 'medium',
 };
 
-export const Overview = (args: SelectProps) => (
-  <Flex flexDirection="column">
-    <SectionHeading as="h3" marginBottom="spacingS">
-      Select small
-    </SectionHeading>
+export const Overview = (args: SelectProps) => {
+  const [controlledValue, setControlledValue] = React.useState('optionTwo');
+  const handleOnChange = (event) => {
+    setControlledValue(event.target.value);
+    action('onChange')(event);
+  };
 
-    <Flex marginBottom="spacingL">
-      <Select id="optionSelect-1" name="optionSelect-1" {...args} size="small">
-        <Select.Option value="optionOne">Option 1</Select.Option>
-        <Select.Option value="optionTwo" isSelected>
-          Option 2
-        </Select.Option>
-        <Select.Option value="optionThree" isDisabled>
-          Disabled option
-        </Select.Option>
-      </Select>
+  return (
+    <Flex flexDirection="column">
+      <SectionHeading as="h3" marginBottom="spacingS">
+        Select controlled input
+      </SectionHeading>
+
+      <Flex marginBottom="spacingL">
+        <Select
+          {...args}
+          id="optionSelect-2"
+          name="optionSelect-2"
+          value={controlledValue}
+          onChange={handleOnChange}
+        >
+          <Select.Option value="optionOne">Option 1</Select.Option>
+          <Select.Option value="optionTwo">Option 2</Select.Option>
+          <Select.Option value="optionThree" isDisabled>
+            Disabled option
+          </Select.Option>
+        </Select>
+      </Flex>
+
+      <SectionHeading as="h3" marginBottom="spacingS">
+        Select small
+      </SectionHeading>
+
+      <Flex marginBottom="spacingL">
+        <Select
+          {...args}
+          id="optionSelect-1"
+          name="optionSelect-1"
+          size="small"
+          defaultValue="optionTwo"
+        >
+          <Select.Option value="optionOne">Option 1</Select.Option>
+          <Select.Option value="optionTwo">Option 2</Select.Option>
+          <Select.Option value="optionThree" isDisabled>
+            Disabled option
+          </Select.Option>
+        </Select>
+      </Flex>
+
+      <SectionHeading as="h3" marginBottom="spacingS">
+        Select default
+      </SectionHeading>
+
+      <Flex marginBottom="spacingL">
+        <Select
+          {...args}
+          id="optionSelect-2"
+          name="optionSelect-2"
+          defaultValue="optionTwo"
+        >
+          <Select.Option value="optionOne">Option 1</Select.Option>
+          <Select.Option value="optionTwo">Option 2</Select.Option>
+          <Select.Option value="optionThree" isDisabled>
+            Disabled option
+          </Select.Option>
+        </Select>
+      </Flex>
+
+      <SectionHeading as="h3" marginBottom="spacingS">
+        Select disabled small
+      </SectionHeading>
+
+      <Flex marginBottom="spacingL">
+        <Select
+          {...args}
+          id="optionSelect-6"
+          name="optionSelect-6"
+          size="small"
+          isDisabled
+          defaultValue="optionTwo"
+        >
+          <Select.Option value="optionOne">Option 1</Select.Option>
+          <Select.Option value="optionTwo">Option 2</Select.Option>
+          <Select.Option value="optionThree" isDisabled>
+            Disabled option
+          </Select.Option>
+        </Select>
+      </Flex>
+
+      <SectionHeading as="h3" marginBottom="spacingS">
+        Select disabled
+      </SectionHeading>
+
+      <Flex marginBottom="spacingL">
+        <Select
+          {...args}
+          id="optionSelect-3"
+          name="optionSelect-3"
+          isDisabled
+          defaultValue="optionTwo"
+        >
+          <Select.Option value="optionOne">Option 1</Select.Option>
+          <Select.Option value="optionTwo">Option 2</Select.Option>
+          <Select.Option value="optionThree" isDisabled>
+            Disabled option
+          </Select.Option>
+        </Select>
+      </Flex>
+
+      <SectionHeading as="h3" marginBottom="spacingS">
+        Select invalid small
+      </SectionHeading>
+
+      <Flex marginBottom="spacingL">
+        <Select
+          {...args}
+          id="optionSelect-4"
+          name="optionSelect-4"
+          size="small"
+          isInvalid
+          defaultValue="optionTwo"
+        >
+          <Select.Option value="optionOne">Option 1</Select.Option>
+          <Select.Option value="optionTwo">Option 2</Select.Option>
+          <Select.Option value="optionThree" isDisabled>
+            Disabled option
+          </Select.Option>
+        </Select>
+      </Flex>
+
+      <SectionHeading as="h3" marginBottom="spacingS">
+        Select invalid
+      </SectionHeading>
+
+      <Flex marginBottom="spacingL">
+        <Select
+          {...args}
+          id="optionSelect-5"
+          name="optionSelect-5"
+          isInvalid
+          defaultValue="optionTwo"
+        >
+          <Select.Option value="optionOne">Option 1</Select.Option>
+          <Select.Option value="optionTwo">Option 2</Select.Option>
+          <Select.Option value="optionThree" isDisabled>
+            Disabled option
+          </Select.Option>
+        </Select>
+      </Flex>
     </Flex>
-
-    <SectionHeading as="h3" marginBottom="spacingS">
-      Select default
-    </SectionHeading>
-
-    <Flex marginBottom="spacingL">
-      <Select id="optionSelect-2" name="optionSelect-2" {...args}>
-        <Select.Option value="optionOne">Option 1</Select.Option>
-        <Select.Option value="optionTwo" isSelected>
-          Option 2
-        </Select.Option>
-        <Select.Option value="optionThree" isDisabled>
-          Disabled option
-        </Select.Option>
-      </Select>
-    </Flex>
-
-    <SectionHeading as="h3" marginBottom="spacingS">
-      Select disabled small
-    </SectionHeading>
-
-    <Flex marginBottom="spacingL">
-      <Select
-        id="optionSelect-6"
-        name="optionSelect-6"
-        {...args}
-        size="small"
-        isDisabled
-      >
-        <Select.Option value="optionOne">Option 1</Select.Option>
-        <Select.Option value="optionTwo" isSelected>
-          Option 2
-        </Select.Option>
-        <Select.Option value="optionThree" isDisabled>
-          Disabled option
-        </Select.Option>
-      </Select>
-    </Flex>
-
-    <SectionHeading as="h3" marginBottom="spacingS">
-      Select disabled
-    </SectionHeading>
-
-    <Flex marginBottom="spacingL">
-      <Select id="optionSelect-3" name="optionSelect-3" {...args} isDisabled>
-        <Select.Option value="optionOne">Option 1</Select.Option>
-        <Select.Option value="optionTwo" isSelected>
-          Option 2
-        </Select.Option>
-        <Select.Option value="optionThree" isDisabled>
-          Disabled option
-        </Select.Option>
-      </Select>
-    </Flex>
-
-    <SectionHeading as="h3" marginBottom="spacingS">
-      Select invalid small
-    </SectionHeading>
-
-    <Flex marginBottom="spacingL">
-      <Select
-        id="optionSelect-4"
-        name="optionSelect-4"
-        {...args}
-        size="small"
-        isInvalid
-      >
-        <Select.Option value="optionOne">Option 1</Select.Option>
-        <Select.Option value="optionTwo" isSelected>
-          Option 2
-        </Select.Option>
-        <Select.Option value="optionThree" isDisabled>
-          Disabled option
-        </Select.Option>
-      </Select>
-    </Flex>
-
-    <SectionHeading as="h3" marginBottom="spacingS">
-      Select invalid
-    </SectionHeading>
-
-    <Flex marginBottom="spacingL">
-      <Select id="optionSelect-5" name="optionSelect-5" {...args} isInvalid>
-        <Select.Option value="optionOne">Option 1</Select.Option>
-        <Select.Option value="optionTwo" isSelected>
-          Option 2
-        </Select.Option>
-        <Select.Option value="optionThree" isDisabled>
-          Disabled option
-        </Select.Option>
-      </Select>
-    </Flex>
-  </Flex>
-);
+  );
+};


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->
* Refactor `Select` component to use `value` and `defaultValue` instead of isSelected on the option.
* Update documentation with examples.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
