### PR TITLE
chore(tooltip): create codemod for Tooltip component

### DIFF
--- a/packages/components/tooltip/Tooltip.mdx
+++ b/packages/components/tooltip/Tooltip.mdx
@@ -5,7 +5,7 @@ status: 'stable'
 slug: /components/tooltip/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/tooltip'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-tooltip--basic'
-typescript: ./src/Tooltip.tsxs
+typescript: ./src/Tooltip.tsx
 ---
 
 ## Tooltip

--- a/packages/forma-36-codemod/README.md
+++ b/packages/forma-36-codemod/README.md
@@ -80,3 +80,6 @@ Migrates `Pill` component from Forma@v3 to Forma@v4
 #### `v4-button`
 
 Migrates `Button` component from Forma@v3 to Forma@v4
+#### `v4-tooltip`
+
+Migrates `Tooltip` component from Forma@v3 to Forma@v4

--- a/packages/forma-36-codemod/README.md
+++ b/packages/forma-36-codemod/README.md
@@ -80,6 +80,7 @@ Migrates `Pill` component from Forma@v3 to Forma@v4
 #### `v4-button`
 
 Migrates `Button` component from Forma@v3 to Forma@v4
+
 #### `v4-tooltip`
 
 Migrates `Tooltip` component from Forma@v3 to Forma@v4

--- a/packages/forma-36-codemod/bin/inquirer-choices.js
+++ b/packages/forma-36-codemod/bin/inquirer-choices.js
@@ -70,6 +70,10 @@ const TRANSFORMS_CHOICES = [
     name: 'v4-skeleton: Converts Skeleton components from Forma v3 to v4',
     value: 'v4-skeleton',
   },
+  {
+    name: 'v4-tooltip: Converts Tooltip component from Forma v3 to v4',
+    value: 'v4-tooltip',
+  },
 ];
 
 module.exports = {

--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4-tooltip.input.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4-tooltip.input.js
@@ -1,0 +1,7 @@
+import React from "react";
+import { Tooltip } from "@contentful/forma-36-react-components";
+import { TextLink } from "@contentful/f36-components";
+
+<Tooltip content="tooltip content" containerElement="div" place="left">
+  <TextLink>Hover me</TextLink>.
+</Tooltip>

--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4-tooltip.output.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4-tooltip.output.js
@@ -1,0 +1,6 @@
+import React from "react";
+import { TextLink, Tooltip } from "@contentful/f36-components";
+
+<Tooltip content="tooltip content" as="div" placement="left">
+  <TextLink>Hover me</TextLink>.
+</Tooltip>

--- a/packages/forma-36-codemod/transforms/__tests__/v4.test.js
+++ b/packages/forma-36-codemod/transforms/__tests__/v4.test.js
@@ -18,6 +18,7 @@ describe('v4 codemods', () => {
     'v4-table',
     'v4-grid',
     'v4-skeleton',
+    'v4-tooltip',
   ];
 
   beforeEach(() => {

--- a/packages/forma-36-codemod/transforms/v4-tooltip.js
+++ b/packages/forma-36-codemod/transforms/v4-tooltip.js
@@ -1,4 +1,7 @@
 const { modifyPropsCodemod } = require('./common/modify-props-codemod');
+const { pipe } = require('./common/pipe');
+const { getComponentLocalName } = require('../utils');
+const { getFormaImport } = require('../utils/config');
 
 module.exports = modifyPropsCodemod({
   componentName: 'Tooltip',
@@ -7,3 +10,33 @@ module.exports = modifyPropsCodemod({
     containerElement: 'as',
   },
 });
+
+module.exports = pipe([
+  (file, api) => {
+    const j = api.jscodeshift;
+
+    let source = file.source;
+
+    const componentName = getComponentLocalName(j, source, {
+      componentName: 'Tooltip',
+      importName: getFormaImport(),
+    });
+
+    if (!componentName) {
+      return source;
+    }
+    // eslint-disable-next-line no-console
+    console.warn(
+      'If you are passing anything other than a string to the `content` prop of the `Tooltip`, please update it to a string.',
+    );
+
+    return source;
+  },
+  modifyPropsCodemod({
+    componentName: 'Tooltip',
+    renameMap: {
+      place: 'placement',
+      containerElement: 'as',
+    },
+  }),
+]);

--- a/packages/forma-36-codemod/transforms/v4-tooltip.js
+++ b/packages/forma-36-codemod/transforms/v4-tooltip.js
@@ -1,0 +1,9 @@
+const { modifyPropsCodemod } = require('./common/modify-props-codemod');
+
+module.exports = modifyPropsCodemod({
+  componentName: 'Tooltip',
+  renameMap: {
+    place: 'placement',
+    containerElement: 'as',
+  },
+});

--- a/packages/forma-36-codemod/transforms/v4-tooltip.js
+++ b/packages/forma-36-codemod/transforms/v4-tooltip.js
@@ -3,14 +3,6 @@ const { pipe } = require('./common/pipe');
 const { getComponentLocalName } = require('../utils');
 const { getFormaImport } = require('../utils/config');
 
-module.exports = modifyPropsCodemod({
-  componentName: 'Tooltip',
-  renameMap: {
-    place: 'placement',
-    containerElement: 'as',
-  },
-});
-
 module.exports = pipe([
   (file, api) => {
     const j = api.jscodeshift;


### PR DESCRIPTION
# Purpose of PR

This PR adds a codemod for Tooltip component from v3 to v4.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
