### PR TITLE
feat: nextjs props types context

### DIFF
--- a/packages/components/datetime/DateTimeUtils.mdx
+++ b/packages/components/datetime/DateTimeUtils.mdx
@@ -4,7 +4,6 @@ type: 'component'
 status: 'stable'
 slug: /components/datetime-functions/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/datetime/src/utils'
-typescript: ./src/utils/index.ts
 ---
 
 The `@contentful/f36-datetime` package provides a couple of functions to format a date following [Forma 36 guidelines](https://f36.contentful.com/guidelines/date-and-time/).

--- a/packages/f36-docs-utils/src/Props/PropsContext.ts
+++ b/packages/f36-docs-utils/src/Props/PropsContext.ts
@@ -1,10 +1,6 @@
 import { createContext, useContext } from 'react';
 import type { PropComponentDefinition } from './types';
 
-// List of props that we do not need to show
-// because they are, basically, inherited props from HTML elements or React
-const propsToHide = ['ref', 'key', 'style'];
-
 export type PropsContextType = {
   [key: string]: PropComponentDefinition;
 };
@@ -31,14 +27,9 @@ export function usePropsOf(componentName: string) {
   }
 
   const { props } = propsContext[componentName];
-  const allProps = Object.values(props)
-    .filter(
-      // We filter out the props that come from @types/react definitions and/or are HTML elements
-      (prop) =>
-        !prop.parent?.fileName.includes('@types/react/index.d.ts') &&
-        !propsToHide.includes(prop.name),
-    )
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const allProps = Object.values(props).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
 
   const requiredProps = [];
   const optionalProps = [];

--- a/packages/f36-docs-utils/src/Props/index.ts
+++ b/packages/f36-docs-utils/src/Props/index.ts
@@ -1,2 +1,7 @@
 export { Props } from './Props';
 export { PropsContextProvider, usePropsContext } from './PropsContext';
+export type {
+  PropType,
+  PropDefinition,
+  PropComponentDefinition,
+} from './types';

--- a/packages/f36-docs-utils/src/index.ts
+++ b/packages/f36-docs-utils/src/index.ts
@@ -1,2 +1,2 @@
-export { Props, PropsContextProvider } from './Props';
-export { PropsHeading } from './PropsHeading';
+export * from './Props';
+export * from './PropsHeading';

--- a/packages/website/components/MdxRenderer.tsx
+++ b/packages/website/components/MdxRenderer.tsx
@@ -14,6 +14,7 @@ import {
   TableRow,
   TextLink,
 } from '@contentful/f36-components';
+import { Props, PropsHeading } from '@contentful/f36-docs-utils';
 
 /* eslint-disable react/display-name */
 const components = {
@@ -41,6 +42,9 @@ const components = {
   tr: (props) => <TableRow {...props} />,
   th: (props) => <TableCell style={{ textAlign: 'left' }} {...props} />,
   td: (props) => <TableCell {...props} />,
+
+  Props,
+  PropsHeading,
 };
 /* eslint-enable react/display-name */
 

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -24,7 +24,8 @@
     "rehype-autolink-headings": "^5.0.1",
     "rehype-slug": "^4.0.1",
     "remark": "^14.0.2",
-    "remark-code-titles": "^0.1.1"
+    "remark-code-titles": "^0.1.1",
+    "react-docgen-typescript": "^2.2.2"
   },
   "devDependencies": {
     "@emotion/babel-preset-css-prop": "^10.2.1",

--- a/packages/website/pages/[...slug].tsx
+++ b/packages/website/pages/[...slug].tsx
@@ -8,8 +8,10 @@ import { serialize } from 'next-mdx-remote/serialize';
 import { MdxRenderer } from '../components/MdxRenderer';
 import { MDXRemoteSerializeResult } from 'next-mdx-remote';
 import { css } from 'emotion';
+import { PropsContextProvider } from '@contentful/f36-docs-utils';
 
 import { getMdxPaths, getMdxSourceBySlug } from '../utils/content';
+import { getPropsMetadata } from '../utils/propsMeta';
 
 const styles = {
   root: css({
@@ -26,10 +28,12 @@ type ComponentPageProps = {
   frontMatter: {
     title: string;
   };
+  propsMetadata: ReturnType<typeof getPropsMetadata>;
 };
 
 export default function ComponentPage(props: ComponentPageProps) {
   const router = useRouter();
+
   if (router.isFallback) {
     return <ErrorPage statusCode={404} />;
   }
@@ -42,7 +46,9 @@ export default function ComponentPage(props: ComponentPageProps) {
       <article className={styles.root}>
         <h1>{props.frontMatter.title}</h1>
         <div>
-          <MdxRenderer source={props.source} />
+          <PropsContextProvider value={{ ...props.propsMetadata }}>
+            <MdxRenderer source={props.source} />
+          </PropsContextProvider>
         </div>
       </article>
     </>
@@ -71,10 +77,13 @@ export async function getStaticProps(props: { params: { slug: string[] } }) {
     scope: data,
   });
 
+  const propsMetadata = getPropsMetadata(result.filepath, data.typescript);
+
   return {
     props: {
       source: mdxSource,
       frontMatter: data,
+      propsMetadata,
     },
   };
 }

--- a/packages/website/utils/propsMeta.ts
+++ b/packages/website/utils/propsMeta.ts
@@ -9,6 +9,8 @@ const docgen = require('react-docgen-typescript');
 // because they are, basically, inherited props from HTML elements or React
 const PROPS_TO_HIDE = ['ref', 'key', 'style'];
 
+type PropsMetadata = { [key: string]: PropComponentDefinition };
+
 const getPreparedComponent = (
   component: PropComponentDefinition,
 ): PropComponentDefinition => {
@@ -51,12 +53,10 @@ function getTypescriptMetaInformation(sourcePath) {
     const components: PropComponentDefinition[] =
       tsConfigParser.parse(sourcePath) || [];
 
-    const result: { [key: string]: PropComponentDefinition } = {};
-    components.map((component) => {
+    return components.reduce<PropsMetadata>((result, component) => {
       result[component.displayName] = getPreparedComponent(component);
-    });
-
-    return result;
+      return result;
+    }, {});
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log('Problem with parsing Typescript props for  ' + sourcePath, e);
@@ -69,7 +69,7 @@ function getPropsMetadata(filePath: string, sourcesPaths?: string) {
     return null;
   }
 
-  const propsMetadata: { [key: string]: PropComponentDefinition } = {};
+  const propsMetadata: PropsMetadata = {};
   const typescriptSources = sourcesPaths.trim().split(',');
 
   typescriptSources.forEach((source) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -26604,6 +26604,11 @@ react-docgen-typescript@^2.0.0:
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.1.0.tgz#20db64a7fd62e63a8a9469fb4abd90600878cbb2"
   integrity sha512-7kpzLsYzVxff//HUVz1sPWLCdoSNvHD3M8b/iQLdF8fgf7zp26eVysRrAUSxiAT4yQv2zl09zHjJEYSYNxQ8Jw==
 
+react-docgen-typescript@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
+  integrity sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==
+
 react-docgen@^5.0.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-5.3.1.tgz#940b519646a6c285c2950b96512aed59e8f90934"


### PR DESCRIPTION
# Purpose of PR

1. Logic for providing context with components props types info.
2. Props filtering logic was moved from `PropsContext` to the script where we gather and prepare all those props. To decrease the size of data transferred to the client.