### PR TITLE
fix(Button): hide spinner when loading is false

### DIFF
--- a/packages/forma-36-react-components/src/components/Button/Button.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { Button, ButtonProps } from './Button';
 import { Flex } from '../Flex';
@@ -318,3 +318,39 @@ export const Overview = (args: ButtonProps) => (
     </Flex>
   </>
 );
+
+export const SubmitButton = (args: ButtonProps) => {
+  const [isLoading, setLoading] = React.useState(false);
+
+  const submitForm = useCallback(() => {
+    setLoading(true);
+    setTimeout(() => {
+      setLoading(false);
+    }, 1000);
+  }, []);
+
+  return (
+    <>
+      <Flex flexDirection="column" marginBottom="spacingL">
+        <Flex marginBottom="spacingS">
+          <SectionHeading element="h3">
+            Submit button with loading state
+          </SectionHeading>
+        </Flex>
+        <Flex flexDirection="row" marginBottom="spacingM">
+          <Flex marginRight="spacingXs">
+            <Button
+              icon={args.icon}
+              buttonType={args.buttonType}
+              loading={isLoading}
+              disabled={isLoading}
+              onClick={submitForm}
+            >
+              Submit me
+            </Button>
+          </Flex>
+        </Flex>
+      </Flex>
+    </>
+  );
+};

--- a/packages/forma-36-react-components/src/components/Button/Button.stories.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.stories.tsx
@@ -32,6 +32,42 @@ basic.args = {
   label: 'Button',
 };
 
+export const SubmitButton = (args: ButtonProps) => {
+  const [isLoading, setLoading] = React.useState(false);
+
+  const submitForm = useCallback(() => {
+    setLoading(true);
+    setTimeout(() => {
+      setLoading(false);
+    }, 1000);
+  }, []);
+
+  return (
+    <>
+      <Flex flexDirection="column" marginBottom="spacingL">
+        <Flex marginBottom="spacingS">
+          <SectionHeading element="h3">
+            Submit button with loading state
+          </SectionHeading>
+        </Flex>
+        <Flex flexDirection="row" marginBottom="spacingM">
+          <Flex marginRight="spacingXs">
+            <Button
+              icon={args.icon}
+              buttonType={args.buttonType}
+              loading={isLoading}
+              disabled={isLoading}
+              onClick={submitForm}
+            >
+              Submit me
+            </Button>
+          </Flex>
+        </Flex>
+      </Flex>
+    </>
+  );
+};
+
 export const Overview = (args: ButtonProps) => (
   <>
     <Flex flexDirection="column" marginBottom="spacingL">
@@ -318,39 +354,3 @@ export const Overview = (args: ButtonProps) => (
     </Flex>
   </>
 );
-
-export const SubmitButton = (args: ButtonProps) => {
-  const [isLoading, setLoading] = React.useState(false);
-
-  const submitForm = useCallback(() => {
-    setLoading(true);
-    setTimeout(() => {
-      setLoading(false);
-    }, 1000);
-  }, []);
-
-  return (
-    <>
-      <Flex flexDirection="column" marginBottom="spacingL">
-        <Flex marginBottom="spacingS">
-          <SectionHeading element="h3">
-            Submit button with loading state
-          </SectionHeading>
-        </Flex>
-        <Flex flexDirection="row" marginBottom="spacingM">
-          <Flex marginRight="spacingXs">
-            <Button
-              icon={args.icon}
-              buttonType={args.buttonType}
-              loading={isLoading}
-              disabled={isLoading}
-              onClick={submitForm}
-            >
-              Submit me
-            </Button>
-          </Flex>
-        </Flex>
-      </Flex>
-    </>
-  );
-};

--- a/packages/forma-36-react-components/src/components/Button/Button.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.tsx
@@ -8,7 +8,7 @@ import type {
   ElementType,
 } from 'react';
 import cn from 'classnames';
-import { CSSTransition } from 'react-transition-group';
+import { CSSTransition, TransitionStatus } from 'react-transition-group';
 
 import { Icon, IconType } from '../Icon';
 import { TabFocusTrap } from '../TabFocusTrap';
@@ -136,18 +136,22 @@ export const Button = ({
           mountOnEnter
           unmountOnExit
         >
-          <div className={styles['Button--spinner-wrapper']}>
-            <Spinner
-              customSize={12}
-              color={
-                buttonType === 'muted' ||
-                buttonType === 'warning' ||
-                buttonType === 'naked'
-                  ? 'default'
-                  : 'white'
-              }
-            />
-          </div>
+          {(state: TransitionStatus) =>
+            state === 'unmounted' ? null : (
+              <div className={styles['Button--spinner-wrapper']}>
+                <Spinner
+                  customSize={12}
+                  color={
+                    buttonType === 'muted' ||
+                    buttonType === 'warning' ||
+                    buttonType === 'naked'
+                      ? 'default'
+                      : 'white'
+                  }
+                />
+              </div>
+            )
+          }
         </CSSTransition>
         {indicateDropdown && (
           <Icon


### PR DESCRIPTION
# Purpose of PR

We want to use the button with a loading state in our use case. We observe buggy behaviour when removing the loading animation (the animation comes back and never disappears). 

We wanted to check if the button actually supports removing the loading animation. Because the storybook is missing an example so far I added one and tested with it. It works in the storybook, so we will do further investigations. I think it's good to keep this story for others.

*Update:*
I found a fix in [this github issue](https://github.com/reactjs/react-transition-group/issues/338#issuecomment-442538453). By checking the transition status on our own we can make sure that it's really unmounted if the status is "unmounted".


### See the buggy behaviour
https://user-images.githubusercontent.com/9327071/132471918-6642c0fc-d701-41fb-ad32-49238f14a808.mov



## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
