### PR TITLE
fix: fix dragHandle issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tsc": "tsc --noEmit",
     "tsc:watch": "tsc --noEmit --watch",
     "docs:next": "lerna run --scope @contentful/f36-website start --stream",
-    "docs:next:build":  "lerna run --scope @contentful/f36-website build:prod --stream",
+    "docs:next:build": "lerna run --scope @contentful/f36-website build:prod --stream",
     "docs:gatsby": "lerna run --scope f36-website start --stream",
     "release-v4-beta-as-latest": "yarn build && yarn lerna publish --exact --no-private --canary --no-git-tag-version --no-push --dist-tag latest --preid beta --force-publish --no-changelog"
   },
@@ -68,8 +68,6 @@
     "@storybook/addon-storysource": "^6.3.12",
     "@storybook/react": "^6.3.12",
     "@storybook/theming": "^6.3.12",
-    "@testing-library/jest-dom": "5.11.6",
-    "@testing-library/react": "11.2.2",
     "@testing-library/jest-dom": "5.15.0",
     "@testing-library/react": "12.1.2",
     "@testing-library/user-event": "12.2.2",
@@ -136,6 +134,7 @@
     "react-dom": "16.14.0",
     "react-focus-lock": "^2.5.2",
     "react-router-dom": "^5.3.0",
+    "react-sortable-hoc": "^2.0.0",
     "rimraf": "^3.0.2",
     "style-loader": "^2.0.0",
     "turbo": "^1.0.6",
@@ -154,8 +153,12 @@
   "turbo": {
     "pipeline": {
       "build": {
-        "dependsOn": ["^build"],
-        "outputs": ["dist/**"]
+        "dependsOn": [
+          "^build"
+        ],
+        "outputs": [
+          "dist/**"
+        ]
       }
     }
   }

--- a/packages/components/card/stories/EntryCard.stories.tsx
+++ b/packages/components/card/stories/EntryCard.stories.tsx
@@ -7,6 +7,11 @@ import { ClockIcon } from '@contentful/f36-icons';
 
 import { EntryCard } from '../src';
 import type { EntryCardProps } from '../src';
