### PR TITLE
docs(autocomplete): improve wording on autocomplete documentation

### DIFF
--- a/packages/components/autocomplete/Autocomplete.mdx
+++ b/packages/components/autocomplete/Autocomplete.mdx
@@ -34,7 +34,7 @@ The Autocomplete requires 3 props to work:
 
 - `items`: It’s an array containing the items that will be shown as selectable options when the user types something in the `TextInput`.
 - `onInputValueChange`: This function will be called every time the user types something in the input.
-  The component will pass the `item` which the filter method is currently integrating and `inputValue` of the `TextInput`.
+  The component will pass the `item`, which the filter method is currently iterating over, and the `inputValue` prop of the `TextInput` component.
 - `onSelectItem`: This function is called when the user selects one of the options of the list. The component will pass the selected item as an argument to the function.
 
 An `Autocomplete` with a list of fruits will look like this:


### PR DESCRIPTION
# Purpose of PR

Improved wording a bit, but if you see how we can make it a bit more clear, I would love some feedback :) 

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
