### PR TITLE
test: add tests to v4 autocomplete

### DIFF
--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -252,7 +252,7 @@ function _Autocomplete<ItemType>(
                       styles.item,
                       highlightedIndex === index && styles.highlighted,
                     ])}
-                    data-test-id="cf-autocomplete-list-item"
+                    data-test-id={`cf-autocomplete-list-item-${index}`}
                   >
                     {renderItem ? renderItem(item) : item}
                   </li>

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -104,7 +104,7 @@ function _Autocomplete<ItemType>(
     isDisabled,
     isRequired,
     isReadOnly,
-    noMatchesMessage = 'No Matches',
+    noMatchesMessage = 'No matches',
     placeholder = 'Search',
     inputRef,
     toggleRef,

--- a/packages/components/autocomplete/test/Autocomplete.test.tsx
+++ b/packages/components/autocomplete/test/Autocomplete.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Autocomplete } from '../src/Autocomplete';
 
 interface Fruit {
@@ -13,6 +13,13 @@ const fruits: Fruit[] = [
   { id: 3, name: 'Avocado 🥑' },
   { id: 4, name: 'Banana 🍌' },
   { id: 5, name: 'Coconut 🥥' },
+  { id: 6, name: 'Lemon 🍋' },
+  { id: 7, name: 'Orange 🍊' },
+  { id: 8, name: 'Peach 🍑' },
+  { id: 9, name: 'Pear 🍐' },
+  { id: 10, name: 'Strawberry 🍓' },
+  { id: 11, name: 'Tangerine 🍊' },
+  { id: 12, name: 'Tomato 🍅' },
 ];
 
 const fruitStrings = fruits.reduce((acc, fruit) => [...acc, fruit.name], []);
@@ -20,16 +27,112 @@ const fruitStrings = fruits.reduce((acc, fruit) => [...acc, fruit.name], []);
 const mockOnFilter = jest.fn();
 const mockOnSelectItem = jest.fn();
 
-describe('Autocomplete', function () {
-  it('renders', () => {
-    const tree = render(
-      <Autocomplete<string>
-        items={fruitStrings}
-        onFilter={mockOnFilter}
-        onSelectItem={mockOnSelectItem}
-      />,
-    );
+describe('Autocomplete', () => {
+  describe('items is an array of strings', () => {
+    it('filters the list and selects the first item', async () => {
+      const handleFilter = (item: string, inputValue: string) =>
+        item.toLowerCase().includes(inputValue.toLowerCase());
 
-    expect(tree).toBeTruthy();
+      renderComponent({ onFilter: handleFilter });
+
+      const input = screen.getByTestId('cf-autocomplete-input');
+      const list = screen.getByTestId('cf-autocomplete-list');
+      const listFirstItem = screen.getByTestId('cf-autocomplete-list-item-0');
+
+      expect(list).not.toBeVisible();
+
+      // Type one letter in the input to open the list
+      fireEvent.input(input, {
+        target: {
+          value: 'a',
+        },
+      });
+
+      // checks if the list is visible
+      await waitFor(() => {
+        expect(list).toBeVisible();
+      });
+
+      // press the ArrowDown key
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown',
+      });
+
+      // checks if the first item of the list gets selected
+      expect(listFirstItem.getAttribute('aria-selected')).toBe('true');
+      expect(listFirstItem.getAttribute('class')).toContain('highlighted');
+
+      // press Enter to select the item
+      fireEvent.keyDown(input, {
+        key: 'Enter',
+      });
+
+      // checks if the list got closed and the value of the input is the one we selected
+      expect(list).not.toBeVisible();
+      expect(input.getAttribute('value')).toBe('Apple 🍎');
+      expect(mockOnSelectItem).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('items is an array of objects', () => {
+    it('filters the list and selects the first item', async () => {
+      const handleFilter = (item: Fruit, inputValue: string) =>
+        item.name.toLowerCase().includes(inputValue.toLowerCase());
+
+      renderComponent({
+        items: fruits,
+        onFilter: handleFilter,
+        itemToString: (item: Fruit) => item.name,
+        renderItem: (item: Fruit) => item.name,
+      });
+
+      const input = screen.getByTestId('cf-autocomplete-input');
+      const list = screen.getByTestId('cf-autocomplete-list');
+      const listFirstItem = screen.getByTestId('cf-autocomplete-list-item-0');
+
+      expect(list).not.toBeVisible();
+
+      // Type one letter in the input to open the list
+      fireEvent.input(input, {
+        target: {
+          value: 'a',
+        },
+      });
+
+      // checks if the list is visible
+      await waitFor(() => {
+        expect(list).toBeVisible();
+      });
+
+      // press the ArrowDown key
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown',
+      });
+
+      // checks if the first item of the list gets selected
+      expect(listFirstItem.getAttribute('aria-selected')).toBe('true');
+      expect(listFirstItem.getAttribute('class')).toContain('highlighted');
+
+      // press Enter to select the item
+      fireEvent.keyDown(input, {
+        key: 'Enter',
+      });
+
+      // checks if the list got closed and the value of the input is the one we selected
+      expect(list).not.toBeVisible();
+      expect(input.getAttribute('value')).toBe('Apple 🍎');
+      expect(mockOnSelectItem).toHaveBeenCalledTimes(1);
+    });
   });
 });
+
+function renderComponent(customProps) {
+  const props = {
+    items: fruitStrings,
+    onFilter: mockOnFilter,
+    onSelectItem: mockOnSelectItem,
+    ...customProps,
+  };
+
+  render(<Autocomplete {...props} />);
+}

--- a/packages/components/popover/src/PopoverContent/PopoverContent.styles.ts
+++ b/packages/components/popover/src/PopoverContent/PopoverContent.styles.ts
@@ -1,8 +1,9 @@
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 
-export const getPopoverContentStyles = () => ({
+export const getPopoverContentStyles = (isOpen: boolean) => ({
   container: css({
+    display: isOpen ? 'initial' : 'none',
     background: tokens.colorWhite,
     border: 0,
     borderRadius: tokens.borderRadiusMedium,

--- a/packages/components/popover/src/PopoverContent/PopoverContent.tsx
+++ b/packages/components/popover/src/PopoverContent/PopoverContent.tsx
@@ -22,10 +22,9 @@ const _PopoverContent = (props: PopoverContentProps, ref) => {
     role = 'dialog',
     ...otherProps
   } = props;
-
-  const styles = getPopoverContentStyles();
-
   const { isOpen, getPopoverProps, usePortal } = usePopoverContext();
+
+  const styles = getPopoverContentStyles(isOpen);
 
   const content = (
     <div
@@ -42,10 +41,6 @@ const _PopoverContent = (props: PopoverContentProps, ref) => {
       {children}
     </div>
   );
-
-  if (!isOpen) {
-    return null;
-  }
 
   return usePortal ? <Portal>{content}</Portal> : content;
 };

--- a/packages/components/popover/test/Popover.test.tsx
+++ b/packages/components/popover/test/Popover.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from '@/scripts/test/axeHelper';
 
@@ -7,8 +7,8 @@ import { Popover } from '../src/.';
 import { Button } from '@contentful/f36-button';
 
 describe('Popover', function () {
-  it('renders the component', () => {
-    const { getByRole } = render(
+  it('renders the component', async () => {
+    render(
       <Popover>
         <Popover.Trigger>
           <Button>Toggle</Button>
@@ -17,13 +17,16 @@ describe('Popover', function () {
       </Popover>,
     );
 
-    const trigger = getByRole('button');
-    expect(trigger).toHaveAttribute('aria-expanded', 'false');
-    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    const trigger = screen.getByRole('button');
+
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    });
   });
 
-  it('renders the components as open', () => {
-    const { getByRole } = render(
+  it('renders the components as open', async () => {
+    render(
       <Popover isOpen={true}>
         <Popover.Trigger>
           <Button>Toggle</Button>
@@ -32,14 +35,16 @@ describe('Popover', function () {
       </Popover>,
     );
 
-    const trigger = getByRole('button');
-    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    const trigger = screen.getByRole('button');
 
-    expect(getByRole('dialog')).toBeTruthy();
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByRole('dialog')).toBeTruthy();
+    });
   });
 
-  it('renders the components with an additional class names', () => {
-    const { getByRole } = render(
+  it('renders the components with an additional class names', async () => {
+    render(
       <Popover isOpen={true}>
         <Popover.Trigger>
           <Button className="trigger">Toggle</Button>
@@ -50,14 +55,16 @@ describe('Popover', function () {
       </Popover>,
     );
 
-    const trigger = getByRole('button');
-    expect(trigger).toHaveClass('trigger');
+    const trigger = screen.getByRole('button');
+    const popover = screen.getByRole('dialog');
 
-    const popover = getByRole('dialog');
-    expect(popover).toHaveClass('popover');
+    await waitFor(() => {
+      expect(trigger).toHaveClass('trigger');
+      expect(popover).toHaveClass('popover');
+    });
   });
 
-  it('call onClose when pressing Esc key', () => {
+  it('call onClose when pressing Esc key', async () => {
     const handleClose = jest.fn();
 
     render(
@@ -72,10 +79,13 @@ describe('Popover', function () {
     fireEvent.keyDown(document.activeElement, {
       key: 'Escape',
     });
-    expect(handleClose).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(handleClose).toHaveBeenCalled();
+    });
   });
 
-  it('do NOT call onClose when pressing Esc key and closeOnEsc prop is false', () => {
+  it('do NOT call onClose when pressing Esc key and closeOnEsc prop is false', async () => {
     const handleClose = jest.fn();
 
     render(
@@ -90,10 +100,13 @@ describe('Popover', function () {
     fireEvent.keyDown(document.activeElement, {
       key: 'Escape',
     });
-    expect(handleClose).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(handleClose).not.toHaveBeenCalled();
+    });
   });
 
-  it('call onClose when clicking outside of popover', () => {
+  it('call onClose when clicking outside of popover', async () => {
     const handleClose = jest.fn();
 
     render(
@@ -106,13 +119,16 @@ describe('Popover', function () {
     );
 
     userEvent.click(document.body);
-    expect(handleClose).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(handleClose).toHaveBeenCalled();
+    });
   });
 
-  it('do NOT call onClose when clicking inside of popover', () => {
+  it('do NOT call onClose when clicking inside of popover', async () => {
     const handleClose = jest.fn();
 
-    const { getByRole } = render(
+    render(
       <Popover isOpen={true} onClose={handleClose}>
         <Popover.Trigger>
           <Button>Toggle</Button>
@@ -121,11 +137,14 @@ describe('Popover', function () {
       </Popover>,
     );
 
-    userEvent.click(getByRole('dialog'));
-    expect(handleClose).not.toHaveBeenCalled();
+    userEvent.click(screen.getByRole('dialog'));
+
+    await waitFor(() => {
+      expect(handleClose).not.toHaveBeenCalled();
+    });
   });
 
-  it('do NOT call onClose when clicking outside of popover and closeOnBlur is false', () => {
+  it('do NOT call onClose when clicking outside of popover and closeOnBlur is false', async () => {
     const handleClose = jest.fn();
 
     render(
@@ -138,11 +157,14 @@ describe('Popover', function () {
     );
 
     userEvent.click(document.body);
-    expect(handleClose).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(handleClose).not.toHaveBeenCalled();
+    });
   });
 
-  it('popover should receive focus when open', () => {
-    const { getByRole } = render(
+  it('popover should receive focus when open', async () => {
+    render(
       <Popover isOpen={true}>
         <Popover.Trigger>
           <Button>Toggle</Button>
@@ -151,11 +173,13 @@ describe('Popover', function () {
       </Popover>,
     );
 
-    expect(getByRole('dialog')).toHaveFocus();
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toHaveFocus();
+    });
   });
 
-  it('popover should NOT receive focus when open and autoFocus is false', () => {
-    const { getByRole } = render(
+  it('popover should NOT receive focus when open and autoFocus is false', async () => {
+    render(
       // eslint-disable-next-line jsx-a11y/no-autofocus
       <Popover isOpen={true} autoFocus={false}>
         <Popover.Trigger>
@@ -165,7 +189,9 @@ describe('Popover', function () {
       </Popover>,
     );
 
-    expect(getByRole('dialog')).not.toHaveFocus();
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).not.toHaveFocus();
+    });
   });
 
   it('has no a11y issues', async () => {


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Besides adding tests I made the Popover.Content to always be in the DOM
That's necessary for a better a11y of the Autocomplete and it makes downshift stop throwing that error about the menuRef that you probably saw already

I made this the default behaviour, do you think it should be optional? Something that we control with a prop?

But I really don't know if I'm breaking something with my solution for that hahahaha
(I'm just using `display: 'none' when !isOpen`)
so please test it!

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
