### PR TITLE
refactor(formcontrol): add possibility to render fieldset and legend

### DIFF
--- a/packages/components/forms/src/checkbox/Checkbox.mdx
+++ b/packages/components/forms/src/checkbox/Checkbox.mdx
@@ -164,8 +164,7 @@ The Checkbox can be rendered as disabled with the `isDisabled` property.
 ## Accessibility
 
 - To ensure `Checkbox` meets accessibility standards, provide `name` and `id`;
-- When using `Checkbox.Group` it whould be wrapper by a `fieldset` and have a `legend`.
-  - We also provide `FormControl` and `FormControl.Label` that can be rendered as `fieldset` and `legend`
+- When using `Checkbox.Group` it should be wrapped in a `<FormControl as="fieldset"> and have a <FormControl.Label as="legend">.
 
 ## Props
 

--- a/packages/components/forms/src/checkbox/Checkbox.mdx
+++ b/packages/components/forms/src/checkbox/Checkbox.mdx
@@ -84,8 +84,8 @@ We also provide the `CheckboxGroup` component that helps when using multiple che
 - `onChange`: Handler that will be executed when any checkbox inside the group receives the event of change.
 
 ```jsx
-<React.Fragment>
-  <FormControl.Label marginBottom="none">
+<FormControl as="fieldset">
+  <FormControl.Label as="legend" marginBottom="none">
     Checkbox group options
   </FormControl.Label>
   <Paragraph>Subtitle with more information if needed</Paragraph>
@@ -97,7 +97,7 @@ We also provide the `CheckboxGroup` component that helps when using multiple che
       Option 2
     </Checkbox>
   </CheckboxGroup>
-</React.Fragment>
+</FormControl>
 ```
 
 ## Code examples
@@ -163,7 +163,9 @@ The Checkbox can be rendered as disabled with the `isDisabled` property.
 
 ## Accessibility
 
-- To ensure `Checkbox` meets accessibility standards, provide `name` and `id`
+- To ensure `Checkbox` meets accessibility standards, provide `name` and `id`;
+- When using `Checkbox.Group` it whould be wrapper by a `fieldset` and have a `legend`.
+  - We also provide `FormControl` and `FormControl.Label` that can be rendered as `fieldset` and `legend`
 
 ## Props
 

--- a/packages/components/forms/src/checkbox/Checkbox.mdx
+++ b/packages/components/forms/src/checkbox/Checkbox.mdx
@@ -164,7 +164,7 @@ The Checkbox can be rendered as disabled with the `isDisabled` property.
 ## Accessibility
 
 - To ensure `Checkbox` meets accessibility standards, provide `name` and `id`;
-- When using `Checkbox.Group` it should be wrapped in a `<FormControl as="fieldset"> and have a <FormControl.Label as="legend">.
+- When using `Checkbox.Group` it should be wrapped in a `<FormControl as="fieldset">` and have a `<FormControl.Label as="legend">`.
 
 ## Props
 

--- a/packages/components/forms/src/form-control/FormControl.mdx
+++ b/packages/components/forms/src/form-control/FormControl.mdx
@@ -82,8 +82,8 @@ To uphold a consistent look and experience for your application, we recommend fo
 ### Example of RagioGroup component with FormControl
 
 ```jsx
-<FormControl>
-  <FormControl.Label>Radio group options</FormControl.Label>
+<FormControl as="fieldset">
+  <FormControl.Label as="legend">Radio group options</FormControl.Label>
   <RadioGroup name="radio-options" defaultValue="option 1">
     <Radio value="option 1" id="option-1" helpText="Help text for option 1">
       Option 1
@@ -99,8 +99,8 @@ To uphold a consistent look and experience for your application, we recommend fo
 ### Example of CheckboxGroup component with FormControl
 
 ```jsx
-<FormControl isRequired>
-  <FormControl.Label>Checkbox group options</FormControl.Label>
+<FormControl as="fieldset" isRequired>
+  <FormControl.Label as="legend">Checkbox group options</FormControl.Label>
   <CheckboxGroup name="checkbox-options">
     <Checkbox value="option 1" id="option-1" helpText="Some help text">
       Option 1

