### PR TITLE
feat(codemod): add codemod for HelpText outisde forms

### DIFF
--- a/packages/forma-36-codemod/README.md
+++ b/packages/forma-36-codemod/README.md
@@ -104,3 +104,7 @@ Migrate AssetCard components from v3 to v4
 #### `v4-entry-card`
 
 Migrate EntryCard components from v3 to v4
+
+#### `v4-helptext`
+
+Migrates HelpText components outside form from v3 to v4

--- a/packages/forma-36-codemod/README.md
+++ b/packages/forma-36-codemod/README.md
@@ -112,4 +112,3 @@ Migrates HelpText components outside form from v3 to v4
 #### `v4-inline-entry-card`
 
 Converts InlineEntryCard from Forma v3 to v4
-

--- a/packages/forma-36-codemod/bin/inquirer-choices.js
+++ b/packages/forma-36-codemod/bin/inquirer-choices.js
@@ -129,6 +129,11 @@ const TRANSFORMS_CHOICES = [
     name: 'v4-entry-card: Migrate Entry components from v3 to v4',
     value: 'v4-entry-card',
   },
+  {
+    name:
+      'v4-helptext: Migrates HelpText components outside form from v3 to v4',
+    value: 'v4-helptext',
+  },
   // Add extra codemods - do not remove
 ];
 

--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-helptext.input.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-helptext.input.js
@@ -1,0 +1,7 @@
+import { Form, HelpText } from "@contentful/forma-36-react-components";
+
+<HelpText>Some help text outside form</HelpText>;
+
+<Form>
+  <HelpText>Help text inside form</HelpText>
+</Form>;

--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-helptext.output.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-helptext.output.js
@@ -1,0 +1,9 @@
+import { Form, HelpText } from "@contentful/forma-36-react-components";
+
+import { Text } from "@contentful/f36-components";
+
+<Text as="p" fontColor="gray500" marginTop="spacingXs">Some help text outside form</Text>;
+
+<Form>
+  <HelpText>Help text inside form</HelpText>
+</Form>;

--- a/packages/forma-36-codemod/transforms/__tests__/v4.test.js
+++ b/packages/forma-36-codemod/transforms/__tests__/v4.test.js
@@ -32,6 +32,7 @@ describe('v4 codemods', () => {
     'v4-notification',
     'v4-asset-card',
     'v4-entry-card',
+    'v4-helptext',
   ];
 
   beforeEach(() => {

--- a/packages/forma-36-codemod/transforms/v4-helptext.js
+++ b/packages/forma-36-codemod/transforms/v4-helptext.js
@@ -1,0 +1,94 @@
+const {
+  getComponentLocalName,
+  addProperty,
+  addImport,
+  removeComponentImport,
+  warningMessage,
+} = require('../utils');
+const { getFormaImport, shouldSkipUpdateImport } = require('../utils/config');
+
+const checkParent = (j, path, parentName) => {
+  if (path.parent) {
+    const parent = path.parent;
+    if (
+      parent.value.type === 'JSXElement' &&
+      parent.value.openingElement.name.name.toLowerCase() === parentName
+    ) {
+      return false;
+    }
+    return checkParent(j, parent, parentName);
+  }
+  return true;
+};
+
+module.exports = function (file, api) {
+  const j = api.jscodeshift;
+
+  let source = file.source;
+
+  const componentName = getComponentLocalName(j, source, {
+    componentName: 'HelpText',
+    importName: getFormaImport(),
+  });
+
+  if (!componentName) {
+    return source;
+  }
+
+  const elements = j(source).findJSXElements(componentName);
+  const filteredElements = elements.filter((path) =>
+    checkParent(j, path, 'form'),
+  );
+  const shouldKeepImport = elements.length > filteredElements.length;
+
+  source = j(source)
+    .findJSXElements(componentName)
+    .filter((path) => checkParent(j, path, 'form'))
+    .find(j.JSXIdentifier, {
+      name: componentName,
+    })
+    .forEach((nodePath) => {
+      nodePath.node.name = 'Text';
+      if (nodePath.parent.value.type === 'JSXOpeningElement') {
+        const { attributes } = nodePath.parent.value;
+        let modifiedAttributes = attributes;
+        const newAttributes = [
+          { propertyName: 'marginTop', propertyValue: j.literal('spacingXs') },
+          { propertyName: 'fontColor', propertyValue: j.literal('gray500') },
+          { propertyName: 'as', propertyValue: j.literal('p') },
+        ];
+        newAttributes.forEach((attribute) => {
+          modifiedAttributes = addProperty(modifiedAttributes, {
+            j,
+            ...attribute,
+          });
+        });
+        nodePath.parent.value.attributes = modifiedAttributes;
+      }
+    })
+    .toSource();
+
+  source = addImport(j, source, [
+    j.template.statement([
+      `import { Text } from "${
+        shouldSkipUpdateImport()
+          ? getFormaImport()
+          : '@contentful/f36-components'
+      }"`,
+    ]),
+  ]).source;
+
+  if (!shouldKeepImport) {
+    source = removeComponentImport(j, source, {
+      importName: getFormaImport(),
+      componentName,
+    });
+  } else {
+    warningMessage(
+      'There are still uses of HelpText inside Form tags, please update to FormControl.HelpText',
+      { file },
+    );
+  }
+
+  return source;
+};


### PR DESCRIPTION
This codemod does a simple check if the `HelpText` component is wrapped inside a `<Form>` or `<form>` tag, and replaces by text if it isn't.