### PR TITLE
[BAU-482] docs: add documentation page for asset card

### DIFF
--- a/packages/components/card/src/asset-card/AssetCard.mdx
+++ b/packages/components/card/src/asset-card/AssetCard.mdx
@@ -1,0 +1,147 @@
+---
+title: 'AssetCard'
+slug: /components/asset-card/
+github: 'https://github.com/contentful/forma-36/tree/forma-v4/packages/components/card/src/asset-card'
+typescript: ./AssetCard.tsx
+v4Doc: true
+---
+
+import { Heading, Stack, TextLink } from '@contentful/f36-components';
+import { ExternalLinkIcon } from '@contentful/f36-icons';
+import { Props } from '@contentful/f36-docs-utils';
+
+The AssetCard component is built on top of the [Card component](/components/card) and it provides more props
+to help you manage the assets of your Contentful implementation.
+
+## Table of contents
+
+- [Import](#import)
+- [Examples](#examples)
+  - [Basic usage](#basic-usage)
+  - [Card actions](#card-actions)
+  - [Loading state](#loading-state)
+  - [Different sizes](#different-sizes)
+- [Props](#props-api-reference)
+- [Content guidelines](#content-guidelines)
+- [Accessibility](#accessibility)
+- [Help improve this page](#help-improve-this-page)
+
+## Import
+
+```jsx static=true
+import { AssetCard } from '@contentful/f36-components';
+// or
+import { AssetCard } from '@contentful/f36-card';
+```
+
+## Examples
+
+The main props to show the content of your asset are `title` and `src`.
+They both accept strings as values and `src` needs the url of the asset’s location.
+To show a badge with the status of the entry,
+you can pass one of "archived", "changed", "deleted", "draft", "new", or "published" to the `status` prop.
+
+It’s also possible to pass the Asset’s type to the `type` prop. The allowed values are:
+
+- archive
+- audio
+- code
+- image
+- markup
+- pdf
+- plaintext
+- presentation
+- richtext
+- spreadsheet
+- video
+
+### Basic usage
+
+```jsx
+<AssetCard
+  status="published"
+  type="image"
+  title="Everest"
+  src="https://bit.ly/31yL3Ps"
+/>
+```
+
+### Card actions
+
+To show a `...` button with a menu in the card, pass an array of `MenuItem` components
+
+```jsx
+<AssetCard
+  status="published"
+  type="image"
+  title="Everest"
+  src="https://bit.ly/31yL3Ps"
+  actions={[
+    <MenuItem key="copy" onClick={() => alert('copy')}>
+      Copy
+    </MenuItem>,
+    <MenuItem key="delete" onClick={() => alert('delete')}>
+      Delete
+    </MenuItem>,
+  ]}
+/>
+```
+
+### Loading state
+
+```jsx
+<AssetCard
+  status="published"
+  type="image"
+  title="Everest"
+  src="https://bit.ly/31yL3Ps"
+  isLoading
+/>
+```
+
+### Different sizes
+
+```jsx
+<Stack>
+  <AssetCard
+    status="published"
+    type="image"
+    title="Everest"
+    src="https://bit.ly/31yL3Ps"
+    size="small"
+  />
+  <AssetCard
+    status="published"
+    type="image"
+    title="Everest"
+    src="https://bit.ly/31yL3Ps"
+    size="default"
+  />
+</Stack>
+```
+
+<Stack justifyContent="space-between" marginTop="spacing2Xl" marginBottom="spacingL">
+  <Heading id="props-api-reference" as="h2" marginTop="none" marginBottom="none">
+    Props (API reference)
+  </Heading>
+
+  <TextLink
+    href="https://v4-f36-storybook.netlify.app/?path=/story/components-card-assetcard"
+    target="_blank"
+    alignIcon="end"
+    icon={<ExternalLinkIcon />}
+  >
+    Open in Storybook
+  </TextLink>
+</Stack>
+
+<Props of="AssetCard" />
+
+## Content guidelines
+
+Since this is a very opinionated component, we recommend using it only to show your assets.
+Similar to how assets are shown in Contentful's fields or in rich text.
+
+## Accessibility
+
+It inherits the accessibility features of [Card](/components/card)

--- a/packages/forma-36-website/gatsby-config.js
+++ b/packages/forma-36-website/gatsby-config.js
@@ -141,6 +141,10 @@ module.exports = {
             link: '',
             menuLinks: [
               {
+                name: 'AssetCard',
+                link: '/components/asset-card/',
+              },
+              {
                 name: 'Card',
                 link: '/components/card/',
               },


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

![Screenshot 2021-12-08 at 15 29 27](https://user-images.githubusercontent.com/6597467/145225838-6f622056-16d7-4e9c-9be2-b000877b6eb3.png)

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
