### PR TITLE
feat: Popover focus trigger after close

### DIFF
--- a/packages/components/menu/src/Menu.tsx
+++ b/packages/components/menu/src/Menu.tsx
@@ -195,7 +195,7 @@ export function Menu(props: MenuProps) {
             return;
           }
 
-          handleClose();
+          closeAndFocusTrigger();
         },
       }),
       getMenuItemProps: (_props = {}) => ({
@@ -206,7 +206,7 @@ export function Menu(props: MenuProps) {
             (event.target as HTMLElement).getAttribute('aria-haspopup'),
           );
           if (closeOnSelect && !isSubmenuTrigger) {
-            handleClose();
+            closeAndFocusTrigger();
           }
         },
       }),
@@ -226,6 +226,7 @@ export function Menu(props: MenuProps) {
       focusMenuItem,
       closeOnBlur,
       closeOnEsc,
+      closeAndFocusTrigger,
     ],
   );
 
@@ -234,7 +235,7 @@ export function Menu(props: MenuProps) {
       <Popover
         {...otherProps}
         isOpen={isOpen}
-        onClose={closeAndFocusTrigger}
+        onClose={handleClose}
         id={menuId}
         closeOnEsc={closeOnEsc}
         // eslint-disable-next-line jsx-a11y/no-autofocus

--- a/packages/components/popover/src/Popover.tsx
+++ b/packages/components/popover/src/Popover.tsx
@@ -167,11 +167,12 @@ export function Popover(props: PopoverProps) {
   const popoverGeneratedId = useId(null, 'popover-content');
   const popoverId = id || popoverGeneratedId;
 
-  const handleClose = useCallback(() => {
-    if (onClose) {
-      onClose();
-    }
-  }, [onClose]);
+  const closeAndFocusTrigger = useCallback(() => {
+    onClose?.();
+
+    // setTimeout trick to make it work with focus-lock
+    setTimeout(() => triggerElement?.focus({ preventScroll: true }), 0);
+  }, [onClose, triggerElement]);
 
   const contextValue: PopoverContextType = useMemo(
     () => ({
@@ -203,16 +204,16 @@ export function Popover(props: PopoverProps) {
 
           const targetIsPopover =
             popoverElement === relatedTarget ||
-            popoverElement.contains(relatedTarget);
+            popoverElement?.contains(relatedTarget);
           const targetIsTrigger =
             triggerElement === relatedTarget ||
-            triggerElement.contains(relatedTarget);
+            triggerElement?.contains(relatedTarget);
 
           if (targetIsPopover || targetIsTrigger) {
             return;
           }
 
-          handleClose();
+          closeAndFocusTrigger();
         },
         onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
           if (_props.onKeyDown) {
@@ -220,7 +221,7 @@ export function Popover(props: PopoverProps) {
           }
 
           if (closeOnEsc && event.key === 'Escape') {
-            handleClose();
+            closeAndFocusTrigger();
           }
         },
       }),
@@ -235,7 +236,7 @@ export function Popover(props: PopoverProps) {
       closeOnBlur,
       popoverElement,
       triggerElement,
-      handleClose,
+      closeAndFocusTrigger,
     ],
   );
 

--- a/packages/components/popover/stories/Popover.stories.tsx
+++ b/packages/components/popover/stories/Popover.stories.tsx
@@ -40,12 +40,7 @@ export const WithFocusLock: Story<PopoverProps> = (args) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <Popover
-      {...args}
-      isOpen={isOpen}
-      onClose={() => setIsOpen(false)}
-      closeOnBlur={false}
-    >
+    <Popover {...args} isOpen={isOpen} onClose={() => setIsOpen(false)}>
       <Popover.Trigger>
         <Button onClick={() => setIsOpen(!isOpen)}>Toggle</Button>
       </Popover.Trigger>


### PR DESCRIPTION
# Purpose of PR

In the `Dropdown` v3 we had logic to focus trigger element when dropdown close. This PR add that logic for our v4 `Popover` and `Menu`.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
