### PR TITLE
fix: DisplayText was not using the as prop

### DIFF
--- a/packages/components/typography/src/DisplayText.tsx
+++ b/packages/components/typography/src/DisplayText.tsx
@@ -28,7 +28,6 @@ function _DisplayText<
     children,
     size = 'default',
     testId = 'cf-ui-display-text',
-    as,
     ...otherProps
   }: DisplayTextProps<E>,
   ref: React.Ref<any>,


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

It was impossible to change the element that DisplayText would be because we were not using the `as` prop and it was being extract from `otherProps` which is passed to the returned Element


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