+import {
+  SortableContainer,
+  SortableElement,
+  SortableHandle,
+} from 'react-sortable-hoc';
 
 export default {
   argTypes: {
@@ -22,6 +27,38 @@ export default {
   },
   title: 'Components/Card/EntryCard',
 } as Meta;
+
+const DragHandle = (props: { drag: React.ReactElement }) => {
+  const SortableDragHandle = SortableHandle(() => props.drag);
+  return <SortableDragHandle />;
+};
+
+const SortableLink = SortableElement(
+  (props: { children: React.ReactElement }) => <div>{props.children}</div>,
+);
+
+const SortableWrapper = SortableContainer(({ children }) => {
+  return <ul>{children}</ul>;
+});
+
+export const WithDragging: Story<EntryCardProps> = (args) => {
+  return (
+    <SortableWrapper useDragHandle>
+      <SortableLink index={1}>
+        <EntryCard {...args} withDragHandle dragHandleRender={DragHandle} />
+      </SortableLink>
+      <SortableLink index={2}>
+        <EntryCard {...args} withDragHandle dragHandleRender={DragHandle} />
+      </SortableLink>
+    </SortableWrapper>
+  );
+};
+
+WithDragging.args = {
+  status: 'published',
+  contentType: 'Content type',
+  title: 'Closer',
+};
 
 export const Default: Story<EntryCardProps> = (args) => {
   return (

--- a/packages/components/drag-handle/src/DragHandle.tsx
+++ b/packages/components/drag-handle/src/DragHandle.tsx
@@ -30,6 +30,10 @@ export type DragHandleInternalProps = CommonProps & {
    * is for screen readers only
    */
   label: string;
+  /**
+   * Set type button for div element
+   */
+  type?: string;
 };
 
 export type DragHandleProps = PropsWithHTMLElement<

--- a/packages/components/drag-handle/src/DragHandle.tsx
+++ b/packages/components/drag-handle/src/DragHandle.tsx
@@ -6,7 +6,7 @@ import React, {
   MouseEventHandler,
 } from 'react';
 import { cx } from 'emotion';
-import type { PropsWithHTMLDivElement } from '@contentful/f36-core';
+import type { PropsWithHTMLElement } from '@contentful/f36-core';
 import type { CommonProps, ExpandProps } from '@contentful/f36-core';
 import { DragIcon } from '@contentful/f36-icons';
 import { getStyles } from './DragHandle.styles';
@@ -32,7 +32,7 @@ export type DragHandleInternalProps = CommonProps & {
   label: string;
 };
 
-export type DragHandleProps = PropsWithHTMLDivElement<
+export type DragHandleProps = PropsWithHTMLElement<
   DragHandleInternalProps,
   'div'
 >;
@@ -107,6 +107,8 @@ export const DragHandle = forwardRef<
     );
 
     return (
+      // We had to change it to div becouse of the issue in library used by field editors
+      // https://github.com/clauderic/react-sortable-hoc/blob/d94ba3cc67cfc7d6d460b585e7723bdb50015e53/src/SortableContainer/defaultShouldCancelStart.js
       <div
         role="button"
         tabIndex={0}

--- a/packages/components/drag-handle/src/DragHandle.tsx
+++ b/packages/components/drag-handle/src/DragHandle.tsx
@@ -6,7 +6,7 @@ import React, {
   MouseEventHandler,
 } from 'react';
 import { cx } from 'emotion';
-import type { PropsWithHTMLElement } from '@contentful/f36-core';
+import type { PropsWithHTMLDivElement } from '@contentful/f36-core';
 import type { CommonProps, ExpandProps } from '@contentful/f36-core';
 import { DragIcon } from '@contentful/f36-icons';
 import { getStyles } from './DragHandle.styles';
@@ -32,13 +32,13 @@ export type DragHandleInternalProps = CommonProps & {
   label: string;
 };
 
-export type DragHandleProps = PropsWithHTMLElement<
+export type DragHandleProps = PropsWithHTMLDivElement<
   DragHandleInternalProps,
-  'button'
+  'div'
 >;
 
 export const DragHandle = forwardRef<
-  HTMLButtonElement,
+  HTMLDivElement,
   ExpandProps<DragHandleProps>
 >(
   (
@@ -62,7 +62,7 @@ export const DragHandle = forwardRef<
     const [isFocused, setisFocused] = useState(isFocusedProp);
     const [isHovered, setisHovered] = useState(isHoveredProp);
 
-    const handleFocus = useCallback<FocusEventHandler<HTMLButtonElement>>(
+    const handleFocus = useCallback<FocusEventHandler<HTMLDivElement>>(
       (event) => {
         setisFocused(true);
 
@@ -73,7 +73,7 @@ export const DragHandle = forwardRef<
       [onFocus],
     );
 
-    const handleBlur = useCallback<FocusEventHandler<HTMLButtonElement>>(
+    const handleBlur = useCallback<FocusEventHandler<HTMLDivElement>>(
       (event) => {
         setisFocused(false);
 
@@ -84,7 +84,7 @@ export const DragHandle = forwardRef<
       [onBlur],
     );
 
-    const handleMouseEnter = useCallback<MouseEventHandler<HTMLButtonElement>>(
+    const handleMouseEnter = useCallback<MouseEventHandler<HTMLDivElement>>(
       (event) => {
         setisHovered(true);
 
@@ -95,7 +95,7 @@ export const DragHandle = forwardRef<
       [onMouseEnter],
     );
 
-    const handleMouseLeave = useCallback<MouseEventHandler<HTMLButtonElement>>(
+    const handleMouseLeave = useCallback<MouseEventHandler<HTMLDivElement>>(
       (event) => {
         setisHovered(false);
 
@@ -107,7 +107,9 @@ export const DragHandle = forwardRef<
     );
 
     return (
-      <button
+      <div
+        role="button"
+        tabIndex={0}
         type="button"
         {...otherProps}
         className={cx(
@@ -124,7 +126,7 @@ export const DragHandle = forwardRef<
       >
         <DragIcon variant="muted" />
         <span className={styles.label}>{label}</span>
-      </button>
+      </div>
     );
   },
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,6 +1672,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.2.0":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
+  integrity sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/standalone@^7.12.6":
   version "7.12.12"
   resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.12.12.tgz#f858ab1c76d9c4c23fe0783a0330ad37755f0176"
@@ -25977,7 +25984,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -26723,6 +26730,15 @@ react-sizeme@^3.0.1:
     invariant "^2.2.4"
     shallowequal "^1.1.0"
     throttle-debounce "^3.0.1"
+
+react-sortable-hoc@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-2.0.0.tgz#f6780d8aa4b922a21f3e754af542f032677078b7"
+  integrity sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    invariant "^2.2.4"
+    prop-types "^15.5.7"
 
 react-syntax-highlighter@^13.5.0, react-syntax-highlighter@^13.5.3:
   version "13.5.3"


### PR DESCRIPTION
Temporary fix to the issue that we face in the field editors.
The library used by field editors (react-sortable-hoc) is canceling events for buttons for some reason (https://github.com/clauderic/react-sortable-hoc/blob/d94ba3cc67cfc7d6d460b585e7723bdb50015e53/src/SortableContainer/defaultShouldCancelStart.js).
We should change the implementation on the field editors at some point. We will have a look at it while working on the keyboard nav for dragHandle (inspiration from user interface, where it's already done)

I added the example in the storybook,but skipped the website, we don't want to encourage anyone to use react-sortable-hoc, but maybe it's still worth keeping the example in the storybook?

