### PR TITLE
Fix asset image fit

### DIFF
--- a/packages/components/asset/src/Asset.styles.ts
+++ b/packages/components/asset/src/Asset.styles.ts
@@ -15,6 +15,7 @@ export function getAssetStyles() {
       height: '100%',
       maxWidth: '100%',
       maxHeight: '100%',
+      objectFit: 'contain',
     }),
     titleContainer: css({
       opacity: 0,

--- a/packages/components/card/stories/AssetCard.stories.tsx
+++ b/packages/components/card/stories/AssetCard.stories.tsx
@@ -159,3 +159,101 @@ export const Overview: Story<Args> = () => {
     </>
   );
 };
+
+export const DifferentImageSizes: Story<Args> = () => {
+  return (
+    <>
+      <SectionHeading as="h3" marginBottom="spacingS">
+        Default
+      </SectionHeading>
+
+      <Flex flexWrap="wrap">
+        <Flex flexDirection="column" marginRight="spacingM">
+          <SectionHeading as="h3" marginBottom="spacingS">
+            200x300
+          </SectionHeading>
+
+          <AssetCard
+            icon={<Icon as={icons.ClockIcon} />}
+            src="https://via.placeholder.com/200x300"
+            title="Asset title"
+            type="image"
+          />
+        </Flex>
+
+        <Flex flexDirection="column" marginRight="spacingM">
+          <SectionHeading as="h3" marginBottom="spacingS">
+            200x600
+          </SectionHeading>
+
+          <AssetCard
+            icon={<Icon as={icons.ClockIcon} />}
+            src="https://via.placeholder.com/200x600"
+            title="Asset title"
+            type="image"
+          />
+        </Flex>
+
+        <Flex flexDirection="column" marginRight="spacingM">
+          <SectionHeading as="h3" marginBottom="spacingS">
+            800x200
+          </SectionHeading>
+
+          <AssetCard
+            icon={<Icon as={icons.ClockIcon} />}
+            src="https://via.placeholder.com/800x200"
+            title="Asset title"
+            type="image"
+          />
+        </Flex>
+      </Flex>
+
+      <SectionHeading as="h3" marginBottom="spacingS" marginTop="spacingL">
+        Small
+      </SectionHeading>
+
+      <Flex flexWrap="wrap">
+        <Flex flexDirection="column" marginRight="spacingM">
+          <SectionHeading as="h3" marginBottom="spacingS">
+            200x300
+          </SectionHeading>
+
+          <AssetCard
+            icon={<Icon as={icons.ClockIcon} />}
+            size="small"
+            src="https://via.placeholder.com/200x300"
+            title="Asset title"
+            type="image"
+          />
+        </Flex>
+
+        <Flex flexDirection="column" marginRight="spacingM">
+          <SectionHeading as="h3" marginBottom="spacingS">
+            200x600
+          </SectionHeading>
+
+          <AssetCard
+            actions={actions}
+            size="small"
+            src="https://via.placeholder.com/200x600"
+            title="Asset title"
+            type="image"
+          />
+        </Flex>
+
+        <Flex flexDirection="column" marginRight="spacingM">
+          <SectionHeading as="h3" marginBottom="spacingS">
+            800x200
+          </SectionHeading>
+
+          <AssetCard
+            size="small"
+            src="https://via.placeholder.com/800x200"
+            title="Asset title"
+            type="image"
+          />
+        </Flex>
+      </Flex>
+    </>
+  );
+};


### PR DESCRIPTION
# Purpose of PR

This fix should prevent the image on Asset preview from being distorted. 

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
