### PR TITLE
docs(docs-website): fix typos on documentation website

### DIFF
--- a/packages/components/autocomplete/Autocomplete.mdx
+++ b/packages/components/autocomplete/Autocomplete.mdx
@@ -34,7 +34,7 @@ The Autocomplete requires 3 props to work:
 
 - `items`: It’s an array containing the items that will be shown as selectable options when the user types something in the `TextInput`.
 - `onInputValueChange`: This function will be called every time the user types something in the input.
-  The component will pass the `item` which the filter method is currently interating and `inputValue` of the `Textinput`.
+  The component will pass the `item` which the filter method is currently integrating and `inputValue` of the `TextInput`.
 - `onSelectItem`: This function is called when the user selects one of the options of the list. The component will pass the selected item as an argument to the function.
 
 An `Autocomplete` with a list of fruits will look like this:
@@ -43,7 +43,7 @@ An `Autocomplete` with a list of fruits will look like this:
 function AutocompleteExample() {
   const fruits = [
     'Apple 🍎',
-    'Ananas 🍍',
+    'Pineapple 🍍',
     'Avocado 🥑',
     'Banana 🍌',
     'Coconut 🥥',
@@ -100,7 +100,7 @@ function AutocompleteExample() {
   // This is our new array of fruits, each one is an object with an id and a name
   const fruits = [
     { id: 1, name: 'Apple', emoji: '🍎' },
-    { id: 2, name: 'Ananas', emoji: '🍍' },
+    { id: 2, name: 'Pineapple', emoji: '🍍' },
     { id: 3, name: 'Avocado', emoji: '🥑' },
     { id: 4, name: 'Banana', emoji: '🍌' },
     { id: 5, name: 'Coconut', emoji: '🥥' },
@@ -187,7 +187,7 @@ import { Autocomplete } from '@contentful/f36-autocomplete';
 function AutocompleteExample() {
   const fruits = [
     { id: 1, name: 'Apple' },
-    { id: 2, name: 'Ananas' },
+    { id: 2, name: 'Pineapple' },
     { id: 3, name: 'Avocado' },
     { id: 4, name: 'Banana' },
     { id: 5, name: 'Coconut' },
@@ -249,7 +249,7 @@ function AutocompleteExample() {
       groupTitle: 'Fruits',
       options: [
         { id: 1, name: 'Apple', emoji: '🍎' },
-        { id: 2, name: 'Ananas', emoji: '🍍' },
+        { id: 2, name: 'Pineapple', emoji: '🍍' },
         { id: 3, name: 'Avocado', emoji: '🥑' },
         { id: 4, name: 'Banana', emoji: '🍌' },
         { id: 5, name: 'Coconut', emoji: '🥥' },
@@ -260,7 +260,7 @@ function AutocompleteExample() {
       options: [
         { id: 1, name: 'Cucumber', emoji: '🥒' },
         { id: 2, name: 'Pumpkin', emoji: '🎃' },
-        { id: 3, name: 'Brokkolie', emoji: '🥦' },
+        { id: 3, name: 'Broccoli', emoji: '🥦' },
         { id: 4, name: 'Pepper', emoji: '🫑' },
       ],
     },
@@ -291,7 +291,7 @@ function AutocompleteExample() {
     <Stack flexDirection="column" alignItems="start">
       <Autocomplete
         items={filteredItems}
-        // this is the imporant prop that tells the component to deal with grouped options
+        // this is the important prop that tells the component to deal with grouped options
         isGrouped
         onInputValueChange={handleInputValueChange}
         onSelectItem={handleSelectItem}
@@ -316,7 +316,7 @@ function AutocompleteExample() {
 function AutocompleteExample() {
   const fruits = [
     'Apple 🍎',
-    'Ananas 🍍',
+    'Pineapple 🍍',
     'Avocado 🥑',
     'Banana 🍌',
     'Coconut 🥥',
@@ -369,7 +369,7 @@ function AutocompleteExample() {
 function AutocompleteExample() {
   const fruits = [
     'Apple 🍎',
-    'Ananas 🍍',
+    'Pineapple 🍍',
     'Avocado 🥑',
     'Banana 🍌',
     'Coconut 🥥',

--- a/packages/components/badge/Badge.mdx
+++ b/packages/components/badge/Badge.mdx
@@ -90,7 +90,7 @@ Badge is used to label or highlight items in the interface.
 
 ### EntityStatusBadge
 
-For easy and quick usage of Badge in Contentful products, in extentions and apps we provide additional component called `EntityStatusBadge`. It's used in the Contentful entity to mark their status.
+For easy and quick usage of Badge in Contentful products, in extensions and apps we provide additional component called `EntityStatusBadge`. It's used in the Contentful entity to mark their status.
 
 EntityStatusBadge can have different mark following statuses. Those values are passed as a `entityStatus` property and displayed as a content in the badge:
 

--- a/packages/components/button/Button.mdx
+++ b/packages/components/button/Button.mdx
@@ -36,7 +36,7 @@ Buttons communicate the action that will occur when the user clicks them. They c
 - **Secondary** - Used for a secondary actions, the most commonly used button type.
 - **Positive** - For use when the action has a positive connotation such as creating or publishing a new entity.
 - **Negative** - For destructive actions - when something can't be undone. For example, deleting entities.
-- **Transparent** - For having an unestylized button.
+- **Transparent** - For having an unstylized button.
 
 ```jsx
 <Stack>

--- a/packages/components/button/src/ButtonGroup/README.mdx
+++ b/packages/components/button/src/ButtonGroup/README.mdx
@@ -50,7 +50,7 @@ It's possible to add a divider for buttons that don't have border:
 </ButtonGroup>
 ```
 
-Example of Group Button with spaced vairant
+Example of Group Button with spaced variant
 
 ```jsx
 // import { ButtonGroup, Button } from '@contentful/f36-button';

--- a/packages/components/card/src/card/README.mdx
+++ b/packages/components/card/src/card/README.mdx
@@ -95,7 +95,7 @@ function CardsExample() {
 
 ### With `link` and `target`
 
-A Card can be used with the pourpose to navigate a user to an external page. To do that a user must pass a value to the `href` prop.
+A Card can be used with the purpose to navigate a user to an external page. To do that a user must pass a value to the `href` prop.
 Optionally, the user can pass a `target` prop to control how the link should be open.
 
 ```jsx

--- a/packages/components/datetime/RelativeDateTime.mdx
+++ b/packages/components/datetime/RelativeDateTime.mdx
@@ -54,7 +54,7 @@ It will compare the date to today or baseDate if provided.
 <Stack flexDirection="column">
   {/* It will display "Yesterday at 3:45 PM" */}
   <RelativeDateTime date="2021-08-17T15:45" isRelativeToCurrentWeek />
-  {/* It willdisplay "5 hours ago" */}
+  {/* It will display "5 hours ago" */}
   <RelativeDateTime date="2021-08-18T10:45" isRelativeToCurrentWeek />
   {/* It will display "Tomorrow at 3:45 PM" */}
   <RelativeDateTime date="2021-08-19T15:45" isRelativeToCurrentWeek />

--- a/packages/components/forms/src/checkbox/Checkbox.mdx
+++ b/packages/components/forms/src/checkbox/Checkbox.mdx
@@ -58,7 +58,7 @@ const ExampleControlled = () => {
 
 You can use the Checkbox as an uncontrolled input, for that you can:
 
-- Set the `defaultChecked` property, it will ensure that the checked state can be altered normaly.
+- Set the `defaultChecked` property, it will ensure that the checked state can be altered normally.
 - Don't set the `isChecked` as it will make the input controlled.
 
 ```jsx static=true

--- a/packages/components/forms/src/form/Form.mdx
+++ b/packages/components/forms/src/form/Form.mdx
@@ -15,13 +15,13 @@ storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/form-elements-form
 - [Code examples](#code-examples)
   - [Basic example](#basic-example)
   - [Using character count](#using-character-count)
-  - [Intergrations](#intergrations)
+  - [Integrations](#integrations)
 
 ## How to use Form
 
 - The `Form` component should wrap form elements into `<form />`
 - Provide an `onSubmit` handler for form validation and submission
-- state of the validation of the form should be maniputated from outside
+- state of the validation of the form should be manipulated from outside
 
 Go ahead and add some fields into your form:
 
@@ -39,9 +39,9 @@ Go ahead and add some fields into your form:
 
 ```jsx
 function FormaExample() {
-  const [submitted, setSubmited] = React.useState(false);
+  const [submitted, setSubmitted] = React.useState(false);
   return (
-    <Form onSubmit={() => setSubmited(true)}>
+    <Form onSubmit={() => setSubmitted(true)}>
       <FormControl>
         <FormControl.Label isRequired>Name</FormControl.Label>
         <TextInput />
@@ -55,7 +55,7 @@ function FormaExample() {
         <Box>
           <Textarea />
         </Box>
-        <FormControl.HelpText>Tell me about youself</FormControl.HelpText>
+        <FormControl.HelpText>Tell me about yourself</FormControl.HelpText>
       </FormControl>
       <Button variant="primary" type="submit" isDisabled={submitted}>
         {submitted ? 'Submitted' : 'Click me to submit'}
@@ -69,9 +69,9 @@ function FormaExample() {
 
 ```jsx
 function FormaExample() {
-  const [submitted, setSubmited] = React.useState(false);
+  const [submitted, setSubmitted] = React.useState(false);
   return (
-    <Form onSubmit={() => setSubmited(true)}>
+    <Form onSubmit={() => setSubmitted(true)}>
       <FormControl>
         <FormControl.Label isRequired>user name</FormControl.Label>
         <TextInput />
@@ -95,6 +95,6 @@ function FormaExample() {
 }
 ```
 
-### Intergrations
+### Integrations
 
 It is possible to integrate the form with solutions like [Formik](/integrations/formik/) or [React form hook](/integrations/react-hook-form/)

--- a/packages/components/forms/src/radio/Radio.mdx
+++ b/packages/components/forms/src/radio/Radio.mdx
@@ -70,7 +70,7 @@ const ExampleControlled = () => {
 
 You can use the Radio as an uncontrolled input, for that you can:
 
-- Set the `defaultChecked` property, it will ensure that the checked state can be altered normaly.
+- Set the `defaultChecked` property, it will ensure that the checked state can be altered normally.
 - Don't set the `isChecked` as it will make the input controlled.
 
 ```jsx static=true

--- a/packages/components/forms/src/switch/Switch.mdx
+++ b/packages/components/forms/src/switch/Switch.mdx
@@ -54,7 +54,7 @@ const ExampleControlled = () => {
 
 You can use the Switch as an uncontrolled input, for that you can:
 
-- Set the `defaultChecked` property, it will ensure that the checked state can be altered normaly.
+- Set the `defaultChecked` property, it will ensure that the checked state can be altered normally.
 - Don't set the `isChecked` as it will make the input controlled.
 
 ```jsx static=true

--- a/packages/components/forms/src/text-input/TextInput.mdx
+++ b/packages/components/forms/src/text-input/TextInput.mdx
@@ -104,7 +104,7 @@ Example of spaced `TextInput.Group`.
 
 ## TextInput variations
 
-Keep in mind, that if you need to use an input without a label, you need to pass `aria-label` attribute to create an input that would be accessibile to assistive technologies, like screen readers.
+Keep in mind, that if you need to use an input without a label, you need to pass `aria-label` attribute to create an input that would be accessible to assistive technologies, like screen readers.
 
 ### TextInput with placeholder
 
@@ -151,8 +151,8 @@ Keep in mind, that if you need to use an input without a label, you need to pass
 ## Accessibility
 
 - To ensure `TextInput` meets accessibility standards, provide `name` and `id`
-- Keep in mind that to provide that accessibile inputs, you need to use labels.
-- If you decide, that for some reason you would not use the label, please provide `aria-label` attribute to make it accessibile for technologies like screen readers.
+- Keep in mind that to provide that accessible inputs, you need to use labels.
+- If you decide, that for some reason you would not use the label, please provide `aria-label` attribute to make it accessible for technologies like screen readers.
 
 ## Props
 

--- a/packages/components/forms/src/textarea/Textarea.mdx
+++ b/packages/components/forms/src/textarea/Textarea.mdx
@@ -100,7 +100,7 @@ which means that you can pass a ref created with `React.createRef()` or `useRef`
 
 - To ensure accessibility, provide a `name` prop
 - In case the input is required, use `isRequired` prop
-- If you are using this component in a form, provide validation to the input and use `isInvalid` to control the error state of `Textarea`. Also show meaninful error messages with the `ValidationMessage` component.
+- If you are using this component in a form, provide validation to the input and use `isInvalid` to control the error state of `Textarea`. Also show meaningful error messages with the `ValidationMessage` component.
 - Provide instructions of how to fill the field with `HelpText` component
 
 ## Props

--- a/packages/components/menu/Menu.mdx
+++ b/packages/components/menu/Menu.mdx
@@ -31,7 +31,7 @@ You can use following components to build a menu:
 1. `<Menu.SectionTitle>` A title that you can use in the menu list.
 1. `<Menu.ListHeader>` The wrapper for one menu item that will be sticked to the top of the menu list. `<Menu.Item>` must be provided as a child.
 1. `<Menu.ListFooter>` The wrapper for one menu item that will be sticked to the bottom of the menu list. `<Menu.Item>` must be provided as a child.
-1. `<Menu.Submenu>` The wrapper for for submenu components. Childrens structure remains the same like in `<Menu>`, except you should use `<Menu.SubmenuTrigger>` instead of `<Menu.Trigger>`.
+1. `<Menu.Submenu>` The wrapper for for submenu components. Structure of the children remains the same like in `<Menu>`, except you should use `<Menu.SubmenuTrigger>` instead of `<Menu.Trigger>`.
 1. `<Menu.SubmenuTrigger>` The wrapper for the submenu list trigger. Must be a direct child of `<Menu.Submenu>`.
 
 ## Code examples
@@ -115,7 +115,7 @@ You can use following components to build a menu:
 
 ### Controlled Menu
 
-By default the Menu component is uncontroled. So when user clicks on the trigger, the menu opens/closes.
+By default the Menu component is uncontrolled. So when user clicks on the trigger, the menu opens/closes.
 But you can control it by passing `isOpen` prop and `onClose`, `onOpen` callbacks.
 
 ```jsx
@@ -147,7 +147,7 @@ function ControlledMenu() {
 ### Controlled Menu with custom trigger onClick callback
 
 In most cases, you will use the [controlled approach](#controlled-menu).
-But if you have to provide your own toggle menu logic on the trigger component, you can do this by providing `onClick` callback on trigger component and omiting `onOpen` callback on the Menu component.
+But if you have to provide your own toggle menu logic on the trigger component, you can do this by providing `onClick` callback on trigger component and omitting `onOpen` callback on the Menu component.
 
 ```jsx
 function ControlledMenuWithCustomTriggerLogic() {
@@ -342,7 +342,7 @@ But you can redefine them on any submenu by passing those props directly to that
 - You can use arrow keys (`ArrowUp` and `ArrowDown`) to navigate through menu items.
 - When the menu is open, click on `Esc` key will close the popover. If you set `closeOnEsc` to `false`, it will not close.
 - When the menu is open, click outside menu or blurring out will close the menu. If you set `closeOnBlur` to `false`, it will not close.
-- All the necessery a11y attributes for `Menu.List`, `Menu.Trigger` and `Menu.Item` are provided.
+- All the necessary a11y attributes for `Menu.List`, `Menu.Trigger` and `Menu.Item` are provided.
 
 ## Props
 

--- a/packages/components/modal/src/ModalLauncher/ModalLauncher.mdx
+++ b/packages/components/modal/src/ModalLauncher/ModalLauncher.mdx
@@ -7,7 +7,7 @@ github: 'https://github.com/contentful/forma-36/tree/master/packages/components/
 storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-modal-modallauncher--basic'
 ---
 
-`ModalLaucher` is a utility that allows calling `Modal` and `ModalConfirm` in an imperative code, in functions.
+`ModalLauncher` is a utility that allows calling `Modal` and `ModalConfirm` in an imperative code, in functions.
 
 ## How to use ModalLauncher
 

--- a/packages/components/notification/Notification.mdx
+++ b/packages/components/notification/Notification.mdx
@@ -15,11 +15,11 @@ Notifications give immediate feedback about an action triggered or experienced b
 
 ## Table of contents
 
-- [How to use Notifiaction](#how-to-use-notifiaction)
+- [How to use Notification](#how-to-use-notification)
 - [Component variations](#component-variations)
 - [Content recommendations](#content-recommendations)
 
-## How to use Notifiaction
+## How to use Notification
 
 - Consider where the notification will be placed and which variation is most appropriate
 - Don't confuse notifications with notes, which persist in the UI and do not dismiss

--- a/packages/components/popover/Popover.mdx
+++ b/packages/components/popover/Popover.mdx
@@ -107,7 +107,7 @@ function PopoverExample() {
 - When the popover is opened, focus is moved to the `Popover.Content`. If you set `autoFocus`to `false`, it will not move the focus.
 - When the popover is open and focus is within the `Popover.Content`, click on `Esc` key will close the popover. If you set `closeOnEsc` to `false`, it will not close.
 - When the popover is open and focus is within the `Popover.Content`, click outside popover or blurring out will close the it. If you set `closeOnBlur` to `false`, it will not close.
-- All the necessery a11y attributes for `Popover.Content` and `Popover.Trigger` are provided.
+- All the necessary a11y attributes for `Popover.Content` and `Popover.Trigger` are provided.
 
 ## Props
 

--- a/packages/components/skeleton/src/SkeletonBodyText/README.mdx
+++ b/packages/components/skeleton/src/SkeletonBodyText/README.mdx
@@ -10,7 +10,7 @@ typescript: ./SkeletonBodyText.tsx
 
 ## How to use SkeletonBodyText
 
-Use the `SkeletonBodyText` component to simiulate bodies of text with multiple lines whenever loading asynchronous data.
+Use the `SkeletonBodyText` component to simulate bodies of text with multiple lines whenever loading asynchronous data.
 
 ### Import
 

--- a/packages/components/skeleton/src/SkeletonDisplayText/README.mdx
+++ b/packages/components/skeleton/src/SkeletonDisplayText/README.mdx
@@ -10,7 +10,7 @@ typescript: ./SkeletonDisplayText.tsx
 
 ## How to use SkeletonDisplayText
 
-Use the `SkeletonDisplayText` component to simiulate headings, subheadings or titles whenever loading asynchronous data.
+Use the `SkeletonDisplayText` component to simulate headings, subheadings or titles whenever loading asynchronous data.
 
 ### Import
 

--- a/packages/components/skeleton/src/SkeletonImage/README.mdx
+++ b/packages/components/skeleton/src/SkeletonImage/README.mdx
@@ -10,7 +10,7 @@ typescript: ./SkeletonImage.tsx
 
 ## How to use SkeletonImage
 
-Use the `SkeletonImage` component to simiulate images, illustrations, avatars or icons whenever loading asynchronous data.
+Use the `SkeletonImage` component to simulate images, illustrations, avatars or icons whenever loading asynchronous data.
 
 ### Import
 

--- a/packages/components/typography/src/Text.mdx
+++ b/packages/components/typography/src/Text.mdx
@@ -86,13 +86,13 @@ To override the element that gets rendered, pass the as prop.
     Italic
   </Text>
   <Text marginBottom="spacingM" as="u">
-    Unterline
+    Underline
   </Text>
   <Text marginBottom="spacingM" as="del">
     Deleted
   </Text>
   <Text marginBottom="spacingM" as="s">
-    Strikethrough
+    Strike Through
   </Text>
 </Flex>
 ```

--- a/packages/core/src/Flex/Flex.mdx
+++ b/packages/core/src/Flex/Flex.mdx
@@ -36,7 +36,7 @@ import { Flex } from '@contentful/f36-core';
 
 Flex components inherits behaviour of [Box] component and allows to pass margins and paddings that are based on our [spacing system].
 
-To control the behaviour of the Flex component you can use specific properies that match [all main Flexbox related CSS attributes](https://cssreference.io/flexbox/).
+To control the behaviour of the Flex component you can use specific properties that match [all main Flexbox related CSS attributes](https://cssreference.io/flexbox/).
 
 ```js
 () => {

--- a/packages/core/src/Stack/Stack.mdx
+++ b/packages/core/src/Stack/Stack.mdx
@@ -35,7 +35,7 @@ import { Stack } from '@contentful/f36-core';
 
 `Stack` components inherits behaviour of [Box] component and allows to pass margins and paddings that are based on our [spacing system].
 
-To control the behaviour of the Flex component you can use specific properies that match [all main Flexbox related CSS attributes](https://cssreference.io/flexbox/).
+To control the behaviour of the Flex component you can use specific properties that match [all main Flexbox related CSS attributes](https://cssreference.io/flexbox/).
 
 ```js
 () => {

--- a/packages/forma-36-website/src/content/contributing.mdx
+++ b/packages/forma-36-website/src/content/contributing.mdx
@@ -50,7 +50,7 @@ Forma 36’s internal team checks the issues in the repo regularly and we will p
 After some discussion we will approve the proposal and you can work on it. We will help you in anything you need.
 
 It’s a good idea to look into the other components’ code
-and our [Code Style Guide](https://github.com/contentful/forma-36/blob/forma-v4/docs/code-style-guide.md) to write your code following our convetions.
+and our [Code Style Guide](https://github.com/contentful/forma-36/blob/forma-v4/docs/code-style-guide.md) to write your code following our conventions.
 
 ### Step 3: Open a Pull Request
 

--- a/packages/forma-36-website/src/content/foundation/color-system/index.mdx
+++ b/packages/forma-36-website/src/content/foundation/color-system/index.mdx
@@ -50,7 +50,7 @@ complete.
 ### Red
 
 Red is used to highlight negative actions or messages. E.g. when performing
-a distructive action such as deleting content, for highlighting validation
+a destructive action such as deleting content, for highlighting validation
 or application error messages, or for showing statuses with a negative
 context.
 

--- a/packages/forma-36-website/src/content/getting-started.mdx
+++ b/packages/forma-36-website/src/content/getting-started.mdx
@@ -40,7 +40,7 @@ yarn add @contentful/f36-button`
 
 ### Install icons
 
-Forma 36 icons are a separate package to reduce the size of the main bundle. If you need to use icons in your project, install them separatly by running either of the following:
+Forma 36 icons are a separate package to reduce the size of the main bundle. If you need to use icons in your project, install them separately by running either of the following:
 
 **When using NPM:**
 

--- a/packages/forma-36-website/src/content/integrations/react-hook-form/index.mdx
+++ b/packages/forma-36-website/src/content/integrations/react-hook-form/index.mdx
@@ -2,7 +2,7 @@
 title: 'React Hook Form'
 ---
 
-It’s possible to build forms using Forma 36’s compoenents and [React Hook Form](https://react-hook-form.com/).
+It’s possible to build forms using Forma 36’s components and [React Hook Form](https://react-hook-form.com/).
 In this page we will show a couple of examples on how to do that.
 
 ## Integrating with `register()`
@@ -42,7 +42,7 @@ export const ReactHookForm = () => {
       <FormControl isInvalid={Boolean(errors.name)}>
         <FormControl.Label isRequired>Name</FormControl.Label>
 
-        {/* Use the register function from reac-hook-form on TextInput */}
+        {/* Use the register function from react-hook-form on TextInput */}
         <TextInput {...register('name', { required: true })} />
 
         {/* Show a ValidationMessage if the input has any errors */}
@@ -166,7 +166,7 @@ export const ReactHookForm = () => {
            * We need to pass an empty string as default value
            * otherwise react will trigger the uncontrolled inputs warning
            *
-           * more infomation in https://react-hook-form.com/api/usecontroller
+           * more information in https://react-hook-form.com/api/usecontroller
            */
           defaultValue=""
         />


### PR DESCRIPTION
# Purpose of PR

Fixing typos in docs - some stuff that was caught in spellchecker. 

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
