### PR TITLE
feat(tooltip-v4): update tooltip-v4 codemod to add console error for wrong prop type

### DIFF
--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4-tooltip.input.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4-tooltip.input.js
@@ -2,6 +2,12 @@ import React from "react";
 import { Tooltip } from "@contentful/forma-36-react-components";
 import { TextLink } from "@contentful/f36-components";
 
-<Tooltip content="tooltip content" containerElement="div" place="left">
+<>
+<Tooltip content={<div>some HTML</div>} containerElement="div" place="left">
   <TextLink>Hover me</TextLink>.
 </Tooltip>
+
+<Tooltip content={'content'} containerElement="div" place="left">
+  <TextLink>Hover me</TextLink>.
+</Tooltip>
+</>

--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4-tooltip.output.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4-tooltip.output.js
@@ -1,6 +1,12 @@
 import React from "react";
 import { TextLink, Tooltip } from "@contentful/f36-components";
 
-<Tooltip content="tooltip content" as="div" placement="left">
+<>
+<Tooltip content={<div>some HTML</div>} as="div" placement="left">
   <TextLink>Hover me</TextLink>.
 </Tooltip>
+
+<Tooltip content={'content'} as="div" placement="left">
+  <TextLink>Hover me</TextLink>.
+</Tooltip>
+</>

--- a/packages/forma-36-codemod/transforms/v4-tooltip.js
+++ b/packages/forma-36-codemod/transforms/v4-tooltip.js
@@ -1,34 +1,21 @@
 const { modifyPropsCodemod } = require('./common/modify-props-codemod');
-const { pipe } = require('./common/pipe');
-const { getComponentLocalName } = require('../utils');
-const { getFormaImport } = require('../utils/config');
+const { hasProperty, getProperty } = require('../utils');
 
-module.exports = pipe([
-  (file, api) => {
-    const j = api.jscodeshift;
-
-    let source = file.source;
-
-    const componentName = getComponentLocalName(j, source, {
-      componentName: 'Tooltip',
-      importName: getFormaImport(),
-    });
-
-    if (!componentName) {
-      return source;
+module.exports = modifyPropsCodemod({
+  componentName: 'Tooltip',
+  beforeRename: (attributes) => {
+    if (
+      hasProperty(attributes, { propertyName: 'content' }) &&
+      typeof getProperty(attributes, { propertyName: 'content' } !== 'string')
+    ) {
+      console.error(
+        'Value of property "content" on Tooltip component should be a string.',
+      );
     }
-    // eslint-disable-next-line no-console
-    console.warn(
-      'If you are passing anything other than a string to the `content` prop of the `Tooltip`, please update it to a string.',
-    );
-
-    return source;
+    return attributes;
   },
-  modifyPropsCodemod({
-    componentName: 'Tooltip',
-    renameMap: {
-      place: 'placement',
-      containerElement: 'as',
-    },
-  }),
-]);
+  renameMap: {
+    place: 'placement',
+    containerElement: 'as',
+  },
+});


### PR DESCRIPTION
# Purpose of PR

To make this change visible, I added a "console.error". If consumer won't update the property, it will lead to type errors.
