### PR TITLE
chore: update redirects with v3 domain

### DIFF
--- a/packages/forma-36-website/_redirects
+++ b/packages/forma-36-website/_redirects
@@ -1,2 +1,1 @@
-/storybook https://forma-36-react-components.netlify.com
-/foundation/color /foundation/color-system
+https://v3.f36.contentful.com https://f36.contentful.com

--- a/scripts/.storybook/docs/General/General.stories.mdx
+++ b/scripts/.storybook/docs/General/General.stories.mdx
@@ -16,7 +16,7 @@ A place for general documentation about the component library.
 
 Design tokens are the granular values we use when designing and implementing UI. Tokens include things such as font-sizes and colours.
 
-Design tokens can now be found on the [Forma 36 documentation website](https://f36.contentful.com/foundation/color/)
+Design tokens can now be found on the [Forma 36 documentation website](https://f36.contentful.com/foundation/color-system)
 
 ## Components
 


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

We need this to redirect people that access v3.f36.contentful.com to the main domain f36.contentful.com
And we need this new subdomain because we will need two version of the website soon (v3 and v4)

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