--- a/packages/components/forms/src/form-control/FormControl.tsx
+++ b/packages/components/forms/src/form-control/FormControl.tsx
@@ -46,6 +46,7 @@ function _FormControl<
   const [inputValue, setInputValue] = useState('');
   const [maxLength, setMaxLength] = useState(0);
   const roleAttr = as === 'fieldset' ? undefined : 'group';
+  const Element: React.ElementType = as || FORM_CONTROL_DEFAULT_TAG;
 
   const context = {
     id: generatedId,
@@ -62,7 +63,7 @@ function _FormControl<
   return (
     <FormControlContext.Provider value={context}>
       <Box
-        as={FORM_CONTROL_DEFAULT_TAG}
+        as={Element}
         ref={ref}
         role={roleAttr}
         testId={testId}

--- a/packages/components/forms/src/form-label/FormLabel.tsx
+++ b/packages/components/forms/src/form-label/FormLabel.tsx
@@ -1,10 +1,14 @@
 import { cx } from 'emotion';
 import React, { forwardRef } from 'react';
 import type { ReactNode } from 'react';
-import type { PropsWithHTMLElement } from '@contentful/f36-core';
 import { getFormLabelStyles } from './FormLabel.styles';
 import { useFormControl } from '../form-control/FormControlContext';
-import { CommonProps, MarginProps } from '@contentful/f36-core';
+import type {
+  CommonProps,
+  MarginProps,
+  PolymorphicProps,
+  PolymorphicComponent,
+} from '@contentful/f36-core';
 import { Text } from '@contentful/f36-typography';
 
 export interface FormLabelInternalProps extends CommonProps, MarginProps {
@@ -25,38 +29,55 @@ export interface FormLabelInternalProps extends CommonProps, MarginProps {
    * @default "required"
    */
   requiredText?: string;
+  /**
+   * Defines how the element will be rendered
+   * @default label
+   */
+  as?: 'label' | 'legend';
 }
 
-export type FormLabelProps = PropsWithHTMLElement<
-  FormLabelInternalProps,
-  'label'
->;
+const FORM_LABEL_DEFAULT_TAG = 'label';
 
-function _FormLabel(
+export type FormLabelProps<
+  E extends React.ElementType = typeof FORM_LABEL_DEFAULT_TAG
+> = PolymorphicProps<FormLabelInternalProps, E>;
+
+function _FormLabel<
+  E extends React.ElementType = typeof FORM_LABEL_DEFAULT_TAG
+>(
   {
+    as,
     children,
     className,
     isRequired,
     requiredText = 'required',
     testId = 'cf-ui-form-label',
     ...otherProps
-  }: FormLabelProps,
+  }: FormLabelProps<E>,
   forwardedRef: React.Ref<HTMLLabelElement>,
 ) {
   const styles = getFormLabelStyles();
   const formControlProps = useFormControl({ isRequired });
 
   const id = formControlProps.id ? formControlProps.id + '-label' : undefined;
-  const htmlFor = otherProps['htmlFor'] || formControlProps.id;
+
+  const labelProps =
+    as !== 'legend'
+      ? {
+          htmlFor: otherProps.htmlFor || formControlProps.id,
+        }
+      : {};
+
+  const Element: React.ElementType = as || FORM_LABEL_DEFAULT_TAG;
 
   return (
     <Text
-      as="label"
+      as={Element}
       marginBottom="spacingXs"
       {...otherProps}
       fontColor="gray900"
       id={id}
-      htmlFor={htmlFor}
+      {...labelProps}
       className={cx(styles.root, className)}
       ref={forwardedRef}
       testId={testId}
@@ -69,4 +90,7 @@ function _FormLabel(
   );
 }
 
-export const FormLabel = forwardRef(_FormLabel);
+export const FormLabel: PolymorphicComponent<
+  FormLabelInternalProps,
+  typeof FORM_LABEL_DEFAULT_TAG
+> = forwardRef(_FormLabel);

--- a/packages/components/forms/src/radio/Radio.mdx
+++ b/packages/components/forms/src/radio/Radio.mdx
@@ -172,7 +172,7 @@ The Radio can be rendered as disabled with the `isDisabled` property.
 ## Accessibility
 
 - To ensure `Radio` meets accessibility standards, provide `name` and `id`
-- When using `Radio.Group` it should be wrapped in a `<FormControl as="fieldset"> and have a <FormControl.Label as="legend">
+- When using `Radio.Group` it should be wrapped in a `<FormControl as="fieldset">` and have a `<FormControl.Label as="legend">`
 
 ## Props
 

--- a/packages/components/forms/src/radio/Radio.mdx
+++ b/packages/components/forms/src/radio/Radio.mdx
@@ -172,8 +172,7 @@ The Radio can be rendered as disabled with the `isDisabled` property.
 ## Accessibility
 
 - To ensure `Radio` meets accessibility standards, provide `name` and `id`
-- When using `Radio.Group` it whould be wrapper by a `fieldset` and have a `legend`.
-  - We also provide `FormControl` and `FormControl.Label` that can be rendered as `fieldset` and `legend`
+- When using `Radio.Group` it should be wrapped in a `<FormControl as="fieldset"> and have a <FormControl.Label as="legend">
 
 ## Props
 

--- a/packages/components/forms/src/radio/Radio.mdx
+++ b/packages/components/forms/src/radio/Radio.mdx
@@ -97,8 +97,10 @@ We also provide the `RadioGroup` component that helps when using multiple radio,
 - `onChange`: Handler that will be executed when any radio inside the group receives the event of change.
 
 ```jsx
-<React.Fragment>
-  <FormControl.Label marginBottom="none">Radio group options</FormControl.Label>
+<FormControl as="fieldset">
+  <FormControl.Label as="legend" marginBottom="none">
+    Radio group options
+  </FormControl.Label>
   <Paragraph>Subtitle with more information if needed</Paragraph>
   <RadioGroup name="radio-options" defaultValue="option 1">
     <Radio value="option 1" id="option-1" helpText="Help text for option 1">
@@ -170,6 +172,8 @@ The Radio can be rendered as disabled with the `isDisabled` property.
 ## Accessibility
 
 - To ensure `Radio` meets accessibility standards, provide `name` and `id`
+- When using `Radio.Group` it whould be wrapper by a `fieldset` and have a `legend`.
+  - We also provide `FormControl` and `FormControl.Label` that can be rendered as `fieldset` and `legend`
 
 ## Props
 

--- a/packages/components/forms/stories/FormControl.stories.tsx
+++ b/packages/components/forms/stories/FormControl.stories.tsx
@@ -86,8 +86,8 @@ export const Invalid = (args: FormControlInternalProps) => {
 export const WithCheckboxGroup = (args: FormControlInternalProps) => {
   return (
     <>
-      <FormControl {...args}>
-        <FormControl.Label marginBottom="none">
+      <FormControl as="fieldset" {...args}>
+        <FormControl.Label as="legend" marginBottom="none">
           Select your ingredients
         </FormControl.Label>
         <Paragraph>No extra costs</Paragraph>
@@ -118,7 +118,7 @@ export const WithCheckboxGroup = (args: FormControlInternalProps) => {
       </FormControl>
 
       <FormControl as="fieldset" {...args}>
-        <FormControl.Label>Burger patty</FormControl.Label>
+        <FormControl.Label as="legend">Burger patty</FormControl.Label>
         <RadioGroup name="burger-patty">
           <Radio
             value="beef"
@@ -138,8 +138,8 @@ export const WithCheckboxGroup = (args: FormControlInternalProps) => {
         )}
       </FormControl>
 
-      <FormControl {...args}>
-        <FormControl.Label>Condiments</FormControl.Label>
+      <FormControl as="fieldset" {...args}>
+        <FormControl.Label as="legend">Condiments</FormControl.Label>
         <CheckboxGroup name="condiments">
           <Checkbox value="ketchup">Ketchup</Checkbox>
           <Checkbox value="mustard">Mustard</Checkbox>

--- a/packages/components/forms/stories/Formik.stories.tsx
+++ b/packages/components/forms/stories/Formik.stories.tsx
@@ -102,8 +102,10 @@ export const Basic = () => {
 
           <Field name="favoritFruit">
             {({ field }) => (
-              <FormControl>
-                <FormControl.Label>Favorite fruit</FormControl.Label>
+              <FormControl as="fieldset">
+                <FormControl.Label as="legend">
+                  Favorite fruit
+                </FormControl.Label>
 
                 <RadioGroup {...field}>
                   <Radio id="apples" value="apples">
@@ -122,8 +124,8 @@ export const Basic = () => {
 
           <Field name="fruits">
             {({ field }) => (
-              <FormControl>
-                <FormControl.Label>Fruits</FormControl.Label>
+              <FormControl as="fieldset">
+                <FormControl.Label as="legend">Fruits</FormControl.Label>
 
                 <CheckboxGroup {...field}>
                   <Checkbox id="apples" value="apples">
@@ -230,8 +232,8 @@ export const WithUseFormik = () => {
         )}
       </FormControl>
 
-      <FormControl>
-        <FormControl.Label>Favorit fruit</FormControl.Label>
+      <FormControl as="fieldset">
+        <FormControl.Label as="legend">Favorit fruit</FormControl.Label>
 
         <RadioGroup
           name="favoriteFruit"

--- a/packages/components/forms/stories/ReactHookForm.stories.tsx
+++ b/packages/components/forms/stories/ReactHookForm.stories.tsx
@@ -116,8 +116,8 @@ export const WithRadioGroup = () => {
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
-      <FormControl>
-        <FormControl.Label>Fruits</FormControl.Label>
+      <FormControl as="fieldset">
+        <FormControl.Label as="legend">Fruits</FormControl.Label>
 
         <RadioGroup defaultValue="apples">
           <Radio
@@ -158,8 +158,8 @@ export const WithCheckboxGroup = () => {
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
-      <FormControl>
-        <FormControl.Label>Fruits</FormControl.Label>
+      <FormControl as="fieldset">
+        <FormControl.Label as="legend">Fruits</FormControl.Label>
 
         <CheckboxGroup name="uncontrolled-fruits" defaultValue={['apples']}>
           <Checkbox

--- a/packages/components/forms/stories/ReactHookFormControlledInputs.stories.tsx
+++ b/packages/components/forms/stories/ReactHookFormControlledInputs.stories.tsx
@@ -142,8 +142,8 @@ export const WithRadioGroup = () => {
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
-      <FormControl>
-        <FormControl.Label>Favorite fruit</FormControl.Label>
+      <FormControl as="fieldset">
+        <FormControl.Label as="legend">Favorite fruit</FormControl.Label>
 
         {/**
          * We need to pass an empty string as default value otherwise react will trigger the uncontrolled inputs warning
@@ -179,8 +179,8 @@ export const WithCheckboxGroup = () => {
 
   return (
     <Form onSubmit={handleSubmit(onSubmit)}>
-      <FormControl>
-        <FormControl.Label>Favorite fruits</FormControl.Label>
+      <FormControl as="fieldset">
+        <FormControl.Label as="legend">Favorite fruits</FormControl.Label>
 
         <CheckboxGroup name="favorite-fruits">
           <ControlledCheckbox control={control} id="apples" value="apples">

--- a/packages/forma-36-website/src/content/integrations/react-hook-form/index.mdx
+++ b/packages/forma-36-website/src/content/integrations/react-hook-form/index.mdx
@@ -78,8 +78,8 @@ export const ReactHookForm = () => {
         </Select>
       </FormControl>
 
-      <FormControl>
-        <FormControl.Label>Martial status</FormControl.Label>
+      <FormControl as="fieldset">
+        <FormControl.Label as="legend">Martial status</FormControl.Label>
 
         {/* When using RadioGroup, it’s necessary to register each Radio with the same "name" */}
         <RadioGroup defaultValue="single">


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

Make it possible to render the `FormControl` as `fieldset` and the `Form.Label` as `legend` to be used when grouping with `RadioGroup` or `CheckboxGroup`

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
