### PR TITLE
fix(menu-item): isDisabled prop

### DIFF
--- a/packages/components/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/components/menu/src/MenuItem/MenuItem.tsx
@@ -16,6 +16,9 @@ interface MenuItemInternalProps extends CommonProps {
   children?: React.ReactNode;
   as?: 'a' | 'button';
 
+  /** Renders item as disabled */
+  isDisabled?: boolean;
+
   /**
    * Sets focus on item
    */


### PR DESCRIPTION
# Purpose of PR

Adds `isDisabled` prop to `MenuItem` component.

Which leaves me with the question, do we want to and if so is there any way to map standard HTML element props to our own names following our style guide? I.e. don't allow `disabled` but always map it to `isDisabled`.