### PR TITLE
fix(asset-card): fix svg assets - unable to display

### DIFF
--- a/packages/components/asset/src/Asset.styles.ts
+++ b/packages/components/asset/src/Asset.styles.ts
@@ -5,12 +5,14 @@ export function getAssetStyles() {
   return {
     relative: css({
       position: 'relative',
+      width: '100%',
     }),
     height100: css({
       height: '100%',
     }),
     image: css({
       width: 'auto',
+      height: '100%',
       maxWidth: '100%',
       maxHeight: '100%',
     }),


### PR DESCRIPTION
# Purpose of PR

When using AssetCard for SVG files, they are not being displayed. This PR fixes this issue. If you have some feedback or ideas on how to deal with it better, I love to hear it :) 

How to reproduce - in storybook pass a link to an SVG file to AssetCard component

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
