### PR TITLE
feat: better ButtonGroup docs and fixed spaced implementation

### DIFF
--- a/packages/components/button/examples/ButtonGroupCollapsedExample.tsx
+++ b/packages/components/button/examples/ButtonGroupCollapsedExample.tsx
@@ -9,7 +9,7 @@ import { ChevronDownIcon, PlusIcon } from '@contentful/f36-icons';
 
 export default function ButtonGroupCollapsedExample() {
   return (
-    <Stack>
+    <Stack flexDirection="column">
       <ButtonGroup>
         <Button variant="secondary" size="small">
           Save

--- a/packages/components/button/examples/ButtonGroupCollapsedExample.tsx
+++ b/packages/components/button/examples/ButtonGroupCollapsedExample.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {
+  Stack,
+  ButtonGroup,
+  Button,
+  IconButton,
+} from '@contentful/f36-components';
+import { ChevronDownIcon, PlusIcon } from '@contentful/f36-icons';
+
+export default function ButtonGroupCollapsedExample() {
+  return (
+    <Stack>
+      <ButtonGroup>
+        <Button variant="secondary" size="small">
+          Save
+        </Button>
+        <IconButton
+          variant="secondary"
+          size="small"
+          aria-label="Add more"
+          icon={<PlusIcon />}
+        />
+      </ButtonGroup>
+      <ButtonGroup withDivider>
+        <Button variant="positive">Publish changes</Button>
+        <IconButton
+          variant="positive"
+          aria-label="Open dropdown"
+          icon={<ChevronDownIcon />}
+        />
+      </ButtonGroup>
+    </Stack>
+  );
+}

--- a/packages/components/button/examples/ButtonGroupMergedExample.tsx
+++ b/packages/components/button/examples/ButtonGroupMergedExample.tsx
@@ -7,7 +7,7 @@ import {
 } from '@contentful/f36-components';
 import { ChevronDownIcon, PlusIcon } from '@contentful/f36-icons';
 
-export default function ButtonGroupCollapsedExample() {
+export default function ButtonGroupMergedExample() {
   return (
     <Stack flexDirection="column">
       <ButtonGroup>

--- a/packages/components/button/examples/ButtonGroupSpacedExample.tsx
+++ b/packages/components/button/examples/ButtonGroupSpacedExample.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ButtonGroup, Button } from '@contentful/f36-components';
+
+export default function ButtonGroupSpacedExample() {
+  return (
+    <ButtonGroup variant="spaced" spacing="spacingM">
+      <Button variant="secondary" size="small">
+        Duplicate
+      </Button>
+      <Button variant="secondary" size="small">
+        Unpublish
+      </Button>
+      <Button variant="positive" size="small">
+        Publish
+      </Button>
+      <Button variant="secondary" size="small">
+        Add to release
+      </Button>
+    </ButtonGroup>
+  );
+}

--- a/packages/components/button/src/ButtonGroup/ButtonGroup.styles.ts
+++ b/packages/components/button/src/ButtonGroup/ButtonGroup.styles.ts
@@ -3,24 +3,7 @@ import tokens from '@contentful/f36-tokens';
 import type { GetStyleArguments } from './types';
 import type { CSSObject } from '@emotion/serialize';
 
-const getGroupContentStyle = ({
-  variant,
-  withDivider,
-  spacing,
-}: GetStyleArguments) => {
-  if (variant === 'spaced') {
-    return {
-      marginLeft: tokens[spacing],
-      marginRight: tokens[spacing],
-      '&:first-child': {
-        marginLeft: 0,
-      },
-      '&:last-child': {
-        marginRight: 0,
-      },
-    };
-  }
-
+const getGroupContentStyle = ({ withDivider }: GetStyleArguments) => {
   const dividerStyle = getDividerStyle(withDivider);
 
   return {
@@ -53,7 +36,7 @@ const getDividerStyle = (withDivider: boolean): CSSObject => {
       opacity: '20%',
       backgroundColor: tokens.colorWhite,
       height: '60%',
-      left: '-1px',
+      left: '0',
       position: 'absolute',
     },
     '&:first-child, &:focus': {
@@ -63,19 +46,15 @@ const getDividerStyle = (withDivider: boolean): CSSObject => {
     },
     '&:hover, &:hover + &': {
       '&:before': {
-        height: '100%',
+        display: 'none',
       },
     },
   };
 };
 
-export default ({
-  variant,
-  withDivider,
-  spacing = 'spacingS',
-}: GetStyleArguments) => ({
+export default ({ withDivider }: GetStyleArguments) => ({
   buttonGroup: css({
     display: 'inline-flex',
   }),
-  groupContent: css(getGroupContentStyle({ variant, withDivider, spacing })),
+  groupContent: css(getGroupContentStyle({ withDivider })),
 });

--- a/packages/components/button/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/button/src/ButtonGroup/ButtonGroup.tsx
@@ -1,6 +1,6 @@
 import { cx } from 'emotion';
 import React from 'react';
-import { Box, ExpandProps } from '@contentful/f36-core';
+import { Box, Stack, ExpandProps } from '@contentful/f36-core';
 import getStyles from './ButtonGroup.styles';
 import type { ButtonGroupProps } from './types';
 
@@ -16,12 +16,25 @@ function _ButtonGroup(
     className,
     spacing,
   } = props;
-  const styles = getStyles({ variant, withDivider, spacing });
+  const styles = getStyles({ withDivider });
+
+  if (variant === 'spaced') {
+    return (
+      <Stack
+        isInline
+        flexDirection="row"
+        testId={testId}
+        ref={ref}
+        spacing={spacing}
+      >
+        {children}
+      </Stack>
+    );
+  }
 
   return (
     <Box
-      as="div"
-      data-test-id={testId}
+      testId={testId}
       ref={ref}
       className={cx(styles.buttonGroup, className)}
     >

--- a/packages/components/button/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/button/src/ButtonGroup/ButtonGroup.tsx
@@ -9,7 +9,7 @@ function _ButtonGroup(
   ref: React.Ref<HTMLDivElement>,
 ) {
   const {
-    variant = 'collapsed',
+    variant = 'merged',
     withDivider,
     testId = 'cf-ui-button-group',
     children,

--- a/packages/components/button/src/ButtonGroup/README.mdx
+++ b/packages/components/button/src/ButtonGroup/README.mdx
@@ -5,61 +5,44 @@ status: 'stable'
 section: 'buttonComponents'
 slug: /components/button-group/
 github: 'https://github.com/contentful/forma-36/tree/forma-v4/packages/components/button/src/ButtonGroup'
-storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-button-buttongroup--basic'
 typescript: ./ButtonGroup.tsx
 ---
 
-import { Props } from '@contentful/f36-docs-utils';
-import { Button } from '@contentful/f36-button';
-import { ChevronDownIcon, PlusIcon } from '@contentful/f36-icons';
+`ButtonGroup` should be used to group buttons whose actions are related, with an option to collapse them together or split them with an equal amount of free space.
 
-## Code examples
+## Import
 
-Example of usage:
-
-```jsx
-// import { ButtonGroup, Button } from '@contentful/f36-button';
-
-<ButtonGroup testId="group-button">
-  <Button variant="secondary">Button</Button>
-  <Button variant="secondary">Button</Button>
-  <Button
-    variant="positive"
-    aria-label="Open dropdown"
-    startIcon={<ChevronDownIcon />}
-  />
-</ButtonGroup>
+```js static=true
+import { ButtonGroup } from '@contentful/f36-components';
 ```
 
-It's possible to add a divider for buttons that don't have border:
+## Examples
 
-```jsx
-// import { ButtonGroup, Button } from '@contentful/f36-button';
-// import { ChevronDownIcon, PlusIcon } from '@contentful/f36-icons';
+### Collapsed
 
-<ButtonGroup testId="group-button" withDivider>
-  <Button startIcon={<PlusIcon />} variant="positive">
-    Button
-  </Button>
-  <Button variant="positive" startIcon={<ChevronDownIcon />} />
-</ButtonGroup>
+The most common example is to group primary button with a secondary button or with a button that opens a dropdown with secondary actions.
+
+Also, it is possible to add a divider for buttons that don't have border.
+
+```jsx file=../../examples/ButtonGroupCollapsedExample.tsx
+
 ```
 
-Example of Group Button with spaced variant
+### Spaced
 
-```jsx
-// import { ButtonGroup, Button } from '@contentful/f36-button';
+Instead of collapsing buttons all together you can use `variant="spaced"` to make them spaced and control an empty space with `spacing` property.
 
-<ButtonGroup variant="spaced" testId="group-button">
-  <Button variant="primary">Button</Button>
-  <Button variant="negative">Button</Button>
-</ButtonGroup>
+```jsx file=../../examples/ButtonGroupSpacedExample.tsx
+
 ```
 
 ## Accessibility
 
-- If using a button that won't have text be sure to provide an aria-label
+If using a button that won't have text be sure to provide an `aria-label` property.
 
-## Props
+## Props (API reference)
 
-<Props of="ButtonGroup" />
+<Props
+  of="ButtonGroup"
+  storybookPath="/story/components-button-buttongroup--basic"
+/>

--- a/packages/components/button/src/ButtonGroup/README.mdx
+++ b/packages/components/button/src/ButtonGroup/README.mdx
@@ -18,19 +18,19 @@ import { ButtonGroup } from '@contentful/f36-components';
 
 ## Examples
 
-### Collapsed
+### Merged
 
-One of the common use cases is to group primary button with a secondary button or with a button that opens a dropdown with secondary actions.
+One of the common use cases is to merge primary button with a secondary button or with a button that opens a dropdown with secondary actions.
 
 Also, it is possible to add a divider for buttons that don't have borders (`primary`, `positive`, and `negative` variants).
 
-```jsx file=../../examples/ButtonGroupCollapsedExample.tsx
+```jsx file=../../examples/ButtonGroupMergedExample.tsx
 
 ```
 
 ### Spaced
 
-Instead of collapsing buttons all together you can use `variant="spaced"` to make them spaced and control an empty space with `spacing` property.
+Instead of merging buttons all together you can use `variant="spaced"` to make them spaced and control an empty space with `spacing` property.
 
 ```jsx file=../../examples/ButtonGroupSpacedExample.tsx
 

--- a/packages/components/button/src/ButtonGroup/README.mdx
+++ b/packages/components/button/src/ButtonGroup/README.mdx
@@ -8,7 +8,7 @@ github: 'https://github.com/contentful/forma-36/tree/forma-v4/packages/component
 typescript: ./ButtonGroup.tsx
 ---
 
-`ButtonGroup` should be used to group buttons whose actions are related, with an option to collapse them together or split them with an equal amount of free space.
+`ButtonGroup` should be used to group buttons whose actions are related, with an option to merge them together or split them with an equal amount of free space.
 
 ## Import
 

--- a/packages/components/button/src/ButtonGroup/README.mdx
+++ b/packages/components/button/src/ButtonGroup/README.mdx
@@ -20,9 +20,9 @@ import { ButtonGroup } from '@contentful/f36-components';
 
 ### Collapsed
 
-The most common example is to group primary button with a secondary button or with a button that opens a dropdown with secondary actions.
+One of the common use cases is to group primary button with a secondary button or with a button that opens a dropdown with secondary actions.
 
-Also, it is possible to add a divider for buttons that don't have border.
+Also, it is possible to add a divider for buttons that don't have borders (`primary`, `positive`, and `negative` variants).
 
 ```jsx file=../../examples/ButtonGroupCollapsedExample.tsx
 

--- a/packages/components/button/src/ButtonGroup/types.ts
+++ b/packages/components/button/src/ButtonGroup/types.ts
@@ -1,18 +1,19 @@
 import { CommonProps } from '@contentful/f36-core';
 import type { SpacingTokens } from '@contentful/f36-tokens';
 
-export type ButtonGroupVariants = 'spaced' | 'collapsed';
+export type ButtonGroupVariants = 'spaced' | 'merged' | 'collapsed';
 
 export type ButtonGroupSpacing = SpacingTokens;
 
 interface BaseButtonGroupProps extends CommonProps {
   /**
    * Determines how the Button Group will display the buttons
-   * @default collapse
+   * @default merged
+   * Note that `collapsed` is a synonym of `merged`
    */
   variant?: ButtonGroupVariants;
   /**
-   * Determines if the divider should be rendered between collapsed buttons
+   * Determines if the divider should be rendered between merged buttons
    * @default false
    */
   withDivider?: boolean;
@@ -29,6 +30,14 @@ interface SpacedButtonGroupProps extends BaseButtonGroupProps {
   withDivider?: never;
 }
 
+interface MergedButtonGroupProps extends BaseButtonGroupProps {
+  variant?: 'merged';
+  spacing?: never;
+}
+
+/**
+ * @deprecated should be removed in v5
+ */
 interface CollapsedButtonGroupProps extends BaseButtonGroupProps {
   variant?: 'collapsed';
   spacing?: never;
@@ -36,6 +45,7 @@ interface CollapsedButtonGroupProps extends BaseButtonGroupProps {
 
 export type ButtonGroupProps =
   | SpacedButtonGroupProps
+  | MergedButtonGroupProps
   | CollapsedButtonGroupProps;
 
 export type GetStyleArguments = {

--- a/packages/components/button/src/ButtonGroup/types.ts
+++ b/packages/components/button/src/ButtonGroup/types.ts
@@ -39,7 +39,5 @@ export type ButtonGroupProps =
   | CollapsedButtonGroupProps;
 
 export type GetStyleArguments = {
-  variant: ButtonGroupVariants;
   withDivider: boolean;
-  spacing: ButtonGroupSpacing;
 };

--- a/packages/components/button/stories/ButtonGroup.stories.tsx
+++ b/packages/components/button/stories/ButtonGroup.stories.tsx
@@ -76,7 +76,7 @@ export const overview: Story<ButtonGroupProps> = () => {
 
         <Flex flexDirection="column" marginBottom="spacingM">
           <Box marginBottom="spacingS">
-            <ButtonGroup variant="collapsed">
+            <ButtonGroup>
               <Button onClick={onClick} variant="secondary">
                 Button
               </Button>
@@ -95,7 +95,7 @@ export const overview: Story<ButtonGroupProps> = () => {
             </ButtonGroup>
           </Box>
           <Box marginBottom="spacingS">
-            <ButtonGroup variant="collapsed" withDivider>
+            <ButtonGroup withDivider>
               <Button onClick={onClick} variant="positive">
                 Button
               </Button>
@@ -108,7 +108,7 @@ export const overview: Story<ButtonGroupProps> = () => {
             </ButtonGroup>
           </Box>
           <Box marginBottom="spacingS">
-            <ButtonGroup variant="collapsed" withDivider>
+            <ButtonGroup withDivider>
               <Button
                 onClick={onClick}
                 variant="primary"

--- a/packages/components/modal/src/ModalControls/ModalControls.tsx
+++ b/packages/components/modal/src/ModalControls/ModalControls.tsx
@@ -29,7 +29,7 @@ export function ModalControls({
       margin="spacingL"
       marginTop="none"
     >
-      <ButtonGroup variant="spaced" spacing="spacingXs">
+      <ButtonGroup variant="spaced" spacing="spacingS">
         {children}
       </ButtonGroup>
     </Flex>


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

- Better documentation for the `ButtonGroup` component with more real-world examples.
- Fixes wrong `spaced` implementation (there was 2 * spacing space between items) by using `Stack` component in the implementation.
- Fixes broken `withDivider` implementation