### PR TITLE
docs: change contribution guide hierarchy

### DIFF
--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -29,6 +29,10 @@ module.exports = {
         link: '/getting-started',
       },
       {
+        name: 'Contributing to Forma 36',
+        link: '/contributing',
+      },
+      {
         name: 'Migration guide',
         link: '/migration-v3-to-v4',
       },
@@ -69,10 +73,6 @@ module.exports = {
           {
             name: 'Accessibility',
             link: '/guidelines/accessibility/',
-          },
-          {
-            name: 'Contributing to Forma 36',
-            link: '/guidelines/contributing/',
           },
           {
             name: 'Copy',

--- a/packages/forma-36-website/src/components/Navigation.js
+++ b/packages/forma-36-website/src/components/Navigation.js
@@ -78,6 +78,16 @@ const styles = {
   `,
 };
 
+const categories = [
+  'Foundation',
+  'Guidelines',
+  'Contributing to Forma 36',
+  'Migration guide',
+  'Getting started',
+  'Components',
+  'Integrations',
+];
+
 const checkActive = (item, currentPath) => {
   if (item.link === currentPath) {
     return true;
@@ -89,22 +99,11 @@ const checkActive = (item, currentPath) => {
   );
 };
 
-const checkCategory = (name) =>
-  name === 'Foundation' ||
-  name === 'Guidelines' ||
-  name === 'Migration guide' ||
-  name === 'Getting started' ||
-  name === 'Components' ||
-  name === 'Integrations';
-
-const checkCategoryAsLink = (name) =>
-  name === 'Migration guide' || name === 'Getting started';
+const checkCategory = (name) => categories.includes(name);
 
 const MenuListItem = React.forwardRef(
   ({ item, currentPath, isActive, hierarchyLevel }, ref) => {
     const isCategory = checkCategory(item.name);
-    const isCategoryAsLink = checkCategoryAsLink(item.name);
-
     const [isExpanded, setIsExpanded] = useState(isActive || isCategory);
 
     const handleToggle = (event) => {
@@ -152,20 +151,6 @@ const MenuListItem = React.forwardRef(
               hierarchyLevel={hierarchyLevel + 1}
             />
           </>
-        ) : isCategoryAsLink ? (
-          <Link
-            ref={ref}
-            css={cx([styles.link, itemOffset, isActive && styles.linkActive])}
-            to={item.link}
-            href={item.link}
-          >
-            <SectionHeading
-              marginBottom={0}
-              css={cx([isActive && styles.linkActive])}
-            >
-              {item.name}
-            </SectionHeading>
-          </Link>
         ) : (
           <Link
             ref={ref}
@@ -173,7 +158,16 @@ const MenuListItem = React.forwardRef(
             to={item.link}
             href={item.link}
           >
-            {item.name}
+            {isCategory ? (
+              <SectionHeading
+                marginBottom={0}
+                css={cx([isActive && styles.linkActive])}
+              >
+                {item.name}
+              </SectionHeading>
+            ) : (
+              item.name
+            )}
           </Link>
         )}
       </li>

--- a/packages/forma-36-website/src/components/Navigation.js
+++ b/packages/forma-36-website/src/components/Navigation.js
@@ -99,11 +99,9 @@ const checkActive = (item, currentPath) => {
   );
 };
 
-const checkCategory = (name) => categories.includes(name);
-
 const MenuListItem = React.forwardRef(
   ({ item, currentPath, isActive, hierarchyLevel }, ref) => {
-    const isCategory = checkCategory(item.name);
+    const isCategory = categories.includes(item.name);
     const [isExpanded, setIsExpanded] = useState(isActive || isCategory);
 
     const handleToggle = (event) => {

--- a/packages/forma-36-website/src/content/contributing.mdx
+++ b/packages/forma-36-website/src/content/contributing.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Contributing to Forma 36'
-slug: '/guidelines/contributing/'
+slug: '/contributing'
 ---
 
 Forma 36 is an open-source design system by Contentful and we welcome contributions from our community.

--- a/packages/forma-36-website/src/pages/index.jsx
+++ b/packages/forma-36-website/src/pages/index.jsx
@@ -57,10 +57,7 @@ function IndexPage() {
         <DisplayText>Forma 36 is open-source</DisplayText>
         <Paragraph>We appreciate your contributions</Paragraph>
         <Paragraph>
-          Check our{' '}
-          <TextLink href="/guidelines/contributing/">
-            contribution guide
-          </TextLink>{' '}
+          Check our <TextLink href="/contributing">contribution guide</TextLink>{' '}
           and learn how to do it
         </Paragraph>
       </Section>


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

It moves the contribution guide from the guidelines section to its own page. And I "dried" some code of the side menu

![Screenshot 2021-11-12 at 12 45 44](https://user-images.githubusercontent.com/6597467/141462233-9a323927-a235-446c-8fe3-6cb4c1867064.png)


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
