### PR TITLE
fix: remove overflow hidden from BaseCard

### DIFF
--- a/packages/components/card/src/base-card/BaseCard.styles.ts
+++ b/packages/components/card/src/base-card/BaseCard.styles.ts
@@ -16,7 +16,6 @@ export const getBaseCardStyles = () => {
       display: 'grid',
       gridTemplateRows: '[header] auto [content] minmax(0, 1fr)',
       gridTemplateColumns: 'auto [content] minmax(0, 1fr)',
-      overflow: 'hidden',
     }),
     dragHandle: css({
       borderBottomLeftRadius: tokens.borderRadiusMedium,

--- a/packages/components/card/stories/Card.stories.tsx
+++ b/packages/components/card/stories/Card.stories.tsx
@@ -4,6 +4,8 @@ import { Flex } from '@contentful/f36-core';
 import { Heading, SectionHeading, Text } from '@contentful/f36-typography';
 import { ClockIcon } from '@contentful/f36-icons';
 import { MenuItem } from '@contentful/f36-menu';
+import { Button } from '@contentful/f36-button';
+import { FormControl, TextInput, Textarea, Form } from '@contentful/f36-forms';
 
 import { Card } from '../src';
 import type { CardProps } from '../src';
@@ -25,7 +27,7 @@ export default {
 
 export const Default: Story<CardProps> = ({ children, ...args }) => {
   return (
-    <Card {...args} as="button">
+    <Card {...args}>
       <Text>{children}</Text>
     </Card>
   );
@@ -33,6 +35,34 @@ export const Default: Story<CardProps> = ({ children, ...args }) => {
 
 Default.args = {
   children: 'This is the Card’s content',
+};
+
+export const WithFocusableChildren = () => {
+  const [submited, setSubmit] = useState(false);
+  const onSubmit = () => setSubmit(true);
+
+  return (
+    <Card>
+      <Form onSubmit={() => onSubmit()}>
+        <FormControl>
+          <FormControl.Label>Name</FormControl.Label>
+          <TextInput />
+          <FormControl.HelpText>
+            Please enter your first name
+          </FormControl.HelpText>
+        </FormControl>
+
+        <FormControl>
+          <FormControl.Label>Description</FormControl.Label>
+          <Textarea />
+          <FormControl.HelpText>Tell me about youself</FormControl.HelpText>
+        </FormControl>
+        <Button variant="primary" type="submit" isDisabled={submited}>
+          {submited ? 'Sumbited' : 'Click me to submit'}
+        </Button>
+      </Form>
+    </Card>
+  );
 };
 
 export const WithOnClick = (args: CardProps) => {
@@ -133,7 +163,7 @@ export const Overview: Story<CardProps> = () => {
           marginRight="spacingM"
         >
           <SectionHeading as="h3" marginBottom="spacingS">
-            Default
+            Idle
           </SectionHeading>
 
           <Card icon={<ClockIcon />} title="Forma 36">
@@ -204,7 +234,7 @@ export const Overview: Story<CardProps> = () => {
           marginRight="spacingM"
         >
           <SectionHeading as="h3" marginBottom="spacingS">
-            Default
+            Idle
           </SectionHeading>
 
           <Card padding="large" title="Forma 36">
@@ -275,7 +305,7 @@ export const Overview: Story<CardProps> = () => {
           marginRight="spacingM"
         >
           <SectionHeading as="h3" marginBottom="spacingS">
-            Default
+            Idle
           </SectionHeading>
 
           <Card padding="none" title="Forma 36">


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

BaseCard had a `overflow: hidden` that was cropping the focus glow of the things inside the card

Before:
![card_focus_bug](https://user-images.githubusercontent.com/6597467/141342587-98d654c9-84f5-41a0-8af1-127b917aa823.gif)

After:
![card_focus_fix](https://user-images.githubusercontent.com/6597467/141342612-ddc0c679-3622-4b7e-8a79-a6de20a67130.gif)

It's possible that we introduced this `overflow: hidden` issue in other places, some people spotted the focus glow getting cropped in Compose and Launch
So let's take care when using `overflow: hidden`, I would say that most of the time we do not need it

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
