### PR TITLE
fix: truncate entry card description

### DIFF
--- a/packages/components/card/src/entry-card/EntryCard.tsx
+++ b/packages/components/card/src/entry-card/EntryCard.tsx
@@ -54,7 +54,11 @@ function EntryCardDescription({
 
   const truncatedDescription = truncate(description, 95, {});
 
-  return <Paragraph marginBottom="none">{truncatedDescription}</Paragraph>;
+  return (
+    <Paragraph marginBottom="none" isTruncated>
+      {truncatedDescription}
+    </Paragraph>
+  );
 }
 
 function _EntryCard<


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Truncate long descriptions in EntryCard using CSS.