### PR TITLE
docs: use double quotes when prop is string

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -539,7 +539,7 @@ To migrate RelativeDateComponent to v4, you must update the import. From this:
 ```tsx static=true
 import { RelativeDate } from '@contentful/forma-36-react-components';
 
-<RelativeDate date="2020-08-17T15:45:00" baseDate={'2020-07-17T15:45:00'} />;
+<RelativeDate date="2020-08-17T15:45:00" baseDate="2020-07-17T15:45:00" />;
 ```
 
 to this:
@@ -547,7 +547,7 @@ to this:
 ```tsx static=true
 import { RelativeDate } from '@contentful/f36-components';
 
-<RelativeDate date="2020-08-17T15:45:00" baseDate={'2020-07-17T15:45:00'} />;
+<RelativeDate date="2020-08-17T15:45:00" baseDate="2020-07-17T15:45:00" />;
 ```
 
 ## Flex
@@ -1307,7 +1307,7 @@ import { Note } from '@contentful/forma-36-react-components';
 </Note>;
 
 <Note
-  title={'Title example'}
+  title="Title example"
   noteType="primary"
   hasCloseButton
   onClose={() => {}}
@@ -1333,7 +1333,7 @@ import { Note } from '@contentful/f36-components';
 </Note>;
 
 <Note
-  title={'Title example'}
+  title="Title example"
   variant="primary"
   withCloseButton
   onClose={() => {}}

--- a/docs/code-style-guide.md
+++ b/docs/code-style-guide.md
@@ -73,3 +73,17 @@ To expose nested elements events add element name between `on..Click`, e.g. `onC
 | ------------ | --------------------- |
 | handleClick  | Process click events  |
 | handleChange | Process change events |
+
+## Props
+
+### Value of the prop is a string
+
+When the value of the prop is a string, pass it directly with double quotes. There is no need to wrap it with curly braces.
+
+```
+// bad
+<Button variant={'primary'} >Add entry</Button>
+
+// good
+<Button variant="primary" >Add entry</Button>
+```

--- a/packages/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -92,7 +92,7 @@ export const Basic = (args: AutocompleteProps<string>) => {
         items={filteredItems}
         onInputValueChange={handleInputValueChange}
         onSelectItem={handleSelectItem}
-        listWidth={'full'}
+        listWidth="full"
       />
 
       <Paragraph>Selected fruit: {selectedFruit}</Paragraph>

--- a/packages/components/forms/src/form/Form.mdx
+++ b/packages/components/forms/src/form/Form.mdx
@@ -57,7 +57,7 @@ function FormaExample() {
         </Box>
         <FormControl.HelpText>Tell me about youself</FormControl.HelpText>
       </FormControl>
-      <Button variant={'primary'} type="submit" isDisabled={submited}>
+      <Button variant="primary" type="submit" isDisabled={submited}>
         {submited ? 'Sumbited' : 'Click me to submit'}
       </Button>
     </Form>
@@ -87,7 +87,7 @@ function FormaExample() {
           <FormControl.Counter />
         </Flex>
       </FormControl>
-      <Button variant={'primary'} type="submit" isDisabled={submited}>
+      <Button variant="primary" type="submit" isDisabled={submited}>
         {submited ? 'Sumbited' : 'Click me to submit'}
       </Button>
     </Form>

--- a/packages/components/forms/src/select/Select.mdx
+++ b/packages/components/forms/src/select/Select.mdx
@@ -69,7 +69,7 @@ To use the Select as uncontrolled, you shouldn't pass the value prop, if you wan
 <Select
   id="optionSelect-controlled"
   name="optionSelect-controlled"
-  defaultValue={'optionOne'}
+  defaultValue="optionOne"
 >
   <Select.Option value="optionOne">Option 1</Select.Option> // This option would
   be selected by default

--- a/packages/components/icon/Icon.mdx
+++ b/packages/components/icon/Icon.mdx
@@ -114,7 +114,7 @@ The icon components can be configured in different ways using variations in colo
 ```tsx
 // import * as f36icons from "@contentful/f36-icons";
 
