### PR TITLE
docs: folder structure guide

### DIFF
--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -52,7 +52,7 @@ In these cases, the folder structure of the package will look more like this:
     index.ts
     Button.tsx
   /stories
-    # stories for storybook
+    # stories for storybook of each component inside the package
   /test
     # test files
   README.mdx

--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -1,0 +1,96 @@
+# F36 Folder Structure
+
+To make it easy to maintain our files and folders we ask every contributor to follow this folder structure.
+Every package has its own folder, except for components which should be kept in the folder `/components` (every component must have its own folder).
+
+## Table of contents
+
+- [Components](#components)
+  - [Packages with more than one component](#packages-with-more-than-one-component)
+  - [Packages with utility functions](#packages-with-utility-functions)
+  - [Why do we use MDX?](#why-do-we-use-mdx)
+  - [Why is every `.mdx` file named "README"](#why-is-every-mdx-file-named-readme)
+
+## Components
+
+The basic folder structure of a component looks like this:
+
+```
+/my-component
+  /src
+    index.ts
+    MyComponent.tsx
+    MyComponent.styles.ts
+  /stories
+    # stories for storybook
+  /test
+    # test files
+  README.mdx
+  package.json
+```
+
+### Packages with more than one component
+
+Sometimes the package will include a "base" component and some variants that are build from the base component (e.g. Button).
+In these cases, the folder structure of the package will look more like this:
+
+```
+/button
+  /src
+    /ButtonGroup
+      README.mdx
+      index.ts
+      ButtonGroup.tsx
+    /IconButton
+      README.mdx
+      index.ts
+      IconButton.tsx
+    /ToggleButton
+      README.mdx
+      index.ts
+      IconButton.tsx
+    index.ts
+    Button.tsx
+  /stories
+    # stories for storybook
+  /test
+    # test files
+  README.mdx
+  package.json
+```
+
+### Packages with utility functions
+
+Another possible case is that the package has a component and some utility functions. The folder structure will loke like this:
+
+```
+/datetime
+  /src
+    /RelativeDateTime
+      README.mdx
+      index.ts
+      RelativeDateTime.tsx
+    /utils
+      README.mdx
+      index.ts
+      formatDateTimeUtils.ts
+    index.ts
+    DateTime.tsx
+  /stories
+    # stories for storybook
+  /test
+    # test files
+  README.mdx
+  package.json
+```
+
+### Why do we use MDX?
+
+We use `.mdx` file format instead of just `.md` because these files are also used
+by our website to generate its pages.
+You can read more about the benefits of mdx [here](https://mdxjs.com/).
+
+### Why is every `.mdx` file named "README"?
+
+The markdown files must be named "README" because we want them to show up in GitHub
+for the people that navigate through the folders of the repo looking for documentation.

--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -1,7 +1,31 @@
 # F36 Folder Structure
 
 To make it easy to maintain our files and folders we ask every contributor to follow this folder structure.
-Every package has its own folder, except for components which should be kept in the folder `/components` (every component must have its own folder).
+Every package that should be published must have its own folder inside the `packages` directory,
+with the exception of UI components that should have their folder and files created inside the `packages/components` directory.
+
+```
+/packages
+  /components
+    /autocomplete
+      README.mdx
+      package.json
+    /button
+      README.mdx
+      package.json
+    /forms
+      README.mdx
+      package.json
+  /forma-36-codemod
+    README.mdx
+    package.json
+  /forma-36-tokens
+    README.mdx
+    package.json
+  /forma-36-website
+    README.mdx
+    package.json
+```
 
 ## Table of contents
 
@@ -22,12 +46,14 @@ The basic folder structure of a component looks like this:
     MyComponent.tsx
     MyComponent.styles.ts
   /stories
-    # stories for storybook
+    # stories for storybook of each component inside the package
   /test
     # test files
   README.mdx
   package.json
 ```
+
+If you run `yarn generate component`, this structure will be generated for you automatically.
 
 ### Packages with more than one component
 
@@ -77,7 +103,7 @@ Another possible case is that the package has a component and some utility funct
     index.ts
     DateTime.tsx
   /stories
-    # stories for storybook
+    # stories for storybook of each component inside the package
   /test
     # test files
   README.mdx


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

While working on the Next.js experiment, I noticed that we are not following any convention on how to organise our files in the repo. This was noticeable because the website tries to generate pages from the .mdx files, but they are not always in the same places or with the same name

I created a guide that proposes a structure for our files similar to what we have in the "features" folder in the webapp project

Please comment, suggest things, and fix my grammar!

## Note on the naming of the files

Right now, in v4, we always have two MD files in a folder because one markdown has the documentation of that component and the other has a warning for people who is using it during our "alpha" phase

We are almost releasing the beta version of v4 and all the documentation of every component will be moved to README.mdx files

That's another reason why this is the RIGHT moment to come up with a folder structure!

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
