### PR TITLE
refactor: compound group components

### DIFF
--- a/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
+++ b/packages/components/forms/src/base-checkbox/BaseCheckbox.tsx
@@ -92,6 +92,13 @@ function _BaseCheckbox(
   const ariaChecked =
     typeof isChecked !== undefined ? isChecked : defaultChecked;
 
+  const helpTextId = id ? `${id}-helptext` : undefined;
+  const ariaDescribedBy = isInvalid
+    ? `${formFieldId}-validation`
+    : helpText
+    ? helpTextId
+    : undefined;
+
   return (
     <Flex className={className}>
       <Text
@@ -122,9 +129,7 @@ function _BaseCheckbox(
           required={isRequired}
           aria-required={isRequired ? 'true' : undefined}
           aria-invalid={isInvalid ? 'true' : undefined}
-          aria-describedby={`${formFieldId}-${
-            isInvalid ? `validation` : `helptext`
-          }`}
+          aria-describedby={ariaDescribedBy}
           id={id}
           name={name}
         />
@@ -137,10 +142,7 @@ function _BaseCheckbox(
         {children}
       </Text>
       {helpText && (
-        <HelpText
-          id={id ? `${id}-helptext` : undefined}
-          className={styles.helpText}
-        >
+        <HelpText id={helpTextId} className={styles.helpText}>
           {helpText}
         </HelpText>
       )}

--- a/packages/components/forms/src/checkbox/Checkbox.mdx
+++ b/packages/components/forms/src/checkbox/Checkbox.mdx
@@ -75,10 +75,10 @@ You can use the Checkbox as an uncontrolled input, for that you can:
 
 import { FormControl } from '@contentful/f36-forms';
 
-We also provide the `Checkbox.Group` component that helps when using multiple checkboxes, you can pass the spacing value and some common properties to be replicated to the checkboxes.
+We also provide the `Checkbox.Group` component that helps when using multiple checkboxes. You can pass some common properties on the `Checkbox.Group` level and they will be passed to the checkboxes inside the group.
 
 - `spacing`: This will set how much space should be between the inputs;
-- `name`: This will set all checkboxes with this name;
+- `name`: By setting this property on the `Checkbox.Group` level, you will set it automatically for all the checkboxes in the group;
 - `defaultValue`: This accepts an array that set the `defaultChecked` property for checkboxes which the value exists in the array;
 - `value`: Same as `defaultValue` but this one sets the `isChecked` property, making the checkbox group controlled;
 - `onChange`: Handler that will be executed when any checkbox inside the group receives the event of change.

--- a/packages/components/forms/src/checkbox/Checkbox.mdx
+++ b/packages/components/forms/src/checkbox/Checkbox.mdx
@@ -9,20 +9,20 @@ typescript: ./Checkbox.tsx,./CheckboxGroup.tsx
 ---
 
 `Checkbox` is a form component that shows a checkbox with it's label.  
-`CheckboxGroup` is a component that makes it easier to handle group of checkboxes.
+`Checkbox.Group` is a component that makes it easier to handle group of checkboxes.
 
 ## Table of contents
 
 - [How to use Checkbox](#how-to-use-checkbox)
   - [Using as a controlled input](#using-as-a-controlled-input)
   - [Using as an uncontrolled input](#using-as-an-uncontrolled-input)
-  - [Using with CheckboxGroup](#using-with-checkboxgroup)
+  - [Using with Group](#using-with-group)
 - [Component variations](#component-variations)
 - [Content recommendations](#content-recommendations)
 - [Accessibility](#accessibility)
 - [Props](#props)
   - [Checkbox](#props-checkbox)
-  - [CheckboxGroup](#props-checkboxgroup)
+  - [Group](#props-group)
 
 ## How to use Checkbox
 
@@ -71,11 +71,11 @@ You can use the Checkbox as an uncontrolled input, for that you can:
 </Checkbox>
 ```
 
-### Using with CheckboxGroup
+### Using with Group
 
 import { FormControl } from '@contentful/f36-forms';
 
-We also provide the `CheckboxGroup` component that helps when using multiple checkboxes, you can pass the spacing value and some common properties to be replicated to the checkboxes.
+We also provide the `Checkbox.Group` component that helps when using multiple checkboxes, you can pass the spacing value and some common properties to be replicated to the checkboxes.
 
 - `spacing`: This will set how much space should be between the inputs;
 - `name`: This will set all checkboxes with this name;
@@ -89,14 +89,14 @@ We also provide the `CheckboxGroup` component that helps when using multiple che
     Checkbox group options
   </FormControl.Label>
   <Paragraph>Subtitle with more information if needed</Paragraph>
-  <CheckboxGroup name="checkbox-options" defaultValue={['option 1']}>
+  <Checkbox.Group name="checkbox-options" defaultValue={['option 1']}>
     <Checkbox value="option 1" id="option-1" helpText="Some help text">
       Option 1
     </Checkbox>
     <Checkbox value="option 2" id="option-2" helpText="Another help text">
       Option 2
     </Checkbox>
-  </CheckboxGroup>
+  </Checkbox.Group>
 </React.Fragment>
 ```
 
@@ -173,6 +173,6 @@ import { Props } from '@contentful/f36-docs-utils';
 
 <Props of="Checkbox" />
 
-### Props CheckboxGroup
+### Props Group
 
 <Props of="CheckboxGroup" />

--- a/packages/components/forms/src/checkbox/CompoundCheckbox.tsx
+++ b/packages/components/forms/src/checkbox/CompoundCheckbox.tsx
@@ -1,0 +1,9 @@
+import { Checkbox as OriginalCheckbox } from './Checkbox';
+import { CheckboxGroup } from './CheckboxGroup';
+
+type CompoundCheckbox = typeof OriginalCheckbox & {
+  Group: typeof CheckboxGroup;
+};
+
+export const Checkbox = OriginalCheckbox as CompoundCheckbox;
+Checkbox.Group = CheckboxGroup;

--- a/packages/components/forms/src/form-control/FormControl.mdx
+++ b/packages/components/forms/src/form-control/FormControl.mdx
@@ -84,14 +84,14 @@ To uphold a consistent look and experience for your application, we recommend fo
 ```jsx
 <FormControl>
   <FormControl.Label>Radio group options</FormControl.Label>
-  <RadioGroup name="radio-options" defaultValue="option 1">
+  <Radio.Group name="radio-options" defaultValue="option 1">
     <Radio value="option 1" id="option-1" helpText="Help text for option 1">
       Option 1
     </Radio>
     <Radio value="option 2" id="option-2" helpText="Help text for option 2">
       Option 2
     </Radio>
-  </RadioGroup>
+  </Radio.Group>
   <FormControl.HelpText>Please, select an option</FormControl.HelpText>
 </FormControl>
 ```

--- a/packages/components/forms/src/form-control/FormControl.mdx
+++ b/packages/components/forms/src/form-control/FormControl.mdx
@@ -18,8 +18,8 @@ typescript: ./FormControl.tsx,../form-label/FormLabel.tsx,../help-text/HelpText.
   - [Basic example](#basic-example)
   - [Invalid input](#example-with-invalid-input)
   - [Select component with FormControl](#example-of-select-component-with-formcontrol)
-  - [Ragio Group component with FormControl](#example-of-ragio-group-component-with-formcontrol)
-  - [Checkbo xGroup component with FormControl](#example-of-checkbox-group-component-with-formcontrol)
+  - [Radio Group component with FormControl](#example-of-radio-group-component-with-formcontrol)
+  - [Checkbox Group component with FormControl](#example-of-checkbox-group-component-with-formcontrol)
   - [Example with character count](#example-with-character-count)
 - [Props](#Props)
   - [FormControl](#formcontrol)
@@ -79,7 +79,7 @@ To uphold a consistent look and experience for your application, we recommend fo
 </FormControl>
 ```
 
-### Example of Ragio Group component with FormControl
+### Example of Radio Group component with FormControl
 
 ```jsx
 <FormControl>

--- a/packages/components/forms/src/form-control/FormControl.mdx
+++ b/packages/components/forms/src/form-control/FormControl.mdx
@@ -18,8 +18,8 @@ typescript: ./FormControl.tsx,../form-label/FormLabel.tsx,../help-text/HelpText.
   - [Basic example](#basic-example)
   - [Invalid input](#example-with-invalid-input)
   - [Select component with FormControl](#example-of-select-component-with-formcontrol)
-  - [RagioGroup component with FormControl](#example-of-ragiogroup-component-with-formcontrol)
-  - [CheckboxGroup component with FormControl](#example-of-checkboxgroup-component-with-formcontrol)
+  - [Ragio Group component with FormControl](#example-of-ragio-group-component-with-formcontrol)
+  - [Checkbo xGroup component with FormControl](#example-of-checkbox-group-component-with-formcontrol)
   - [Example with character count](#example-with-character-count)
 - [Props](#Props)
   - [FormControl](#formcontrol)
@@ -79,7 +79,7 @@ To uphold a consistent look and experience for your application, we recommend fo
 </FormControl>
 ```
 
-### Example of RagioGroup component with FormControl
+### Example of Ragio Group component with FormControl
 
 ```jsx
 <FormControl>
@@ -96,19 +96,19 @@ To uphold a consistent look and experience for your application, we recommend fo
 </FormControl>
 ```
 
-### Example of CheckboxGroup component with FormControl
+### Example of Checkbox Group component with FormControl
 
 ```jsx
 <FormControl isRequired>
   <FormControl.Label>Checkbox group options</FormControl.Label>
-  <CheckboxGroup name="checkbox-options">
+  <Checkbox.Group name="checkbox-options">
     <Checkbox value="option 1" id="option-1" helpText="Some help text">
       Option 1
     </Checkbox>
     <Checkbox value="option 2" id="option-2" helpText="Another help text">
       Option 2
     </Checkbox>
-  </CheckboxGroup>
+  </Checkbox.Group>
   <FormControl.HelpText>
     Please, select at least one option
   </FormControl.HelpText>

--- a/packages/components/forms/src/index.ts
+++ b/packages/components/forms/src/index.ts
@@ -2,9 +2,8 @@ export { HelpText } from './help-text/HelpText';
 export type { HelpTextProps } from './help-text/HelpText';
 export { ValidationMessage } from './validation-message/ValidationMessage';
 export type { ValidationMessageProps } from './validation-message/ValidationMessage';
-export { Checkbox } from './checkbox/Checkbox';
+export { Checkbox } from './checkbox/CompoundCheckbox';
 export type { CheckboxProps } from './checkbox/Checkbox';
-export { CheckboxGroup } from './checkbox/CheckboxGroup';
 export type { CheckboxGroupProps } from './checkbox/CheckboxGroup';
 export { FormControl } from './form-control/CompoundFormControl';
 export type {

--- a/packages/components/forms/src/index.ts
+++ b/packages/components/forms/src/index.ts
@@ -16,9 +16,8 @@ export type {
   FormLabelInternalProps,
   FormLabelProps,
 } from './form-label/FormLabel';
-export { Radio } from './radio/Radio';
+export { Radio } from './radio/CompoundRadio';
 export type { RadioProps } from './radio/Radio';
-export { RadioGroup } from './radio/RadioGroup';
 export type { RadioGroupProps } from './radio/RadioGroup';
 export { TextInput } from './text-input/CompoundTextInput';
 export type { TextInputProps } from './text-input/types';

--- a/packages/components/forms/src/radio/CompoundRadio.tsx
+++ b/packages/components/forms/src/radio/CompoundRadio.tsx
@@ -1,0 +1,9 @@
+import { Radio as OriginalRadio } from './Radio';
+import { RadioGroup } from './RadioGroup';
+
+type CompoundRadio = typeof OriginalRadio & {
+  Group: typeof RadioGroup;
+};
+
+export const Radio = OriginalRadio as CompoundRadio;
+Radio.Group = RadioGroup;

--- a/packages/components/forms/src/radio/Radio.mdx
+++ b/packages/components/forms/src/radio/Radio.mdx
@@ -88,11 +88,11 @@ You can use the Radio as an uncontrolled input, for that you can:
 
 import { FormControl } from '@contentful/f36-forms';
 
-We also provide the `Radio.Group` component that helps when using multiple radio, you can pass the spacing value and some common properties to be replicated to the radios.
+We also provide the `Radio.Group` component that helps when using multiple radios. You can pass some common properties on the `Radio.Group` level and they will be passed to the radios inside the group.
 
 - `spacing`: This will set how much space should be between the inputs;
-- `name`: This will set all radios with this name;
-- `defaultValue`: This accepts a value that set the `defaultChecked` property for the radio that have the same value.
+- `name`: By setting this property on the `Radio.Group` level, you will set it automatically for all the radios in the group;
+- `defaultValue`: This accepts a value that set the `defaultChecked` property for the radio that have the same value;
 - `value`: Same as `defaultValue` but this one sets the `isChecked` property, making the radio group controlled;
 - `onChange`: Handler that will be executed when any radio inside the group receives the event of change.
 

--- a/packages/components/forms/src/radio/Radio.mdx
+++ b/packages/components/forms/src/radio/Radio.mdx
@@ -9,20 +9,20 @@ typescript: ./Radio.tsx,./RadioGroup.tsx
 ---
 
 `Radio` is a form component, that shows a radio input with its label. It is used to allow users to choose single option from the list. If you want to let the user select multiple options, use the `Checkbox` component.  
-`RadioGroup` is a component that makes it easier to handle group of radios.
+`Radio.Group` is a component that makes it easier to handle group of radios.
 
 ## Table of contents
 
 - [How to use Radio](#how-to-use-radio)
   - [Using as a controlled input](#using-as-a-controlled-input)
   - [Using as an uncontrolled input](#using-as-an-uncontrolled-input)
-  - [Using with RadioGroup](#using-with-radiogroup)
+  - [Using with Group](#using-with-group)
 - [Component variations](#component-variations)
 - [Content recommendations](#content-recommendations)
 - [Accessibility](#accessibility)
 - [Props](#props)
   - [Radio](#props-radio)
-  - [RadioGroup](#props-radiogroup)
+  - [Group](#props-group)
 
 ## How to use Radio
 
@@ -84,11 +84,11 @@ You can use the Radio as an uncontrolled input, for that you can:
 </React.Fragment>
 ```
 
-### Using with RadioGroup
+### Using with Group
 
 import { FormControl } from '@contentful/f36-forms';
 
-We also provide the `RadioGroup` component that helps when using multiple radio, you can pass the spacing value and some common properties to be replicated to the radios.
+We also provide the `Radio.Group` component that helps when using multiple radio, you can pass the spacing value and some common properties to be replicated to the radios.
 
 - `spacing`: This will set how much space should be between the inputs;
 - `name`: This will set all radios with this name;
@@ -100,14 +100,14 @@ We also provide the `RadioGroup` component that helps when using multiple radio,
 <React.Fragment>
   <FormControl.Label marginBottom="none">Radio group options</FormControl.Label>
   <Paragraph>Subtitle with more information if needed</Paragraph>
-  <RadioGroup name="radio-options" defaultValue="option 1">
+  <Radio.Group name="radio-options" defaultValue="option 1">
     <Radio value="option 1" id="option-1" helpText="Help text for option 1">
       Option 1
     </Radio>
     <Radio value="option 2" id="option-2" helpText="Help text for option 2">
       Option 2
     </Radio>
-  </RadioGroup>
+  </Radio.Group>
 </React.Fragment>
 ```
 
@@ -179,6 +179,6 @@ import { Props } from '@contentful/f36-docs-utils';
 
 <Props of="Radio" />
 
-### Props RadioGroup
+### Props Group
 
 <Props of="RadioGroup" />

--- a/packages/components/forms/stories/CheckboxGroup.stories.tsx
+++ b/packages/components/forms/stories/CheckboxGroup.stories.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { action } from '@storybook/addon-actions';
-import { Checkbox, CheckboxGroup, CheckboxGroupProps } from '../src';
+import { Checkbox, CheckboxGroupProps } from '../src';
 
 export default {
   title: 'Form Elements/Checkbox/CheckboxGroup',
-  component: CheckboxGroup,
+  component: Checkbox.Group,
   argTypes: {
     className: { control: { disable: true } },
     testId: { control: { disable: true } },
@@ -32,14 +32,14 @@ export const Basic = (args: CheckboxGroupProps) => {
   }, [value]);
 
   return (
-    <CheckboxGroup {...args} value={groupState} onChange={handleOnChange}>
+    <Checkbox.Group {...args} value={groupState} onChange={handleOnChange}>
       <Checkbox value="apples">Apples</Checkbox>
       <Checkbox value="pears">Pears</Checkbox>
       <Checkbox value="peaches">Peaches</Checkbox>
       <Checkbox value="mangos">Mangos</Checkbox>
       <Checkbox value="kiwis">Kiwis</Checkbox>
       <Checkbox value="bananas">Bananas</Checkbox>
-    </CheckboxGroup>
+    </Checkbox.Group>
   );
 };
 
@@ -49,14 +49,14 @@ Basic.args = {
 
 export const Uncontrolled = (args: CheckboxGroupProps) => {
   return (
-    <CheckboxGroup defaultValue={args.defaultValue}>
+    <Checkbox.Group defaultValue={args.defaultValue}>
       <Checkbox value="apples">Apples</Checkbox>
       <Checkbox value="pears">Pears</Checkbox>
       <Checkbox value="peaches">Peaches</Checkbox>
       <Checkbox value="mangos">Mangos</Checkbox>
       <Checkbox value="kiwis">Kiwis</Checkbox>
       <Checkbox value="bananas">Bananas</Checkbox>
-    </CheckboxGroup>
+    </Checkbox.Group>
   );
 };
 

--- a/packages/components/forms/stories/FormControl.stories.tsx
+++ b/packages/components/forms/stories/FormControl.stories.tsx
@@ -7,7 +7,6 @@ import {
   Textarea,
   Select,
   Checkbox,
-  CheckboxGroup,
   Radio,
 } from '../src';
 import { Flex, Box } from '@contentful/f36-core';
@@ -91,7 +90,7 @@ export const WithCheckboxGroup = (args: FormControlInternalProps) => {
         </FormControl.Label>
         <Paragraph>No extra costs</Paragraph>
 
-        <CheckboxGroup name="ingredients">
+        <Checkbox.Group name="ingredients">
           <Checkbox
             value="pickled-onions"
             helpText="Red onion sliced paper-thin, pickled in lime and gentle sea salt"
@@ -110,7 +109,7 @@ export const WithCheckboxGroup = (args: FormControlInternalProps) => {
           >
             Double-fried fries
           </Checkbox>
-        </CheckboxGroup>
+        </Checkbox.Group>
         {args.isInvalid && (
           <FormControl.ValidationMessage>Error</FormControl.ValidationMessage>
         )}
@@ -139,11 +138,11 @@ export const WithCheckboxGroup = (args: FormControlInternalProps) => {
 
       <FormControl {...args}>
         <FormControl.Label>Condiments</FormControl.Label>
-        <CheckboxGroup name="condiments">
+        <Checkbox.Group name="condiments">
           <Checkbox value="ketchup">Ketchup</Checkbox>
           <Checkbox value="mustard">Mustard</Checkbox>
           <Checkbox value="mayo">Mayo</Checkbox>
-        </CheckboxGroup>
+        </Checkbox.Group>
         {args.isInvalid && (
           <FormControl.ValidationMessage>Error</FormControl.ValidationMessage>
         )}

--- a/packages/components/forms/stories/FormControl.stories.tsx
+++ b/packages/components/forms/stories/FormControl.stories.tsx
@@ -9,7 +9,6 @@ import {
   Checkbox,
   CheckboxGroup,
   Radio,
-  RadioGroup,
 } from '../src';
 import { Flex, Box } from '@contentful/f36-core';
 import { TextLink } from '@contentful/f36-text-link';
@@ -119,7 +118,7 @@ export const WithCheckboxGroup = (args: FormControlInternalProps) => {
 
       <FormControl as="fieldset" {...args}>
         <FormControl.Label>Burger patty</FormControl.Label>
-        <RadioGroup name="burger-patty">
+        <Radio.Group name="burger-patty">
           <Radio
             value="beef"
             helpText="Grass-fed cows from Erdhof Hohenzollerdamm"
@@ -132,7 +131,7 @@ export const WithCheckboxGroup = (args: FormControlInternalProps) => {
           >
             Beyound meat (vegan)
           </Radio>
-        </RadioGroup>
+        </Radio.Group>
         {args.isInvalid && (
           <FormControl.ValidationMessage>Error</FormControl.ValidationMessage>
         )}

--- a/packages/components/forms/stories/Formik.stories.tsx
+++ b/packages/components/forms/stories/Formik.stories.tsx
@@ -6,7 +6,6 @@ import { Button } from '@contentful/f36-button';
 
 import {
   Checkbox,
-  CheckboxGroup,
   Form,
   FormControl,
   Radio,
@@ -124,7 +123,7 @@ export const Basic = () => {
               <FormControl>
                 <FormControl.Label>Fruits</FormControl.Label>
 
-                <CheckboxGroup {...field}>
+                <Checkbox.Group {...field}>
                   <Checkbox id="apples" value="apples">
                     Apples
                   </Checkbox>
@@ -134,7 +133,7 @@ export const Basic = () => {
                   <Checkbox id="peaches" value="peaches">
                     Peaches
                   </Checkbox>
-                </CheckboxGroup>
+                </Checkbox.Group>
               </FormControl>
             )}
           </Field>

--- a/packages/components/forms/stories/Formik.stories.tsx
+++ b/packages/components/forms/stories/Formik.stories.tsx
@@ -9,7 +9,6 @@ import {
   CheckboxGroup,
   Form,
   FormControl,
-  RadioGroup,
   Radio,
   Select,
   Textarea,
@@ -105,7 +104,7 @@ export const Basic = () => {
               <FormControl>
                 <FormControl.Label>Favorite fruit</FormControl.Label>
 
-                <RadioGroup {...field}>
+                <Radio.Group {...field}>
                   <Radio id="apples" value="apples">
                     Apples
                   </Radio>
@@ -115,7 +114,7 @@ export const Basic = () => {
                   <Radio id="peaches" value="peaches">
                     Peaches
                   </Radio>
-                </RadioGroup>
+                </Radio.Group>
               </FormControl>
             )}
           </Field>
@@ -233,7 +232,7 @@ export const WithUseFormik = () => {
       <FormControl>
         <FormControl.Label>Favorit fruit</FormControl.Label>
 
-        <RadioGroup
+        <Radio.Group
           name="favoriteFruit"
           value={formik.values.favoriteFruit}
           onChange={formik.handleChange}
@@ -247,7 +246,7 @@ export const WithUseFormik = () => {
           <Radio id="peaches" value="peaches">
             Peaches
           </Radio>
-        </RadioGroup>
+        </Radio.Group>
       </FormControl>
 
       <FormControl

--- a/packages/components/forms/stories/RadioGroup.stories.tsx
+++ b/packages/components/forms/stories/RadioGroup.stories.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { action } from '@storybook/addon-actions';
-import { Radio, RadioGroup, RadioGroupProps } from '../src';
+import { Radio, RadioGroupProps } from '../src';
 
 export default {
   title: 'Form Elements/Radio/RadioGroup',
-  component: RadioGroup,
+  component: Radio.Group,
   argTypes: {
     className: { control: { disable: true } },
     testId: { control: { disable: true } },
@@ -27,14 +27,14 @@ export const Basic = (args: RadioGroupProps) => {
   }, [value]);
 
   return (
-    <RadioGroup {...args} value={groupState} onChange={handleOnChange}>
+    <Radio.Group {...args} value={groupState} onChange={handleOnChange}>
       <Radio value="apples">Apples</Radio>
       <Radio value="pears">Pears</Radio>
       <Radio value="peaches">Peaches</Radio>
       <Radio value="mangos">Mangos</Radio>
       <Radio value="kiwis">Kiwis</Radio>
       <Radio value="bananas">Bananas</Radio>
-    </RadioGroup>
+    </Radio.Group>
   );
 };
 
@@ -53,14 +53,14 @@ Basic.args = {
 
 export const Uncontrolled = (args: RadioGroupProps) => {
   return (
-    <RadioGroup {...args}>
+    <Radio.Group {...args}>
       <Radio value="apples">Apples</Radio>
       <Radio value="pears">Pears</Radio>
       <Radio value="peaches">Peaches</Radio>
       <Radio value="mangos">Mangos</Radio>
       <Radio value="kiwis">Kiwis</Radio>
       <Radio value="bananas">Bananas</Radio>
-    </RadioGroup>
+    </Radio.Group>
   );
 };
 

--- a/packages/components/forms/stories/ReactHookForm.stories.tsx
+++ b/packages/components/forms/stories/ReactHookForm.stories.tsx
@@ -6,7 +6,6 @@ import { Button } from '@contentful/f36-button';
 
 import {
   Checkbox,
-  CheckboxGroup,
   Form,
   FormControl,
   Radio,
@@ -160,7 +159,7 @@ export const WithCheckboxGroup = () => {
       <FormControl>
         <FormControl.Label>Fruits</FormControl.Label>
 
-        <CheckboxGroup name="uncontrolled-fruits" defaultValue={['apples']}>
+        <Checkbox.Group name="uncontrolled-fruits" defaultValue={['apples']}>
           <Checkbox
             id="apples"
             value="apples"
@@ -182,7 +181,7 @@ export const WithCheckboxGroup = () => {
           >
             Peaches
           </Checkbox>
-        </CheckboxGroup>
+        </Checkbox.Group>
       </FormControl>
 
       <Button variant="primary" type="submit">

--- a/packages/components/forms/stories/ReactHookForm.stories.tsx
+++ b/packages/components/forms/stories/ReactHookForm.stories.tsx
@@ -9,7 +9,6 @@ import {
   CheckboxGroup,
   Form,
   FormControl,
-  RadioGroup,
   Radio,
   Select,
   Textarea,
@@ -119,7 +118,7 @@ export const WithRadioGroup = () => {
       <FormControl>
         <FormControl.Label>Fruits</FormControl.Label>
 
-        <RadioGroup defaultValue="apples">
+        <Radio.Group defaultValue="apples">
           <Radio
             id="uncontrolled-apples"
             value="apples"
@@ -141,7 +140,7 @@ export const WithRadioGroup = () => {
           >
             Peaches
           </Radio>
-        </RadioGroup>
+        </Radio.Group>
       </FormControl>
 
       <Button variant="primary" type="submit">

--- a/packages/components/forms/stories/ReactHookFormControlledInputs.stories.tsx
+++ b/packages/components/forms/stories/ReactHookFormControlledInputs.stories.tsx
@@ -9,7 +9,6 @@ import {
   CheckboxGroup,
   Form,
   FormControl,
-  RadioGroup,
   Radio,
   Select,
   Textarea,
@@ -245,8 +244,8 @@ function ControlledSelect(props) {
 function ControlledRadioGroup(props) {
   const { ref, inputProps } = useReactHookFormController(props);
   return (
-    <RadioGroup {...inputProps} ref={ref}>
+    <Radio.Group {...inputProps} ref={ref}>
       {props.children}
-    </RadioGroup>
+    </Radio.Group>
   );
 }

--- a/packages/components/forms/stories/ReactHookFormControlledInputs.stories.tsx
+++ b/packages/components/forms/stories/ReactHookFormControlledInputs.stories.tsx
@@ -6,7 +6,6 @@ import { Button } from '@contentful/f36-button';
 
 import {
   Checkbox,
-  CheckboxGroup,
   Form,
   FormControl,
   Radio,
@@ -181,7 +180,7 @@ export const WithCheckboxGroup = () => {
       <FormControl>
         <FormControl.Label>Favorite fruits</FormControl.Label>
 
-        <CheckboxGroup name="favorite-fruits">
+        <Checkbox.Group name="favorite-fruits">
           <ControlledCheckbox control={control} id="apples" value="apples">
             Apples
           </ControlledCheckbox>
@@ -193,7 +192,7 @@ export const WithCheckboxGroup = () => {
           <ControlledCheckbox control={control} id="peaches" value="peaches">
             Peaches
           </ControlledCheckbox>
-        </CheckboxGroup>
+        </Checkbox.Group>
       </FormControl>
 
       <Button variant="primary" type="submit">

--- a/packages/components/forms/test/Formik.test.tsx
+++ b/packages/components/forms/test/Formik.test.tsx
@@ -7,7 +7,6 @@ import { Flex } from '@contentful/f36-core';
 
 import {
   Checkbox,
-  CheckboxGroup,
   Form,
   FormControl,
   Radio,
@@ -86,11 +85,11 @@ const MockForm = ({ handleData }) => {
 
           <Field name="checkboxGroup">
             {({ field }) => (
-              <CheckboxGroup {...field}>
+              <Checkbox.Group {...field}>
                 <Checkbox value="apples">Apples</Checkbox>
                 <Checkbox value="pears">Pears</Checkbox>
                 <Checkbox value="peaches">Peaches</Checkbox>
-              </CheckboxGroup>
+              </Checkbox.Group>
             )}
           </Field>
 
@@ -165,7 +164,7 @@ describe('Formik integration', function () {
     // Change Radio option
     fireEvent.click(screen.getByRole('radio', { name: /pears/i }));
 
-    // Change CheckboxGroup options
+    // Change Checkbox.Group options
     fireEvent.click(screen.getByRole('checkbox', { name: /apples/i }));
     fireEvent.click(screen.getByRole('checkbox', { name: /pears/i }));
 

--- a/packages/components/forms/test/Formik.test.tsx
+++ b/packages/components/forms/test/Formik.test.tsx
@@ -10,7 +10,6 @@ import {
   CheckboxGroup,
   Form,
   FormControl,
-  RadioGroup,
   Radio,
   Select,
   Textarea,
@@ -77,11 +76,11 @@ const MockForm = ({ handleData }) => {
 
           <Field name="radioGroup">
             {({ field }) => (
-              <RadioGroup {...field}>
+              <Radio.Group {...field}>
                 <Radio value="apples">Apples</Radio>
                 <Radio value="pears">Pears</Radio>
                 <Radio value="peaches">Peaches</Radio>
-              </RadioGroup>
+              </Radio.Group>
             )}
           </Field>
 

--- a/packages/components/forms/test/ReactHookForm.test.tsx
+++ b/packages/components/forms/test/ReactHookForm.test.tsx
@@ -9,7 +9,6 @@ import {
   Checkbox,
   Form,
   FormControl,
-  RadioGroup,
   Radio,
   Select,
   Textarea,
@@ -60,7 +59,7 @@ const MockForm = ({ handleData }) => {
         </Select>
       </FormControl>
 
-      <RadioGroup name="radioGroup" defaultValue="apples">
+      <Radio.Group name="radioGroup" defaultValue="apples">
         <Radio id="apples" value="apples" {...register('radioGroup')}>
           Apples
         </Radio>
@@ -70,7 +69,7 @@ const MockForm = ({ handleData }) => {
         <Radio id="peaches" value="peaches" {...register('radioGroup')}>
           Peaches
         </Radio>
-      </RadioGroup>
+      </Radio.Group>
 
       <FormControl isInvalid={Boolean(errors.checkbox)}>
         <Checkbox

--- a/packages/forma-36-website/src/content/integrations/formik/index.mdx
+++ b/packages/forma-36-website/src/content/integrations/formik/index.mdx
@@ -106,12 +106,12 @@ export const FormikForm = () => {
           {/* Checkbox group */}
           <Field name="checkboxGroup">
             {({ field }) => (
-              {/* For CheckboxGroup we need to pass the field props into the CheckboxGroup component */}
-              <CheckboxGroup {...field}>
+              {/* For Checkbox.Group we need to pass the field props into the Checkbox.Group component */}
+              <Checkbox.Group {...field}>
                 <Checkbox value="apples">Apples</Checkbox>
                 <Checkbox value="pears">Pears</Checkbox>
                 <Checkbox value="peaches">Peaches</Checkbox>
-              </CheckboxGroup>
+              </Checkbox.Group>
             )}
           </Field>
 

--- a/packages/forma-36-website/src/content/integrations/formik/index.mdx
+++ b/packages/forma-36-website/src/content/integrations/formik/index.mdx
@@ -16,7 +16,6 @@ import {
   Form,
   FormControl,
   Radio,
-  RadioGroup,
   Select,
   Textarea,
   TextInput,
@@ -95,12 +94,12 @@ export const FormikForm = () => {
           {/* Radio group */}
           <Field name="radioGroup">
             {({ field }) => (
-              {/* For RadioGroup we need to pass the field props into the RadioGroup component */}
-              <RadioGroup {...field}>
+              {/* For Radio.Group we need to pass the field props into the Radio.Group component */}
+              <Radio.Group {...field}>
                 <Radio value="apples">Apples</Radio>
                 <Radio value="pears">Pears</Radio>
                 <Radio value="peaches">Peaches</Radio>
-              </RadioGroup>
+              </Radio.Group>
             )}
           </Field>
 

--- a/packages/forma-36-website/src/content/integrations/react-hook-form/index.mdx
+++ b/packages/forma-36-website/src/content/integrations/react-hook-form/index.mdx
@@ -80,7 +80,10 @@ export const ReactHookForm = () => {
       <FormControl>
         <FormControl.Label>Martial status</FormControl.Label>
 
-        {/* When using Radio.Group, it’s necessary to register each Radio with the same "name" */}
+        {/*
+          When using Radio.Group, it’s necessary to register each Radio with the same "name".
+          This is necessary because of how react-hook-form works.
+        */}
         <Radio.Group defaultValue="single">
           <Radio value="married" {...register('martial-status')} >
             Married

--- a/packages/forma-36-website/src/content/integrations/react-hook-form/index.mdx
+++ b/packages/forma-36-website/src/content/integrations/react-hook-form/index.mdx
@@ -16,7 +16,6 @@ import {
   Form,
   FormControl,
   Radio,
-  RadioGroup,
   Select,
   Textarea,
   TextInput,
@@ -81,15 +80,15 @@ export const ReactHookForm = () => {
       <FormControl>
         <FormControl.Label>Martial status</FormControl.Label>
 
-        {/* When using RadioGroup, it’s necessary to register each Radio with the same "name" */}
-        <RadioGroup defaultValue="single">
+        {/* When using Radio.Group, it’s necessary to register each Radio with the same "name" */}
+        <Radio.Group defaultValue="single">
           <Radio value="married" {...register('martial-status')} >
             Married
           </Radio>
           <Radio value="single" {...register('martial-status')}>
             Single
           </Radio>
-        </RadioGroup>
+        </Radio.Group>
       </FormControl>
 
       <FormControl isInvalid={Boolean(errors.checkbox)}>


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->
Refactor `RadioGroup` and `CheckboxGroup` to be compound components.
Fix `aria-describedby` when helptext is not set, and points to Checkbox helptext, instead of formControl helptext

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
