### PR TITLE
fix: remove button type attribute when href is defined

### DIFF
--- a/packages/forma-36-react-components/src/components/Button/Button.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.tsx
@@ -68,7 +68,7 @@ export const Button = ({
   onClick,
   size = 'medium',
   testId = 'cf-ui-button',
-  type = href ? 'button' : undefined,
+  type = href ? undefined : 'button',
   ...otherProps
 }: ButtonProps) => {
   const classNames = cn(

--- a/packages/forma-36-react-components/src/components/Button/Button.tsx
+++ b/packages/forma-36-react-components/src/components/Button/Button.tsx
@@ -68,7 +68,7 @@ export const Button = ({
   onClick,
   size = 'medium',
   testId = 'cf-ui-button',
-  type = 'button',
+  type = href ? 'button' : undefined,
   ...otherProps
 }: ButtonProps) => {
   const classNames = cn(

--- a/packages/forma-36-react-components/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/forma-36-react-components/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -26,7 +26,6 @@ exports[`renders the button as an external link 1`] = `
   href="/"
   rel="noreferrer noopener"
   target="_blank"
-  type="button"
 >
   <span
     class="TabFocusTrap Button__inner-wrapper"
@@ -46,7 +45,6 @@ exports[`renders the button as link 1`] = `
   class="Button Button--primary Button--medium"
   data-test-id="cf-ui-button"
   href="/"
-  type="button"
 >
   <span
     class="TabFocusTrap Button__inner-wrapper"


### PR DESCRIPTION
# Purpose of PR

Remove button `type` attribute when href is defined

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
