### PR TITLE
refactor(iconbutton): add default icon colors and default variant

### DIFF
--- a/packages/components/button/src/IconButton/IconButton.tsx
+++ b/packages/components/button/src/IconButton/IconButton.tsx
@@ -25,11 +25,28 @@ function _IconButton<E extends React.ElementType = typeof DEFAULT_TAG>(
   props: IconButtonProps<E>,
   ref: React.Ref<any>,
 ) {
-  const { testId = 'cf-ui-icon-button', icon, ...otherProps } = props;
+  const {
+    testId = 'cf-ui-icon-button',
+    variant = 'transparent',
+    icon,
+    ...otherProps
+  } = props;
+  const defaultIconColor: {
+    [Property in ButtonInternalProps['variant']]: string;
+  } = {
+    primary: 'white',
+    secondary: 'secondary',
+    positive: 'white',
+    negative: 'white',
+    transparent: 'secondary',
+  };
 
   return (
-    <Button testId={testId} ref={ref} {...otherProps}>
-      {icon}
+    <Button testId={testId} ref={ref} variant={variant} {...otherProps}>
+      {React.cloneElement(icon, {
+        variant: defaultIconColor[variant],
+        ...icon.props,
+      })}
     </Button>
   );
 }

--- a/packages/components/button/stories/IconButton.stories.tsx
+++ b/packages/components/button/stories/IconButton.stories.tsx
@@ -55,65 +55,65 @@ export const Overview = () => (
       <Stack spacing="spacingXs" marginBottom="spacingM">
         <IconButton
           variant="transparent"
-          icon={<Icon as={icons.CloseIcon} variant="secondary" />}
+          icon={<Icon as={icons.CloseIcon} />}
           aria-label="Close"
         />
 
         <IconButton
           variant="transparent"
-          icon={<Icon as={icons.MoreHorizontalIcon} variant="secondary" />}
+          icon={<Icon as={icons.MoreHorizontalIcon} />}
           aria-label="More"
         />
 
         <IconButton
           variant="secondary"
-          icon={<Icon as={icons.DownloadIcon} variant="secondary" />}
+          icon={<Icon as={icons.DownloadIcon} />}
           aria-label="Download"
         />
 
         <IconButton
           variant="secondary"
-          icon={<Icon as={icons.DownloadIcon} variant="secondary" />}
+          icon={<Icon as={icons.DownloadIcon} />}
           aria-label="Loading"
           isLoading
         />
 
         <IconButton
           variant="positive"
-          icon={<Icon as={icons.DragIcon} variant="white" />}
+          icon={<Icon as={icons.DragIcon} />}
           aria-label="Resize"
         />
 
         <IconButton
           variant="negative"
-          icon={<Icon as={icons.DeleteIcon} variant="white" />}
+          icon={<Icon as={icons.DeleteIcon} />}
           aria-label="Delete"
         />
 
         <IconButton
           variant="primary"
-          icon={<Icon as={icons.PlusIcon} variant="white" />}
+          icon={<Icon as={icons.PlusIcon} />}
           aria-label="Add"
         />
       </Stack>
       <Stack spacing="spacingXs" marginBottom="spacingM">
         <IconButton
           variant="primary"
-          icon={<Icon as={icons.PlusIcon} variant="white" />}
+          icon={<Icon as={icons.PlusIcon} />}
           aria-label="Plus"
           size="small"
         />
 
         <IconButton
           variant="primary"
-          icon={<Icon as={icons.PlusIcon} variant="white" />}
+          icon={<Icon as={icons.PlusIcon} />}
           aria-label="Plus"
           size="medium"
         />
 
         <IconButton
           variant="primary"
-          icon={<Icon as={icons.PlusIcon} variant="white" />}
+          icon={<Icon as={icons.PlusIcon} />}
           aria-label="Plus"
           size="large"
         />


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->
Add default variant, and default icon color per variant to make the usage easier

https://5fd1dda724cc620021ace8c5-qzqoodjook.chromatic.com/?path=/story/components-button-iconbutton--basic&args=iconProps.variant:negative;iconProps.size:large