### PR TITLE
chore(migration-guide): add migration guide for DateTime and RelativeDateTime

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -491,7 +491,7 @@ const isCollapsed = true;
 
 ## DateTime
 
-The API of the DateTime component hasn't changed. The only property that has some updates, is `format` property. From `"FULL"`, `"DATE_ONLY"`, `"TIME_ONLY"`, `"WEEKDAY_DATE"` to `"full"`, `"day"`, `"time"`, `"weekday"`.
+The API of the DateTime component hasn't changed. The `format` property is the only one that was updated: from `"FULL"`, `"DATE_ONLY"`, `"TIME_ONLY"`, `"WEEKDAY_DATE"` to `"full"`, `"day"`, `"time"`, `"weekday"`.
 
 ```tsx static=true
 import { DateTime } from '@contentful/f36-datetime';
@@ -504,7 +504,7 @@ import { DateTime } from '@contentful/f36-datetime';
 
 ### How to migrate your DateTime components
 
-Update `format` value and import. It should change form this:
+Update the `format` value and import. It changes from this:
 
 ```tsx static=true
 import { DateTime } from '@contentful/forma-36-react-components';

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -13,6 +13,10 @@
     - [How to migrate your Icon components](#how-to-migrate-your-icon-components)
   - [IconButton](#iconbutton)
     - [How to migrate your IconButton components](#how-to-migrate-your-iconbutton-components)
+  - [DateTime](#datetime)
+    - [How to migrate your DateTime components](#how-to-migrate-your-datetime-components)
+  - [RelativeDateTime](#relativedatetime)
+    - [How to migrate your RelativeDateTime components](#how-to-migrate-your-relativedatetime-components)
   - [Flex](#flex)
     - [How to migrate your Flex components](#how-to-migrate-your-flex-components)
   - [Grid](#grid)
@@ -483,6 +487,59 @@ const isCollapsed = true;
   aria-label="Delete"
   onClick={() => {}}
 />;
+```
+
+## DateTime
+
+The API of the DateTime component hasn't changed. The only property that has some updates, is `format` property. From `"FULL"`, `"DATE_ONLY"`, `"TIME_ONLY"`, `"WEEKDAY_DATE"` to `"full"`, `"day"`, `"time"`, `"weekday"`.
+
+```tsx static=true
+import { DateTime } from '@contentful/f36-datetime';
+
+<DateTime date="2020-08-17T15:45:00" />
+<DateTime date="2020-08-17T15:45:00" format="day" />
+<DateTime date="2020-08-17T15:45:00" format="weekday" />
+<DateTime date="2020-08-17T15:45:00" format="time" />
+```
+
+### How to migrate your DateTime components
+
+Update `format` value and import. It should change form this:
+
+```tsx static=true
+import { DateTime } from '@contentful/forma-36-react-components';
+
+<DateTime date="2020-08-17T15:45:00" format="WEEKDAY_DATE" />;
+```
+
+to this:
+
+```tsx static=true
+import { DateTime } from '@contentful/f36-components';
+
+<DateTime date="2020-08-17T15:45:00" format="weekday" />;
+```
+
+## RelativeDateTime
+
+The API of the RelativeDateComponent was not changed.
+
+### How to migrate your RelativeDateTime components
+
+You just need to update import. From this:
+
+```tsx static=true
+import { RelativeDate } from '@contentful/forma-36-react-components';
+
+<RelativeDate date="2020-08-17T15:45:00" baseDate={'2020-07-17T15:45:00'} />;
+```
+
+to this:
+
+```tsx static=true
+import { RelativeDate } from '@contentful/f36-components';
+
+<RelativeDate date="2020-08-17T15:45:00" baseDate={'2020-07-17T15:45:00'} />;
 ```
 
 ## Flex

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -504,7 +504,7 @@ import { DateTime } from '@contentful/f36-datetime';
 
 ### How to migrate your DateTime components
 
-Update the `format` value and import. It changes from this:
+To migrate your DateTime component to v4, you must update the format value and import. It changes from this:
 
 ```tsx static=true
 import { DateTime } from '@contentful/forma-36-react-components';
@@ -526,7 +526,7 @@ The API of the RelativeDateComponent has not changed.
 
 ### How to migrate your RelativeDateTime components
 
-You just need to update import. From this:
+To migrate RelativeDateComponent to v4, you must update the import. From this:
 
 ```tsx static=true
 import { RelativeDate } from '@contentful/forma-36-react-components';

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -491,7 +491,7 @@ const isCollapsed = true;
 
 ## DateTime
 
-The API of the DateTime component hasn't changed. The `format` property is the only one that was updated: from `"FULL"`, `"DATE_ONLY"`, `"TIME_ONLY"`, `"WEEKDAY_DATE"` to `"full"`, `"day"`, `"time"`, `"weekday"`.
+The API of the DateTime component has not changed. The `format` property is the only one that was updated: from `"FULL"`, `"DATE_ONLY"`, `"TIME_ONLY"`, `"WEEKDAY_DATE"` to `"full"`, `"day"`, `"time"`, `"weekday"`.
 
 ```tsx static=true
 import { DateTime } from '@contentful/f36-datetime';
@@ -522,7 +522,7 @@ import { DateTime } from '@contentful/f36-components';
 
 ## RelativeDateTime
 
-The API of the RelativeDateComponent was not changed.
+The API of the RelativeDateComponent has not changed.
 
 ### How to migrate your RelativeDateTime components
 

--- a/packages/forma-36-website/src/content/migration-v3-to-v4.mdx
+++ b/packages/forma-36-website/src/content/migration-v3-to-v4.mdx
@@ -35,6 +35,7 @@ To migrate your project easily, we provided you with a codemod for most of the c
 - **IconButton**: Now you can pass any icon as an element to IconButton component. For more information, see [the detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#how-to-migrate-your-iconbutton-components).
 
 - **Flex**: Some properties of the Flex components were migrated or changed. For more information, see [the detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#how-to-migrate-your-flex-components).
+
 - **DateTime**: You only need to update `format` prop value. For more information on how to migrate your DateTime components, see [the detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#how-to-migrate-your-datetime-components)
 
 - **RelativeDateTime**: No changes, just import new component. For more information on how to migrate your RelativeDateTime components, see [the detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#how-to-migrate-your-datetime-components)

--- a/packages/forma-36-website/src/content/migration-v3-to-v4.mdx
+++ b/packages/forma-36-website/src/content/migration-v3-to-v4.mdx
@@ -38,7 +38,7 @@ To migrate your project easily, we provided you with a codemod for most of the c
 
 - **DateTime**: You only need to update `format` prop value. For more information on how to migrate your DateTime components, see [the detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#how-to-migrate-your-datetime-components)
 
-- **RelativeDateTime**: No changes, just import new component. For more information on how to migrate your RelativeDateTime components, see [the detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#how-to-migrate-your-datetime-components)
+- **RelativeDateTime**: No changes, just import new component. For more information on how to migrate your RelativeDateTime components, see [the detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#how-to-migrate-your-relativedatetime-components)
 
 - **Grid**: Some properties of the Grid components were migrated or changed. For more information, see [the detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#how-to-migrate-your-grid-components).
 

--- a/packages/forma-36-website/src/content/migration-v3-to-v4.mdx
+++ b/packages/forma-36-website/src/content/migration-v3-to-v4.mdx
@@ -35,6 +35,9 @@ To migrate your project easily, we provided you with a codemod for most of the c
 - **IconButton**: Now you can pass any icon as an element to IconButton component. For more information, see [the detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#how-to-migrate-your-iconbutton-components).
 
 - **Flex**: Some properties of the Flex components were migrated or changed. For more information, see [the detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#how-to-migrate-your-flex-components).
+- **DateTime**: You only need to update `format` prop value. For more information on how to migrate your DateTime components, see [the detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#how-to-migrate-your-datetime-components)
+
+- **RelativeDateTime**: No changes, just import new component. For more information on how to migrate your RelativeDateTime components, see [the detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#how-to-migrate-your-datetime-components)
 
 - **Grid**: Some properties of the Grid components were migrated or changed. For more information, see [the detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#how-to-migrate-your-grid-components).
 


### PR DESCRIPTION
# Purpose of PR

Migration guide for two components: DateTime and RelativeDateTime

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
