### PR TITLE
fix(workbench): fix exports for regular and compound components of workbench

### DIFF
--- a/packages/components/workbench/src/CompoundWorkbench.tsx
+++ b/packages/components/workbench/src/CompoundWorkbench.tsx
@@ -4,9 +4,9 @@ import { WorkbenchContent } from './WorkbenchContent';
 import { WorkbenchSidebar } from './WorkbenchSidebar';
 
 type CompoundWorkbench = typeof OriginalWorkbench & {
-  Header?: typeof WorkbenchHeader;
-  Content?: typeof WorkbenchContent;
-  Sidebar?: typeof WorkbenchSidebar;
+  Header: typeof WorkbenchHeader;
+  Content: typeof WorkbenchContent;
+  Sidebar: typeof WorkbenchSidebar;
 };
 
 export const Workbench = OriginalWorkbench as CompoundWorkbench;

--- a/packages/components/workbench/src/index.ts
+++ b/packages/components/workbench/src/index.ts
@@ -1,2 +1,9 @@
 export { Workbench } from './CompoundWorkbench';
 export type { WorkbenchProps } from './Workbench';
+export { WorkbenchHeader } from './WorkbenchHeader';
+export type { WorkbenchHeaderProps } from './WorkbenchHeader';
+export { WorkbenchSidebar } from './WorkbenchSidebar';
+export type { WorkbenchSidebarProps } from './WorkbenchSidebar';
+export { WorkbenchContent } from './WorkbenchContent';
+export type { WorkbenchContentProps } from './WorkbenchContent';
+

--- a/packages/components/workbench/src/index.ts
+++ b/packages/components/workbench/src/index.ts
@@ -6,4 +6,3 @@ export { WorkbenchSidebar } from './WorkbenchSidebar';
 export type { WorkbenchSidebarProps } from './WorkbenchSidebar';
 export { WorkbenchContent } from './WorkbenchContent';
 export type { WorkbenchContentProps } from './WorkbenchContent';
-


### PR DESCRIPTION

# Purpose of PR

After feedback about usage of Workbench components, we discovered the components were not exported property and didn't work in apps framework. This PR should fix the issue. 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
