### PR TITLE
fix: provide noop functions if there is no context provided

### DIFF
--- a/packages/components/forms/src/form-control/FormControlContext.tsx
+++ b/packages/components/forms/src/form-control/FormControlContext.tsx
@@ -1,6 +1,10 @@
 import { createContext, useContext } from 'react';
 import type { FormControlContextProps } from './types';
 
+const noop = () => {
+  // do nothing
+};
+
 export const FormControlContext = createContext<
   FormControlContextProps | undefined
 >(undefined);
@@ -25,7 +29,7 @@ export const useFormControl = (
     id: props.id ?? context.id,
     maxLength: context.maxLength,
     inputValue: context.inputValue,
-    setMaxLength: context.setMaxLength,
-    setInputValue: context.setInputValue,
+    setMaxLength: context.setMaxLength || noop,
+    setInputValue: context.setInputValue || noop,
   };
 };

--- a/packages/components/forms/src/text-input/TextInput.tsx
+++ b/packages/components/forms/src/text-input/TextInput.tsx
@@ -43,13 +43,15 @@ export const _TextInput = (
   });
 
   useEffect(() => {
-    if (maxLength !== undefined) {
+    if (maxLength !== undefined && typeof setMaxLength === 'function') {
       setMaxLength(maxLength);
     }
   }, [maxLength, setMaxLength]);
 
   const handleOnChange = (event) => {
-    setInputValue(event.target.value);
+    if (typeof setInputValue === 'function') {
+      setInputValue(event.target.value);
+    }
     onChange?.(event);
   };
 

--- a/packages/components/forms/src/textarea/Textarea.tsx
+++ b/packages/components/forms/src/textarea/Textarea.tsx
@@ -43,13 +43,15 @@ const _Textarea = (
   });
 
   useEffect(() => {
-    if (maxLength !== undefined) {
+    if (maxLength !== undefined && typeof setMaxLength === 'function') {
       setMaxLength(maxLength);
     }
   }, [maxLength, setMaxLength]);
 
   const handleOnChange = (event) => {
-    setInputValue(event.target.value);
+    if (typeof setInputValue === 'function') {
+      setInputValue(event.target.value);
+    }
     onChange?.(event);
   };
 


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Fixes broken TextArea and TextInput when they are used outside of FormControl wrapper.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
