### PR TITLE
[BAU-302] docs: update plop template with new format

### DIFF
--- a/packages/components/accordion/Accordion.mdx
+++ b/packages/components/accordion/Accordion.mdx
@@ -1,11 +1,9 @@
 ---
 title: 'Accordion'
-type: 'component'
-status: 'stable'
 slug: /components/accordion/
 github: 'https://github.com/contentful/forma-36/tree/forma-v4/packages/components/accordion'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-accordion'
-typescript: ./src/Accordion.tsx
+typescript: ./src/Accordion.tsx,./src/AccordionItem/AccordionItem.tsx
 v4Doc: true
 ---
 
@@ -83,9 +81,9 @@ Other typographic components can be passed as the accordion's title and anything
 
 <Props of="Accordion" />
 
-### AccordionItem
+### Accordion.Item
 
-<Props of="Accordion.Item" />
+<Props of="AccordionItem" />
 
 ## Content guidelines
 

--- a/packages/components/accordion/Accordion.mdx
+++ b/packages/components/accordion/Accordion.mdx
@@ -2,7 +2,7 @@
 title: 'Accordion'
 slug: /components/accordion/
 github: 'https://github.com/contentful/forma-36/tree/forma-v4/packages/components/accordion'
-storybook: 'https://f36-storybook.contentful.com/?path=/story/components-accordion'
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-accordion'
 typescript: ./src/Accordion.tsx,./src/AccordionItem/AccordionItem.tsx
 v4Doc: true
 ---

--- a/packages/components/accordion/Accordion.mdx
+++ b/packages/components/accordion/Accordion.mdx
@@ -34,8 +34,7 @@ import { Accordion } from '@contentful/f36-components';
 
 ## Examples
 
-The title prop accepts React nodes, but we recommend that only Typography components are used.
-Since the whole header is a button, do not use Buttons or Links in the title prop. The only click event that should exist is the header's event.
+The accordion has two variations that define the alignment of the chevron icon: left or right.
 
 ### Basic usage
 
@@ -58,14 +57,22 @@ Other typographic components can be passed as the accordion's title and anything
 ```jsx
 <Accordion>
   <Accordion.Item
-    title={<SectionHeading>What payment methods do you accept?</SectionHeading>}
+    title={
+      <SectionHeading marginBottom="none">
+        What payment methods do you accept?
+      </SectionHeading>
+    }
   >
-    <Text marginBottom="spacingS">
-      Customers on the Team tier can pay with a credit card (American Express,
-      MasterCard or Visa). Enterprise customers have the choice of paying with a
-      credit card or wire transfer.
-    </Text>
-    <Button onClick={() => console.log('clicked!')}>Accordion’s button</Button>
+    <Stack flexDirection="column">
+      <Text marginBottom="spacingS">
+        Customers on the Team tier can pay with a credit card (American Express,
+        MasterCard or Visa). Enterprise customers have the choice of paying with
+        a credit card or wire transfer.
+      </Text>
+      <Button onClick={() => console.log('clicked!')}>
+        Accordion’s button
+      </Button>
+    </Stack>
   </Accordion.Item>
 </Accordion>
 ```

--- a/packages/components/accordion/Accordion.mdx
+++ b/packages/components/accordion/Accordion.mdx
@@ -1,36 +1,43 @@
 ---
 title: 'Accordion'
 type: 'component'
+status: 'stable'
 slug: /components/accordion/
-github: 'https://github.com/contentful/forma-36/tree/master/packages/components/accordion'
-storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-accordion--basic'
-typescript: ./src/Accordion.tsx,./src/AccordionItem/AccordionItem.tsx
+github: 'https://github.com/contentful/forma-36/tree/forma-v4/packages/components/accordion'
+storybook: 'https://f36-storybook.contentful.com/?path=/story/components-accordion'
+typescript: ./src/Accordion.tsx
+v4Doc: true
 ---
 
