### PR TITLE
feat(menu): add initial focused item index logic

### DIFF
--- a/packages/components/menu/Menu.mdx
+++ b/packages/components/menu/Menu.mdx
@@ -40,7 +40,11 @@ You can use following components to build a menu:
 ```jsx
 <Menu>
   <Menu.Trigger>
-    <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+    <IconButton
+      variant="secondary"
+      icon={<MenuIcon />}
+      aria-label="toggle menu"
+    />
   </Menu.Trigger>
   <Menu.List>
     <Menu.Item>Create an entry</Menu.Item>
@@ -70,7 +74,11 @@ You can use following components to build a menu:
 ```jsx
 <Menu>
   <Menu.Trigger>
-    <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+    <IconButton
+      variant="secondary"
+      icon={<MenuIcon />}
+      aria-label="toggle menu"
+    />
   </Menu.Trigger>
   <Menu.List>
     <Menu.SectionTitle>Entry</Menu.SectionTitle>
@@ -90,7 +98,11 @@ You can use following components to build a menu:
 ```jsx
 <Menu defaultIsOpen>
   <Menu.Trigger>
-    <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+    <IconButton
+      variant="secondary"
+      icon={<MenuIcon />}
+      aria-label="toggle menu"
+    />
   </Menu.Trigger>
   <Menu.List>
     <Menu.Item>Create an entry</Menu.Item>
@@ -115,7 +127,11 @@ function ControlledMenu() {
       onClose={() => setIsOpen(false)}
     >
       <Menu.Trigger>
-        <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+        <IconButton
+          variant="secondary"
+          icon={<MenuIcon />}
+          aria-label="toggle menu"
+        />
       </Menu.Trigger>
       <Menu.List>
         <Menu.Item>Create an entry</Menu.Item>
@@ -132,7 +148,11 @@ function ControlledMenu() {
 ```jsx
 <Menu>
   <Menu.Trigger>
-    <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+    <IconButton
+      variant="secondary"
+      icon={<MenuIcon />}
+      aria-label="toggle menu"
+    />
   </Menu.Trigger>
   <Menu.List style={{ maxHeight: '200px' }}>
     <Menu.Item>Item 1</Menu.Item>
