### PR TITLE
fix: remove common types from Menu and Popover

### DIFF
--- a/packages/components/menu/src/Menu.tsx
+++ b/packages/components/menu/src/Menu.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useEffect,
 } from 'react';
-import { CommonProps, mergeRefs, useId } from '@contentful/f36-core';
+import { mergeRefs, useId } from '@contentful/f36-core';
 import { useArrowKeyNavigation } from '@contentful/f36-utils';
 import { Popover, PopoverProps } from '@contentful/f36-popover';
 import { MenuContextProvider, MenuContextType } from './MenuContext';
@@ -13,8 +13,7 @@ import { MenuContextProvider, MenuContextType } from './MenuContext';
 const MENU_ITEMS_SELECTOR = '[role="menuitem"]:not(:disabled)';
 
 export interface MenuProps
-  extends CommonProps,
-    Omit<PopoverProps, 'autoFocus' | 'id' | 'closeOnBlur'> {
+  extends Omit<PopoverProps, 'autoFocus' | 'id' | 'closeOnBlur'> {
   /**
    * If `true`, the Menu will be opened in controlled mode.
    * By default the Menu is uncontrolled

--- a/packages/components/popover/src/Popover.tsx
+++ b/packages/components/popover/src/Popover.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
-import { CommonProps, useId, mergeRefs } from '@contentful/f36-core';
+import { useId, mergeRefs } from '@contentful/f36-core';
 import { Placement, Modifier } from '@popperjs/core';
 import { PopoverContextProvider, PopoverContextType } from './PopoverContext';
 import { usePopper } from 'react-popper';
 
-export interface PopoverProps extends CommonProps {
+export interface PopoverProps {
   children: React.ReactNode;
 
   /**


### PR DESCRIPTION
# Purpose of PR
Remove redundant common types from `Menu` and `Popover`

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
