### PR TITLE
fix: sidebar cropping docsearch and footer not sticky to the bottom

### DIFF
--- a/packages/website/components/Layout.tsx
+++ b/packages/website/components/Layout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 import { Grid } from '@contentful/f36-components';
-import { Topbar } from './Topbar';
+import { Topbar, TopbarHeight } from './Topbar';
 import { Footer } from './Footer';
 import { Sidebar } from './Sidebar';
 import tokens from '@contentful/f36-tokens';
@@ -16,14 +16,14 @@ const styles = {
   sidebarItem: css({
     display: 'flex',
     flexDirection: 'column',
-    overflow: 'hidden',
-    height: '100%',
+    height: `calc(100vh - ${TopbarHeight})`,
     borderRight: `1px solid ${tokens.gray300}`,
   }),
   mainItem: css({
     display: 'flex',
     flexDirection: 'column',
     overflow: 'auto',
+    height: `calc(100vh - ${TopbarHeight})`,
   }),
 };
 

--- a/packages/website/components/PageContent.tsx
+++ b/packages/website/components/PageContent.tsx
@@ -17,6 +17,7 @@ const styles = {
   root: css`
     display: flex;
     flex-direction: column;
+    flex: 1;
     margin: 0 auto;
     padding: ${tokens.spacingXl} ${tokens.spacing2Xl} 0 ${tokens.spacing2Xl};
   `,


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

- Makes content of the page grow to the maximum always so the footer is sticky to the bottom
![Screenshot 2022-01-06 at 13 58 34](https://user-images.githubusercontent.com/6597467/148386616-0697c708-4871-47f8-816c-4024c86aa1c8.png)

- Removes sidebar's `overflow: hidden`
![Screenshot 2022-01-06 at 13 58 16](https://user-images.githubusercontent.com/6597467/148386631-34fa79d1-ef8e-4a89-af97-c4211d09b1bf.png)

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