+import { Stack, TextLink } from '@contentful/f36-components';
 import { Props } from '@contentful/f36-docs-utils';
-
-## Accordion
 
 Accordions are a good way to deliver a large amount of information. An accordion is a list of headers that after being clicked reveal or hide more content related to them.
 The header gives the user a summary of the content and the user decides if they need to see the extended content or not.
 
 ## Table of contents
 
-- [How to use Accordions](#how-to-use-accordions)
-- [Component variations](#component-variations)
-- [Code examples](#code-examples)
-- [Content recommendations](#content-recommendations)
+- [Import](#import)
+- [Examples](#examples)
+  - [Basic usage](#basic-usage)
+  - [Using it with other components](#using-it-with-other-components)
+- [Props](#props-api-reference)
+- [Content guidelines](#content-guidelines)
+- [Accessibility](#accessibility)
+- [Help improve this page](#help-improve-this-page)
 
-## How to use Accordions
+## Import
 
-- The title prop accepts React nodes, but we recommend that only Typography components are used.
-- Since the whole header is a button, do not use Buttons or Links in the title prop. The only click event that should exist is the header's event.
+```jsx static=true
+import { Accordion } from '@contentful/f36-components';
+```
 
-## Component variations
+## Examples
 
-The accordion has two variations that define the alignment of the chevron icon: left or right.
+The title prop accepts React nodes, but we recommend that only Typography components are used.
+Since the whole header is a button, do not use Buttons or Links in the title prop. The only click event that should exist is the header's event.
 
-## Code examples
+### Basic usage
 
 ```jsx
 <Accordion>
@@ -43,6 +50,8 @@ The accordion has two variations that define the alignment of the chevron icon: 
   </Accordion.Item>
 </Accordion>
 ```
+
+### Using it with other components
 
 Other typographic components can be passed as the accordion's title and anything can be used as the accordion's content. For example:
 
@@ -61,13 +70,7 @@ Other typographic components can be passed as the accordion's title and anything
 </Accordion>
 ```
 
-## Content recommendations
-
-- The title should be a short message that summarize the content of the accordion.
-- Anything can be passed as the content of the accordion, but often organizing it with Texts and Tables would be enough.
-- When using headings, be mindful about the heading levels. The header is a Subheading with `h2` tag.
-
-## Props
+## Props (API reference)
 
 ### Accordion
 
@@ -75,4 +78,14 @@ Other typographic components can be passed as the accordion's title and anything
 
 ### AccordionItem
 
-<Props of="AccordionItem" />
+<Props of="Accordion.Item" />
+
+## Content guidelines
+
+- The title should be a short message that summarize the content of the accordion.
+- Anything can be passed as the content of the accordion, but often organizing it with Texts and Tables would be enough.
+- When using headings, be mindful about the heading levels. The header is a Subheading with `h2` tag.
+
+## Accessibility
+
+- It allows keyboard navigation to open and close the accordions

--- a/packages/forma-36-website/gatsby-node.js
+++ b/packages/forma-36-website/gatsby-node.js
@@ -57,6 +57,7 @@ exports.createPages = ({ graphql, actions }) => {
                 github
                 storybook
                 typescript
+                v4Doc
               }
               body
             }

--- a/packages/forma-36-website/src/components/MDXPage.js
+++ b/packages/forma-36-website/src/components/MDXPage.js
@@ -77,18 +77,14 @@ const styles = {
 /* eslint-disable react/display-name */
 const markToComponentMap = {
   h1: (props) => <DisplayText {...props} />,
-  h2: (props) => <Heading as="h2" {...props} />,
-  h3: (props) => <Subheading as="h3" {...props} />,
+  h2: (props) => <Heading as="h2" marginTop="spacing2Xl" {...props} />,
+  h3: (props) => <Subheading as="h3" marginTop="spacingL" {...props} />,
   h4: (props) => <Subheading as="h4" {...props} />,
   h5: (props) => <Subheading as="h5" {...props} />,
   h6: (props) => <Subheading as="h6" {...props} />,
   p: (props) => <Paragraph {...props} />,
   a: (props) => <TextLink {...props} />,
-  ul: (props) => (
-    <Box marginBottom="spacingM">
-      <List {...props} />
-    </Box>
-  ),
+  ul: (props) => <List {...props} />,
   li: (props) => <List.Item {...props} />,
   code: (props) => {
     if (props.static) {
@@ -173,7 +169,11 @@ export default function MDXPageV4({ mdxContent, frontmatter, propsMetadata }) {
 
             {frontmatter.v4Doc && (
               <>
-                <Heading as="h2" id="help-improve-this-page">
+                <Heading
+                  as="h2"
+                  id="help-improve-this-page"
+                  marginTop="spacing2Xl"
+                >
                   Help improve this page
                 </Heading>
                 <Stack>

--- a/packages/forma-36-website/src/components/MDXPage.js
+++ b/packages/forma-36-website/src/components/MDXPage.js
@@ -13,6 +13,7 @@ import {
   Heading,
   List,
   Paragraph,
+  Stack,
   Subheading,
   Table,
   TableBody,
@@ -75,50 +76,13 @@ const styles = {
 
 /* eslint-disable react/display-name */
 const markToComponentMap = {
-  h1: (props) => (
-    <DisplayText marginBottom="spacingL" marginTop="spacingXl" {...props} />
-  ),
-  h2: (props) => (
-    <Heading
-      element="h2"
-      marginBottom="spacingL"
-      marginTop="spacingXl"
-      {...props}
-    />
-  ),
-  h3: (props) => (
-    <Subheading
-      element="h3"
-      marginBottom="spacingM"
-      marginTop="spacingL"
-      {...props}
-    />
-  ),
-  h4: (props) => (
-    <Subheading
-      element="h4"
-      marginBottom="spacingM"
-      marginTop="spacingL"
-      {...props}
-    />
-  ),
-  h5: (props) => (
-    <Subheading
-      element="h5"
-      marginBottom="spacingM"
-      marginTop="spacingL"
-      {...props}
-    />
-  ),
-  h6: (props) => (
-    <Subheading
-      marginBottom="spacingS"
-      marginTop="spacingM"
-      element="h6"
-      {...props}
-    />
-  ),
-  p: (props) => <Paragraph marginBottom="spacingS" {...props} />,
+  h1: (props) => <DisplayText {...props} />,
+  h2: (props) => <Heading as="h2" {...props} />,
+  h3: (props) => <Subheading as="h3" {...props} />,
+  h4: (props) => <Subheading as="h4" {...props} />,
+  h5: (props) => <Subheading as="h5" {...props} />,
+  h6: (props) => <Subheading as="h6" {...props} />,
+  p: (props) => <Paragraph {...props} />,
   a: (props) => <TextLink {...props} />,
   ul: (props) => (
     <Box marginBottom="spacingM">
@@ -145,58 +109,84 @@ const markToComponentMap = {
 };
 /* eslint-enable react/display-name */
 
-export default function MDXPage({ mdxContent, frontmatter, propsMetadata }) {
+export default function MDXPageV4({ mdxContent, frontmatter, propsMetadata }) {
+  console.log(frontmatter);
   return (
     <Box className={styles.pageContent}>
       <PropsProvider metadata={propsMetadata}>
         <MDXProvider components={markToComponentMap}>
-          <header className={styles.header}>
-            {frontmatter?.title && (
-              <DisplayText marginBottom="spacingL">
+          {!frontmatter.v4Doc && (
+            <header className={styles.header}>
+              {frontmatter?.title && (
+                <DisplayText marginBottom="spacingL">
+                  {frontmatter.title}
+                </DisplayText>
+              )}
+
+              <div className={styles.subheaderRow}>
+                <div className={styles.buttonList}>
+                  {frontmatter?.storybook && (
+                    <a
+                      className={styles.imageLink}
+                      href={frontmatter.storybook}
+                      title={`View ${frontmatter?.title} in Storybook`}
+                    >
+                      <img src={storybookIcon} alt="" />
+                      <span>Storybook</span>
+                    </a>
+                  )}
+                  {frontmatter?.github && (
+                    <a
+                      className={styles.imageLink}
+                      href={frontmatter.github}
+                      title={`View ${frontmatter?.title} on GitHub`}
+                    >
+                      <img src={githubIcon} alt="" />
+                      <span>Github</span>
+                    </a>
+                  )}
+                </div>
+
+                {frontmatter?.status && (
+                  <span className={styles.badge}>
+                    <Badge
+                      variant={
+                        frontmatter.status === 'alpha' ? 'warning' : 'positive'
+                      }
+                    >
+                      {frontmatter.status}
+                    </Badge>
+                  </span>
+                )}
+              </div>
+            </header>
+          )}
+
+          <main>
+            {frontmatter.v4Doc && (
+              <DisplayText as="h1" size="large">
                 {frontmatter.title}
               </DisplayText>
             )}
 
-            <div className={styles.subheaderRow}>
-              <div className={styles.buttonList}>
-                {frontmatter?.storybook && (
-                  <a
-                    className={styles.imageLink}
-                    href={frontmatter.storybook}
-                    title={`View ${frontmatter?.title} in Storybook`}
-                  >
-                    <img src={storybookIcon} alt="" />
-                    <span>Storybook</span>
-                  </a>
-                )}
-                {frontmatter?.github && (
-                  <a
-                    className={styles.imageLink}
-                    href={frontmatter.github}
-                    title={`View ${frontmatter?.title} on GitHub`}
-                  >
-                    <img src={githubIcon} alt="" />
-                    <span>Github</span>
-                  </a>
-                )}
-              </div>
-
-              {frontmatter?.status && (
-                <span className={styles.badge}>
-                  <Badge
-                    variant={
-                      frontmatter.status === 'alpha' ? 'warning' : 'positive'
-                    }
-                  >
-                    {frontmatter.status}
-                  </Badge>
-                </span>
-              )}
-            </div>
-          </header>
-
-          <main>
             <MDXRenderer>{mdxContent}</MDXRenderer>
+
+            {frontmatter.v4Doc && (
+              <>
+                <Heading as="h2" id="help-improve-this-page">
+                  Help improve this page
+                </Heading>
+                <Stack>
+                  <TextLink href={frontmatter.githubUrl} target="_blank">
+                    Edit on Github
+                  </TextLink>
+
+                  <TextLink href="/contributing">
+                    Read the contribution guide
+                  </TextLink>
+                </Stack>
+              </>
+            )}
           </main>
         </MDXProvider>
       </PropsProvider>
@@ -204,7 +194,7 @@ export default function MDXPage({ mdxContent, frontmatter, propsMetadata }) {
   );
 }
 
-MDXPage.propTypes = {
+MDXPageV4.propTypes = {
   mdxContent: PropTypes.string.isRequired,
   frontmatter: PropTypes.shape({
     type: PropTypes.string,

--- a/packages/forma-36-website/src/components/MDXPage.js
+++ b/packages/forma-36-website/src/components/MDXPage.js
@@ -105,8 +105,7 @@ const markToComponentMap = {
 };
 /* eslint-enable react/display-name */
 
-export default function MDXPageV4({ mdxContent, frontmatter, propsMetadata }) {
-  console.log(frontmatter);
+export default function MDXPage({ mdxContent, frontmatter, propsMetadata }) {
   return (
     <Box className={styles.pageContent}>
       <PropsProvider metadata={propsMetadata}>
@@ -194,7 +193,7 @@ export default function MDXPageV4({ mdxContent, frontmatter, propsMetadata }) {
   );
 }
 
-MDXPageV4.propTypes = {
+MDXPage.propTypes = {
   mdxContent: PropTypes.string.isRequired,
   frontmatter: PropTypes.shape({
     type: PropTypes.string,

--- a/packages/forma-36-website/src/components/MDXPage.js
+++ b/packages/forma-36-website/src/components/MDXPage.js
@@ -176,7 +176,7 @@ export default function MDXPage({ mdxContent, frontmatter, propsMetadata }) {
                   Help improve this page
                 </Heading>
                 <Stack>
-                  <TextLink href={frontmatter.githubUrl} target="_blank">
+                  <TextLink href={frontmatter.github} target="_blank">
                     Edit on Github
                   </TextLink>
 
@@ -198,7 +198,7 @@ MDXPage.propTypes = {
   frontmatter: PropTypes.shape({
     type: PropTypes.string,
     title: PropTypes.string,
-    githubUrl: PropTypes.string,
+    github: PropTypes.string,
     storybookUrl: PropTypes.string,
     status: PropTypes.string,
   }).isRequired,

--- a/scripts/plop-templates/package/v4ComponentDoc.mdx.hbs
+++ b/scripts/plop-templates/package/v4ComponentDoc.mdx.hbs
@@ -57,15 +57,3 @@ Optional: Things to avoid
 ## Accessibility
 
 What makes this component accessible
-
-## Help improve this page
-
-<Stack>
-  <TextLink href="https://github.com/contentful/forma-36/tree/master/packages/components/{{packageName}}" target="_blank">
-    Edit on Github
-  </TextLink>
-
-  <TextLink href="/contributing">
-    Read the contribution guide
-  </TextLink>
-</Stack>

--- a/scripts/plop-templates/package/v4ComponentDoc.mdx.hbs
+++ b/scripts/plop-templates/package/v4ComponentDoc.mdx.hbs
@@ -1,0 +1,71 @@
+---
+title: '{{componentName}}'
+type: 'component'
+status: 'stable'
+slug: /components/{{packageName}}/
+github: 'https://github.com/contentful/forma-36/tree/forma-v4/packages/components/{{packageName}}'
+storybook: 'https://f36-storybook.contentful.com/?path=/story/components-{{packageName}}'
+typescript: ./src/{{componentName}}.tsx
+v4Doc: true
+---
+
+import { Stack, TextLink } from '@contentful/f36-components';
+import { Props } from '@contentful/f36-docs-utils';
+
+Short component description covering when it's used. 
+(Optional: give a most common example)
+
+Optional: Most common misuse and what to use instead.
+
+## Table of contents
+
+- [Import](#import)
+- [Examples](#examples)
+  - [Basic usage](#basic-usage)
+- [Props](#props-api-reference)
+- [Content guidelines](#content-guidelines)
+- [Accessibility](#accessibility)
+- [Help improve this page](#help-improve-this-page)
+
+## Import
+
+```jsx static=true
+import { {{componentName}} } from '@contentful/f36-components'
+```
+
+## Examples
+
+Repeat for every important variant
+
+### Example title (variant name)
+
+Optional: Short "when to use" with considerations towards the end user
+
+```jsx
+<{{componentName}}>This is an example</{{componentName}}>
+```
+
+## Props (API reference)
+
+<Props of="{{componentName}}" />
+
+## Content guidelines
+
+At least one important thing to consider when writing copy for this component
+Optional: Things to avoid
+
+## Accessibility
+
+What makes this component accessible
+
+## Help improve this page
+
+<Stack>
+  <TextLink href="https://github.com/contentful/forma-36/tree/master/packages/components/{{packageName}}" target="_blank">
+    Edit on Github
+  </TextLink>
+
+  <TextLink href="/contributing">
+    Read the contribution guide
+  </TextLink>
+</Stack>

--- a/scripts/plop-templates/package/v4ComponentDoc.mdx.hbs
+++ b/scripts/plop-templates/package/v4ComponentDoc.mdx.hbs
@@ -1,7 +1,5 @@
 ---
 title: '{{componentName}}'
-type: 'component'
-status: 'stable'
 slug: /components/{{packageName}}/
 github: 'https://github.com/contentful/forma-36/tree/forma-v4/packages/components/{{packageName}}'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-{{packageName}}'

--- a/scripts/plopfile.js
+++ b/scripts/plopfile.js
@@ -117,4 +117,73 @@ module.exports = function (plop) {
       return actions;
     },
   });
+
+  plop.setGenerator('add documentation with new format', {
+    description:
+      'add a file with the base to write documentation in the new format',
+    prompts: [
+      {
+        type: 'input',
+        name: 'packageName',
+        message:
+          'name of the package to which you want to add documentation, all lowercase (e.g. textfield)',
+        validate: (answer) => answer.length > 0,
+      },
+      {
+        type: 'input',
+        name: 'componentName',
+        message:
+          'component name, please use appropriate uppercase (e.g. TextField)',
+        validate: (answer) => answer.length > 0,
+      },
+    ],
+    actions: function (data) {
+      let { packageName, componentName } = data;
+      let actions = [];
+
+      actions.push({
+        type: 'add',
+        path: `../packages/components/${packageName}/NEW_${componentName}.mdx`,
+        templateFile: './plop-templates/package/v4ComponentDoc.mdx.hbs',
+        // data: { transform },
+      });
+
+      return actions;
+    },
+  });
+
+  plop.setGenerator('convert documentation to new format', {
+    description:
+      'replaces all the content in the Component.mdx file with the new format template',
+    prompts: [
+      {
+        type: 'input',
+        name: 'packageName',
+        message:
+          'name of the package to which you want to add documentation, all lowercase (e.g. textfield)',
+        validate: (answer) => answer.length > 0,
+      },
+      {
+        type: 'input',
+        name: 'componentName',
+        message:
+          'component name, please use appropriate uppercase (e.g. TextField)',
+        validate: (answer) => answer.length > 0,
+      },
+    ],
+    actions: function (data) {
+      let { packageName, componentName } = data;
+      let actions = [];
+
+      actions.push({
+        type: 'modify',
+        templateFile: './plop-templates/package/v4ComponentDoc.mdx.hbs',
+        path: `../packages/components/${packageName}/${componentName}.mdx`,
+        pattern: /(.|\n)*/,
+        data: { componentName, packageName },
+      });
+
+      return actions;
+    },
+  });
 };

--- a/scripts/plopfile.js
+++ b/scripts/plopfile.js
@@ -145,7 +145,6 @@ module.exports = function (plop) {
         type: 'add',
         path: `../packages/components/${packageName}/NEW_${componentName}.mdx`,
         templateFile: './plop-templates/package/v4ComponentDoc.mdx.hbs',
-        // data: { transform },
       });
 
       return actions;


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

The title is a bit misleading, this PR is not updating the current template but it's creating a new template for the new format.

It also creates to new plop actions: "add documentation with new format" and "convert documentation to new format" to help us convert the current pages to the new format

The changes in MDXPage were necessary because we will need to render both formats for a while and I used this PR to fix some spacing inconsistencies in our documentation pages

To know if a page is in the new format or not, MDXPage will check the property `v4Doc` in that mdx's frontmatter

I kept the table of contents the same way it is in the current format because @domarku is still working on this 🙏 

current format:

![Screenshot 2021-11-24 at 17 04 13](https://user-images.githubusercontent.com/6597467/143273956-2ee54ec0-2f80-45b9-88c1-77a8fab8ef4d.png)

new format:

![Screenshot 2021-11-24 at 17 03 55](https://user-images.githubusercontent.com/6597467/143273988-7e762ccd-7067-4766-8e8f-c467ed46737b.png)


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
