### PR TITLE
fix: do not focus menu trigger on mouse click outside

### DIFF
--- a/packages/components/menu/src/Menu.tsx
+++ b/packages/components/menu/src/Menu.tsx
@@ -198,7 +198,7 @@ export function Menu(props: MenuProps) {
             return;
           }
 
-          closeAndFocusTrigger();
+          handleClose();
         },
       }),
       getMenuItemProps: (_props = {}) => ({

--- a/packages/components/popover/src/Popover.tsx
+++ b/packages/components/popover/src/Popover.tsx
@@ -213,7 +213,7 @@ export function Popover(props: PopoverProps) {
             return;
           }
 
-          closeAndFocusTrigger();
+          onClose();
         },
         onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
           if (_props.onKeyDown) {
@@ -237,6 +237,7 @@ export function Popover(props: PopoverProps) {
       popoverElement,
       triggerElement,
       closeAndFocusTrigger,
+      onClose,
     ],
   );
 

--- a/packages/components/popover/src/Popover.tsx
+++ b/packages/components/popover/src/Popover.tsx
@@ -25,7 +25,7 @@ export interface PopoverProps {
   /**
    * Callback fired when the popover closes
    */
-  onClose?: Function;
+  onClose?: () => void;
 
   /**
    * Determines the preferred position of the Popover. This position is not
@@ -213,7 +213,7 @@ export function Popover(props: PopoverProps) {
             return;
           }
 
-          onClose();
+          onClose?.();
         },
         onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => {
           if (_props.onKeyDown) {

--- a/packages/components/popover/src/PopoverContent/PopoverContent.styles.ts
+++ b/packages/components/popover/src/PopoverContent/PopoverContent.styles.ts
@@ -11,6 +11,8 @@ export const getPopoverContentStyles = (isOpen: boolean) => ({
     zIndex: tokens.zIndexDropdown,
     '&:focus': {
       outline: 'none',
+    },
+    '&:focus-visible': {
       boxShadow: tokens.glowPrimary,
     },
   }),

--- a/packages/components/popover/src/PopoverContent/PopoverContent.styles.ts
+++ b/packages/components/popover/src/PopoverContent/PopoverContent.styles.ts
@@ -9,5 +9,9 @@ export const getPopoverContentStyles = (isOpen: boolean) => ({
     borderRadius: tokens.borderRadiusMedium,
     boxShadow: tokens.boxShadowDefault,
     zIndex: tokens.zIndexDropdown,
+    '&:focus': {
+      outline: 'none',
+      boxShadow: tokens.glowPrimary,
+    },
   }),
 });


### PR DESCRIPTION
# Purpose of PR

Don't focus menu trigger on blur, and default to browser behaviour

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
