### PR TITLE
fix(forma-36-website): remove extra back-ticks

### DIFF
--- a/packages/forma-36-website/src/content/getting-started.mdx
+++ b/packages/forma-36-website/src/content/getting-started.mdx
@@ -17,7 +17,7 @@ npm i @contentful/f36-components
 **When using Yarn:**
 
 ```bash static=true
-yarn add @contentful/f36-components`
+yarn add @contentful/f36-components
 ```
 
 When you install `@contentful/f36-components` package, tree shaking will make your bundle contain only components that you actually import and need.
@@ -35,7 +35,7 @@ npm i @contentful/f36-button
 **When using Yarn:**
 
 ```bash static=true
-yarn add @contentful/f36-button`
+yarn add @contentful/f36-button
 ```
 
 ### Install icons
@@ -51,7 +51,7 @@ npm i @contentful/f36-icons
 **When using Yarn:**
 
 ```bash static=true
-yarn add @contentful/f36-icons`
+yarn add @contentful/f36-icons
 ```
 
 #### Additional learning


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
