### PR TITLE
fix: small Modal adjustments

### DIFF
--- a/packages/components/modal/src/ModalContent/ModalContent.styles.ts
+++ b/packages/components/modal/src/ModalContent/ModalContent.styles.ts
@@ -10,7 +10,8 @@ export function getModalContentStyles() {
       fontFamily: tokens.fontStackPrimary,
       lineHeight: tokens.lineHeightM,
       overflowY: 'auto',
-      overflowX: 'hidden',
+      overflowX: 'auto',
+      boxSizing: 'border-box',
     }),
   };
 }

--- a/packages/components/modal/src/ModalHeader/ModalHeader.styles.ts
+++ b/packages/components/modal/src/ModalHeader/ModalHeader.styles.ts
@@ -4,9 +4,20 @@ import { css } from 'emotion';
 export function getModalHeaderStyles() {
   return {
     root: css({
+      position: 'relative',
       padding: `${tokens.spacingM} ${tokens.spacingM} ${tokens.spacingM} ${tokens.spacingL}`,
       borderRadius: `${tokens.borderRadiusMedium} ${tokens.borderRadiusMedium} 0 0`,
       borderBottom: `1px solid ${tokens.gray300}`,
+    }),
+    buttonContainer: css({
+      position: 'relative',
+      width: tokens.spacing2Xl,
+      height: tokens.spacingL,
+      button: {
+        position: 'absolute',
+        top: `calc(-1 * ${tokens.spacing2Xs})`,
+        right: 0,
+      },
     }),
   };
 }

--- a/packages/components/modal/src/ModalHeader/ModalHeader.tsx
+++ b/packages/components/modal/src/ModalHeader/ModalHeader.tsx
@@ -39,15 +39,17 @@ export function ModalHeader({
         {title}
       </Subheading>
       {onClose && (
-        <Button
-          variant="transparent"
-          aria-label="Close"
-          startIcon={<CloseIcon size="small" />}
-          onClick={() => {
-            onClose();
-          }}
-          size="small"
-        />
+        <Flex alignItems="center" className={styles.buttonContainer}>
+          <Button
+            variant="transparent"
+            aria-label="Close"
+            startIcon={<CloseIcon size="small" />}
+            onClick={() => {
+              onClose();
+            }}
+            size="small"
+          />
+        </Flex>
       )}
     </Flex>
   );


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

* Removes `overflowX: 'hidden'` from ModalContent, so text input and button focus selections are not getting cut.
* Sets modal close button as an absolutely position element, so it doesn't get focused before the first focusable element inside the modal.