### PR TITLE
refactor: Add default styling for BaseCheckboxGroup

### DIFF
--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.styles.ts
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.styles.ts
@@ -22,7 +22,7 @@ const getStyles = ({
   size,
 }: Pick<BaseCheckboxInternalProps, 'isDisabled' | 'type' | 'size'>) => ({
   wrapper: css({
-    alignItems: 'center',
+    alignItems: 'flex-start',
     display: 'inline-flex',
     position: 'relative',
     margin: '0',
@@ -32,6 +32,7 @@ const getStyles = ({
       cursor: isDisabled ? 'not-allowed' : 'pointer',
       height: tokens.spacingM,
       margin: 0,
+      marginTop: `calc(${tokens.spacing2Xs}/2)`,
       opacity: 0,
       position: 'absolute',
       width: tokens.spacingM,

--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.styles.ts
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.styles.ts
@@ -16,6 +16,18 @@ const sizeToStyle = (size) => {
   };
 };
 
+const getHelpTextStyle = ({ size, type }) => {
+  let inputWidth = tokens.spacingM;
+  if (type === 'switch') {
+    inputWidth = sizeToStyle(size).width;
+  }
+
+  return {
+    marginLeft: `calc(${inputWidth} + ${tokens.spacingXs})`,
+    marginTop: 0,
+  };
+};
+
 const getStyles = ({
   isDisabled,
   type,
@@ -46,6 +58,7 @@ const getStyles = ({
     },
     type === 'switch' && sizeToStyle(size),
   ]),
+  helpText: css(getHelpTextStyle({ size, type })),
 });
 
 export default getStyles;

--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect } from 'react';
-import { cx } from 'emotion';
 import { useForwardedRef, PropsWithHTMLElement } from '@contentful/f36-core';
 import type { BaseCheckboxInternalProps } from './types';
 import { GhostCheckbox } from './GhostCheckbox';

--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
@@ -121,7 +121,7 @@ function _BaseCheckbox(
         isIndeterminate={isIndeterminate}
         size={size}
       />
-      {children}
+      <span>{children}</span>
     </Text>
   );
 }

--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
@@ -115,6 +115,7 @@ function _BaseCheckbox(
           required={isRequired}
           aria-required={isRequired ? 'true' : undefined}
           aria-invalid={isInvalid ? 'true' : undefined}
+          aria-describedby={helpText && `${id}-helptext`}
           id={id}
           name={name}
         />
@@ -126,7 +127,11 @@ function _BaseCheckbox(
         />
         {children}
       </Text>
-      {helpText && <HelpText className={styles.helpText}>{helpText}</HelpText>}
+      {helpText && (
+        <HelpText id={`${id}-helptext`} className={styles.helpText}>
+          {helpText}
+        </HelpText>
+      )}
     </div>
   );
 }

--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
@@ -1,10 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { cx } from 'emotion';
-import {
-  useId,
-  useForwardedRef,
-  PropsWithHTMLElement,
-} from '@contentful/f36-core';
+import { useForwardedRef, PropsWithHTMLElement } from '@contentful/f36-core';
 import type { BaseCheckboxInternalProps } from './types';
 import { GhostCheckbox } from './GhostCheckbox';
 import getStyles from './BaseCheckbox.styles';
@@ -45,7 +41,6 @@ function _BaseCheckbox(
     ...otherProps
   } = props;
   const inputRef = useForwardedRef<HTMLInputElement>(ref);
-  const inputId = useId(id, type);
 
   useEffect(() => {
     inputRef.current.indeterminate = isIndeterminate;
@@ -94,7 +89,7 @@ function _BaseCheckbox(
       as="label"
       fontColor="gray900"
       className={cx(styles.wrapper, className)}
-      htmlFor={inputId}
+      htmlFor={id}
       testId={testId}
       {...otherProps}
     >
@@ -117,7 +112,7 @@ function _BaseCheckbox(
         required={isRequired}
         aria-required={isRequired ? 'true' : undefined}
         aria-invalid={isInvalid ? 'true' : undefined}
-        id={inputId}
+        id={id}
         name={name}
       />
       <GhostCheckbox

--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import {
-  Box,
-  useForwardedRef,
-  PropsWithHTMLElement,
-} from '@contentful/f36-core';
+import { cx } from 'emotion';
+import { useForwardedRef, PropsWithHTMLElement } from '@contentful/f36-core';
 import type { BaseCheckboxInternalProps } from './types';
 import { GhostCheckbox } from './GhostCheckbox';
 import getStyles from './BaseCheckbox.styles';
@@ -90,11 +87,11 @@ function _BaseCheckbox(
     typeof isChecked !== undefined ? isChecked : defaultChecked;
 
   return (
-    <Box className={className}>
+    <div>
       <Text
         as="label"
         fontColor="gray900"
-        className={styles.wrapper}
+        className={cx(styles.wrapper, className)}
         htmlFor={id}
         testId={testId}
         {...otherProps}
@@ -130,7 +127,7 @@ function _BaseCheckbox(
         {children}
       </Text>
       {helpText && <HelpText className={styles.helpText}>{helpText}</HelpText>}
-    </Box>
+    </div>
   );
 }
 

--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
@@ -91,6 +91,7 @@ function _BaseCheckbox(
       <Text
         as="label"
         fontColor="gray900"
+        fontWeight="fontWeightMedium"
         className={cx(styles.wrapper, className)}
         htmlFor={id}
         testId={testId}

--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
@@ -87,12 +87,12 @@ function _BaseCheckbox(
     typeof isChecked !== undefined ? isChecked : defaultChecked;
 
   return (
-    <div>
+    <div className={className}>
       <Text
         as="label"
         fontColor="gray900"
         fontWeight="fontWeightMedium"
-        className={cx(styles.wrapper, className)}
+        className={styles.wrapper}
         htmlFor={id}
         testId={testId}
         {...otherProps}

--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
@@ -1,10 +1,14 @@
 import React, { useCallback, useEffect } from 'react';
-import { cx } from 'emotion';
-import { useForwardedRef, PropsWithHTMLElement } from '@contentful/f36-core';
+import {
+  Box,
+  useForwardedRef,
+  PropsWithHTMLElement,
+} from '@contentful/f36-core';
 import type { BaseCheckboxInternalProps } from './types';
 import { GhostCheckbox } from './GhostCheckbox';
 import getStyles from './BaseCheckbox.styles';
 import { Text } from '@contentful/f36-typography';
+import { HelpText } from '../help-text';
 
 export type BaseCheckboxProps = PropsWithHTMLElement<
   BaseCheckboxInternalProps & { label?: string },
@@ -38,6 +42,7 @@ function _BaseCheckbox(
     children,
     'aria-label': ariaLabel,
     size = 'medium',
+    helpText,
     ...otherProps
   } = props;
   const inputRef = useForwardedRef<HTMLInputElement>(ref);
@@ -85,44 +90,47 @@ function _BaseCheckbox(
     typeof isChecked !== undefined ? isChecked : defaultChecked;
 
   return (
-    <Text
-      as="label"
-      fontColor="gray900"
-      className={cx(styles.wrapper, className)}
-      htmlFor={id}
-      testId={testId}
-      {...otherProps}
-    >
-      <input
-        {...inputProps}
-        aria-label={ariaLabel}
-        checked={isChecked}
-        defaultChecked={defaultChecked}
-        className={styles.input}
-        type={type === 'switch' ? 'checkbox' : type}
-        onChange={onChange}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        onKeyDown={handleKeyDown}
-        value={value}
-        disabled={isDisabled}
-        role={type}
-        aria-checked={isIndeterminate ? 'mixed' : ariaChecked}
-        ref={inputRef}
-        required={isRequired}
-        aria-required={isRequired ? 'true' : undefined}
-        aria-invalid={isInvalid ? 'true' : undefined}
-        id={id}
-        name={name}
-      />
-      <GhostCheckbox
-        type={type}
-        isDisabled={isDisabled}
-        isIndeterminate={isIndeterminate}
-        size={size}
-      />
-      <span>{children}</span>
-    </Text>
+    <Box className={className}>
+      <Text
+        as="label"
+        fontColor="gray900"
+        className={styles.wrapper}
+        htmlFor={id}
+        testId={testId}
+        {...otherProps}
+      >
+        <input
+          {...inputProps}
+          aria-label={ariaLabel}
+          checked={isChecked}
+          defaultChecked={defaultChecked}
+          className={styles.input}
+          type={type === 'switch' ? 'checkbox' : type}
+          onChange={onChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          value={value}
+          disabled={isDisabled}
+          role={type}
+          aria-checked={isIndeterminate ? 'mixed' : ariaChecked}
+          ref={inputRef}
+          required={isRequired}
+          aria-required={isRequired ? 'true' : undefined}
+          aria-invalid={isInvalid ? 'true' : undefined}
+          id={id}
+          name={name}
+        />
+        <GhostCheckbox
+          type={type}
+          isDisabled={isDisabled}
+          isIndeterminate={isIndeterminate}
+          size={size}
+        />
+        {children}
+      </Text>
+      {helpText && <HelpText className={styles.helpText}>{helpText}</HelpText>}
+    </Box>
   );
 }
 

--- a/packages/components/forms/src/base-checkbox/BaseCheckboxGroup.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckboxGroup.tsx
@@ -1,8 +1,9 @@
 import React, { ChangeEventHandler } from 'react';
 import { Stack } from '@contentful/f36-core';
+import type { Spacing, CommonProps } from '@contentful/f36-core';
 import { BaseCheckboxGroupContext } from './BaseCheckboxGroupContext';
 
-export interface BaseCheckboxGroupProps {
+export interface BaseCheckboxGroupProps extends CommonProps {
   /**
    * Handler that will be triggered when any checkbox inside the group has their checked state changed
    */
@@ -12,7 +13,7 @@ export interface BaseCheckboxGroupProps {
    */
   name?: string;
   /**
-   * Checkboxes that should be in the group
+   * Elements that should be in the group
    */
   children: React.ReactNode;
   /**
@@ -27,13 +28,29 @@ export interface BaseCheckboxGroupProps {
    * Array of values for checkboxes or single value for radio, that should be checked for controlled inputs
    */
   value?: Array<string> | string;
+  /**
+   * Defines the spacing between elements on the group
+   */
+  spacing?: Spacing;
 }
 
 export const BaseCheckboxGroup = (props: BaseCheckboxGroupProps) => {
-  const { children, ...contextProps } = props;
+  const {
+    children,
+    spacing = 'spacingXs',
+    className,
+    testId = 'cf-ui-base-checkbox-group',
+    ...contextProps
+  } = props;
   return (
     <BaseCheckboxGroupContext.Provider value={contextProps}>
-      <Stack flexDirection="column" alignItems="flex-start" spacing="spacingXs">
+      <Stack
+        testId={testId}
+        className={className}
+        flexDirection="column"
+        alignItems="flex-start"
+        spacing={spacing}
+      >
         {children}
       </Stack>
     </BaseCheckboxGroupContext.Provider>

--- a/packages/components/forms/src/base-checkbox/BaseCheckboxGroup.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckboxGroup.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEventHandler } from 'react';
 import { Stack } from '@contentful/f36-core';
-import type { Spacing, CommonProps } from '@contentful/f36-core';
+import type { CommonProps } from '@contentful/f36-core';
 import { BaseCheckboxGroupContext } from './BaseCheckboxGroupContext';
 
 export interface BaseCheckboxGroupProps extends CommonProps {
@@ -28,16 +28,11 @@ export interface BaseCheckboxGroupProps extends CommonProps {
    * Array of values for checkboxes or single value for radio, that should be checked for controlled inputs
    */
   value?: Array<string> | string;
-  /**
-   * Defines the spacing between elements on the group
-   */
-  spacing?: Spacing;
 }
 
 export const BaseCheckboxGroup = (props: BaseCheckboxGroupProps) => {
   const {
     children,
-    spacing = 'spacingXs',
     className,
     testId = 'cf-ui-base-checkbox-group',
     ...contextProps
@@ -49,7 +44,7 @@ export const BaseCheckboxGroup = (props: BaseCheckboxGroupProps) => {
         className={className}
         flexDirection="column"
         alignItems="flex-start"
-        spacing={spacing}
+        spacing="spacingXs"
       >
         {children}
       </Stack>

--- a/packages/components/forms/src/base-checkbox/BaseCheckboxGroup.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckboxGroup.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEventHandler } from 'react';
+import { Flex } from '@contentful/f36-core';
 import { BaseCheckboxGroupContext } from './BaseCheckboxGroupContext';
 
 export interface BaseCheckboxGroupProps {
@@ -32,7 +33,7 @@ export const BaseCheckboxGroup = (props: BaseCheckboxGroupProps) => {
   const { children, ...contextProps } = props;
   return (
     <BaseCheckboxGroupContext.Provider value={contextProps}>
-      {children}
+      <Flex flexDirection="column">{children}</Flex>
     </BaseCheckboxGroupContext.Provider>
   );
 };

--- a/packages/components/forms/src/base-checkbox/BaseCheckboxGroup.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckboxGroup.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEventHandler } from 'react';
-import { Flex } from '@contentful/f36-core';
+import { Stack } from '@contentful/f36-core';
 import { BaseCheckboxGroupContext } from './BaseCheckboxGroupContext';
 
 export interface BaseCheckboxGroupProps {
@@ -33,7 +33,9 @@ export const BaseCheckboxGroup = (props: BaseCheckboxGroupProps) => {
   const { children, ...contextProps } = props;
   return (
     <BaseCheckboxGroupContext.Provider value={contextProps}>
-      <Flex flexDirection="column">{children}</Flex>
+      <Stack flexDirection="column" alignItems="flex-start" spacing="spacingXs">
+        {children}
+      </Stack>
     </BaseCheckboxGroupContext.Provider>
   );
 };

--- a/packages/components/forms/src/base-checkbox/BaseCheckboxGroupContext.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckboxGroupContext.tsx
@@ -1,6 +1,4 @@
 import { createContext, useContext } from 'react';
-import { css } from 'emotion';
-import tokens from '@contentful/f36-tokens';
 import { BaseCheckboxProps } from './BaseCheckbox';
 import { BaseCheckboxGroupProps } from './BaseCheckboxGroup';
 
@@ -10,7 +8,7 @@ export type BaseCheckboxGroupContextProps = Omit<
 >;
 export type BaseCheckboxGroupContextValue = Pick<
   BaseCheckboxProps,
-  'isChecked' | 'defaultChecked' | 'onChange' | 'name' | 'value' | 'className'
+  'isChecked' | 'defaultChecked' | 'onChange' | 'name' | 'value'
 >;
 
 export const BaseCheckboxGroupContext = createContext<
@@ -29,12 +27,6 @@ export const useBaseCheckboxGroup = (
   if (!context) {
     return props;
   }
-
-  const className = css({
-    '&:not(:last-child)': {
-      marginBottom: tokens.spacingXs,
-    },
-  });
 
   let isChecked, defaultChecked;
 
@@ -69,6 +61,5 @@ export const useBaseCheckboxGroup = (
     onChange,
     name: context.name ?? props.name,
     value: props.value,
-    className,
   };
 };

--- a/packages/components/forms/src/base-checkbox/BaseCheckboxGroupContext.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckboxGroupContext.tsx
@@ -1,4 +1,6 @@
 import { createContext, useContext } from 'react';
+import { css } from 'emotion';
+import tokens from '@contentful/f36-tokens';
 import { BaseCheckboxProps } from './BaseCheckbox';
 import { BaseCheckboxGroupProps } from './BaseCheckboxGroup';
 
@@ -8,7 +10,7 @@ export type BaseCheckboxGroupContextProps = Omit<
 >;
 export type BaseCheckboxGroupContextValue = Pick<
   BaseCheckboxProps,
-  'isChecked' | 'defaultChecked' | 'onChange' | 'name' | 'value'
+  'isChecked' | 'defaultChecked' | 'onChange' | 'name' | 'value' | 'className'
 >;
 
 export const BaseCheckboxGroupContext = createContext<
@@ -27,6 +29,12 @@ export const useBaseCheckboxGroup = (
   if (!context) {
     return props;
   }
+
+  const className = css({
+    '&:not(:last-child)': {
+      marginBottom: tokens.spacingXs,
+    },
+  });
 
   let isChecked, defaultChecked;
 
@@ -61,5 +69,6 @@ export const useBaseCheckboxGroup = (
     onChange,
     name: context.name ?? props.name,
     value: props.value,
+    className,
   };
 };

--- a/packages/components/forms/src/base-checkbox/GhostCheckbox.styles.ts
+++ b/packages/components/forms/src/base-checkbox/GhostCheckbox.styles.ts
@@ -14,6 +14,7 @@ const getBaseGhostStyles = ({ isDisabled }): CSSObject => ({
   height: tokens.spacingM,
   justifyContent: 'center',
   marginRight: tokens.spacingXs,
+  marginTop: `calc(${tokens.spacing2Xs}/2)`,
   width: tokens.spacingM,
 });
 

--- a/packages/components/forms/src/base-checkbox/types.ts
+++ b/packages/components/forms/src/base-checkbox/types.ts
@@ -41,5 +41,9 @@ export interface BaseCheckboxInternalProps
    * @default medium
    */
   size?: 'small' | 'medium';
+  /**
+   * Optional text to be added as help text bellow the label
+   */
+  helpText?: string;
   onChange?: ChangeEventHandler<HTMLInputElement>;
 }

--- a/packages/components/forms/src/checkbox/Checkbox.mdx
+++ b/packages/components/forms/src/checkbox/Checkbox.mdx
@@ -83,14 +83,12 @@ We also provide the `CheckboxGroup` component that helps when using multiple che
 
 ```jsx
 <CheckboxGroup name="checkbox-options" defaultValue={['option 1']}>
-  <Flex flexDirection="column">
-    <Checkbox value="option 1" id="option-1" helpText="Some help text">
-      Option 1
-    </Checkbox>
-    <Checkbox value="option 2" id="option-2" helpText="Another help text">
-      Option 2
-    </Checkbox>
-  </Flex>
+  <Checkbox value="option 1" id="option-1" helpText="Some help text">
+    Option 1
+  </Checkbox>
+  <Checkbox value="option 2" id="option-2" helpText="Another help text">
+    Option 2
+  </Checkbox>
 </CheckboxGroup>
 ```
 

--- a/packages/components/forms/src/checkbox/Checkbox.mdx
+++ b/packages/components/forms/src/checkbox/Checkbox.mdx
@@ -82,14 +82,18 @@ We also provide the `CheckboxGroup` component that helps when using multiple che
 - `onChange`: Handler that will be executed when any checkbox inside the group receives the event of change.
 
 ```jsx
-<CheckboxGroup name="checkbox-options" defaultValue={['option 1']}>
-  <Checkbox value="option 1" id="option-1" helpText="Some help text">
-    Option 1
-  </Checkbox>
-  <Checkbox value="option 2" id="option-2" helpText="Another help text">
-    Option 2
-  </Checkbox>
-</CheckboxGroup>
+<React.Fragment>
+  <Form.Label marginBottom="none">Checkbox group options</Form.Label>
+  <Paragraph>Subtitle with more information if needed</Paragraph>
+  <CheckboxGroup name="checkbox-options" defaultValue={['option 1']}>
+    <Checkbox value="option 1" id="option-1" helpText="Some help text">
+      Option 1
+    </Checkbox>
+    <Checkbox value="option 2" id="option-2" helpText="Another help text">
+      Option 2
+    </Checkbox>
+  </CheckboxGroup>
+</React.Fragment>
 ```
 
 ## Code examples

--- a/packages/components/forms/src/checkbox/Checkbox.mdx
+++ b/packages/components/forms/src/checkbox/Checkbox.mdx
@@ -73,9 +73,9 @@ You can use the Checkbox as an uncontrolled input, for that you can:
 
 ### Using with CheckboxGroup
 
-We also provide the `CheckboxGroup` component that helps when using multiple checkboxes, you can pass some common properties to be replicated to the checkboxes.  
-This only set the context for the checkboxes, it doesn't handle any styling.
+We also provide the `CheckboxGroup` component that helps when using multiple checkboxes, you can pass the spacing value and some common properties to be replicated to the checkboxes.
 
+- `spacing`: This will set how much space should be between the inputs;
 - `name`: This will set all checkboxes with this name;
 - `defaultValue`: This accepts an array that set the `defaultChecked` property for checkboxes which the value exists in the array;
 - `value`: Same as `defaultValue` but this one sets the `isChecked` property, making the checkbox group controlled;
@@ -84,10 +84,10 @@ This only set the context for the checkboxes, it doesn't handle any styling.
 ```jsx
 <CheckboxGroup name="checkbox-options" defaultValue={['option 1']}>
   <Flex flexDirection="column">
-    <Checkbox value="option 1" id="option-1">
+    <Checkbox value="option 1" id="option-1" helpText="Some help text">
       Option 1
     </Checkbox>
-    <Checkbox value="option 2" id="option-2">
+    <Checkbox value="option 2" id="option-2" helpText="Another help text">
       Option 2
     </Checkbox>
   </Flex>

--- a/packages/components/forms/src/checkbox/Checkbox.tsx
+++ b/packages/components/forms/src/checkbox/Checkbox.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { cx } from 'emotion';
 import { useId } from '@contentful/f36-core';
 import { BaseCheckbox, BaseCheckboxProps } from '../base-checkbox';
 import { useFormControl } from '../form-control/FormControlContext';
@@ -40,11 +41,14 @@ const _Checkbox = (props: CheckboxProps, ref: React.Ref<HTMLInputElement>) => {
     isRequired,
   });
 
+  const rootClassName = cx(otherProps?.className, groupProps?.className);
+
   return (
     <BaseCheckbox
       {...formProps}
       {...groupProps}
       {...otherProps}
+      className={rootClassName}
       type="checkbox"
       testId={testId}
       ref={ref}

--- a/packages/components/forms/src/checkbox/Checkbox.tsx
+++ b/packages/components/forms/src/checkbox/Checkbox.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { cx } from 'emotion';
 import { useId } from '@contentful/f36-core';
 import { BaseCheckbox, BaseCheckboxProps } from '../base-checkbox';
 import { useFormControl } from '../form-control/FormControlContext';
@@ -41,14 +40,11 @@ const _Checkbox = (props: CheckboxProps, ref: React.Ref<HTMLInputElement>) => {
     isRequired,
   });
 
-  const rootClassName = cx(otherProps?.className, groupProps?.className);
-
   return (
     <BaseCheckbox
       {...formProps}
       {...groupProps}
       {...otherProps}
-      className={rootClassName}
       type="checkbox"
       testId={testId}
       ref={ref}

--- a/packages/components/forms/src/checkbox/Checkbox.tsx
+++ b/packages/components/forms/src/checkbox/Checkbox.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useId } from '@contentful/f36-core';
 import { BaseCheckbox, BaseCheckboxProps } from '../base-checkbox';
 import { useFormControl } from '../form-control/FormControlContext';
 import { useBaseCheckboxGroup } from '../base-checkbox/BaseCheckboxGroupContext';
@@ -21,6 +22,8 @@ const _Checkbox = (props: CheckboxProps, ref: React.Ref<HTMLInputElement>) => {
     ...otherProps
   } = props;
 
+  const inputId = useId(id, 'checkbox');
+
   const groupProps = useBaseCheckboxGroup({
     onChange,
     value,
@@ -31,7 +34,7 @@ const _Checkbox = (props: CheckboxProps, ref: React.Ref<HTMLInputElement>) => {
 
   // Removes the isReadOnly property that comes from FormControl context.
   const { isReadOnly, ...formProps } = useFormControl({
-    id,
+    id: inputId,
     isDisabled,
     isInvalid,
     isRequired,

--- a/packages/components/forms/src/checkbox/CheckboxGroup.tsx
+++ b/packages/components/forms/src/checkbox/CheckboxGroup.tsx
@@ -17,9 +17,9 @@ export interface CheckboxGroupProps
 }
 
 export const CheckboxGroup = (props: CheckboxGroupProps) => {
-  const { children, ...groupProps } = props;
+  const { children, testId = 'cf-ui-checkbox-group', ...otherProps } = props;
   return (
-    <BaseCheckboxGroup type="checkbox" {...groupProps}>
+    <BaseCheckboxGroup testId={testId} type="checkbox" {...otherProps}>
       {children}
     </BaseCheckboxGroup>
   );

--- a/packages/components/forms/src/form-label/FormLabel.tsx
+++ b/packages/components/forms/src/form-label/FormLabel.tsx
@@ -52,7 +52,7 @@ function _FormLabel(
   return (
     <Text
       as="label"
-      marginBottom="spacingS"
+      marginBottom="spacingXs"
       {...otherProps}
       fontColor="gray900"
       id={id}

--- a/packages/components/forms/src/radio/Radio.mdx
+++ b/packages/components/forms/src/radio/Radio.mdx
@@ -97,10 +97,10 @@ We also provide the `RadioGroup` component that helps when using multiple radio,
 ```jsx
 <RadioGroup name="radio-options" defaultValue={'option 1'}>
   <Flex flexDirection="column">
-    <Radio value="option 1" id="option-1">
+    <Radio value="option 1" id="option-1" helpText="Help text for option 1">
       Option 1
     </Radio>
-    <Radio value="option 2" id="option-2">
+    <Radio value="option 2" id="option-2" helpText="Help text for option 2">
       Option 2
     </Radio>
   </Flex>

--- a/packages/components/forms/src/radio/Radio.mdx
+++ b/packages/components/forms/src/radio/Radio.mdx
@@ -86,9 +86,9 @@ You can use the Radio as an uncontrolled input, for that you can:
 
 ### Using with RadioGroup
 
-We also provide the `RadioGroup` component that helps when using multiple radio, you can pass some common properties to be replicated to the radios.  
-This only set the context for the radio, it doesn't handle any styling.
+We also provide the `RadioGroup` component that helps when using multiple radio, you can pass the spacing value and some common properties to be replicated to the radios.
 
+- `spacing`: This will set how much space should be between the inputs;
 - `name`: This will set all radios with this name;
 - `defaultValue`: This accepts a value that set the `defaultChecked` property for the radio that have the same value.
 - `value`: Same as `defaultValue` but this one sets the `isChecked` property, making the radio group controlled;

--- a/packages/components/forms/src/radio/Radio.mdx
+++ b/packages/components/forms/src/radio/Radio.mdx
@@ -95,14 +95,18 @@ We also provide the `RadioGroup` component that helps when using multiple radio,
 - `onChange`: Handler that will be executed when any radio inside the group receives the event of change.
 
 ```jsx
-<RadioGroup name="radio-options" defaultValue={'option 1'}>
-  <Radio value="option 1" id="option-1" helpText="Help text for option 1">
-    Option 1
-  </Radio>
-  <Radio value="option 2" id="option-2" helpText="Help text for option 2">
-    Option 2
-  </Radio>
-</RadioGroup>
+<React.Fragment>
+  <Form.Label marginBottom="none">Radio group options</Form.Label>
+  <Paragraph>Subtitle with more information if needed</Paragraph>
+  <RadioGroup name="radio-options" defaultValue={'option 1'}>
+    <Radio value="option 1" id="option-1" helpText="Help text for option 1">
+      Option 1
+    </Radio>
+    <Radio value="option 2" id="option-2" helpText="Help text for option 2">
+      Option 2
+    </Radio>
+  </RadioGroup>
+</React.Fragment>
 ```
 
 ## Code examples

--- a/packages/components/forms/src/radio/Radio.mdx
+++ b/packages/components/forms/src/radio/Radio.mdx
@@ -96,14 +96,12 @@ We also provide the `RadioGroup` component that helps when using multiple radio,
 
 ```jsx
 <RadioGroup name="radio-options" defaultValue={'option 1'}>
-  <Flex flexDirection="column">
-    <Radio value="option 1" id="option-1" helpText="Help text for option 1">
-      Option 1
-    </Radio>
-    <Radio value="option 2" id="option-2" helpText="Help text for option 2">
-      Option 2
-    </Radio>
-  </Flex>
+  <Radio value="option 1" id="option-1" helpText="Help text for option 1">
+    Option 1
+  </Radio>
+  <Radio value="option 2" id="option-2" helpText="Help text for option 2">
+    Option 2
+  </Radio>
 </RadioGroup>
 ```
 

--- a/packages/components/forms/src/radio/Radio.mdx
+++ b/packages/components/forms/src/radio/Radio.mdx
@@ -5,7 +5,7 @@ status: 'stable'
 slug: /components/radio/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/forms/src/radio'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/form-elements-radio--basic'
-typescript: ./Radio.tsx, ./RadioGroup.tsx
+typescript: ./Radio.tsx,./RadioGroup.tsx
 ---
 
 `Radio` is a form component, that shows a radio input with its label. It is used to allow users to choose single option from the list. If you want to let the user select multiple options, use the `Checkbox` component.  

--- a/packages/components/forms/src/radio/Radio.tsx
+++ b/packages/components/forms/src/radio/Radio.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useId } from '@contentful/f36-core';
 import { BaseCheckbox, BaseCheckboxProps } from '../base-checkbox';
 import { useFormControl } from '../form-control/FormControlContext';
 import { useBaseCheckboxGroup } from '../base-checkbox/BaseCheckboxGroupContext';
@@ -24,6 +25,8 @@ const _Radio = (props: RadioProps, ref: React.Ref<HTMLInputElement>) => {
     ...otherProps
   } = props;
 
+  const inputId = useId(id, 'radio');
+
   const groupProps = useBaseCheckboxGroup({
     onChange,
     value,
@@ -34,7 +37,7 @@ const _Radio = (props: RadioProps, ref: React.Ref<HTMLInputElement>) => {
 
   // Removes the isReadOnly property that comes from FormControl context.
   const { isReadOnly, ...formProps } = useFormControl({
-    id,
+    id: inputId,
     isDisabled,
     isInvalid,
     isRequired,

--- a/packages/components/forms/src/radio/Radio.tsx
+++ b/packages/components/forms/src/radio/Radio.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { cx } from 'emotion';
 import { useId } from '@contentful/f36-core';
 import { BaseCheckbox, BaseCheckboxProps } from '../base-checkbox';
 import { useFormControl } from '../form-control/FormControlContext';
@@ -44,14 +43,11 @@ const _Radio = (props: RadioProps, ref: React.Ref<HTMLInputElement>) => {
     isRequired,
   });
 
-  const rootClassName = cx(otherProps?.className, groupProps?.className);
-
   return (
     <BaseCheckbox
       {...formProps}
       {...otherProps}
       {...groupProps}
-      className={rootClassName}
       type="radio"
       testId={testId}
       ref={ref}

--- a/packages/components/forms/src/radio/Radio.tsx
+++ b/packages/components/forms/src/radio/Radio.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { cx } from 'emotion';
 import { useId } from '@contentful/f36-core';
 import { BaseCheckbox, BaseCheckboxProps } from '../base-checkbox';
 import { useFormControl } from '../form-control/FormControlContext';
@@ -43,11 +44,14 @@ const _Radio = (props: RadioProps, ref: React.Ref<HTMLInputElement>) => {
     isRequired,
   });
 
+  const rootClassName = cx(otherProps?.className, groupProps?.className);
+
   return (
     <BaseCheckbox
       {...formProps}
       {...otherProps}
       {...groupProps}
+      className={rootClassName}
       type="radio"
       testId={testId}
       ref={ref}

--- a/packages/components/forms/src/radio/RadioGroup.tsx
+++ b/packages/components/forms/src/radio/RadioGroup.tsx
@@ -16,9 +16,9 @@ export interface RadioGroupProps extends Omit<BaseCheckboxGroupProps, 'type'> {
 }
 
 export const RadioGroup = (props: RadioGroupProps) => {
-  const { children, ...groupProps } = props;
+  const { children, testId = 'cf-ui-radio-group', ...groupProps } = props;
   return (
-    <BaseCheckboxGroup type="radio" {...groupProps}>
+    <BaseCheckboxGroup testId={testId} type="radio" {...groupProps}>
       {children}
     </BaseCheckboxGroup>
   );

--- a/packages/components/forms/stories/CheckboxGroup.stories.tsx
+++ b/packages/components/forms/stories/CheckboxGroup.stories.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { action } from '@storybook/addon-actions';
-import { Flex } from '@contentful/f36-core';
 import { Checkbox, CheckboxGroup, CheckboxGroupProps } from '../src/checkbox';
 
 export default {
@@ -9,11 +8,13 @@ export default {
   argTypes: {
     className: { control: { disable: true } },
     testId: { control: { disable: true } },
+    children: { control: { disable: true } },
+    onChange: { control: { disable: true } },
   },
 };
 
 export const Basic = (args: CheckboxGroupProps) => {
-  const [groupState, setGroupState] = useState(args.defaultValue);
+  const [groupState, setGroupState] = useState(args.value || args.defaultValue);
   const handleOnChange = (e) => {
     e.persist();
     const value = e.target.value;
@@ -25,39 +26,42 @@ export const Basic = (args: CheckboxGroupProps) => {
     action('onChange')(e);
   };
 
+  const { value } = args;
+  useEffect(() => {
+    Array.isArray(value) && setGroupState(value);
+  }, [value]);
+
   return (
     <CheckboxGroup {...args} value={groupState} onChange={handleOnChange}>
-      <Flex flexDirection="column">
-        <Checkbox value="apples">Apples</Checkbox>
-        <Checkbox value="pears">Pears</Checkbox>
-        <Checkbox value="peaches">Peaches</Checkbox>
-        <Checkbox value="mangos">Mangos</Checkbox>
-        <Checkbox value="kiwis">Kiwis</Checkbox>
-        <Checkbox value="bananas">Bananas</Checkbox>
-      </Flex>
+      <Checkbox value="apples">Apples</Checkbox>
+      <Checkbox value="pears">Pears</Checkbox>
+      <Checkbox value="peaches">Peaches</Checkbox>
+      <Checkbox value="mangos">Mangos</Checkbox>
+      <Checkbox value="kiwis">Kiwis</Checkbox>
+      <Checkbox value="bananas">Bananas</Checkbox>
     </CheckboxGroup>
   );
 };
 
 Basic.args = {
+  direction: 'column',
   defaultValue: ['apples', 'kiwis'],
 };
 
 export const Uncontrolled = (args: CheckboxGroupProps) => {
   return (
     <CheckboxGroup defaultValue={args.defaultValue}>
-      <Flex flexDirection="column">
-        <Checkbox value="apples">Apples</Checkbox>
-        <Checkbox value="pears">Pears</Checkbox>
-        <Checkbox value="peaches">Peaches</Checkbox>
-        <Checkbox value="mangos">Mangos</Checkbox>
-        <Checkbox value="kiwis">Kiwis</Checkbox>
-        <Checkbox value="bananas">Bananas</Checkbox>
-      </Flex>
+      <Checkbox value="apples">Apples</Checkbox>
+      <Checkbox value="pears">Pears</Checkbox>
+      <Checkbox value="peaches">Peaches</Checkbox>
+      <Checkbox value="mangos">Mangos</Checkbox>
+      <Checkbox value="kiwis">Kiwis</Checkbox>
+      <Checkbox value="bananas">Bananas</Checkbox>
     </CheckboxGroup>
   );
 };
 
 Uncontrolled.args = {
+  direction: 'column',
   defaultValue: ['apples', 'kiwis'],
 };

--- a/packages/components/forms/stories/CheckboxGroup.stories.tsx
+++ b/packages/components/forms/stories/CheckboxGroup.stories.tsx
@@ -44,7 +44,6 @@ export const Basic = (args: CheckboxGroupProps) => {
 };
 
 Basic.args = {
-  direction: 'column',
   defaultValue: ['apples', 'kiwis'],
 };
 
@@ -62,6 +61,5 @@ export const Uncontrolled = (args: CheckboxGroupProps) => {
 };
 
 Uncontrolled.args = {
-  direction: 'column',
   defaultValue: ['apples', 'kiwis'],
 };

--- a/packages/components/forms/stories/FormControl.stories.tsx
+++ b/packages/components/forms/stories/FormControl.stories.tsx
@@ -14,6 +14,7 @@ import {
 import { Flex, Box } from '@contentful/f36-core';
 import { TextLink } from '@contentful/f36-text-link';
 import { LockIcon } from '@contentful/f36-icons';
+import { Subheading, Paragraph } from '@contentful/f36-typography';
 
 export default {
   title: 'Form Elements/FormControl',
@@ -82,47 +83,56 @@ export const WithCheckboxGroup = (args: FormControlInternalProps) => {
   return (
     <>
       <FormControl {...args}>
-        <FormControl.Label>Select your ingredients:</FormControl.Label>
-        <FormControl.HelpText>No extra costs</FormControl.HelpText>
+        <Subheading marginBottom="none">Select your ingredients:</Subheading>
+        <Paragraph>No extra costs</Paragraph>
 
         <CheckboxGroup name="ingredients">
-          <Checkbox value="pickled-onions">
+          <Checkbox
+            value="pickled-onions"
+            helpText="Red onion sliced paper-thin, pickled in lime and gentle sea salt"
+          >
             Pickled onions
-            <FormControl.HelpText>
-              Red onion sliced paper-thin, pickled in lime and gentle sea salt
-            </FormControl.HelpText>
           </Checkbox>
-          <Checkbox value="pepper-jam">
+          <Checkbox
+            value="pepper-jam"
+            helpText="Slow roasted red bell peppers with olive oil, garlic and sumac"
+          >
             Pepper jam
-            <FormControl.HelpText>
-              Slow roasted red bell peppers with olive oil, garlic and sumac
-            </FormControl.HelpText>
           </Checkbox>
-          <Checkbox value="double-fried-fries">
+          <Checkbox
+            value="double-fried-fries"
+            helpText="Local grown organic potatoes fried in peanut oil"
+          >
             Double-fried fries
-            <FormControl.HelpText>
-              Local grown organic potatoes fried in peanut oil
-            </FormControl.HelpText>
           </Checkbox>
         </CheckboxGroup>
       </FormControl>
 
       <FormControl {...args}>
-        <FormControl.Label>Burger patty:</FormControl.Label>
+        <Subheading>Burger patty:</Subheading>
         <RadioGroup name="burger-patty">
-          <Radio value="beef">
+          <Radio
+            value="beef"
+            helpText="Grass-fed cows from Erdhof Hohenzollerdamm"
+          >
             Beef
-            <FormControl.HelpText>
-              Grass-fed cows from Erdhof Hohenzollerdamm
-            </FormControl.HelpText>
           </Radio>
-          <Radio value="beyound-meat">
+          <Radio
+            value="beyound-meat"
+            helpText="Pea protein, beetroot and magic"
+          >
             Beyound meat (vegan)
-            <FormControl.HelpText>
-              Pea protein, beetroot and magic
-            </FormControl.HelpText>
           </Radio>
         </RadioGroup>
+      </FormControl>
+
+      <FormControl>
+        <Subheading>Condiments:</Subheading>
+        <CheckboxGroup name="condiments">
+          <Checkbox value="ketchup">Ketchup</Checkbox>
+          <Checkbox value="mustard">Mustard</Checkbox>
+          <Checkbox value="mayo">Mayo</Checkbox>
+        </CheckboxGroup>
       </FormControl>
     </>
   );

--- a/packages/components/forms/stories/FormControl.stories.tsx
+++ b/packages/components/forms/stories/FormControl.stories.tsx
@@ -14,7 +14,7 @@ import {
 import { Flex, Box } from '@contentful/f36-core';
 import { TextLink } from '@contentful/f36-text-link';
 import { LockIcon } from '@contentful/f36-icons';
-import { Subheading, Paragraph } from '@contentful/f36-typography';
+import { Paragraph } from '@contentful/f36-typography';
 
 export default {
   title: 'Form Elements/FormControl',
@@ -83,7 +83,9 @@ export const WithCheckboxGroup = (args: FormControlInternalProps) => {
   return (
     <>
       <FormControl {...args}>
-        <Subheading marginBottom="none">Select your ingredients:</Subheading>
+        <FormControl.Label marginBottom="none">
+          Select your ingredients
+        </FormControl.Label>
         <Paragraph>No extra costs</Paragraph>
 
         <CheckboxGroup name="ingredients">
@@ -106,10 +108,13 @@ export const WithCheckboxGroup = (args: FormControlInternalProps) => {
             Double-fried fries
           </Checkbox>
         </CheckboxGroup>
+        {args.isInvalid && (
+          <FormControl.ValidationMessage>Error</FormControl.ValidationMessage>
+        )}
       </FormControl>
 
       <FormControl {...args}>
-        <Subheading>Burger patty:</Subheading>
+        <FormControl.Label>Burger patty</FormControl.Label>
         <RadioGroup name="burger-patty">
           <Radio
             value="beef"
@@ -124,15 +129,21 @@ export const WithCheckboxGroup = (args: FormControlInternalProps) => {
             Beyound meat (vegan)
           </Radio>
         </RadioGroup>
+        {args.isInvalid && (
+          <FormControl.ValidationMessage>Error</FormControl.ValidationMessage>
+        )}
       </FormControl>
 
-      <FormControl>
-        <Subheading>Condiments:</Subheading>
+      <FormControl {...args}>
+        <FormControl.Label>Condiments</FormControl.Label>
         <CheckboxGroup name="condiments">
           <Checkbox value="ketchup">Ketchup</Checkbox>
           <Checkbox value="mustard">Mustard</Checkbox>
           <Checkbox value="mayo">Mayo</Checkbox>
         </CheckboxGroup>
+        {args.isInvalid && (
+          <FormControl.ValidationMessage>Error</FormControl.ValidationMessage>
+        )}
       </FormControl>
     </>
   );

--- a/packages/components/forms/stories/FormControl.stories.tsx
+++ b/packages/components/forms/stories/FormControl.stories.tsx
@@ -7,6 +7,9 @@ import {
   Textarea,
   Select,
   Checkbox,
+  CheckboxGroup,
+  Radio,
+  RadioGroup,
 } from '../src';
 import { Flex, Box } from '@contentful/f36-core';
 import { TextLink } from '@contentful/f36-text-link';
@@ -72,6 +75,56 @@ export const Invalid = (args: FormControlInternalProps) => {
     <Basic {...args} isInvalid>
       {args.children}
     </Basic>
+  );
+};
+
+export const WithCheckboxGroup = (args: FormControlInternalProps) => {
+  return (
+    <>
+      <FormControl {...args}>
+        <FormControl.Label>Select your ingredients:</FormControl.Label>
+        <FormControl.HelpText>No extra costs</FormControl.HelpText>
+
+        <CheckboxGroup name="ingredients">
+          <Checkbox value="pickled-onions">
+            Pickled onions
+            <FormControl.HelpText>
+              Red onion sliced paper-thin, pickled in lime and gentle sea salt
+            </FormControl.HelpText>
+          </Checkbox>
+          <Checkbox value="pepper-jam">
+            Pepper jam
+            <FormControl.HelpText>
+              Slow roasted red bell peppers with olive oil, garlic and sumac
+            </FormControl.HelpText>
+          </Checkbox>
+          <Checkbox value="double-fried-fries">
+            Double-fried fries
+            <FormControl.HelpText>
+              Local grown organic potatoes fried in peanut oil
+            </FormControl.HelpText>
+          </Checkbox>
+        </CheckboxGroup>
+      </FormControl>
+
+      <FormControl {...args}>
+        <FormControl.Label>Burger patty:</FormControl.Label>
+        <RadioGroup name="burger-patty">
+          <Radio value="beef">
+            Beef
+            <FormControl.HelpText>
+              Grass-fed cows from Erdhof Hohenzollerdamm
+            </FormControl.HelpText>
+          </Radio>
+          <Radio value="beyound-meat">
+            Beyound meat (vegan)
+            <FormControl.HelpText>
+              Pea protein, beetroot and magic
+            </FormControl.HelpText>
+          </Radio>
+        </RadioGroup>
+      </FormControl>
+    </>
   );
 };
 

--- a/packages/components/forms/stories/RadioGroup.stories.tsx
+++ b/packages/components/forms/stories/RadioGroup.stories.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { action } from '@storybook/addon-actions';
-import { Flex } from '@contentful/f36-core';
 import { Radio, RadioGroup, RadioGroupProps } from '../src/radio';
 
 export default {
@@ -9,6 +8,8 @@ export default {
   argTypes: {
     className: { control: { disable: true } },
     testId: { control: { disable: true } },
+    children: { control: { disable: true } },
+    onChange: { control: { disable: true } },
   },
 };
 
@@ -20,36 +21,56 @@ export const Basic = (args: RadioGroupProps) => {
     action('onChange')(e);
   };
 
+  const { value } = args;
+  useEffect(() => {
+    setGroupState(value);
+  }, [value]);
+
   return (
     <RadioGroup {...args} value={groupState} onChange={handleOnChange}>
-      <Flex flexDirection="column">
-        <Radio value="apples">Apples</Radio>
-        <Radio value="pears">Pears</Radio>
-        <Radio value="peaches">Peaches</Radio>
-        <Radio value="mangos">Mangos</Radio>
-        <Radio value="kiwis">Kiwis</Radio>
-        <Radio value="bananas">Bananas</Radio>
-      </Flex>
+      <Radio value="apples">Apples</Radio>
+      <Radio value="pears">Pears</Radio>
+      <Radio value="peaches">Peaches</Radio>
+      <Radio value="mangos">Mangos</Radio>
+      <Radio value="kiwis">Kiwis</Radio>
+      <Radio value="bananas">Bananas</Radio>
     </RadioGroup>
   );
+};
+
+Basic.argTypes = {
+  defaultValue: { control: { disable: true } },
+  value: {
+    options: ['apples', 'pears', 'peaches', 'mangos', 'kiwis', 'bananas'],
+    control: { type: 'select' },
+  },
 };
 
 Basic.args = {
-  defaultValue: 'apples',
+  defaultValue: 'peaches',
   name: 'fruits',
+  direction: 'column',
 };
 
-export const Uncontrolled = () => {
+export const Uncontrolled = (args: RadioGroupProps) => {
   return (
-    <RadioGroup name="fruits" defaultValue={'kiwis'}>
-      <Flex flexDirection="column">
-        <Radio value="apples">Apples</Radio>
-        <Radio value="pears">Pears</Radio>
-        <Radio value="peaches">Peaches</Radio>
-        <Radio value="mangos">Mangos</Radio>
-        <Radio value="kiwis">Kiwis</Radio>
-        <Radio value="bananas">Bananas</Radio>
-      </Flex>
+    <RadioGroup {...args}>
+      <Radio value="apples">Apples</Radio>
+      <Radio value="pears">Pears</Radio>
+      <Radio value="peaches">Peaches</Radio>
+      <Radio value="mangos">Mangos</Radio>
+      <Radio value="kiwis">Kiwis</Radio>
+      <Radio value="bananas">Bananas</Radio>
     </RadioGroup>
   );
+};
+
+Uncontrolled.argTypes = {
+  value: { control: { disable: true } },
+};
+
+Uncontrolled.args = {
+  direction: 'column',
+  defaultValue: 'kiwis',
+  name: 'fruits',
 };

--- a/packages/components/forms/stories/RadioGroup.stories.tsx
+++ b/packages/components/forms/stories/RadioGroup.stories.tsx
@@ -49,7 +49,6 @@ Basic.argTypes = {
 Basic.args = {
   defaultValue: 'peaches',
   name: 'fruits',
-  direction: 'column',
 };
 
 export const Uncontrolled = (args: RadioGroupProps) => {
@@ -70,7 +69,6 @@ Uncontrolled.argTypes = {
 };
 
 Uncontrolled.args = {
-  direction: 'column',
   defaultValue: 'kiwis',
   name: 'fruits',
 };


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->
Add a default styling for the BaseCheckboxGroup.


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
