### PR TITLE
fix: double scroll in the sidemenu

### DIFF
--- a/packages/website/components/Layout.tsx
+++ b/packages/website/components/Layout.tsx
@@ -16,10 +16,9 @@ const styles = {
   sidebarItem: css({
     display: 'flex',
     flexDirection: 'column',
-    overflowY: 'scroll',
-    overflowX: 'auto',
-    fontSize: tokens.fontSizeL,
-    lineHeight: tokens.lineHeightL,
+    overflow: 'hidden',
+    height: '100%',
+    borderRight: `1px solid ${tokens.gray300}`,
   }),
   mainItem: css({
     display: 'flex',

--- a/packages/website/components/Sidebar.tsx
+++ b/packages/website/components/Sidebar.tsx
@@ -14,10 +14,6 @@ import { DocSearch } from './DocSearch';
 const sidebarLinks = require('../utils/sidebarLinks.json');
 
 const styles = {
-  sidebar: css({
-    height: '100%',
-    borderRight: `1px solid ${tokens.gray300}`,
-  }),
   nav: css({
     borderTop: `1px solid ${tokens.gray300}`,
     padding: `${tokens.spacingM} 0`,
@@ -88,7 +84,7 @@ const components: Array<SidebarSectionType | SidebarLinkType> = [
 
 export function Sidebar({ currentPage = '/' }: Props) {
   return (
-    <Flex className={styles.sidebar} flexDirection="column">
+    <>
       <DocSearch />
 
       <Flex
@@ -149,6 +145,6 @@ export function Sidebar({ currentPage = '/' }: Props) {
           />
         </List>
       </Flex>
-    </Flex>
+    </>
   );
 }


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

I have OCD and the double scrollbar of the website was annoying me so I created this small fix, it removes unnecessary styles and html that was creating the double bar

before:
![Screenshot 2022-01-03 at 13 38 02](https://user-images.githubusercontent.com/6597467/147932672-111189b8-180b-46ed-84e3-bf15f1defe1e.png)

after:
![Screenshot 2022-01-03 at 13 46 09](https://user-images.githubusercontent.com/6597467/147932691-2f82aa62-89f8-4daa-8e6f-766176135785.png)


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
