### PR TITLE
[BAU-345] docs: it creates a page for entry card

### DIFF
--- a/packages/components/card/src/entry-card/EntryCard.mdx
+++ b/packages/components/card/src/entry-card/EntryCard.mdx
@@ -1,0 +1,169 @@
+---
+title: 'EntryCard'
+slug: /components/entry-card/
+github: 'https://github.com/contentful/forma-36/tree/forma-v4/packages/components/card/src/entry-card'
+typescript: ./EntryCard.tsx
+v4Doc: true
+---
+
+import { Heading, Stack, TextLink } from '@contentful/f36-components';
+import { ExternalLinkIcon } from '@contentful/f36-icons';
+import { Props } from '@contentful/f36-docs-utils';
+
+The EntryCard component is built on top of the [Card component](/components/card) and it provides more props
+to help you manage the entries of your Contentful implementation.
+
+## Table of contents
+
+- [Import](#import)
+- [Examples](#examples)
+  - [Basic usage](#basic-usage)
+- [Props](#props-api-reference)
+- [Content guidelines](#content-guidelines)
+- [Accessibility](#accessibility)
+- [Help improve this page](#help-improve-this-page)
+
+## Import
+
+```jsx static=true
+import { EntryCard } from '@contentful/f36-components';
+// or
+import { EntryCard } from '@contentful/f36-card';
+```
+
+## Examples
+
+The two main props to show the content of your entry are `title` and `desciption`.
+It’s also possible to pass the Entry’s content type in the `contentType` prop.
+To show a badge with the status of the entry,
+you can pass one of "archived", "changed", "deleted", "draft", "new", or "published" to the `status` prop.
+
+### Basic usage
+
+```jsx
+<EntryCard
+  status="published"
+  contentType="Author"
+  title="John Doe"
+  description="Research and recommendations for modern stack websites."
+/>
+```
+
+### Clickble card
+
+Like the `Card` component, it’s possible to pass a function to the `onClick` prop
+and it will be called when the user clicks on the card.
+
+```jsx
+<EntryCard
+  status="published"
+  contentType="Author"
+  title="John Doe"
+  description="Research and recommendations for modern stack websites."
+  onClick={() => alert('click')}
+/>
+```
+
+### Card actions
+
+To show a `...` button in the card pass an array of `MenuItem` components
+
+```jsx
+<EntryCard
+  status="published"
+  contentType="Author"
+  title="John Doe"
+  description="Research and recommendations for modern stack websites."
+  actions={[
+    <MenuItem key="copy" onClick={() => alert('copy')}>
+      Copy
+    </MenuItem>,
+    <MenuItem key="delete" onClick={() => alert('delete')}>
+      Delete
+    </MenuItem>,
+  ]}
+/>
+```
+
+### Loading state
+
+```jsx
+<EntryCard
+  status="published"
+  contentType="Author"
+  title="John Doe"
+  description="Research and recommendations for modern stack websites."
+  isLoading
+/>
+```
+
+### Different sizes
+
+```jsx
+<Stack flexDirection="column">
+  <EntryCard
+    status="published"
+    contentType="Author"
+    title="John Doe"
+    description="Research and recommendations for modern stack websites."
+    size="small"
+  />
+  <EntryCard
+    status="published"
+    contentType="Author"
+    title="John Doe"
+    description="Research and recommendations for modern stack websites."
+    size="default"
+  />
+</Stack>
+```
+
+### With a drag handle
+
+```jsx
+<EntryCard
+  status="published"
+  contentType="Author"
+  title="John Doe"
+  description="Research and recommendations for modern stack websites."
+  withDragHandle
+/>
+```
+
+### With a thumbnail
+
+```jsx
+<EntryCard
+  status="published"
+  contentType="Author"
+  title="John Doe"
+  description="Research and recommendations for modern stack websites."
+  thumbnailElement={<img src="https://picsum.photos/200" />}
+/>
+```
+
+<Stack justifyContent="space-between" marginTop="spacing2Xl" marginBottom="spacingL">
+  <Heading id="props-api-reference" as="h2" marginTop="none" marginBottom="none">
+    Props (API reference)
+  </Heading>
+
+  <TextLink
+    href="https://v4-f36-storybook.netlify.app/?path=/story/components-card-entrycard"
+    target="_blank"
+    alignIcon="end"
+    icon={<ExternalLinkIcon />}
+  >
+    Open in Storybook
+  </TextLink>
+</Stack>
+
+<Props of="EntryCard" />
+
+## Content guidelines
+
+Since this is a very opinionated component, we recommend using it only to show your entries.
+Similar to how references are shown in Contentful.
+
+## Accessibility
+
+It inherits the accessibility features of [Card](/components/card)

--- a/packages/components/card/src/entry-card/EntryCard.mdx
+++ b/packages/components/card/src/entry-card/EntryCard.mdx
@@ -18,6 +18,12 @@ to help you manage the entries of your Contentful implementation.
 - [Import](#import)
 - [Examples](#examples)
   - [Basic usage](#basic-usage)
+  - [Clickable card](#clickable-card)
+  - [Card actions](#card-actions)
+  - [Loading state](#loading-state)
+  - [Different sizes](#different-sizes)
+  - [With a drag handle](#with-a-drag-handle)
+  - [With a thumbnail](#with-a-thumbnail)
 - [Props](#props-api-reference)
 - [Content guidelines](#content-guidelines)
 - [Accessibility](#accessibility)
@@ -49,7 +55,7 @@ you can pass one of "archived", "changed", "deleted", "draft", "new", or "publis
 />
 ```
 
-### Clickble card
+### Clickable card
 
 Like the `Card` component, it’s possible to pass a function to the `onClick` prop
 and it will be called when the user clicks on the card.
@@ -66,7 +72,7 @@ and it will be called when the user clicks on the card.
 
 ### Card actions
 
-To show a `...` button in the card pass an array of `MenuItem` components
+To show a `...` button with a menu in the card, pass an array of `MenuItem` components
 
 ```jsx
 <EntryCard

--- a/packages/components/card/stories/EntryCard.stories.tsx
+++ b/packages/components/card/stories/EntryCard.stories.tsx
@@ -65,6 +65,8 @@ tools and guidance for digital teams building and extending
 Contentful products.`;
 
 export const Overview: Story<EntryCardProps> = () => {
+  const sizes: EntryCardProps['size'][] = ['default', 'small'];
+
   return (
     <>
       <Flex flexDirection="column" gap="spacingL">
@@ -73,14 +75,14 @@ export const Overview: Story<EntryCardProps> = () => {
             Default
           </SectionHeading>
 
-          {['default', 'small'].map((size) => (
+          {sizes.map((size) => (
             <EntryCard
               key={size}
               icon={<ClockIcon />}
               thumbnailElement={thumbnail}
               title="Forma 36"
               contentType="Design system"
-              size={size as any}
+              size={size}
             />
           ))}
         </Flex>
@@ -90,7 +92,7 @@ export const Overview: Story<EntryCardProps> = () => {
             Hover
           </SectionHeading>
 
-          {['default', 'small'].map((size) => (
+          {sizes.map((size) => (
             <EntryCard
               key={size}
               as="a"
@@ -105,7 +107,7 @@ export const Overview: Story<EntryCardProps> = () => {
               title="Forma 36"
               description={description}
               contentType="Design system"
-              size={size as any}
+              size={size}
             />
           ))}
         </Flex>
@@ -115,7 +117,7 @@ export const Overview: Story<EntryCardProps> = () => {
             Selected
           </SectionHeading>
 
-          {['default', 'small'].map((size) => (
+          {sizes.map((size) => (
             <EntryCard
               key={size}
               isSelected
@@ -124,7 +126,7 @@ export const Overview: Story<EntryCardProps> = () => {
               description={description}
               contentType="Design system"
               withDragHandle
-              size={size as any}
+              size={size}
             />
           ))}
         </Flex>

--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -137,8 +137,18 @@ module.exports = {
             link: '/components/button-group',
           },
           {
-            name: 'Card',
-            link: '/components/card/',
+            name: 'Card Components',
+            link: '',
+            menuLinks: [
+              {
+                name: 'Card',
+                link: '/components/card/',
+              },
+              {
+                name: 'EntryCard',
+                link: '/components/entry-card/',
+              },
+            ],
           },
           {
             name: 'CopyButton',


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

![Screenshot 2021-12-08 at 10 27 10](https://user-images.githubusercontent.com/6597467/145183476-7d1385ee-5479-43bd-b14a-3c52e6a3a2c1.png)

Besides adding a page for EntryCard, this PR creates a `Card Components` section with both Card and EntryCard in it. I suggested to add the documentation for the other "card" components in this place

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
