### PR TITLE
fix: dropdown container focus styles

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.css
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.css
@@ -25,7 +25,7 @@
 
   &:focus {
     outline: none;
-    box-shadow: var(--glow-muted), var(--box-shadow-default);
+    box-shadow: var(--glow-primary), var(--box-shadow-default);
   }
 }
 

--- a/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.css
+++ b/packages/forma-36-react-components/src/components/Dropdown/DropdownContainer/DropdownContainer.css
@@ -22,6 +22,11 @@
   margin: 0;
 
   z-index: var(--z-index-dropdown);
+
+  &:focus {
+    outline: none;
+    box-shadow: var(--glow-muted), var(--box-shadow-default);
+  }
 }
 
 .DropdownContainer > div {


### PR DESCRIPTION
# Purpose of PR

Refine dropdown container focus style 

**Before**
<img width="477" alt="Screenshot 2021-09-14 at 15 03 47" src="https://user-images.githubusercontent.com/6163988/133262604-ac814653-2b46-4149-9655-4eb7b156a50c.png">

**After**
<img width="373" alt="Screenshot 2021-09-14 at 15 04 58" src="https://user-images.githubusercontent.com/6163988/133262788-37741b3f-4efd-40b8-86b0-cc23fef32977.png">


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
