### PR TITLE
fix(globalstyles): add fieldset reset to GlobalStyles

### DIFF
--- a/packages/components/forms/stories/FormControl.stories.tsx
+++ b/packages/components/forms/stories/FormControl.stories.tsx
@@ -113,7 +113,7 @@ export const WithCheckboxGroup = (args: FormControlInternalProps) => {
         )}
       </FormControl>
 
-      <FormControl {...args}>
+      <FormControl as="fieldset" {...args}>
         <FormControl.Label>Burger patty</FormControl.Label>
         <RadioGroup name="burger-patty">
           <Radio

--- a/packages/core/src/GlobalStyles/GlobalStyles.tsx
+++ b/packages/core/src/GlobalStyles/GlobalStyles.tsx
@@ -14,23 +14,28 @@ export const GlobalStyles = ({
         ${withNormalize ? emotionNormalize : undefined};
 
         html {
+          border: 0;
           box-sizing: border-box;
           margin: 0;
-          margin: 0;
-          padding: 0;
-          border: 0;
           min-height: 100%;
+          padding: 0;
         }
 
         body {
-          font-size: ${tokens.fontSizeM};
-          font-family: ${tokens.fontStackPrimary};
           color: ${tokens.gray800};
+          font-family: ${tokens.fontStackPrimary};
+          font-size: ${tokens.fontSizeM};
           line-height: ${tokens.lineHeightM};
         }
 
         code {
           font-family: ${tokens.fontStackMonospace};
+        }
+
+        fieldset {
+          border: 0;
+          margin: 0;
+          padding: 0;
         }
 
         *,


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->
Add css reset for `fieldset` on `GlobalStyles`
