### PR TITLE
feat: add docs for deprecated components

### DIFF
--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -163,10 +163,22 @@ module.exports = {
             ],
           },
           {
+            name: 'Dropdown',
+            link: '/deprecated-components/dropdown/',
+          },
+          {
+            name: 'EditorToolbar',
+            link: '/deprecated-components/editor-toolbar',
+            status: 'deprecated',
+          },
+          {
+            name: 'EmptyState',
+            link: '/deprecated-components/empty-state',
+          },
+          {
             name: 'EntityList',
             link: '/components/entity-list/',
           },
-
           {
             name: 'Form Components',
             link: '',
@@ -212,6 +224,10 @@ module.exports = {
           {
             name: 'IconButton',
             link: '/components/icon-button/',
+          },
+          {
+            name: 'Illustration',
+            link: '/deprecated-components/illustration/',
           },
           {
             name: 'Layout Components',
@@ -312,6 +328,14 @@ module.exports = {
             link: '/components/spinner/',
           },
           {
+            name: 'TabFocusTrap',
+            link: '/deprecated-components/tab-focus-trap/',
+          },
+          {
+            name: 'Tag - deprecated',
+            link: '/components/badge/',
+          },
+          {
             name: 'Table',
             link: '/components/table/',
           },
@@ -335,6 +359,10 @@ module.exports = {
             name: 'Typography Components',
             link: '',
             menuLinks: [
+              {
+                name: 'Typography',
+                link: '/deprecated-components/typography/',
+              },
               {
                 name: 'Text',
                 link: '/components/text/',

--- a/packages/forma-36-website/src/components/MDXPage.js
+++ b/packages/forma-36-website/src/components/MDXPage.js
@@ -185,7 +185,11 @@ export default function MDXPage({ mdxContent, frontmatter, propsMetadata }) {
                 <span className={styles.badge}>
                   <Badge
                     variant={
-                      frontmatter.status === 'alpha' ? 'warning' : 'positive'
+                      frontmatter.status === 'alpha'
+                        ? 'warning'
+                        : frontmatter?.status === 'deprecated'
+                        ? 'negative'
+                        : 'positive'
                     }
                   >
                     {frontmatter.status}

--- a/packages/forma-36-website/src/content/deprecated-components/dropdown/index.mdx
+++ b/packages/forma-36-website/src/content/deprecated-components/dropdown/index.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Dropdown'
+status: 'deprecated'
+---
+
+# Dropdown
+
+The Dropdown component in version 4 got replaced with three new components:
+
+- [Menu](https://github.com/contentful/forma-36/blob/forma-v4/packages/components/menu/Menu.mdx),
+- [Autocomplete](https://github.com/contentful/forma-36/blob/forma-v4/packages/components/autocomplete/Autocomplete.mdx)
+- [Popover](https://github.com/contentful/forma-36/blob/forma-v4/packages/components/popover/Popover.mdx).
+
+By creating separate components we improved the accessibility and simplified its API. Each of these new components serves its own purpose.
+[Checkout detailed documentation](https://github.com/contentful/forma-36/blob/forma-v4/MIGRATION.md#dropdown) and learn how to migrate your dropdown component to use new solutions

--- a/packages/forma-36-website/src/content/deprecated-components/editor-toolbar/index.mdx
+++ b/packages/forma-36-website/src/content/deprecated-components/editor-toolbar/index.mdx
@@ -1,0 +1,31 @@
+---
+title: 'Editor Toolbar'
+status: 'deprecated'
+---
+
+# Editor Toolbar
+
+Edito Toolbar component got removed in version 4.
+
+Now instead of using this components:
+
+```tsx static=true
+<EditorToolbar>
+  <EditorToolbarButton
+    icon="FormatBold"
+    tooltip="Bold"
+    label="Bold"
+    isActive={false}
+  />
+</EditorToolbar>
+```
+
+You can have a look on this codesandbox to see how it might be done:
+
+<iframe
+  src="https://codesandbox.io/s/hopeful-worker-ivscb?file=/src/App.js:293-428?autoresize=1&fontsize=14&hidenavigation=1&theme=dark"
+  style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+  title="EditorToolbar"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>

--- a/packages/forma-36-website/src/content/deprecated-components/editor-toolbar/index.mdx
+++ b/packages/forma-36-website/src/content/deprecated-components/editor-toolbar/index.mdx
@@ -5,9 +5,9 @@ status: 'deprecated'
 
 # Editor Toolbar
 
-Edito Toolbar component got removed in version 4.
+Editor Toolbar component got removed in version 4.
 
-Now instead of using this components:
+This is how you were using EditorToolbar in version 3:
 
 ```tsx static=true
 <EditorToolbar>
@@ -20,7 +20,7 @@ Now instead of using this components:
 </EditorToolbar>
 ```
 
-You can have a look on this codesandbox to see how it might be done:
+You can have a look on this codesandbox to see how it might be done in version 4:
 
 <iframe
   src="https://codesandbox.io/s/hopeful-worker-ivscb?file=/src/App.js:293-428?autoresize=1&fontsize=14&hidenavigation=1&theme=dark"

--- a/packages/forma-36-website/src/content/deprecated-components/empty-state/index.mdx
+++ b/packages/forma-36-website/src/content/deprecated-components/empty-state/index.mdx
@@ -7,9 +7,9 @@ status: 'deprecated'
 
 `EmptyState` component got removed in the version 4.
 
-If you are using this component in your project you can refactor to use other exising components.
+If you are using this component in your project you can refactor to use other existing components.
 
-You must migrate exisitng code:
+You must migrate existing code:
 
 ```tsx static=true
 <EmptyState

--- a/packages/forma-36-website/src/content/deprecated-components/empty-state/index.mdx
+++ b/packages/forma-36-website/src/content/deprecated-components/empty-state/index.mdx
@@ -1,0 +1,48 @@
+---
+title: 'Empty state'
+status: 'deprecated'
+---
+
+## Empty State component was removed in version 4
+
+`EmptyState` component got removed in the version 4.
+
+If you are using this component in your project you can refactor to use other exising components.
+
+You must migrate exisitng code:
+
+```tsx static=true
+<EmptyState
+  headingProps={{ text: 'Heading' }}
+  imageProps={{
+    url: 'https://via.placeholder.com/200x200',
+    width: '340px',
+    height: '250px',
+    description: 'Image descriptionProps',
+  }}
+  descriptionProps={{
+    text:
+      'This is a descriptionProps for the empty state. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis vulputate, sem a porttitor porttitor, velit nulla lacinia dolor, sit amet interdum ligula lectus hendrerit sem. Aliquam ultricies viverra tincidunt.',
+  }}
+/>
+```
+
+to:
+
+```tsx
+<Flex flexDirection="column" justifyContent="center" alignItems="center">
+  <Flex flexDirection="column" justifyContent="center" alignItems="center">
+    <img src="https://via.placeholder.com/200x200" alt="Illustration" />
+    <Subheading marginTop="spacingM" marginBottom="spacingM">
+      Heading
+    </Subheading>
+    <Paragraph>
+      {' '}
+      This is a descriptionProps for the empty state. Lorem ipsum dolor sit
+      amet, consectetur adipiscing elit. Duis vulputate, sem a porttitor
+      porttitor, velit nulla lacinia dolor, sit amet interdum ligula lectus
+      hendrerit sem. Aliquam ultricies viverra tincidunt.{' '}
+    </Paragraph>
+  </Flex>
+</Flex>
+```

--- a/packages/forma-36-website/src/content/deprecated-components/illustration/index.mdx
+++ b/packages/forma-36-website/src/content/deprecated-components/illustration/index.mdx
@@ -5,11 +5,11 @@ status: 'deprecated'
 
 # Illustration
 
-In version 4, `Illustration` component got removed. In order to replace this component we recommend to use `<img />` tag or exising in Forma 36 icons.
+In version 4, `Illustration` component got removed. In order to replace this component, we recommend using `<img />` tag or existing in Forma 36 icons.
 
-Icons that were use previously by the `Illustration` component were moved to the `@contentful/f36-icons` packages, so you can still use them in your project. Have a look on the full [overview of icons](https://v4.f36.contentful.com/components/icon/)
+Icons that were used previously by the `Illustration` component were moved to the `@contentful/f36-icons` packages, so you can still use them in your project. Have a look at the full [overview of icons](https://v4.f36.contentful.com/components/icon/)
 
-You can replace exising `Illustration`:
+You can replace existing `Illustration`:
 
 ```tsx static=true
 <Illustration illustration="Archive" />

--- a/packages/forma-36-website/src/content/deprecated-components/illustration/index.mdx
+++ b/packages/forma-36-website/src/content/deprecated-components/illustration/index.mdx
@@ -1,0 +1,22 @@
+---
+title: 'Illustration'
+status: 'deprecated'
+---
+
+# Illustration
+
+In version 4, `Illustration` component got removed. In order to replace this component we recommend to use `<img />` tag.
+
+Icons that were use previously by the `Illustration` component were moved to the `@contentful/f36-icons` packages, so you can still use them in your project. Have a look on the full [overview of icons](https://v4.f36.contentful.com/components/icon/)
+
+You can replace exising `Illustration`:
+
+```tsx static=true
+<Illustration illustration="Archive" />
+```
+
+with:
+
+```tsx static=true
+<ArchiveIcon size="large" variant="secondary" />
+```

--- a/packages/forma-36-website/src/content/deprecated-components/illustration/index.mdx
+++ b/packages/forma-36-website/src/content/deprecated-components/illustration/index.mdx
@@ -5,7 +5,7 @@ status: 'deprecated'
 
 # Illustration
 
-In version 4, `Illustration` component got removed. In order to replace this component we recommend to use `<img />` tag.
+In version 4, `Illustration` component got removed. In order to replace this component we recommend to use `<img />` tag or exising in Forma 36 icons.
 
 Icons that were use previously by the `Illustration` component were moved to the `@contentful/f36-icons` packages, so you can still use them in your project. Have a look on the full [overview of icons](https://v4.f36.contentful.com/components/icon/)
 

--- a/packages/forma-36-website/src/content/deprecated-components/tab-focus-trap/index.mdx
+++ b/packages/forma-36-website/src/content/deprecated-components/tab-focus-trap/index.mdx
@@ -1,0 +1,8 @@
+---
+title: 'TabFocusTrap'
+status: 'deprecated'
+---
+
+# TabFocusTrap
+
+In version 4 `TabFocusTrap` was removed. To handle any cases that might need to trap the focus, we recommend to use [react-focus-lock](https://github.com/theKashey/react-focus-lock)

--- a/packages/forma-36-website/src/content/deprecated-components/tab-focus-trap/index.mdx
+++ b/packages/forma-36-website/src/content/deprecated-components/tab-focus-trap/index.mdx
@@ -5,4 +5,4 @@ status: 'deprecated'
 
 # TabFocusTrap
 
-In version 4 `TabFocusTrap` was removed. To handle any cases that might need to trap the focus, we recommend to use [react-focus-lock](https://github.com/theKashey/react-focus-lock)
+In version 4 `TabFocusTrap` was removed. To handle any cases that might need to trap the focus, we recommend using [react-focus-lock](https://github.com/theKashey/react-focus-lock)

--- a/packages/forma-36-website/src/content/deprecated-components/typography/index.mdx
+++ b/packages/forma-36-website/src/content/deprecated-components/typography/index.mdx
@@ -5,8 +5,8 @@ status: 'deprecated'
 
 # Typography
 
-Typography component was removed in version 4. The main reason for this component was to mantain the spacing between typography components. In version 4 we gave this possiblity to each, individual typography component.
-Right now istead of wrapping your typography in `Typography` component, you can just set margin value to each insividual typography componennts.
+`Typography` component was removed in version 4. The main reason for this component was to maintain the spacing between typography components. In version 4 we gave this possibility to each, individual typography component.
+Right now instead of wrapping your typography in `Typography` component, you can just set margin value to each individual typography components.
 
 You might have used `Typography` in version 3 like that:
 

--- a/packages/forma-36-website/src/content/deprecated-components/typography/index.mdx
+++ b/packages/forma-36-website/src/content/deprecated-components/typography/index.mdx
@@ -1,0 +1,27 @@
+---
+title: 'Typography'
+status: 'deprecated'
+---
+
+# Typography
+
+Typography component was removed in version 4. The main reason for this component was to mantain the spacing between typography components. In version 4 we gave this possiblity to each, individual typography component.
+Right now istead of wrapping your typography in `Typography` component, you can just set margin value to each insividual typography componennts.
+
+You might have used `Typography` in version 3 like that:
+
+```tsx static=true
+<Typography>
+  <Heading element="h4" className="className">
+    Some text
+  </Heading>
+</Typography>
+```
+
+All you need to do is to use this components directly, without a wrapper:
+
+```tsx static=true
+<Heading as="h4" className="className">
+  Some text
+</Heading>
+```


### PR DESCRIPTION
Adding docs for components that got removed in v4.

2 more missing:
 - Portal
 - InViewport
 
 Those will be done in the next PR.
 
 Idea for separate PR: maybe we could add Badge to the navigation items to indicate components that got removed? WDYT?