### PR TITLE
fix: fix issue with padding for cards

### DIFF
--- a/packages/components/card/src/asset-card/AssetCard.styles.ts
+++ b/packages/components/card/src/asset-card/AssetCard.styles.ts
@@ -21,9 +21,6 @@ export const getAssetCardStyles = () => {
             : `calc(1rem * (300 / ${tokens.fontBaseDefault}))`,
         padding: 0,
         textAlign: 'center',
-        '[data-card-part="content"]': {
-          padding: 0,
-        },
       };
 
       return css(styles);

--- a/packages/components/card/src/base-card/BaseCard.styles.ts
+++ b/packages/components/card/src/base-card/BaseCard.styles.ts
@@ -7,9 +7,6 @@ export const getBaseCardStyles = () => {
     contentBody: css({
       gridColumn: 'content',
       gridRow: 'content',
-      paddingBottom: tokens.spacingM,
-      paddingLeft: tokens.spacingM,
-      paddingRight: tokens.spacingM,
       whiteSpace: 'initial',
     }),
     wrapper: css({

--- a/packages/components/card/src/card/Card.styles.ts
+++ b/packages/components/card/src/card/Card.styles.ts
@@ -21,8 +21,5 @@ export const getCardStyles = ({ padding }) => ({
   }),
   root: css({
     padding: getCardPaddingValue(padding),
-    '[data-card-part="content"]': {
-      padding: 0,
-    },
   }),
 });

--- a/packages/components/card/src/entry-card/EntryCard.styles.ts
+++ b/packages/components/card/src/entry-card/EntryCard.styles.ts
@@ -19,6 +19,11 @@ export const getEntryCardStyles = () => {
       }),
     root: css({
       padding: 0,
+      '[data-card-part="content"]': {
+        paddingBottom: tokens.spacingM,
+        paddingLeft: tokens.spacingM,
+        paddingRight: tokens.spacingM,
+      },
     }),
     header: css({
       borderBottomWidth: 1,

--- a/packages/components/card/src/inline-entry-card/InlineEntryCard.styles.ts
+++ b/packages/components/card/src/inline-entry-card/InlineEntryCard.styles.ts
@@ -25,9 +25,6 @@ export const getInlineEntryCardStyles = () => {
         paddingTop: 0,
         paddingLeft: tokens.spacingS,
         paddingRight: tokens.spacing2Xs,
-        '[data-card-part="content"]': {
-          padding: 0,
-        },
         '[data-card-part="wrapper"]': {
           display: 'inline-flex',
           flexDirection: 'row-reverse',


### PR DESCRIPTION
So there was an issue with paddings for cards reported. 👀 

![Screenshot 2021-12-07 at 15 33 56](https://user-images.githubusercontent.com/4272331/145099535-90ae9f2c-3609-46f9-9540-2953f83ca925.png)

In general styling for cards seems complex and for some reason, I have a feeling it might bring more issues in the future, if we would like to extend API for example. Maybe we should have a look at the API of cards and think of a slightly different approach. I don't have anything specific in mind, but maybe it's worth having a deeper look. (Forma 36 4.1 ?)
This PR might fix the issue at the moment, I am not sure if I am not forgetting about some use cases 🤔 Maybe some examples are not added in the overviews for each card. dunno. WDYT?

Also, interesting thing brought by @gui-santos , this issue is right now not visible in storybook for EntryCard, which is very confusing, since we can see it in prod, or when you reproduce the component on the website. which brings me to the question: why we couldn’t rely on the storybook for that case?