### PR TITLE
feat: add `aria-describedby` to FormControl and inputs

### DIFF
--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
@@ -6,6 +6,7 @@ import getStyles from './BaseCheckbox.styles';
 import { Text } from '@contentful/f36-typography';
 import { Flex } from '@contentful/f36-core';
 import { HelpText } from '../help-text/HelpText';
+import { useFormControl } from '../form-control/FormControlContext';
 
 export type BaseCheckboxProps = PropsWithHTMLElement<
   BaseCheckboxInternalProps & { label?: string },
@@ -45,6 +46,7 @@ function _BaseCheckbox(
 
   const inputRef = useRef<HTMLInputElement>(null);
   const finalRef = ref || inputRef;
+  const { id: formFieldId } = useFormControl({});
 
   useEffect(() => {
     if (finalRef.current) {
@@ -120,7 +122,9 @@ function _BaseCheckbox(
           required={isRequired}
           aria-required={isRequired ? 'true' : undefined}
           aria-invalid={isInvalid ? 'true' : undefined}
-          aria-describedby={helpText && `${id}-helptext`}
+          aria-describedby={`${formFieldId}-${
+            isInvalid ? `validation` : `helptext`
+          }`}
           id={id}
           name={name}
         />

--- a/packages/components/forms/src/base-input/BaseInput.tsx
+++ b/packages/components/forms/src/base-input/BaseInput.tsx
@@ -120,6 +120,7 @@ function _BaseInput<E extends React.ElementType = typeof DEFAULT_TAG>(
       aria-readonly={isReadOnly ? 'true' : undefined}
       aria-required={isRequired ? 'true' : undefined}
       aria-invalid={isInvalid ? 'true' : undefined}
+      aria-describedby={`${id}-${isInvalid ? `validation` : `helptext`}`}
       disabled={isDisabled}
       required={isRequired}
       onChange={handleChange}

--- a/packages/components/forms/src/form-control/FormControl.tsx
+++ b/packages/components/forms/src/form-control/FormControl.tsx
@@ -27,6 +27,7 @@ export type FormControlProps<
 
 function _FormControl<E extends React.ElementType = typeof DEFAULT_TAG>(
   {
+    as,
     isInvalid,
     isRequired,
     isDisabled,
@@ -42,6 +43,7 @@ function _FormControl<E extends React.ElementType = typeof DEFAULT_TAG>(
   const generatedId = useId(id, 'field-');
   const [inputValue, setInputValue] = useState('');
   const [maxLength, setMaxLength] = useState(0);
+  const roleAttr = as === 'fieldset' ? undefined : 'group';
 
   const context = {
     id: generatedId,
@@ -60,7 +62,7 @@ function _FormControl<E extends React.ElementType = typeof DEFAULT_TAG>(
       <Box
         as={DEFAULT_TAG}
         ref={ref}
-        role="group"
+        role={roleAttr}
         testId={testId}
         marginBottom={marginBottom}
         {...otherProps}

--- a/packages/components/forms/src/help-text/HelpText.tsx
+++ b/packages/components/forms/src/help-text/HelpText.tsx
@@ -5,6 +5,7 @@ import {
   PropsWithHTMLElement,
 } from '@contentful/f36-core';
 import { Text } from '@contentful/f36-typography';
+import { useFormControl } from '../form-control/FormControlContext';
 
 export interface HelpTextInternalProps extends CommonProps, MarginProps {
   children: React.ReactNode;
@@ -18,12 +19,14 @@ export type HelpTextProps = PropsWithHTMLElement<HelpTextInternalProps, 'p'>;
 
 export const HelpText = React.forwardRef<HTMLParagraphElement, HelpTextProps>(
   ({ testId = 'cf-ui-help-text', ...otherProps }, ref) => {
+    const { id } = useFormControl({});
     return (
       <Text
         as="p"
         fontColor="gray500"
         fontSize="fontSizeM"
         testId={testId}
+        id={`${id}-helptext`}
         marginTop="spacingXs"
         {...otherProps}
         ref={ref}

--- a/packages/components/forms/src/select/Select.tsx
+++ b/packages/components/forms/src/select/Select.tsx
@@ -85,6 +85,9 @@ const _Select = (
         required={formProps.isRequired}
         aria-required={formProps.isRequired ? 'true' : undefined}
         aria-invalid={formProps.isInvalid ? true : undefined}
+        aria-describedby={`${formProps.id}-${
+          formProps.isInvalid ? `validation` : `helptext`
+        }`}
         disabled={formProps.isDisabled}
         defaultValue={defaultValue}
         value={value}

--- a/packages/components/forms/src/validation-message/ValidationMessage.tsx
+++ b/packages/components/forms/src/validation-message/ValidationMessage.tsx
@@ -7,6 +7,7 @@ import type {
 } from '@contentful/f36-core';
 import { ErrorCircleOutlineIcon } from '@contentful/f36-icons';
 import { Text } from '@contentful/f36-typography';
+import { useFormControl } from '../form-control/FormControlContext';
 
 export interface ValidationMessageInternalProps
   extends CommonProps,
@@ -23,6 +24,7 @@ export const ValidationMessage = forwardRef<
   HTMLDivElement,
   ValidationMessageProps
 >(({ children, testId = 'cf-ui-validation-message', ...otherProps }, ref) => {
+  const { id } = useFormControl({});
   return (
     <Flex
       marginTop="spacingXs"
@@ -30,6 +32,7 @@ export const ValidationMessage = forwardRef<
       ref={ref}
       testId={testId}
       alignItems="center"
+      id={`${id}-validation`}
       aria-live="assertive"
     >
       <Flex marginRight="spacing2Xs">

--- a/packages/components/forms/stories/FormControl.stories.tsx
+++ b/packages/components/forms/stories/FormControl.stories.tsx
@@ -46,7 +46,7 @@ export const Basic = (args: FormControlInternalProps) => {
       <FormControl {...args}>
         <FormControl.Label>Description</FormControl.Label>
         <Textarea />
-        <FormControl.HelpText>Tell me about youself</FormControl.HelpText>
+        <FormControl.HelpText>Tell me about yourself</FormControl.HelpText>
         {args.isInvalid && (
           <FormControl.ValidationMessage>Error</FormControl.ValidationMessage>
         )}


### PR DESCRIPTION
# Purpose of PR

Add [aria-describedby](https://www.w3.org/TR/WCAG20-TECHS/ARIA1.html) to form elements, and link it to validation message or help text 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
