### PR TITLE
Fix/add title attribute to base card [ZEND-1740]

### DIFF
--- a/packages/components/card/src/base-card/BaseCard.tsx
+++ b/packages/components/card/src/base-card/BaseCard.tsx
@@ -189,6 +189,7 @@ function _BaseCard<E extends React.ElementType = typeof BASE_CARD_DEFAULT_TAG>(
       {...otherProps}
       ref={forwardedRef}
       testId={testId}
+      title={title}
     >
       {withDragHandle
         ? dragHandleRender


### PR DESCRIPTION
# Purpose of PR

When hovering over the asset card, if the title is cut by ellipsis it's hard to know the full title of the assets because hovering over the title doesn't show the full title.

This PR adds the "title" attribute to "BaseCard" component.

Before:
![Screenshot 2022-01-03 at 13 27 33](https://user-images.githubusercontent.com/30434146/147930392-30a7a8f1-48ff-4201-ad16-20ae898ff509.png)

Now: 
![Screenshot 2022-01-03 at 13 26 52](https://user-images.githubusercontent.com/30434146/147930324-ffe2ad3c-b632-4c5e-ac06-d0b6af0a1b45.png)


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
