### PR TITLE
fix: remove migration note regarding colors migration

### DIFF
--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -7,11 +7,10 @@ require('dotenv').config({
 module.exports = {
   siteMetadata: {
     title: 'Forma 36 - The Contentful Design System',
-    promoText: `Updated color system with new tokens.`,
-    promoLink:
-      'https://github.com/contentful/forma-36/blob/master/packages/forma-36-tokens/MIGRATION.md',
-    promoLinkText: 'Migration notes',
-    promoTagText: 'New colors',
+    promoText: ``,
+    promoLink: '',
+    promoLinkText: '',
+    promoTagText: '',
     menuLinks: [
       {
         name: 'Foundation',


### PR DESCRIPTION
This might be a moment to remove the note regarding the colors update from the website? It's been there for 2 months. WDYT?