### PR TITLE
docs(website): add missing prop tables

### DIFF
--- a/packages/components/badge/Badge.mdx
+++ b/packages/components/badge/Badge.mdx
@@ -5,7 +5,7 @@ status: 'stable'
 slug: /components/badge/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/badge'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-badge--basic'
-typescript: ./Badge.tsx
+typescript: ./src/Badge.tsx
 ---
 
 Badge is used to label or highlight items in the interface.
@@ -90,7 +90,7 @@ Badge is used to label or highlight items in the interface.
 
 ### EntityStatusBadge
 
-For easy and quick usage of Badge in Contentful products, in extentions and apps we provide additional component called `EntityStatusBadge`. It's used in the Cotnentful entity to mark their status.
+For easy and quick usage of Badge in Contentful products, in extentions and apps we provide additional component called `EntityStatusBadge`. It's used in the Contentful entity to mark their status.
 
 EntityStatusBadge can have different mark following statuses. Those values are passed as a `entityStatus` property and displayed as a content in the badge:
 

--- a/packages/components/entity-list/EntityList.mdx
+++ b/packages/components/entity-list/EntityList.mdx
@@ -5,7 +5,7 @@ status: 'stable'
 slug: /components/entity-list/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/entity-list'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-entity-list--default'
-typescript: ./src/EntityList.tsx
+typescript: ./src/EntityList.tsx,./src/EntityListItem/EntityListItem.tsx
 ---
 
 # EntityList
@@ -100,8 +100,14 @@ This component should be used in combination with the EntityList.Item component.
 </EntityList>
 ```
 
-## Props of EntityList
+## Props
 
 import { Props } from '@contentful/f36-docs-utils';
+
+### EntityList
+
+<Props of="EntityList" />
+
+### EntityList.Item
 
 <Props of="EntityListItem" />

--- a/packages/components/list/List.mdx
+++ b/packages/components/list/List.mdx
@@ -5,7 +5,7 @@ status: 'stable'
 slug: /components/list/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/List'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-list--default'
-typescript: ./src/List.tsx
+typescript: ./src/List.tsx,./src/ListItem/ListItem.tsx
 ---
 
 List is component that helps with vertical indexing of content.
@@ -51,4 +51,10 @@ The List component can be configured in two different ways: to display bulleted 
 
 import { Props } from '@contentful/f36-docs-utils';
 
+### List
+
 <Props of="List" />
+
+### List.Item
+
+<Props of="ListItem" />

--- a/packages/core/src/Grid/Grid.mdx
+++ b/packages/core/src/Grid/Grid.mdx
@@ -4,7 +4,7 @@ type: 'component'
 slug: /components/grid/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/core/src/Grid'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-grid--default'
-typescript: ./Grid.tsx,./Grid.Item/Grid.Item.tsx
+typescript: ./Grid.tsx,./GridItem/GridItem.tsx
 ---
 
 [CSS Grid](https://developer.mozilla.org/en-US/docs/Glossary/Grid) based React component, comes with predefined values to ensure design consistency, and ease of use.

--- a/scripts/lint-packages.js
+++ b/scripts/lint-packages.js
@@ -60,11 +60,7 @@ for (const pkg of packages) {
     'src/index.ts',
     `${pkg} did not match "src/index.ts"`,
   );
-  softAssert.deepEqual(
-    json.files,
-    ['dist', 'src'],
-    `${pkg} did not match "files"`,
-  );
+  softAssert.deepEqual(json.files, ['dist'], `${pkg} did not match "files"`);
   softAssert(
     json.dependencies && json.dependencies['@babel/runtime'],
     `${pkg} is missing a dependency on @babel/runtime`,


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
