### PR TITLE
fix: Adjust card components

### DIFF
--- a/packages/components/card/src/asset-card/AssetCard.styles.ts
+++ b/packages/components/card/src/asset-card/AssetCard.styles.ts
@@ -26,8 +26,9 @@ export const getAssetCardStyles = () => {
       lineHeight: tokens.lineHeightM,
       paddingBottom: tokens.spacingXs,
       paddingLeft: tokens.spacingM,
-      paddingRight: tokens.spacingM,
+      paddingRight: tokens.spacingXs,
       paddingTop: tokens.spacingXs,
+      minHeight: '37px',
     }),
     headerItem: css({
       marginLeft: tokens.spacingXs,

--- a/packages/components/card/src/asset-card/AssetCard.tsx
+++ b/packages/components/card/src/asset-card/AssetCard.tsx
@@ -46,11 +46,9 @@ export const AssetCard = ({
   const styles = getAssetCardStyles();
   const badge = status ? <EntityStatusBadge entityStatus={status} /> : null;
   const header =
-    type || icon || badge || actions ? (
+    icon || badge || actions ? (
       <Flex className={cx(styles.header, actions && styles.headerWithActions)}>
-        <Flex as="footer" flexGrow={1}>
-          {type}
-        </Flex>
+        <Flex flexGrow={1} />
         {icon}
         {badge && (
           <Flex alignItems="center" className={styles.headerItem}>

--- a/packages/components/card/src/base-card/BaseCard.styles.ts
+++ b/packages/components/card/src/base-card/BaseCard.styles.ts
@@ -34,8 +34,9 @@ export const getBaseCardStyles = () => {
       lineHeight: tokens.lineHeightM,
       paddingBottom: tokens.spacingXs,
       paddingLeft: tokens.spacingM,
-      paddingRight: tokens.spacingM,
+      paddingRight: tokens.spacingXs,
       paddingTop: tokens.spacingXs,
+      minHeight: '37px',
     }),
     headerItem: css({
       marginLeft: tokens.spacingXs,

--- a/packages/components/card/src/base-card/BaseCard.tsx
+++ b/packages/components/card/src/base-card/BaseCard.tsx
@@ -16,6 +16,7 @@ import type {
   PolymorphicProps,
 } from '@contentful/f36-core';
 import { Icon, IconComponent } from '@contentful/f36-icon';
+import { Text } from '@contentful/f36-typography';
 import type { ButtonProps } from '@contentful/f36-button';
 import { DragHandle } from '@contentful/f36-drag-handle';
 
@@ -158,8 +159,8 @@ function _BaseCard<E extends React.ElementType = typeof BASE_CARD_DEFAULT_TAG>(
   const defaultHeader =
     type || icon || badge || actions ? (
       <Flex className={cx(styles.header, actions && styles.headerWithActions)}>
-        <Flex as="footer" flexGrow={1}>
-          {type}
+        <Flex flexGrow={1}>
+          <Text fontColor="gray600">{type}</Text>
         </Flex>
         {icon && <Icon as={icon} className={styles.headerItem} />}
         {badge && (

--- a/packages/components/card/src/base-card/CardActions.tsx
+++ b/packages/components/card/src/base-card/CardActions.tsx
@@ -29,6 +29,7 @@ export const CardActions = ({
           icon={<MoreHorizontalIcon />}
           {...buttonProps}
           className={cx(styles.root, buttonProps?.className)}
+          size="small"
           variant="transparent"
         />
       </Menu.Trigger>


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

- Don't show content type for AssetCard component
- Proper header padding and consistent header height
- Use Text to render content type in EntryCard