### PR TITLE
fix: color demo spacing

### DIFF
--- a/packages/website/mdx-components/ColorSwatchGroup.tsx
+++ b/packages/website/mdx-components/ColorSwatchGroup.tsx
@@ -22,7 +22,7 @@ export function ColorSwatchGroup({ colorGroup }: Props) {
   const colors = tokens[colorGroup];
 
   return (
-    <Grid columns={5} rowGap="spacingM" marginBottom="spacingL">
+    <Grid columns={4} rowGap="spacingM" marginBottom="spacingL">
       {Object.keys(colors).map((color, idx) => {
         const value = colors[color];
 


### PR DESCRIPTION
# Purpose of PR

Give more space for colors

<img width="899" alt="Screenshot 2022-01-10 at 23 35 00" src="https://user-images.githubusercontent.com/6163988/148845656-e0e9cecc-1988-46d9-bbeb-7f80afde403c.png">

<img width="884" alt="Screenshot 2022-01-10 at 23 57 31" src="https://user-images.githubusercontent.com/6163988/148845667-8e90865e-3f0b-44aa-bb35-8e9f630d211b.png">


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
