### PR TITLE
feat: pass native props like ID to Collapse node

### DIFF
--- a/packages/components/collapse/src/Collapse.tsx
+++ b/packages/components/collapse/src/Collapse.tsx
@@ -1,10 +1,10 @@
 import React, { useLayoutEffect, useRef } from 'react';
 import tokens from '@contentful/f36-tokens';
-import type { CommonProps } from '@contentful/f36-core';
+import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 import { Box } from '@contentful/f36-core';
 import { getCollapseStyles } from './Collapse.styles';
 
-export interface CollapseProps extends CommonProps {
+interface CollapseInternalProps extends CommonProps {
   /**
    * Child nodes to be rendered in the component
    */
@@ -18,6 +18,11 @@ export interface CollapseProps extends CommonProps {
    */
   className?: string;
 }
+
+export type CollapseProps = PropsWithHTMLElement<
+  CollapseInternalProps,
+  'div'
+>;
 
 export const Collapse = ({
   children,


### PR DESCRIPTION
# Purpose of PR

In order to extend my Collapse element with properties like `ID` to link it via ARIA to my DragHandle button, we should allow passing through native properties to the DOM node.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
