### PR TITLE
fix(autocomplete): fix dropdown props type

### DIFF
--- a/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/forma-36-react-components/src/components/Autocomplete/Autocomplete.tsx
@@ -49,7 +49,7 @@ export interface AutocompleteProps<T extends {}> {
   emptyListMessage?: string;
   noMatchesMessage?: string;
   willClearQueryOnClose?: boolean;
-  dropdownProps?: DropdownProps;
+  dropdownProps?: Partial<DropdownProps>;
   renderToggleElement?: (props: RenderToggleElementProps) => React.ReactElement;
   validationMessage?: string;
 }

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
@@ -86,7 +86,7 @@ export interface DropdownProps {
   /**
    * Child nodes to be rendered in the component
    */
-  children?: React.ReactNode;
+  children: React.ReactNode;
   /**
    * Class names to be appended to the className prop of the Dropdown wrapper
    */

--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
@@ -86,7 +86,7 @@ export interface DropdownProps {
   /**
    * Child nodes to be rendered in the component
    */
-  children: React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Class names to be appended to the className prop of the Dropdown wrapper
    */


### PR DESCRIPTION
# Purpose of PR

This PR is a reaction to feedback about Autocomplete component - passing the `dropdownProps` prop causes a type error, because the `children` prop is required, but not passed. 

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
