### PR TITLE
[ZEND-1727] fix: modal confirm does not show if opened from another modal

### DIFF
--- a/packages/components/modal/src/Modal.styles.ts
+++ b/packages/components/modal/src/Modal.styles.ts
@@ -102,7 +102,7 @@ export function getModalStyles(props: {
           : null,
       ),
       afterOpen: css({
-        opacity: 1,
+        opacity: '1 !important',
       }),
       beforeClose: css({
         opacity: 0,


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

For some reason, `react-modal` and `emotion` are not playing nice and they invert the order a CSS class is defined when a user opens a ModelConfirm inside of another Modal using ModalLauncher

yes, I know...

Because this is kinda urgent for a customer, we had to add `!important` to the "afterOpen" class to make sure that the modal shows up after the opening transition

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
