### PR TITLE
fix: remove select on disabled and readonly

### DIFF
--- a/packages/components/forms/src/base-input/BaseInput.tsx
+++ b/packages/components/forms/src/base-input/BaseInput.tsx
@@ -57,14 +57,11 @@ function _BaseInput<E extends React.ElementType = typeof DEFAULT_TAG>(
   const handleFocus = useCallback(
     (e: FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       e.persist();
-      if (isDisabled || isReadOnly) {
-        (e.target as HTMLInputElement).select();
-      }
       if (onFocus) {
         onFocus(e);
       }
     },
-    [isDisabled, isReadOnly, onFocus],
+    [onFocus],
   );
 
   const handleChange = useCallback(


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Completely removes `(e.target as HTMLInputElement).select();`. Fixes https://github.com/contentful/field-editors/pull/867