### PR TITLE
fix(website docs): remove reference to Sketch UI kit from forma-36 website

### DIFF
--- a/packages/forma-36-website/src/content/foundation/typography/index.mdx
+++ b/packages/forma-36-website/src/content/foundation/typography/index.mdx
@@ -338,7 +338,7 @@ The base line grid assures that the Forma 36 typography system adapts flawlessly
 
 ### Use Forma 36 Sizes
 
-To ensure consistency across user interfaces utilizing the Forma 36 design system, use available text styles from the Sketch UI kit.
+To ensure consistency across user interfaces utilizing the Forma 36 design system, use available text styles from the Figma UI kit.
 
 ### Color Contrast
 


### PR DESCRIPTION
A small copy update
