### PR TITLE
refactor(codemod): remove width from Select component codemod

### DIFF
--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4-select.output.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4-select.output.js
@@ -15,7 +15,6 @@ import { Select, FormControl } from "@contentful/f36-components";
   aria-label="Select"
   testId="timezone-input"
   value="value"
-  size="medium"
   isDisabled={true}
   onChange={() => {}}>
   <Select.Option value='1'>Option 1</Select.Option>
@@ -37,7 +36,6 @@ const options = [{
   aria-label="Select"
   testId="timezone-input"
   value="value"
-  size="medium"
   isDisabled={true}
   onChange={() => {}}>
     {options.map(({value, label}) => {

--- a/packages/forma-36-codemod/transforms/v4-select.js
+++ b/packages/forma-36-codemod/transforms/v4-select.js
@@ -8,8 +8,7 @@ const {
   removeComponentImport,
   changeComponentName,
   changeProperties,
-  updatePropertyValue,
-  updateTernaryValues,
+  deleteProperty,
 } = require('../utils');
 const { getFormaImport, shouldSkipUpdateImport } = require('../utils/config');
 const { pipe } = require('./common/pipe');
@@ -36,26 +35,11 @@ function selectCodemod(file, api) {
         renameMap: {
           required: 'isRequired',
           hasError: 'isInvalid',
-          width: 'size',
         },
       });
 
-      modifiedAttributes = updatePropertyValue(modifiedAttributes, {
-        propertyName: 'size',
-        propertyValue: (value) => {
-          const valueMap = {
-            auto: 'medium',
-            small: 'small',
-            medium: 'medium',
-            large: 'medium',
-            full: 'medium',
-          };
-          if (value.value !== undefined) {
-            return j.literal(valueMap[value.value]);
-          }
-
-          return updateTernaryValues(value, { j, valueMap });
-        },
+      modifiedAttributes = deleteProperty(modifiedAttributes, {
+        propertyName: 'width',
       });
 
       return modifiedAttributes;


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->
Update Select codemod to drop width property.