@@ -156,7 +176,11 @@ function ControlledMenu() {
 ```jsx
 <Menu>
   <Menu.Trigger>
-    <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+    <IconButton
+      variant="secondary"
+      icon={<MenuIcon />}
+      aria-label="toggle menu"
+    />
   </Menu.Trigger>
   <Menu.List>
     <Menu.Item>Item 1</Menu.Item>
@@ -176,7 +200,11 @@ function ControlledMenu() {
 ```jsx
 <Menu>
   <Menu.Trigger>
-    <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+    <IconButton
+      variant="secondary"
+      icon={<MenuIcon />}
+      aria-label="toggle menu"
+    />
   </Menu.Trigger>
   <Menu.List style={{ maxHeight: '300px' }}>
     <Menu.ListHeader>
@@ -205,7 +233,11 @@ function ControlledMenu() {
 <Router>
   <Menu>
     <Menu.Trigger>
-      <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+      <IconButton
+        variant="secondary"
+        icon={<MenuIcon />}
+        aria-label="toggle menu"
+      />
     </Menu.Trigger>
     <Menu.List>
       <Link to="/" component={Menu.Item} as="a">
@@ -227,7 +259,11 @@ function ControlledMenu() {
 ```jsx
 <Menu initialFocusedItemIndex={1}>
   <Menu.Trigger>
-    <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+    <IconButton
+      variant="secondary"
+      icon={<MenuIcon />}
+      aria-label="toggle menu"
+    />
   </Menu.Trigger>
   <Menu.List>
     <Menu.Item>Create an entry</Menu.Item>

--- a/packages/components/menu/Menu.mdx
+++ b/packages/components/menu/Menu.mdx
@@ -203,7 +203,7 @@ function ControlledMenu() {
 
 ```jsx static=true
 <Router>
-  <Menu defaultIsOpen {...args}>
+  <Menu>
     <Menu.Trigger>
       <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
     </Menu.Trigger>
@@ -220,6 +220,21 @@ function ControlledMenu() {
     </Menu.List>
   </Menu>
 </Router>
+```
+
+### With predetermined focused menu item on initial open
+
+```jsx
+<Menu initialFocusedItemIndex={1}>
+  <Menu.Trigger>
+    <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+  </Menu.Trigger>
+  <Menu.List>
+    <Menu.Item>Create an entry</Menu.Item>
+    <Menu.Item>Remove an entry</Menu.Item>
+    <Menu.Item>Embed existing entry</Menu.Item>
+  </Menu.List>
+</Menu>
 ```
 
 ## Content recommendations

--- a/packages/components/menu/src/Menu.tsx
+++ b/packages/components/menu/src/Menu.tsx
@@ -43,10 +43,18 @@ export interface MenuProps
    * @default true
    */
   closeOnSelect?: boolean;
+
+  /**
+   * Focus the menu item with provided index on initial open.
+   * Indexing starts from 0.
+   *
+   * @default 0
+   */
+  initialFocusedItemIndex?: number;
 }
 
 export function Menu(props: MenuProps) {
-  const { closeOnSelect = true } = props;
+  const { closeOnSelect = true, initialFocusedItemIndex = 0 } = props;
   const { isOpen, handleOpen, handleClose } = useMenuOpenState(props);
 
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -55,6 +63,7 @@ export function Menu(props: MenuProps) {
   const { focusedIndex, handleArrowsKeyDown } = useArrowKeyNavigation({
     itemsContainerRef: menuListRef,
     itemsSelector: MENU_ITEMS_SELECTOR,
+    initialFocusedIndex: initialFocusedItemIndex,
   });
 
   useEffect(() => {
@@ -70,6 +79,13 @@ export function Menu(props: MenuProps) {
         (availableElements[focusedIndex] as HTMLElement).focus({
           preventScroll: false,
         });
+      }
+
+      if (initialFocusedItemIndex >= availableElements.length) {
+        // eslint-disable-next-line no-console
+        console.error(
+          'initialFocusedItemIndex prop can not have a value bigger than the actual menu items number',
+        );
       }
     }
   }, [isOpen, focusedIndex]);

--- a/packages/components/menu/stories/Menu.stories.tsx
+++ b/packages/components/menu/stories/Menu.stories.tsx
@@ -143,6 +143,23 @@ export const WithReactRouterLinks: Story<MenuProps> = (args) => {
   );
 };
 
+export const WithInitialFocusedItem: Story<MenuProps> = (args) => {
+  return (
+    <Router>
+      <Menu defaultIsOpen initialFocusedItemIndex={1} {...args}>
+        <Menu.Trigger>
+          <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+        </Menu.Trigger>
+        <Menu.List>
+          <Menu.Item>Create an entry</Menu.Item>
+          <Menu.Item>Remove an entry</Menu.Item>
+          <Menu.Item>Embed existing entry</Menu.Item>
+        </Menu.List>
+      </Menu>
+    </Router>
+  );
+};
+
 Basic.parameters = {
   chromatic: { delay: 300 },
 };
@@ -159,5 +176,8 @@ WithDisabledItems.parameters = {
   chromatic: { delay: 300 },
 };
 WithReactRouterLinks.parameters = {
+  chromatic: { delay: 300 },
+};
+WithInitialFocusedItem.parameters = {
   chromatic: { delay: 300 },
 };

--- a/packages/components/menu/stories/Menu.stories.tsx
+++ b/packages/components/menu/stories/Menu.stories.tsx
@@ -17,7 +17,11 @@ export const Basic: Story<MenuProps> = (args) => {
   return (
     <Menu defaultIsOpen {...args}>
       <Menu.Trigger>
-        <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+        <IconButton
+          variant="secondary"
+          icon={<MenuIcon />}
+          aria-label="toggle menu"
+        />
       </Menu.Trigger>
       <Menu.List>
         <Menu.SectionTitle>Entry Title</Menu.SectionTitle>
@@ -46,7 +50,11 @@ export const Controlled: Story<MenuProps> = (args) => {
       }}
     >
       <Menu.Trigger>
-        <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+        <IconButton
+          variant="secondary"
+          icon={<MenuIcon />}
+          aria-label="toggle menu"
+        />
       </Menu.Trigger>
       <Menu.List>
         <Menu.SectionTitle>Entry Title</Menu.SectionTitle>
@@ -65,7 +73,11 @@ export const WithDisabledItems: Story<MenuProps> = (args) => {
   return (
     <Menu defaultIsOpen {...args}>
       <Menu.Trigger>
-        <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+        <IconButton
+          variant="secondary"
+          icon={<MenuIcon />}
+          aria-label="toggle menu"
+        />
       </Menu.Trigger>
       <Menu.List>
         <Menu.Item>Item 1</Menu.Item>
@@ -85,7 +97,11 @@ export const WithMaxHeight: Story<MenuProps> = (args) => {
   return (
     <Menu defaultIsOpen {...args}>
       <Menu.Trigger>
-        <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+        <IconButton
+          variant="secondary"
+          icon={<MenuIcon />}
+          aria-label="toggle menu"
+        />
       </Menu.Trigger>
       <Menu.List
         // You can pass a classname with maxHeight style or a style object directly
@@ -103,7 +119,11 @@ export const WithStickyHeaderAndFooter: Story<MenuProps> = (args) => {
   return (
     <Menu defaultIsOpen {...args}>
       <Menu.Trigger>
-        <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+        <IconButton
+          variant="secondary"
+          icon={<MenuIcon />}
+          aria-label="toggle menu"
+        />
       </Menu.Trigger>
       <Menu.List style={{ maxHeight: '300px' }}>
         <Menu.ListHeader>
@@ -125,7 +145,11 @@ export const WithReactRouterLinks: Story<MenuProps> = (args) => {
     <Router>
       <Menu defaultIsOpen {...args}>
         <Menu.Trigger>
-          <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+          <IconButton
+            variant="secondary"
+            icon={<MenuIcon />}
+            aria-label="toggle menu"
+          />
         </Menu.Trigger>
         <Menu.List>
           <Link to="/" component={Menu.Item} as="a">
@@ -148,7 +172,11 @@ export const WithInitialFocusedItem: Story<MenuProps> = (args) => {
     <Router>
       <Menu defaultIsOpen initialFocusedItemIndex={1} {...args}>
         <Menu.Trigger>
-          <IconButton icon={<MenuIcon />} aria-label="toggle menu" />
+          <IconButton
+            variant="secondary"
+            icon={<MenuIcon />}
+            aria-label="toggle menu"
+          />
         </Menu.Trigger>
         <Menu.List>
           <Menu.Item>Create an entry</Menu.Item>

--- a/packages/components/menu/test/Menu.test.tsx
+++ b/packages/components/menu/test/Menu.test.tsx
@@ -236,4 +236,25 @@ describe('Menu', function () {
     });
     expect(document.activeElement).toBe(getByTestId('third-item'));
   });
+
+  it('should focus predefined item based on initialFocusedItemIndex prop', async () => {
+    const { getByTestId, getByRole } = render(
+      <Menu isOpen={true} initialFocusedItemIndex={1}>
+        <Menu.Trigger>
+          <Button>Toggle</Button>
+        </Menu.Trigger>
+        <Menu.List>
+          <Menu.Item testId="first-item">Create an entry</Menu.Item>
+          <Menu.Item testId="second-item">Remove an entry</Menu.Item>
+          <Menu.Item testId="third-item">Embed existing entry</Menu.Item>
+        </Menu.List>
+      </Menu>,
+    );
+
+    await waitFor(() => {
+      expect(getByRole('menu')).toBeInTheDocument();
+    });
+
+    expect(document.activeElement).toBe(getByTestId('second-item'));
+  });
 });

--- a/packages/components/utils/src/ArrowKeyNavigation/useArrowKeyNavigation.ts
+++ b/packages/components/utils/src/ArrowKeyNavigation/useArrowKeyNavigation.ts
@@ -4,6 +4,7 @@ interface UseArrowKeyNavigationProps {
   itemsContainerRef: React.MutableRefObject<HTMLElement>;
   itemsSelector: string;
   keyType?: 'vertical' | 'horizontal';
+  initialFocusedIndex?: number;
 }
 
 const ARROW_KEY_TYPES = {
@@ -21,8 +22,9 @@ export const useArrowKeyNavigation = ({
   itemsContainerRef,
   itemsSelector,
   keyType = 'vertical',
+  initialFocusedIndex = 0,
 }: UseArrowKeyNavigationProps) => {
-  const [focusedIndex, setFocusedIndex] = useState(0);
+  const [focusedIndex, setFocusedIndex] = useState<number>(initialFocusedIndex);
 
   const handleArrowsKeyDown = useCallback(
     (event: React.KeyboardEvent) => {


### PR DESCRIPTION
# Purpose of PR
Extend Menu component logic to be able to accept `initialFocusedItem` prop

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
