### PR TITLE
refactor(website): Improve navigation on menu and submenu rendering

### DIFF
--- a/packages/forma-36-website/src/components/Navigation.js
+++ b/packages/forma-36-website/src/components/Navigation.js
@@ -104,6 +104,12 @@ const MenuListItem = React.forwardRef(
       setIsExpanded(!isExpanded);
     };
 
+    const handleKeyDown = (event) => {
+      if (event.nativeEvent.code === 'Enter') {
+        handleToggle(event);
+      }
+    };
+
     const itemOffset = { paddingLeft: `${1 + hierarchyLevel}rem` };
 
     return (
@@ -113,6 +119,9 @@ const MenuListItem = React.forwardRef(
             <div
               css={[styles.link, styles.linkGroup, itemOffset]}
               onClick={handleToggle}
+              onKeyDown={handleKeyDown}
+              // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+              tabIndex={0}
             >
               {isCategory ? (
                 <SectionHeading>{item.name}</SectionHeading>

--- a/packages/forma-36-website/src/components/Navigation.js
+++ b/packages/forma-36-website/src/components/Navigation.js
@@ -36,6 +36,10 @@ const styles = {
     margin-top: 0;
   `,
 
+  hidden: css`
+    display: none;
+  `,
+
   link: css`
     display: flex;
     justify-content: space-between;
@@ -123,13 +127,12 @@ const MenuListItem = React.forwardRef(
                 icon={isExpanded ? 'ChevronDown' : 'ChevronRight'}
               />
             </div>
-            {isExpanded && (
-              <MenuList
-                menuItems={item.menuLinks}
-                currentPath={currentPath}
-                hierarchyLevel={hierarchyLevel + 1}
-              />
-            )}
+            <MenuList
+              isHidden={!isExpanded}
+              menuItems={item.menuLinks}
+              currentPath={currentPath}
+              hierarchyLevel={hierarchyLevel + 1}
+            />
           </>
         ) : (
           <Link
@@ -161,7 +164,12 @@ MenuListItem.defaultProps = {
   hierarchyLevel: 0,
 };
 
-const MenuList = ({ menuItems, currentPath, hierarchyLevel }) => {
+const MenuList = ({
+  menuItems,
+  currentPath,
+  hierarchyLevel,
+  isHidden = false,
+}) => {
   const activeRef = useRef(null);
   useEffect(() => {
     if (activeRef.current) {
@@ -169,7 +177,7 @@ const MenuList = ({ menuItems, currentPath, hierarchyLevel }) => {
     }
   }, []);
   return (
-    <ul css={styles.list}>
+    <ul css={[styles.list, isHidden && styles.hidden]}>
       {menuItems.map((item, index) => {
         const active = checkActive(item, currentPath);
         return (


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->
Make it so the submenus area always rendered even when not expanded, so the docsearch crawler can correctly find the links to be indexed.
Improve keyboard navigation on the menu

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
