### PR TITLE
fix: autocomplete style & empty groups

### DIFF
--- a/packages/components/autocomplete/src/Autocomplete.styles.ts
+++ b/packages/components/autocomplete/src/Autocomplete.styles.ts
@@ -31,6 +31,7 @@ export const getAutocompleteStyles = (listMaxHeight: number) => ({
   }),
   noMatchesTitle: css({
     color: tokens.gray500,
+    margin: `${tokens.spacingM} 0 ${tokens.spacingM} 0`,
   }),
   item: css({
     display: 'block',

--- a/packages/components/autocomplete/src/Autocomplete.styles.ts
+++ b/packages/components/autocomplete/src/Autocomplete.styles.ts
@@ -29,6 +29,9 @@ export const getAutocompleteStyles = (listMaxHeight: number) => ({
     padding: `${tokens.spacingXs} ${tokens.spacingM}`,
     lineHeight: tokens.lineHeightM,
   }),
+  noMatchesTitle: css({
+    color: tokens.gray500,
+  }),
   item: css({
     display: 'block',
     padding: `${tokens.spacingXs} ${tokens.spacingM}`,

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -279,7 +279,7 @@ function _Autocomplete<ItemType>(
 
           {!isLoading && isShowingNoMatches && (
             <div className={cx(styles.item, styles.disabled)}>
-              <Subheading margin="none" className={styles.noMatchesTitle}>
+              <Subheading className={styles.noMatchesTitle}>
                 {noMatchesMessage}
               </Subheading>
             </div>

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -275,7 +275,7 @@ function _Autocomplete<ItemType>(
 
           {!isLoading && items.length === 0 && (
             <div className={cx(styles.item, styles.disabled)}>
-              <Subheading margin="spacingXs" className="styles.NoMatchesTitle">
+              <Subheading margin="none" className={styles.noMatchesTitle}>
                 {noMatchesMessage}
               </Subheading>
             </div>

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -278,7 +278,7 @@ function _Autocomplete<ItemType>(
             ))}
 
           {!isLoading && isShowingNoMatches && (
-            <div className={cx(styles.item, styles.disabled)}>
+            <div className={styles.item}>
               <Subheading className={styles.noMatchesTitle}>
                 {noMatchesMessage}
               </Subheading>

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -8,7 +8,7 @@ import { TextInput, TextInputProps } from '@contentful/f36-forms';
 import { CloseIcon, ChevronDownIcon } from '@contentful/f36-icons';
 import { SkeletonContainer, SkeletonBodyText } from '@contentful/f36-skeleton';
 import { Popover } from '@contentful/f36-popover';
-import { SectionHeading } from '@contentful/f36-typography';
+import { Subheading, SectionHeading } from '@contentful/f36-typography';
 
 import { AutocompleteItems } from './AutocompleteItems';
 import { getAutocompleteStyles } from './Autocomplete.styles';
@@ -275,13 +275,18 @@ function _Autocomplete<ItemType>(
 
           {!isLoading && items.length === 0 && (
             <div className={cx(styles.item, styles.disabled)}>
-              {noMatchesMessage}
+              <Subheading margin="spacingXs" className="styles.NoMatchesTitle">
+                {noMatchesMessage}
+              </Subheading>
             </div>
           )}
 
           {!isLoading &&
             isUsingGroups(isGrouped, items) &&
             items.map((group: GroupType, index: number) => {
+              if (group.options.length < 1) {
+                return;
+              }
               const render = (
                 <div key={index}>
                   <SectionHeading
@@ -306,16 +311,18 @@ function _Autocomplete<ItemType>(
               return render;
             })}
 
-          {!isLoading && !isUsingGroups(isGrouped, items) && (
-            <AutocompleteItems
-              items={items}
-              elementStartIndex={elementStartIndex}
-              highlightedIndex={highlightedIndex}
-              getItemProps={getItemProps}
-              renderItem={renderItem}
-              inputValue={inputValue}
-            />
-          )}
+          {!isLoading &&
+            !isUsingGroups(isGrouped, items) &&
+            items.length > 0 && (
+              <AutocompleteItems
+                items={items}
+                elementStartIndex={elementStartIndex}
+                highlightedIndex={highlightedIndex}
+                getItemProps={getItemProps}
+                renderItem={renderItem}
+                inputValue={inputValue}
+              />
+            )}
         </Popover.Content>
       </Popover>
     </div>

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -158,6 +158,10 @@ function _Autocomplete<ItemType>(
       )
     : items;
 
+  const isShowingNoMatches = isUsingGroups(isGrouped, items)
+    ? items.every((group: GroupType) => group.options.length === 0)
+    : items.length === 0;
+
   const {
     getComboboxProps,
     getInputProps,
@@ -273,7 +277,7 @@ function _Autocomplete<ItemType>(
               </div>
             ))}
 
-          {!isLoading && items.length === 0 && (
+          {!isLoading && isShowingNoMatches && (
             <div className={cx(styles.item, styles.disabled)}>
               <Subheading margin="none" className={styles.noMatchesTitle}>
                 {noMatchesMessage}

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -282,6 +282,9 @@ function _Autocomplete<ItemType>(
           {!isLoading &&
             isUsingGroups(isGrouped, items) &&
             items.map((group: GroupType, index: number) => {
+              if (group.options.length === 0) {
+                return null;
+              }
               const render = (
                 <div key={index}>
                   <SectionHeading

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -282,9 +282,6 @@ function _Autocomplete<ItemType>(
           {!isLoading &&
             isUsingGroups(isGrouped, items) &&
             items.map((group: GroupType, index: number) => {
-              if (group.options.length === 0) {
-                return null;
-              }
               const render = (
                 <div key={index}>
                   <SectionHeading

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -124,7 +124,7 @@ function _Autocomplete<ItemType>(
     isDisabled,
     isRequired,
     isReadOnly,
-    noMatchesMessage = 'No matches',
+    noMatchesMessage = 'No matches found',
     placeholder = 'Search',
     inputRef,
     toggleRef,

--- a/packages/components/autocomplete/src/AutocompleteItems.tsx
+++ b/packages/components/autocomplete/src/AutocompleteItems.tsx
@@ -2,6 +2,7 @@ import React, { HTMLAttributes } from 'react';
 import { cx } from 'emotion';
 
 import { getStringMatch } from '@contentful/f36-utils';
+import { Text } from '@contentful/f36-typography';
 import { getAutocompleteStyles } from './Autocomplete.styles';
 import { UseComboboxGetItemPropsOptions } from 'downshift';
 
@@ -38,8 +39,9 @@ export function AutocompleteItems<ItemType>(
         const itemIndex = elementStartIndex + index;
         const itemProps = getItemProps({ item, index: itemIndex });
         return (
-          <li
+          <Text
             {...itemProps}
+            as="li"
             key={itemIndex}
             className={cx([
               styles.item,
@@ -54,7 +56,7 @@ export function AutocompleteItems<ItemType>(
             ) : (
               item
             )}
-          </li>
+          </Text>
         );
       })}
     </ul>

--- a/packages/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -148,17 +148,13 @@ export const UsingGroupedItems = (args: AutocompleteProps<GroceryList>) => {
   const [filteredItems, setFilteredItems] = useState(groceryList);
 
   const handleInputValueChange = (value: string) => {
-    const newFilteredItems: GroceryList[] = [];
-    groceryList.forEach((group) => {
-      const filteredOptions = group.options.filter((item: Produce) =>
-        item.name.toLowerCase().includes(value.toLowerCase()),
-      );
-      if (filteredOptions.length > 0) {
-        newFilteredItems.push({
-          groupTitle: group.groupTitle,
-          options: filteredOptions,
-        });
-      }
+    const newFilteredItems = groceryList.map((group) => {
+      return {
+        ...group,
+        options: group.options.filter((item: Produce) =>
+          item.name.toLowerCase().includes(value.toLowerCase()),
+        ),
+      };
     });
     setFilteredItems(newFilteredItems);
   };

--- a/packages/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -148,14 +148,22 @@ export const UsingGroupedItems = (args: AutocompleteProps<GroceryList>) => {
   const [filteredItems, setFilteredItems] = useState(groceryList);
 
   const handleInputValueChange = (value: string) => {
-    const newFilteredItems = groceryList.map((group) => {
-      return {
-        ...group,
-        options: group.options.filter((item: Produce) =>
+    const newFilteredItems = groceryList
+      .map((group) => {
+        const filteredOptions = group.options.filter((item: Produce) =>
           item.name.toLowerCase().includes(value.toLowerCase()),
-        ),
-      };
-    });
+        );
+        if (filteredOptions.length > 0) {
+          return {
+            ...group,
+            options: filteredOptions,
+          };
+        }
+        return undefined;
+      })
+      .filter((group: GroceryList | undefined): group is GroceryList => {
+        return !!group;
+      });
     setFilteredItems(newFilteredItems);
   };
 

--- a/packages/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -55,6 +55,11 @@ const groceryList: GroceryList[] = [
     groupTitle: 'Vegetables',
     options: veggis,
   },
+  /* Empty groups are not rendered  */
+  {
+    groupTitle: 'Sweet',
+    options: [],
+  },
 ];
 
 const fruitStrings = fruits.reduce((acc, fruit) => [...acc, fruit.name], []);

--- a/packages/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -148,22 +148,18 @@ export const UsingGroupedItems = (args: AutocompleteProps<GroceryList>) => {
   const [filteredItems, setFilteredItems] = useState(groceryList);
 
   const handleInputValueChange = (value: string) => {
-    const newFilteredItems = groceryList
-      .map((group) => {
-        const filteredOptions = group.options.filter((item: Produce) =>
-          item.name.toLowerCase().includes(value.toLowerCase()),
-        );
-        if (filteredOptions.length > 0) {
-          return {
-            ...group,
-            options: filteredOptions,
-          };
-        }
-        return undefined;
-      })
-      .filter((group: GroceryList | undefined): group is GroceryList => {
-        return !!group;
-      });
+    const newFilteredItems: GroceryList[] = [];
+    groceryList.forEach((group) => {
+      const filteredOptions = group.options.filter((item: Produce) =>
+        item.name.toLowerCase().includes(value.toLowerCase()),
+      );
+      if (filteredOptions.length > 0) {
+        newFilteredItems.push({
+          groupTitle: group.groupTitle,
+          options: filteredOptions,
+        });
+      }
+    });
     setFilteredItems(newFilteredItems);
   };
 

--- a/packages/components/autocomplete/test/Autocomplete.test.tsx
+++ b/packages/components/autocomplete/test/Autocomplete.test.tsx
@@ -146,7 +146,7 @@ describe('Autocomplete', () => {
       renderComponent({ noMatchesMessage, items: [] });
 
       const input = screen.getByTestId('cf-autocomplete-input');
-      const list = screen.getByTestId('cf-autocomplete-list');
+      const list = screen.getByTestId('cf-autocomplete-container');
 
       // type anything to open the list
       fireEvent.input(input, {

--- a/packages/components/autocomplete/test/Autocomplete.test.tsx
+++ b/packages/components/autocomplete/test/Autocomplete.test.tsx
@@ -44,6 +44,10 @@ const groceryList: GroceryList[] = [
     groupTitle: 'Vegetable',
     options: vegetables,
   },
+  {
+    groupTitle: 'Sweet',
+    options: [],
+  },
 ];
 
 const fruitStrings = fruits.reduce(
@@ -306,6 +310,22 @@ describe('Autocomplete', () => {
       expect(
         screen.queryAllByTestId('cf-autocomplete-grouptitle'),
       ).toHaveLength(2);
+    });
+    it("doesn't render an empty group", async () => {
+      renderComponent<Fruit>({
+        isGrouped: true,
+        items: groceryList,
+        itemToString: (item: Fruit) => item.name,
+        renderItem: (item: Fruit) => item.name,
+      });
+
+      const renderedGroupTitles = screen
+        .getAllByTestId('cf-autocomplete-grouptitle')
+        .map((node) => node.textContent);
+
+      expect(renderedGroupTitles).toContain('Fruit');
+      expect(renderedGroupTitles).toContain('Vegetable');
+      expect(renderedGroupTitles).not.toContain('Sweet');
     });
     it('selects the first item', async () => {
       renderComponent<Fruit>({


### PR DESCRIPTION
# Purpose of PR

- I don't see the need in rendering an empty group. It should be our default behaviour to not render this until needed otherwise.
- Currently, we need to define the font explicitly for the AutoCompleteItems (only for those). Same as for all components, this should be defined in the library.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
