### PR TITLE
fix: FormLabel font weight should be 500

### DIFF
--- a/packages/components/forms/src/form-label/FormLabel.styles.ts
+++ b/packages/components/forms/src/form-label/FormLabel.styles.ts
@@ -5,6 +5,7 @@ export function getFormLabelStyles() {
   return {
     root: css({
       display: 'inline-block',
+      fontWeight: tokens.fontWeightMedium,
     }),
     indicator: css({
       color: tokens.gray500,


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

While working on integrating our v4 forms to react-hook-form, I noticed that our FormLabels had `font-weight: 400`
But looking in the designs they should have `font-weight: 500` which is our `fontWeightMedium` token
So I created this PR

before:
![Screenshot 2021-09-08 at 11 47 19](https://user-images.githubusercontent.com/6597467/132487797-7bb8df5d-2ac5-407c-890c-75aefc89271d.png)

after:
![Screenshot 2021-09-08 at 11 47 04](https://user-images.githubusercontent.com/6597467/132487812-7ba995d2-c191-4978-8168-0694e734afec.png)

design in Figma:
![Screenshot 2021-09-08 at 11 47 54](https://user-images.githubusercontent.com/6597467/132487837-c66721f2-6249-4cfe-a4bf-33a873b33e3d.png)


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
