### PR TITLE
[BAU-289]: fix: expose defaultValue prop in autocomplete

### DIFF
--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -17,7 +17,12 @@ export interface AutocompleteProps<ItemType = any>
   extends CommonProps,
     Pick<
       TextInputProps,
-      'isDisabled' | 'isInvalid' | 'isReadOnly' | 'isRequired' | 'id'
+      | 'isDisabled'
+      | 'isInvalid'
+      | 'isReadOnly'
+      | 'isRequired'
+      | 'id'
+      | 'defaultValue'
     > {
   /**
    * It’s an array of data to be used as "options" by the autocomplete component.
@@ -96,6 +101,7 @@ function _Autocomplete<ItemType>(
     id,
     className,
     clearAfterSelect = false,
+    defaultValue = '',
     items,
     onInputValueChange,
     onSelectItem,
@@ -118,7 +124,7 @@ function _Autocomplete<ItemType>(
 
   const styles = getAutocompleteStyles(listMaxHeight);
 
-  const [inputValue, setInputValue] = useState('');
+  const [inputValue, setInputValue] = useState(defaultValue);
 
   const handleInputValueChange = useCallback(
     (value) => {


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
