### PR TITLE
fix(modal): add props to modal examples and add focus state for tabs

### DIFF
--- a/packages/components/modal/src/Modal.mdx
+++ b/packages/components/modal/src/Modal.mdx
@@ -47,7 +47,13 @@ function ModalExample() {
   return (
     <React.Fragment>
       <Button onClick={() => setShown(true)}>Show centered modal</Button>
-      <Modal title="Centered modal" isShown={isShown}>
+      <Modal
+        onClose={() => setShown(false)}
+        shouldCloseOnOverlayClick
+        shouldCloseOnEscapePress
+        title="Centered modal"
+        isShown={isShown}
+      >
         {() => (
           <React.Fragment>
             <Modal.Header title="Title" onClose={() => setShown(false)} />
@@ -103,7 +109,14 @@ function ModalExample() {
           Show center modal
         </Button>
       </Form>
-      <Modal title="Centered modal" isShown={isShown} position={position}>
+      <Modal
+        onClose={() => setShown(false)}
+        shouldCloseOnOverlayClick
+        shouldCloseOnEscapePress
+        title="Centered modal"
+        isShown={isShown}
+        position={position}
+      >
         {() => (
           <React.Fragment>
             <Modal.Header title="Title" onClose={() => setShown(false)} />
@@ -157,7 +170,14 @@ function ModalExample() {
           Show modal
         </Button>
       </Form>
-      <Modal title="Centered modal" isShown={isShown} size={size}>
+      <Modal
+        onClose={() => setShown(false)}
+        shouldCloseOnOverlayClick
+        shouldCloseOnEscapePress
+        title="Centered modal"
+        isShown={isShown}
+        size={size}
+      >
         {() => (
           <React.Fragment>
             <Modal.Header title="Title" onClose={() => setShown(false)} />

--- a/packages/components/tabs/src/Tabs.styles.ts
+++ b/packages/components/tabs/src/Tabs.styles.ts
@@ -20,7 +20,7 @@ const styles = {
     border: 'none',
     cursor: 'pointer',
     outline: 'none',
-    '&:focus-visible &:focus': {
+    '&:focus-visible': {
       boxShadow: tokens.glowPrimary,
     },
     '&:before': {

--- a/packages/components/tabs/src/Tabs.styles.ts
+++ b/packages/components/tabs/src/Tabs.styles.ts
@@ -20,7 +20,7 @@ const styles = {
     border: 'none',
     cursor: 'pointer',
     outline: 'none',
-    '&:focus-visible': {
+    '&:focus-visible, &[aria-selected="true"]': {
       boxShadow: tokens.glowPrimary,
     },
     '&:before': {

--- a/packages/components/tabs/src/Tabs.styles.ts
+++ b/packages/components/tabs/src/Tabs.styles.ts
@@ -20,7 +20,7 @@ const styles = {
     border: 'none',
     cursor: 'pointer',
     outline: 'none',
-    '&:focus-visible, &[aria-selected="true"]': {
+    '&:focus-visible &:focus': {
       boxShadow: tokens.glowPrimary,
     },
     '&:before': {

--- a/packages/components/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/components/tooltip/stories/Tooltip.stories.tsx
@@ -21,7 +21,7 @@ export default {
 export const Basic = (args: { content: string }) => {
   return (
     <Tooltip {...args}>
-      <TextLink>Hover me</TextLink>
+      <TextLink href="/">Hover me</TextLink>
     </Tooltip>
   );
 };
@@ -62,7 +62,7 @@ export const AutoPlacement = (args: { content: string }) => {
         }}
       >
         <Tooltip {...args}>
-          <TextLink>Hover me</TextLink>
+          <TextLink href="/">Hover me</TextLink>
         </Tooltip>
       </div>
     </div>
@@ -100,7 +100,9 @@ export const Overview = () => {
       </SectionHeading>
       <Flex marginBottom="spacingS">
         <Tooltip content="I am a Tooltip 🙌" maxWidth={360} placement="top">
-          <TextLink isDisabled>Hover me</TextLink>
+          <TextLink href="/" isDisabled>
+            Hover me
+          </TextLink>
         </Tooltip>
       </Flex>
 
@@ -115,7 +117,9 @@ export const Overview = () => {
           placement="left"
           isVisible
         >
-          <TextLink isDisabled={false}>Hover me</TextLink>
+          <TextLink href="/" isDisabled={false}>
+            Hover me
+          </TextLink>
         </Tooltip>
       </Flex>
 
@@ -130,7 +134,9 @@ export const Overview = () => {
           placement="right"
           isVisible
         >
-          <TextLink isDisabled={false}>Hover me</TextLink>
+          <TextLink href="/" isDisabled={false}>
+            Hover me
+          </TextLink>
         </Tooltip>
       </Flex>
 
@@ -145,7 +151,9 @@ export const Overview = () => {
           placement="top"
           isVisible
         >
-          <TextLink isDisabled={false}>Hover me</TextLink>
+          <TextLink href="/" isDisabled={false}>
+            Hover me
+          </TextLink>
         </Tooltip>
       </Flex>
 
@@ -160,7 +168,9 @@ export const Overview = () => {
           placement="bottom"
           isVisible
         >
-          <TextLink isDisabled={false}>Hover me</TextLink>
+          <TextLink href="/" isDisabled={false}>
+            Hover me
+          </TextLink>
         </Tooltip>
       </Flex>
     </>


### PR DESCRIPTION
# Purpose of PR

- add 'shouldCloseOnOverlayClick' and 'shouldCloseOnEscapePress' props to Modal examples
- Add visual focused state for Tab (focus state was missing on the active state)

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
