### PR TITLE
fix: input related components fixes

### DIFF
--- a/packages/components/forms/src/counter/Counter.styles.ts
+++ b/packages/components/forms/src/counter/Counter.styles.ts
@@ -1,0 +1,11 @@
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+export function getCounterStyles() {
+  return {
+    root: css({
+      flexShrink: 0,
+      paddingLeft: tokens.spacingM,
+    }),
+  };
+}

--- a/packages/components/forms/src/counter/Counter.tsx
+++ b/packages/components/forms/src/counter/Counter.tsx
@@ -1,14 +1,18 @@
 import React, { forwardRef } from 'react';
+import { cx } from 'emotion';
 import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 import { Text } from '@contentful/f36-typography';
+import { getCounterStyles } from './Counter.styles';
 
 import { useFormControl } from '../form-control/FormControlContext';
 
 export type CounterProps = PropsWithHTMLElement<CommonProps, 'p'>;
 
 export const Counter = forwardRef<HTMLParagraphElement, CounterProps>(
-  ({ testId = 'cf-ui-counter', ...otherProps }, ref) => {
+  ({ testId = 'cf-ui-counter', className, ...otherProps }, ref) => {
     const { maxLength, inputValue } = useFormControl({});
+    const styles = getCounterStyles();
+
     return (
       Boolean(maxLength) && (
         <Text
@@ -18,6 +22,7 @@ export const Counter = forwardRef<HTMLParagraphElement, CounterProps>(
           testId={testId}
           marginTop="spacingXs"
           {...otherProps}
+          className={cx(styles.root, className)}
           ref={ref}
         >
           {inputValue.length} / {maxLength}

--- a/packages/components/forms/src/text-input/input-group/InputGroup.styles.ts
+++ b/packages/components/forms/src/text-input/input-group/InputGroup.styles.ts
@@ -8,20 +8,20 @@ const getInputGroupStyle = ({ spacing }) => {
   }
 
   return {
-    '& *': {
+    '& button, & input': {
       borderRadius: '0 !important',
     },
     '& > *': {
       marginRight: '-1px !important',
       zIndex: tokens.zIndexDefault,
-      '&:not(: focus)': {
+      '&:not(:focus), & button:not(:focus)': {
         boxShadow: 'none !important',
       },
-      '&:first-child, &:first-child > input': {
+      '&:first-child, &:first-child > input, &:first-child button': {
         borderBottomLeftRadius: `${tokens.borderRadiusMedium} !important`,
         borderTopLeftRadius: `${tokens.borderRadiusMedium} !important`,
       },
-      '&:last-child, &:last-child > input': {
+      '&:last-child, &:last-child > input, &:last-child button': {
         borderBottomRightRadius: `${tokens.borderRadiusMedium} !important`,
         borderTopRightRadius: `${tokens.borderRadiusMedium} !important`,
         marginRight: '0 !important',

--- a/packages/components/forms/stories/InputGroup.stories.tsx
+++ b/packages/components/forms/stories/InputGroup.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { IconButton, Button } from '@contentful/f36-button';
 import { LockIcon } from '@contentful/f36-icons';
 import { SectionHeading } from '@contentful/f36-typography';
+import { Tooltip } from '@contentful/f36-tooltip';
 import { Flex } from '@contentful/f36-core';
 import { TextInput, InputGroupProps } from '../src';
 
@@ -157,6 +158,25 @@ export const Overview = () => {
             icon={<LockIcon />}
             aria-label="Lock"
           />
+        </TextInput.Group>
+      </Flex>
+      <SectionHeading as="h3" marginBottom="spacingS">
+        With button wrapped in tooltip
+      </SectionHeading>
+      <Flex marginBottom="spacingM" fullWidth>
+        <TextInput.Group>
+          <TextInput
+            aria-label="Text Input"
+            id="TextInput4"
+            defaultValue="Some value"
+          />
+          <Tooltip content="Tooltip text">
+            <IconButton
+              variant="secondary"
+              icon={<LockIcon />}
+              aria-label="Lock"
+            />
+          </Tooltip>
         </TextInput.Group>
       </Flex>
     </Flex>

--- a/yarn.lock
+++ b/yarn.lock
@@ -26056,6 +26056,15 @@ read-package-tree@^5.1.6, read-package-tree@^5.3.1:
     readdir-scoped-modules "^1.0.0"
     util-promisify "^2.1.0"
 
+read-pkg-up@7.0.1, read-pkg-up@^7.0.0, read-pkg-up@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
+  integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
+  dependencies:
+    find-up "^4.1.0"
+    read-pkg "^5.2.0"
+    type-fest "^0.8.1"
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -26079,15 +26088,6 @@ read-pkg-up@^3.0.0:
   dependencies:
     find-up "^2.0.0"
     read-pkg "^3.0.0"
-
-read-pkg-up@^7.0.0, read-pkg-up@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
-  integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
-  dependencies:
-    find-up "^4.1.0"
-    read-pkg "^5.2.0"
-    type-fest "^0.8.1"
 
 read-pkg@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
# Purpose of PR
1. Make the counter not shrinking, when the input help text is too long.
2. Adjust `InputGroup` styles to accept wrapped buttons. For example, a button wrapped in our `Tooltip`.
