### PR TITLE
fix(Collapse): enrich props type and add display none for collapsed state

### DIFF
--- a/packages/components/collapse/src/Collapse.styles.ts
+++ b/packages/components/collapse/src/Collapse.styles.ts
@@ -8,6 +8,7 @@ export const getCollapseStyles = ({ className }: { className?: string }) => {
         boxSizing: 'border-box',
         overflow: 'hidden',
         height: 0,
+        display: 'none',
         transition: `height ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}, padding ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}`,
       }),
       className,

--- a/packages/components/collapse/src/Collapse.tsx
+++ b/packages/components/collapse/src/Collapse.tsx
@@ -19,10 +19,7 @@ interface CollapseInternalProps extends CommonProps {
   className?: string;
 }
 
-export type CollapseProps = PropsWithHTMLElement<
-  CollapseInternalProps,
-  'div'
->;
+export type CollapseProps = PropsWithHTMLElement<CollapseInternalProps, 'div'>;
 
 export const Collapse = ({
   children,
@@ -51,30 +48,26 @@ export const Collapse = ({
 
     const handleTransitionEnd = () => {
       if (current) {
-        current.style.height = 'auto';
+        if (isExpanded) {
+          current.style.removeProperty('height');
+        } else {
+          current.style.setProperty('display', 'none');
+        }
       }
     };
 
     if (current) {
-      if (isExpanded) {
-        current.addEventListener('transitionend', handleTransitionEnd);
+      current.addEventListener('transitionend', handleTransitionEnd);
+      const fromHeight = isExpanded ? '0px' : getPanelContentHeight();
+      const toHeight = isExpanded ? getPanelContentHeight() : '0px';
+      requestAnimationFrame(function () {
+        current.style.removeProperty('display');
+        current.style.setProperty('height', fromHeight);
 
         requestAnimationFrame(function () {
-          current.style.height = '0px';
-
-          requestAnimationFrame(function () {
-            current.style.height = getPanelContentHeight();
-          });
+          current.style.setProperty('height', toHeight);
         });
-      } else {
-        requestAnimationFrame(function () {
-          current.style.height = getPanelContentHeight();
-
-          requestAnimationFrame(function () {
-            current.style.height = '0px';
-          });
-        });
-      }
+      });
     }
 
     return () => {

--- a/packages/components/collapse/src/Collapse.tsx
+++ b/packages/components/collapse/src/Collapse.tsx
@@ -1,5 +1,4 @@
 import React, { useLayoutEffect, useRef } from 'react';
-import tokens from '@contentful/f36-tokens';
 import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 import { Box } from '@contentful/f36-core';
 import { getCollapseStyles } from './Collapse.styles';
@@ -40,7 +39,7 @@ export const Collapse = ({
       return '0px';
     }
 
-    return `${current.scrollHeight / parseInt(tokens.fontBaseDefault, 10)}rem`; // converting height pixels into rem
+    return `${current.scrollHeight}px`;
   };
 
   useLayoutEffect(() => {

--- a/packages/components/collapse/src/Collapse.tsx
+++ b/packages/components/collapse/src/Collapse.tsx
@@ -1,10 +1,10 @@
 import React, { useLayoutEffect, useRef } from 'react';
 import tokens from '@contentful/f36-tokens';
-import type { CommonProps } from '@contentful/f36-core';
+import type { CommonProps, PropsWithHTMLElement } from '@contentful/f36-core';
 import { Box } from '@contentful/f36-core';
 import { getCollapseStyles } from './Collapse.styles';
 
-export interface CollapseProps extends CommonProps {
+interface CollapseInternalProps extends CommonProps {
   /**
    * Child nodes to be rendered in the component
    */
@@ -18,6 +18,11 @@ export interface CollapseProps extends CommonProps {
    */
   className?: string;
 }
+
+export type CollapseProps = PropsWithHTMLElement<
+  CollapseInternalProps,
+  'div'
+>;
 
 export const Collapse = ({
   children,

--- a/packages/components/collapse/src/Collapse.tsx
+++ b/packages/components/collapse/src/Collapse.tsx
@@ -49,8 +49,9 @@ export const Collapse = ({
     const handleTransitionEnd = () => {
       if (current) {
         if (isExpanded) {
-          current.style.removeProperty('height');
+          current.style.setProperty('height', 'auto');
         } else {
+          current.style.removeProperty('pointer-events');
           current.style.setProperty('display', 'none');
         }
       }
@@ -58,10 +59,17 @@ export const Collapse = ({
 
     if (current) {
       current.addEventListener('transitionend', handleTransitionEnd);
-      const fromHeight = isExpanded ? '0px' : getPanelContentHeight();
-      const toHeight = isExpanded ? getPanelContentHeight() : '0px';
       requestAnimationFrame(function () {
-        current.style.removeProperty('display');
+        if (!isExpanded) {
+          // Don't allow interaction while collapsing
+          current.style.setProperty('pointer-events', 'none');
+        } else {
+          // Overwrite none display to see expanding transition
+          current.style.setProperty('display', 'block');
+        }
+        // Calculate panel height after removing none display
+        const fromHeight = isExpanded ? '0px' : getPanelContentHeight();
+        const toHeight = isExpanded ? getPanelContentHeight() : '0px';
         current.style.setProperty('height', fromHeight);
 
         requestAnimationFrame(function () {

--- a/packages/components/collapse/stories/Collapse.stories.tsx
+++ b/packages/components/collapse/stories/Collapse.stories.tsx
@@ -28,8 +28,15 @@ export const Basic: Story<CollapseProps> = () => {
 
   return (
     <Stack flexDirection="column">
-      <Button onClick={() => setIsExpanded(!isExpanded)}>Toggle content</Button>
-      <Collapse isExpanded={isExpanded}>
+      <Button
+        onClick={() => setIsExpanded(!isExpanded)}
+        aria-label={`${isExpanded ? 'Collapse' : 'Expand'} foo content`}
+        aria-controls="collapsible-foo"
+        aria-expanded={isExpanded}
+      >
+        Toggle content
+      </Button>
+      <Collapse id="collapsible-foo" isExpanded={isExpanded}>
         <SectionHeading>Collapsable Element</SectionHeading>
         <Text>{defaultText}</Text>
       </Collapse>


### PR DESCRIPTION
# Purpose of PR

1. In order to extend my Collapse element with properties like ID to link it via ARIA to my DragHandle button, we should allow passing through native properties to the DOM node.

2. When the element is collapsed (and the transition is done), it adds `display: none` to the region. Thereby, the elements within are not reachable with `Tab` anymore. The style is removed when the expanding transition starts.

- feat: pass native props like ID to Collapse node
- fix: hide collapsed content with display none

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
