### PR TITLE
fix: remove custom asset card selection

### DIFF
--- a/packages/components/card/src/asset-card/AssetCard.styles.ts
+++ b/packages/components/card/src/asset-card/AssetCard.styles.ts
@@ -7,7 +7,7 @@ export const getAssetCardStyles = () => {
     asset: css({
       height: '100%',
     }),
-    root: ({ isSelected, size }) => {
+    root: ({ size }) => {
       const styles: ObjectInterpolation<undefined> = {
         borderRadius: tokens.borderRadiusMedium,
         minWidth: `calc(1rem * (120 / ${tokens.fontBaseDefault}))`,
@@ -25,12 +25,6 @@ export const getAssetCardStyles = () => {
           padding: 0,
         },
       };
-
-      if (isSelected) {
-        styles.backgroundColor = tokens.colorWhite;
-        styles.borderColor = tokens.blue500;
-        styles.boxShadow = `0 0 0 1px ${tokens.gray300}`;
-      }
 
       return css(styles);
     },

--- a/packages/components/card/src/asset-card/AssetCard.tsx
+++ b/packages/components/card/src/asset-card/AssetCard.tsx
@@ -35,7 +35,7 @@ export const AssetCard = ({
   status,
   title,
   type,
-  withDragHandle = true,
+  withDragHandle = false,
   isLoading,
   testId = 'cf-ui-asset-card',
   ...otherProps
@@ -63,7 +63,7 @@ export const AssetCard = ({
     <BaseCard
       {...otherProps}
       badge={badge}
-      className={cx(styles.root({ isSelected, size }), className)}
+      className={cx(styles.root({ size }), className)}
       header={header}
       isSelected={isSelected}
       title={title}

--- a/packages/components/card/src/entry-card/EntryCard.tsx
+++ b/packages/components/card/src/entry-card/EntryCard.tsx
@@ -67,6 +67,7 @@ function _EntryCard<
     status,
     thumbnailElement,
     description,
+    withDragHandle = false,
     title,
     size,
     testId = 'cf-ui-entry-card',
@@ -85,6 +86,7 @@ function _EntryCard<
       actions={actions}
       badge={badge}
       className={cx(styles.root, className)}
+      withDragHandle={withDragHandle}
       ref={forwardedRef}
       type={contentType}
       testId={testId}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

* Consistent `withDragHandle` default value
* Removed custom AssetCard selection styles 