### PR TITLE
docs: disable search and show version number

### DIFF
--- a/packages/website/components/Sidebar.tsx
+++ b/packages/website/components/Sidebar.tsx
@@ -9,7 +9,7 @@ import {
   SidebarSectionType,
   SidebarLinkType,
 } from './SidebarSection';
-import { DocSearch } from './DocSearch';
+// import { DocSearch } from './DocSearch';
 
 const sidebarLinks = require('../utils/sidebarLinks.json');
 
@@ -85,7 +85,7 @@ const components: Array<SidebarSectionType | SidebarLinkType> = [
 export function Sidebar({ currentPage = '/' }: Props) {
   return (
     <>
-      <DocSearch />
+      {/* <DocSearch /> */}
 
       <Flex
         as="nav"

--- a/packages/website/components/Topbar.tsx
+++ b/packages/website/components/Topbar.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
 import Link from 'next/link';
+// eslint-disable-next-line
+// @ts-ignore
+import pkg from '../../forma-36-react-components/package.json';
 
 export const TopbarHeight = '70px';
 
@@ -25,6 +28,11 @@ const styles = {
     font-weight: ${tokens.fontWeightDemiBold};
     font-size: ${tokens.fontSizeXl};
     margin-left: ${tokens.spacingL};
+  `,
+  versionText: css`
+    font-weight: ${tokens.fontWeightDemiBold};
+    font-size: ${tokens.fontSizeL};
+    margin-left: ${tokens.spacingM};
   `,
   searchNavContainer: css`
     display: flex;
@@ -77,6 +85,7 @@ export const Topbar = () => (
         <div className={styles.logoText}>Forma 36</div>
       </a>
     </Link>
+    <div className={styles.versionText}>v{pkg.version}</div>
 
     <div className={styles.searchNavContainer}>
       <nav>

--- a/packages/website/pages/index.tsx
+++ b/packages/website/pages/index.tsx
@@ -32,7 +32,7 @@ function Home() {
         <Resources>
           <Resource
             title="New version of the UIKit is still in progress"
-            description="Fresh UIKit will be released with version 4 of Forma 36"
+            description="Fresh UIKit for Forma 36 v4 will be shortly released"
             imageNode={
               <Image {...uiKitImg} alt="Illustration for Forma 36 UI Kit" />
             }


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

* We're disabling the search for the time being, it has to be reindexed first.
* We want to show the current version number at the top bar