### PR TITLE
fix: add whiteSpace breaks in BaseCard content

### DIFF
--- a/packages/components/card/src/base-card/BaseCard.styles.ts
+++ b/packages/components/card/src/base-card/BaseCard.styles.ts
@@ -10,6 +10,7 @@ export const getBaseCardStyles = () => {
       paddingBottom: tokens.spacingM,
       paddingLeft: tokens.spacingM,
       paddingRight: tokens.spacingM,
+      whiteSpace: 'initial',
     }),
     wrapper: css({
       flex: '1 1 0',

--- a/packages/components/card/stories/Card.stories.tsx
+++ b/packages/components/card/stories/Card.stories.tsx
@@ -23,6 +23,13 @@ export default {
     propTypes: Card['__docgenInfo'],
   },
   title: 'Components/Card',
+  decorators: [
+    (Story) => (
+      <Flex flexDirection="column" style={{ maxWidth: '500px' }}>
+        <Story />
+      </Flex>
+    ),
+  ],
 } as Meta;
 
 export const Default: Story<CardProps> = ({ children, ...args }) => {


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

I spotted this bug while writing some docs

![Screenshot 2021-11-12 at 13 05 17](https://user-images.githubusercontent.com/6597467/141472216-b2b0ca9b-c7dd-4ae2-8b80-bba632ae4216.png)

The content of the card was not breaking into new lines for some reason so I added `whiteSpace: initial` and it fixed it

![Screenshot 2021-11-12 at 13 07 55](https://user-images.githubusercontent.com/6597467/141472285-64df5693-c3fa-4ce5-94fb-c0d745fe604c.png)


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
