### PR TITLE
docs: fix code preview after changes in Card

### DIFF
--- a/packages/forma-36-website/src/components/ComponentSource.js
+++ b/packages/forma-36-website/src/components/ComponentSource.js
@@ -9,10 +9,6 @@ import { Icon } from '@contentful/f36-icon';
 import { Flex } from '@contentful/f36-core';
 
 const styles = {
-  preview: css`
-    padding: ${tokens.spacingM};
-  `,
-
   error: css`
     font-family: ${tokens.fontStackMonospace};
     font-size: ${tokens.fontSizeS};
@@ -29,10 +25,12 @@ const styles = {
 
   // !important was necessary because these styles are being applied after the Card component styles
   card: css`
+    font-family: ${tokens.fontStackPrimary};
     border-radius: ${tokens.borderRadiusMedium} ${tokens.borderRadiusMedium} 0 0 !important;
   `,
 
   toggle: css`
+    font-family: ${tokens.fontStackPrimary};
     border-radius: 0 0 ${tokens.borderRadiusMedium} ${tokens.borderRadiusMedium};
   `,
 };
@@ -58,15 +56,15 @@ export default function ComponentSource({ children }) {
           Icon,
         }}
       >
-        <Card className={styles.card} padding="none">
-          <LivePreview className={styles.preview} />
-          {showSource && (
-            <>
-              <LiveError className={styles.error} />
-              <LiveEditor className={styles.editor} />
-            </>
-          )}
+        <Card className={styles.card}>
+          <LivePreview />
         </Card>
+        {showSource && (
+          <>
+            <LiveError className={styles.error} />
+            <LiveEditor className={styles.editor} />
+          </>
+        )}
         <Button
           className={styles.toggle}
           variant="secondary"


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

I think the Card component now does not allow us to do `padding="none"` so the code preview got some weird spacing, and this PR tries to fix it

before the fix
![Screenshot 2021-09-30 at 11 39 58](https://user-images.githubusercontent.com/6597467/135428933-eca65577-74b4-4680-b631-1215c4aa2076.png)

after fix
![Screenshot 2021-09-30 at 11 39 11](https://user-images.githubusercontent.com/6597467/135428982-cb3380d4-0604-49a4-bed0-d35161bbe5c8.png)

## Font Family issues

For some reason, emotion is working differently in production
So if you check the website in production, the whole example of the components are using monospace fonts
but in local development, only the code editor is using monospace (as expected)

And this makes it hard to fix this issue. This PR tries to change some styles to make only the code editor monospace, but we will only know when this is deployed

I will open a bug ticket to check why are we having this difference between the styles in prod and in dev

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
