### PR TITLE
docs(Button): show example for as property

### DIFF
--- a/packages/components/button/Button.mdx
+++ b/packages/components/button/Button.mdx
@@ -67,11 +67,9 @@ Contentful buttons are available in 3 different sizes:
 Contentful buttons can be rendered as a-tag which allows also use them with a href.
 
 ```jsx
-<Stack>
-  <Button as="a" href="#">
-    As a with href tag
-  </Button>
-</Stack>
+<Button as="a" href="#">
+  As a with href tag
+</Button>
 ```
 
 ## Code examples

--- a/packages/components/button/Button.mdx
+++ b/packages/components/button/Button.mdx
@@ -62,6 +62,18 @@ Contentful buttons are available in 3 different sizes:
 </Stack>
 ```
 
+### Rendered as different Elements
+
+Contentful buttons can be rendered as a-tag which allows also use them with a href.
+
+```jsx
+<Stack>
+  <Button as="a" href="#">
+    As a with href tag
+  </Button>
+</Stack>
+```
+
 ## Code examples
 
 ```jsx

--- a/packages/components/button/stories/Button.stories.tsx
+++ b/packages/components/button/stories/Button.stories.tsx
@@ -350,6 +350,16 @@ export const Overview = ({ startIcon, endIcon }) => {
           </Button>
         </Flex>
       </Flex>
+      <Flex flexDirection="column" marginBottom="spacingL">
+        <SectionHeading as="h3" marginBottom="spacingS">
+          Button as link
+        </SectionHeading>
+        <Flex flexDirection="row" marginBottom="spacingS">
+          <Button as="a" href="#">
+            As a-tag with href property
+          </Button>
+        </Flex>
+      </Flex>
     </>
   );
 };


### PR DESCRIPTION
This updates the documentation to show the variation of Buttons as links.

<img width="160" alt="Screenshot at Nov 23 09-37-57" src="https://user-images.githubusercontent.com/1789174/142994762-e733c7ad-b016-4b6c-8f24-8eba5c3f6550.png">
<img width="510" alt="Screenshot at Nov 23 09-45-45" src="https://user-images.githubusercontent.com/1789174/142994788-1e94fa56-a529-42b2-828e-7ef45ec5b559.png">