-<Grid columns={'repeat(3, 1fr)'}>
+<Grid columns="repeat(3, 1fr)">
   {Object.entries(f36icons).map(([name, icon]) => {
     const Component = icon;
 

--- a/packages/components/icons/stories/Icons.stories.tsx
+++ b/packages/components/icons/stories/Icons.stories.tsx
@@ -41,7 +41,7 @@ export const Overview: Story = () => {
         Built-in icons
       </SectionHeading>
 
-      <Grid columns={'auto 1fr 1fr 1fr 1fr'}>
+      <Grid columns="auto 1fr 1fr 1fr 1fr">
         {Object.keys(icons).map((icon) => {
           const Component = icons[icon];
 

--- a/packages/core/src/Grid/Grid.mdx
+++ b/packages/core/src/Grid/Grid.mdx
@@ -39,7 +39,7 @@ When defined as a number, it will split the space into equally sized columns; it
 ```jsx static=true
 <React.Fragment>
   <Grid columns={6}></Grid>
-  <Grid columns={'auto 1fr'}></Grid>
+  <Grid columns="auto 1fr"></Grid>
 </React.Fragment>
 ```
 
@@ -50,7 +50,7 @@ Accepts a number or any of [grid-template-rows](https://developer.mozilla.org/en
 ```jsx static=true
 <React.Fragment>
   <Grid rows={6}></Grid>
-  <Grid rows={'auto 1fr'}></Grid>
+  <Grid rows="auto 1fr"></Grid>
 </React.Fragment>
 ```
 
@@ -111,7 +111,7 @@ The grid layout consists of different components that helps defining your layout
 
 `repeat()` is a css notation that you can use with the `gridColumns` and `girdRows` properties to make your rules more concise and easier to understand when creating a large amount of columns or rows
 
-**Example:** `gridColumns={'1fr 2fr 1fr 2fr 1fr 2fr'}` is same as `gridColumns={'repeat(3, 1fr 2fr)'}` see below.
+**Example:** `gridColumns="1fr 2fr 1fr 2fr 1fr 2fr"` is same as `gridColumns="repeat(3, 1fr 2fr)"` see below.
 
 ```jsx
 <div>
@@ -148,7 +148,7 @@ Fr is a fractional unit and 1fr is for 1 part of the available space. it differs
 If you place a larger item into a track then the way the fr until will work is to allow that track to take up more space and distribute what is left over.
 
 ```jsx
-<Grid columns={'1fr 1fr 1fr'}>
+<Grid columns="1fr 1fr 1fr">
   <p style={{ border: '1px solid #263545' }}>
     WelcomeToTheAwesomeContentfulGridSystem
   </p>
@@ -174,7 +174,7 @@ i.e. instead of specifying `columnStart` and `columnEnd` you can use span to mak
 <Grid columns={6}>
   <Grid.Item style={{ backgroundColor: '#263545', height: '100px' }} />
   <Grid.Item
-    area={'span 4 / span 4'}
+    area="span 4 / span 4"
     style={{ backgroundColor: '#263545', height: '100px' }}
   />
 </Grid>
@@ -187,7 +187,7 @@ i.e. instead of specifying `columnStart` and `columnEnd` you can use span to mak
 Just like flexbox the grid comes with `justifyContent`, `justifyItems`, `alignItems`, `alignContent`, ..etc.
 
 ```jsx
-<Grid columns={'250px 250px'} justifyContent={'space-between'}>
+<Grid columns="250px 250px" justifyContent="space-between">
   <Grid.Item style={{ backgroundColor: '#263545', height: '100px' }} />
   <Grid.Item style={{ backgroundColor: '#263545', height: '100px' }} />
 </Grid>

--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-note.input.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-note.input.js
@@ -11,7 +11,7 @@ import { Note } from "@contentful/forma-36-react-components";
 </Note>;
 
 <Note
-  title={'Title example'}
+  title="Title example"
   noteType="primary"
   hasCloseButton
   onClose={() => {}}>

--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-note.output.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-note.output.js
@@ -11,7 +11,7 @@ import { Note } from "@contentful/f36-components";
 </Note>;
 
 <Note
-  title={'Title example'}
+  title="Title example"
   variant="primary"
   withCloseButton
   onClose={() => {}}>

--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-tooltip.input.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-tooltip.input.js
@@ -7,7 +7,7 @@ import { TextLink } from "@contentful/f36-components";
   <TextLink>Hover me</TextLink>.
 </Tooltip>
 
-<Tooltip content={'content'} containerElement="div" place="left">
+<Tooltip content="content" containerElement="div" place="left">
   <TextLink>Hover me</TextLink>.
 </Tooltip>
 </>

--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-tooltip.output.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-tooltip.output.js
@@ -6,7 +6,7 @@ import { TextLink, Tooltip } from "@contentful/f36-components";
   <TextLink>Hover me</TextLink>.
 </Tooltip>
 
-<Tooltip content={'content'} as="div" placement="left">
+<Tooltip content="content" as="div" placement="left">
   <TextLink>Hover me</TextLink>.
 </Tooltip>
 </>


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

I propose to add this convention to or code style guide

When the value of the prop is a string, pass it directly with double quotes. There is no need to wrap it with curly braces.

```
// bad
<Button variant={'primary'} >Add entry</Button>

// good
<Button variant="primary" >Add entry</Button>
```

This PR also replaces all the places where this convention is not being done now

This should be something that our eslint and/or prettier should warn but I didn't have time to check why it's not throwing warns when linting the code

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
