### PR TITLE
docs: screen reader only under components

### DIFF
--- a/packages/core/src/ScreenReaderOnly/ScreenReaderOnly.mdx
+++ b/packages/core/src/ScreenReaderOnly/ScreenReaderOnly.mdx
@@ -2,7 +2,7 @@
 title: 'ScreenReaderOnly'
 type: 'component'
 status: 'stable'
-slug: /components/ScreenReaderOnly/
+slug: /components/screen-reader-only/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/core/src/ScreenReaderOnly'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/utilities-screenreaderonly--basic'
 typescript: ./ScreenReaderOnly.tsx

--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -70,17 +70,7 @@ module.exports = {
         menuLinks: [
           {
             name: 'Accessibility',
-            link: '',
-            menuLinks: [
-              {
-                name: 'Accessibility Principiles',
-                link: '/guidelines/accessibility/',
-              },
-              {
-                name: 'ScreenReaderOnly Helper Component',
-                link: '/components/ScreenReaderOnly/',
-              },
-            ],
+            link: '/guidelines/accessibility/',
           },
           {
             name: 'Copy',
@@ -328,6 +318,10 @@ module.exports = {
           {
             name: 'Pill',
             link: '/components/pill/',
+          },
+          {
+            name: 'ScreenReaderOnly',
+            link: '/components/ScreenReaderOnly/',
           },
           {
             name: 'Skeletons',

--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -321,7 +321,7 @@ module.exports = {
           },
           {
             name: 'ScreenReaderOnly',
-            link: '/components/ScreenReaderOnly/',
+            link: '/components/screen-reader-only/',
           },
           {
             name: 'Skeletons',


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Since `ScreenReaderOnly` is a component and its route is `/components/ScreenReaderOnly`, I moved it to the Components section and changed the route to follow our convention

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
