### PR TITLE
fix: removes DisplayText huge size

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3040,7 +3040,7 @@ import {
   Some text
 </Paragraph>;
 
-<DisplayText size="huge" element="h4" className="className">
+<DisplayText size="large" element="h4" className="className">
   Some text
 </DisplayText>;
 ```
@@ -3072,7 +3072,7 @@ import {
   Some text
 </Paragraph>;
 
-<DisplayText marginBottom="none" size="huge" as="h4" className="className">
+<DisplayText marginBottom="none" size="large" as="h4" className="className">
   Some text
 </DisplayText>;
 ```
@@ -3105,7 +3105,7 @@ For components wrapped with Typography component, change:
 </Typography>;
 
 <Typography>
-  <DisplayText size="huge" element="h4" className="className">
+  <DisplayText size="large" element="h4" className="className">
     Some text
   </DisplayText>
 </Typography>;
@@ -3139,7 +3139,7 @@ into:
 </React.Fragment>;
 
 <React.Fragment>
-  <DisplayText size="huge" as="h4" className="className">
+  <DisplayText size="large" as="h4" className="className">
     Some text
   </DisplayText>
 </React.Fragment>;

--- a/packages/components/typography/examples/DisplayTextExample.tsx
+++ b/packages/components/typography/examples/DisplayTextExample.tsx
@@ -4,7 +4,6 @@ import { Flex, DisplayText } from '@contentful/f36-components';
 export default function DisplayTextExample() {
   return (
     <Flex flexDirection="column">
-      <DisplayText size="huge">Welcome!</DisplayText>
       <DisplayText size="large">Pages</DisplayText>
       <DisplayText>Select space</DisplayText>
     </Flex>

--- a/packages/components/typography/examples/DisplayTextMarginsExample.tsx
+++ b/packages/components/typography/examples/DisplayTextMarginsExample.tsx
@@ -4,9 +4,6 @@ import { Flex, DisplayText } from '@contentful/f36-components';
 export default function DisplayTextMarginsExample() {
   return (
     <Flex flexDirection="column">
-      <DisplayText size="huge" marginBottom="none">
-        Welcome!
-      </DisplayText>
       <DisplayText size="large" marginBottom="spacing4Xl">
         Pages
       </DisplayText>

--- a/packages/components/typography/src/DisplayText/DisplayText.tsx
+++ b/packages/components/typography/src/DisplayText/DisplayText.tsx
@@ -13,7 +13,7 @@ import type { HeadingElement } from '../Heading';
 const DISPLAY_TEXT_DEFAULT_TAG = 'h2';
 
 export interface DisplayTextInternalProps extends CommonProps, MarginProps {
-  size?: 'default' | 'large' | 'huge';
+  size?: 'default' | 'large';
   as?: HeadingElement;
   isTruncated?: boolean;
 }
@@ -36,10 +36,7 @@ function _DisplayText<
   let fontSize: FontSizeTokens = 'fontSize2Xl';
   let lineHeight: LineHeightTokens = 'lineHeight2Xl';
 
-  if (size === 'huge') {
-    fontSize = 'fontSize4Xl';
-    lineHeight = 'lineHeight4Xl';
-  } else if (size === 'large') {
+  if (size === 'large') {
     fontSize = 'fontSize3Xl';
     lineHeight = 'lineHeight3Xl';
   }

--- a/packages/components/typography/stories/DisplayText.stories.tsx
+++ b/packages/components/typography/stories/DisplayText.stories.tsx
@@ -30,13 +30,6 @@ export const Overview = (props: DisplayTextInternalProps) => (
   <>
     <Flex alignItems="center">
       <Flex marginRight="spacingS">
-        <Paragraph>48</Paragraph>
-      </Flex>
-      <DisplayText {...props} size="huge" />
-    </Flex>
-
-    <Flex alignItems="center">
-      <Flex marginRight="spacingS">
         <Paragraph>36</Paragraph>
       </Flex>
       <DisplayText {...props} size="large" />

--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-typography.input.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-typography.input.js
@@ -16,7 +16,7 @@ import {
 
 <Paragraph element="p" className="className"></Paragraph>;
 
-<DisplayText size="huge" element="h4" className="className"></DisplayText>;
+<DisplayText size="large" element="h4" className="className"></DisplayText>;
 
 <Typography>
   <Heading element="h4" className="className"></Heading>
@@ -35,7 +35,7 @@ import {
 </Typography>;
 
 <Typography>
-  <DisplayText size="huge" element="h4" className="className"></DisplayText>
+  <DisplayText size="large" element="h4" className="className"></DisplayText>
 </Typography>;
 
 <Typography>

--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-typography.output.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-typography.output.js
@@ -10,7 +10,7 @@ import { Heading, DisplayText, Paragraph, Subheading, SectionHeading } from "@co
 
 <Paragraph marginBottom="none" as="p" className="className"></Paragraph>;
 
-<DisplayText marginBottom="none" size="huge" as="h4" className="className"></DisplayText>;
+<DisplayText marginBottom="none" size="large" as="h4" className="className"></DisplayText>;
 
 <React.Fragment>
   <Heading as="h4" className="className"></Heading>
@@ -29,7 +29,7 @@ import { Heading, DisplayText, Paragraph, Subheading, SectionHeading } from "@co
 </React.Fragment>;
 
 <React.Fragment>
-  <DisplayText size="huge" as="h4" className="className"></DisplayText>
+  <DisplayText size="large" as="h4" className="className"></DisplayText>
 </React.Fragment>;
 
 <React.Fragment>


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Removes `DisplayText` size `huge`