### PR TITLE
fix: text field codemod to include case where HelpText and Counter exist

### DIFF
--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-text-field.input.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-text-field.input.js
@@ -83,11 +83,20 @@ const controlledInputValue = 'input controlled value';
 <TextField
   id="inputId"
   name="email"
-  labelText="Counting characters"
+  labelText="Counting characters and HelpText"
   textInputProps={{
     maxLength: 10,
   }}
   helpText="Some help text"
+/>;
+
+<TextField
+  id="inputId"
+  name="email"
+  labelText="Counting characters"
+  textInputProps={{
+    maxLength: 10,
+  }}
 />;
 
 const conditionalIsDisabled = true;

--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-text-field.output.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-text-field.output.js
@@ -71,10 +71,18 @@ const controlledInputValue = 'input controlled value';
 </FormControl>;
 
 <FormControl id="inputId">
-  <FormControl.Label>Counting characters</FormControl.Label>
+  <FormControl.Label>Counting characters and HelpText</FormControl.Label>
   <TextInput name="email" maxLength={10} />
   <Flex justifyContent="space-between">
     <FormControl.HelpText>Some help text</FormControl.HelpText>
+    <FormControl.Counter />
+  </Flex>
+</FormControl>;
+
+<FormControl id="inputId">
+  <FormControl.Label>Counting characters</FormControl.Label>
+  <TextInput name="email" maxLength={10} />
+  <Flex justifyContent="flex-end">
     <FormControl.Counter />
   </Flex>
 </FormControl>;


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
