### PR TITLE
fix: allow to pass usePortal to Autocomplete

### DIFF
--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -104,6 +104,13 @@ export interface AutocompleteProps<ItemType>
    * @default false
    */
   isLoading?: boolean;
+  /**
+   * Boolean to control whether or not to render the suggestions box in a React Portal.
+   * Rendering content inside a Portal allows the suggestions box to escape the bounds
+   * of its parent while still being positioned correctly.
+   * Defaults to `false`
+   */
+  usePortal?: boolean;
 }
 
 function _Autocomplete<ItemType>(
@@ -133,6 +140,7 @@ function _Autocomplete<ItemType>(
     listMaxHeight = 180,
     isGrouped = false,
     isLoading = false,
+    usePortal = false,
     testId = 'cf-autocomplete',
   } = props;
 
@@ -212,7 +220,7 @@ function _Autocomplete<ItemType>(
       ref={ref}
     >
       <Popover
-        usePortal={false}
+        usePortal={usePortal}
         isOpen={isOpen}
         isFullWidth={listWidth === 'full'}
         // This is necessary, otherwise the focus will change from the input to the Popover


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

We need an ability to pass truthy `usePortal` value in Autocomplete component as discovered while integrating v4 in Launch application.