### PR TITLE
fix(docs): fix in-page nvigation with anchors

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,16 +3,16 @@
 ## Table of contents
 
 - [Table of contents](#table-of-contents)
-- [How to migrate your packages to v4](#How-to-migrate-your-packages-to-v4)
-- [Changes per Component in v4](#Changes-per-component-in-v4)
-  - [Tag becomes Badge](#Tag-becomes-Badge)
-    - [How to migrate your Tag to Badge](#How-to-migrate-your-Tag-to-Badge)
+- [How to migrate your packages to v4](#how-to-migrate-your-packages-to-v4)
+- [Changes per Component in v4](#changes-per-component-in-v4)
+  - [Tag becomes Badge](#tag-becomes-Badge)
+    - [How to migrate your Tag to Badge](#how-to-migrate-your-Tag-to-Badge)
   - [Button](#button)
-    - [How to migrate your Button components](#How-to-migrate-your-Button-components)
+    - [How to migrate your Button components](#how-to-migrate-your-gutton-components)
   - [Flex](#flex)
-    - [How to migrate your Flex components](#How-to-migrate-your-Flex-components)
+    - [How to migrate your Flex components](#how-to-migrate-your-flex-components)
   - [Grid](#grid)
-    - [How to migrate your Grid components](#How-to-migrate-your-Grid-components)
+    - [How to migrate your Grid components](#how-to-migrate-your-grid-components)
 
 ## How to migrate your packages to v4
 

--- a/packages/components/copybutton/CopyButton.mdx
+++ b/packages/components/copybutton/CopyButton.mdx
@@ -15,7 +15,7 @@ The CopyButton is a styled button that copies text into the user's clipboard. Th
 
 ## Table of contents
 
-- [How to use CopyButton](#how-to-use-CopyButton)
+- [How to use CopyButton](#how-to-use-copybutton)
 - [Code examples](#code-examples)
 - [Content recommendations](#content-recommendations)
 - [Accessibility](#accessibility)

--- a/packages/components/forms/src/radio/Radio.mdx
+++ b/packages/components/forms/src/radio/Radio.mdx
@@ -16,7 +16,7 @@ typescript: ./Radio.tsx,./RadioGroup.tsx
 - [How to use Radio](#how-to-use-radio)
   - [Using as a controlled input](#using-as-a-controlled-input)
   - [Using as an uncontrolled input](#using-as-an-uncontrolled-input)
-  - [Using with RadioGroup](#using-with-RadioGroup)
+  - [Using with RadioGroup](#using-with-radiogroup)
 - [Component variations](#component-variations)
 - [Content recommendations](#content-recommendations)
 - [Accessibility](#accessibility)

--- a/packages/components/forms/src/text-input/TextInput.mdx
+++ b/packages/components/forms/src/text-input/TextInput.mdx
@@ -12,7 +12,7 @@ typescript: ./TextInput.tsx,./input-group/InputGroup.tsx
 
 ## Table of contents
 
-- [How to use TextInput](#how-to-use-TextInput)
+- [How to use TextInput](#how-to-use-textinput)
 - [Code examples](#code-examples)
   - [Basic example](#basic-example)
   - [TextInput with label](#textInput-with-label)

--- a/packages/components/popover/Popover.mdx
+++ b/packages/components/popover/Popover.mdx
@@ -13,7 +13,7 @@ It is a base for other more specific component, like `Menu`, `Autocomplete` and 
 
 ## Table of contents
 
-- [How to use Popover](#how-to-use-Popover)
+- [How to use Popover](#how-to-use-popover)
 - [Code examples](#code-examples)
 - [Content recommendations](#content-recommendations)
 - [Accessibility](#accessibility)

--- a/packages/components/text-link/TextLink.mdx
+++ b/packages/components/text-link/TextLink.mdx
@@ -12,7 +12,7 @@ TextLinks communicate actions and linked resources to users.
 
 ## Table of contents
 
-- [How to use TextLinks](#how-to-use-TextLinks)
+- [How to use TextLinks](#how-to-use-textlinks)
 - [Component variations](#component-variations)
 - [Code examples](#code-examples)
 - [Content recommendations](#content-recommendations)

--- a/packages/components/tooltip/Tooltip.mdx
+++ b/packages/components/tooltip/Tooltip.mdx
@@ -12,7 +12,7 @@ typescript: ./src/Tooltip.tsx
 
 Tooltips are very useful to communicate extra information related to an element on the screen. The information should be contextual, useful, and nonessential.
 
-- [How to use Tooltip](#how-to-use-Tooltip)
+- [How to use Tooltip](#how-to-use-tooltip)
 - [Component variations](#component-variations)
 - [Code examples](#code-examples)
 - [Content recommendations](#content-recommendations)

--- a/packages/core/src/ScreenReaderOnly/ScreenReaderOnly.mdx
+++ b/packages/core/src/ScreenReaderOnly/ScreenReaderOnly.mdx
@@ -12,7 +12,7 @@ This is a helper component to add content and components which is only visible f
 
 ## Table of contents
 
-- [How to use ScreenReaderOnly](#how-to-use-ScreenReaderOnly)
+- [How to use ScreenReaderOnly](#how-to-use-screenreaderonly)
 - [Code examples](#code-examples)
 - [Content recommendations](#content-recommendations)
 


### PR DESCRIPTION
# Purpose of PR

a small fix for documentation website: use all-lower-case on anchor on-page links
Why: the anchor navigation only works with all-lower-case letters in the link

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
