### PR TITLE
feat: add useKeyboard hook to f36-utils

### DIFF
--- a/packages/components/utils/src/index.ts
+++ b/packages/components/utils/src/index.ts
@@ -3,3 +3,5 @@ export type { PortalProps } from './Portal/Portal';
 export { TabFocusTrap } from './TabFocusTrap/TabFocusTrap';
 export type { TabFocusTrapProps } from './TabFocusTrap/TabFocusTrap';
 export { useArrowKeyNavigation } from './ArrowKeyNavigation/useArrowKeyNavigation';
+export { useKeyboard } from './useKeyboard/useKeyboard';
+export type { UseKeyboardProps } from './useKeyboard/useKeyboard';

--- a/packages/components/utils/src/useKeyboard/useKeyboard.spec.tsx
+++ b/packages/components/utils/src/useKeyboard/useKeyboard.spec.tsx
@@ -1,0 +1,66 @@
+import React, { useRef } from 'react';
+import { render, fireEvent, getByText } from '@testing-library/react';
+
+import { useKeyboard } from './useKeyboard';
+
+const handleEnter = jest.fn();
+const handleArrowUp = jest.fn();
+
+const Component = () => {
+  useKeyboard({
+    keys: {
+      ArrowUp: handleArrowUp,
+      Enter: handleEnter,
+    },
+  });
+
+  return <button type="button">Button</button>;
+};
+
+const ComponentWithRef = () => {
+  const divRef = useRef(null);
+
+  useKeyboard({
+    ref: divRef,
+    keys: {
+      ArrowUp: handleArrowUp,
+      Enter: handleEnter,
+    },
+  });
+
+  return (
+    <button type="button" ref={divRef}>
+      Button
+    </button>
+  );
+};
+
+describe('useKeyboard', () => {
+  it('should attach handler to document by default', () => {
+    const events = {};
+    document.addEventListener = jest.fn((event, callback) => {
+      events[event] = callback;
+    });
+
+    render(<Component />);
+
+    expect(document.addEventListener).toHaveBeenCalledWith(
+      'keydown',
+      expect.any(Function),
+    );
+  });
+
+  it('should trigger handlers correctly', () => {
+    const { container } = render(<ComponentWithRef />);
+
+    fireEvent.keyDown(getByText(container as HTMLElement, 'Button'), {
+      key: 'Enter',
+    });
+    expect(handleEnter).toHaveBeenCalled();
+
+    fireEvent.keyDown(getByText(container as HTMLElement, 'Button'), {
+      key: 'ArrowUp',
+    });
+    expect(handleArrowUp).toHaveBeenCalled();
+  });
+});

--- a/packages/components/utils/src/useKeyboard/useKeyboard.spec.tsx
+++ b/packages/components/utils/src/useKeyboard/useKeyboard.spec.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { render, fireEvent, getByText } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 import { useKeyboard } from './useKeyboard';
 
@@ -51,14 +51,14 @@ describe('useKeyboard', () => {
   });
 
   it('should trigger handlers correctly', () => {
-    const { container } = render(<ComponentWithRef />);
+    render(<ComponentWithRef />);
 
-    fireEvent.keyDown(getByText(container as HTMLElement, 'Button'), {
+    fireEvent.keyDown(screen.getByRole('button'), {
       key: 'Enter',
     });
     expect(handleEnter).toHaveBeenCalled();
 
-    fireEvent.keyDown(getByText(container as HTMLElement, 'Button'), {
+    fireEvent.keyDown(screen.getByRole('button'), {
       key: 'ArrowUp',
     });
     expect(handleArrowUp).toHaveBeenCalled();

--- a/packages/components/utils/src/useKeyboard/useKeyboard.ts
+++ b/packages/components/utils/src/useKeyboard/useKeyboard.ts
@@ -6,7 +6,7 @@ export interface UseKeyboardProps {
    * value is a callback function to be called when key matches
    */
   keys: {
-    [key: KeyboardEvent['key']]: (e: KeyboardEvent) => void;
+    [key: string]: (e: KeyboardEvent) => void;
   };
   /**
    * @description defines the attached event type

--- a/packages/components/utils/src/useKeyboard/useKeyboard.ts
+++ b/packages/components/utils/src/useKeyboard/useKeyboard.ts
@@ -48,7 +48,7 @@ export const useKeyboard = (props: UseKeyboardProps) => {
   );
 
   useEffect(() => {
-    if (ref) {
+    if (ref && ref.current) {
       element = ref.current;
     }
 
@@ -56,5 +56,5 @@ export const useKeyboard = (props: UseKeyboardProps) => {
     return () => {
       element.removeEventListener(event, handleKeyEvent);
     };
-  }, [ref, event, handleKeyEvent]);
+  }, [event, handleKeyEvent]);
 };

--- a/packages/components/utils/src/useKeyboard/useKeyboard.ts
+++ b/packages/components/utils/src/useKeyboard/useKeyboard.ts
@@ -56,5 +56,5 @@ export const useKeyboard = (props: UseKeyboardProps) => {
     return () => {
       element.removeEventListener(event, handleKeyEvent);
     };
-  }, [element, ref, event, handleKeyEvent]);
+  }, [ref, event, handleKeyEvent]);
 };

--- a/packages/components/utils/src/useKeyboard/useKeyboard.ts
+++ b/packages/components/utils/src/useKeyboard/useKeyboard.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export interface UseKeyboardProps {
+  /**
+   * @description defines which element is the event attached to
+   * @default document
+   */
+  ref?: Document | Window | HTMLElement;
+  /**
+   * @description defines which key to look for i.e. `ArrowUp`, `Escape`, `Shift`
+   */
+  key: KeyboardEvent['key'];
+  /**
+   * @description defines the attached event type
+   * @default 'keyup'
+   */
+  event?: 'keyup' | 'keypress' | 'keydown';
+  /**
+   * @description callback function to be called when key is matched
+   */
+  handler?: (e: KeyboardEvent) => void;
+}
+
+/**
+ *
+ * @description hook to attach a handler keyboard event listener with garbage collection
+ * @example useKeyboard({key: 'ArrowUp', ref: document, handler: yourHandlerFunction})
+ * @returns boolean
+ */
+export const useKeyboard = (props: UseKeyboardProps) => {
+  const { ref = document, key, event = 'keyup', handler } = props;
+  const [isKey, setIsKey] = useState(false);
+
+  const handleKeyEvent = useCallback(
+    (e) => {
+      if (e.key === key) {
+        setIsKey(true);
+        if (handler) {
+          handler(e);
+        }
+      }
+      setIsKey(false);
+    },
+    [key, handler],
+  );
+
+  useEffect(() => {
+    ref.addEventListener(event, handleKeyEvent);
+    return () => {
+      ref.removeEventListener(event, handleKeyEvent);
+    };
+  }, [ref, event, handleKeyEvent]);
+
+  return isKey;
+};


### PR DESCRIPTION
# Purpose of PR

closes https://github.com/contentful/forma-36/discussions/1008

Example usage

```js
useKeyboard({
   event: 'keydown', // Optional, default is `keydown`
   ref: yourReactRef, // Optional, by default event is attached to document
   keys: {
     ArrowUp: (e) => handleArrowUp(e),
     Tab: (e) => handleTab(e)
   }
})
```

## Todo
- [x] Add tests

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
