### PR TITLE
[BAU-496] fix: autocomplete screen reader now reads the items

### DIFF
--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -219,6 +219,7 @@ function _Autocomplete<ItemType>(
         // and the user won't be able to type in the input
         // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus={false}
+        id={menuProps.id}
       >
         <Popover.Trigger>
           <div {...comboboxProps} className={styles.combobox}>
@@ -301,7 +302,7 @@ function _Autocomplete<ItemType>(
                   >
                     {group.groupTitle}
                   </SectionHeading>
-                  <AutocompleteItems
+                  <AutocompleteItems<ItemType>
                     items={group.options}
                     highlightedIndex={highlightedIndex}
                     getItemProps={getItemProps}
@@ -318,7 +319,7 @@ function _Autocomplete<ItemType>(
           {!isLoading &&
             !isUsingGroups(isGrouped, items) &&
             items.length > 0 && (
-              <AutocompleteItems
+              <AutocompleteItems<ItemType>
                 items={items}
                 elementStartIndex={elementStartIndex}
                 highlightedIndex={highlightedIndex}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

When using screen reader, it should read the items when they are selected

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
