### PR TITLE
docs: add embed code sandbox template to website

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -19,6 +19,9 @@ If you have any questions feel free to get in touch on the #forma36 channel on o
 
 <!--
 Please provide us with a brief summary of the bug, a few words will do. Providing screenshots is encouraged
+
+You can also use our Codesandbox template to provide us with a reproducible example
+https://codesandbox.io/s/forma-36-template-v3-x-x-stxbz
 -->
 
 ## Environment

--- a/packages/forma-36-website/src/pages/index.jsx
+++ b/packages/forma-36-website/src/pages/index.jsx
@@ -77,6 +77,30 @@ const IndexPage = () => (
     </Section>
 
     <Section isSecondary>
+      <DisplayText>Get started</DisplayText>
+      <Paragraph
+        style={{ fontSize: tokens.fontSizeL, marginBottom: tokens.spacingM }}
+      >
+        You can use our Codesandbox template to start using Forma 36 right away
+      </Paragraph>
+
+      <iframe
+        src="https://codesandbox.io/embed/forma-36-template-v3-x-x-stxbz?fontsize=14&hidenavigation=1&theme=dark"
+        style={{
+          width: '100%',
+          maxWidth: '960px',
+          height: '500px',
+          border: 0,
+          borderRadius: '4px',
+          overflow: 'hidden',
+        }}
+        title="Forma 36 Template (v3.x.x) "
+        allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+        sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+      ></iframe>
+    </Section>
+
+    <Section isSecondary>
       <DisplayText>Forma 36 is open-source</DisplayText>
       <Paragraph
         style={{


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

I created the Codesandbox template so people can share examples of their usage faster with us
and the dev relationship team suggested to put it in the official docs somewhere so I opened this PR that will add this to Forma 36’s home

![Screenshot 2021-09-13 at 16 25 34](https://user-images.githubusercontent.com/6597467/133102294-f66e6dfb-5c3c-4079-bc22-ef0deb80e56f.png)

It also adds link to the template in our Bug report template


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
