### PR TITLE
fix: disable search and align typography in the sidebar

### DIFF
--- a/packages/website/components/Footer.tsx
+++ b/packages/website/components/Footer.tsx
@@ -29,11 +29,7 @@ export const Footer = () => {
         <Flex flexDirection="column" marginRight="spacing2Xl">
           <Flex marginRight="spacingL" marginBottom="spacingM">
             <Link href="/playground" passHref>
-              <TextLink
-                href="/playground"
-                variant="secondary"
-                alignIcon="end"
-              >
+              <TextLink href="/playground" variant="secondary" alignIcon="end">
                 Playground
               </TextLink>
             </Link>

--- a/packages/website/components/Layout.tsx
+++ b/packages/website/components/Layout.tsx
@@ -12,7 +12,6 @@ const styles = {
     overflow: 'hidden',
     gridTemplateAreas: `"topbar topbar"
     "sidemenu content"`,
-    gridTemplateColumns: '2fr 10fr',
   }),
   sidebarItem: css({
     display: 'flex',
@@ -37,7 +36,7 @@ export function Layout({ children, currentPage }: Props) {
   return (
     <Grid
       className={styles.grid}
-      columns="285px auto"
+      columns="2fr 10fr"
       rows="auto 1fr"
       columnGap="none"
     >

--- a/packages/website/components/Layout.tsx
+++ b/packages/website/components/Layout.tsx
@@ -12,6 +12,7 @@ const styles = {
     overflow: 'hidden',
     gridTemplateAreas: `"topbar topbar"
     "sidemenu content"`,
+    gridTemplateColumns: '2fr 10fr',
   }),
   sidebarItem: css({
     display: 'flex',

--- a/packages/website/components/Sidebar.tsx
+++ b/packages/website/components/Sidebar.tsx
@@ -32,6 +32,8 @@ interface Props {
 }
 
 const components: Array<SidebarSectionType | SidebarLinkType> = [
+  ...sidebarLinks.unassigned,
+
   {
     type: 'section',
     links: sidebarLinks.layoutComponents,
@@ -72,7 +74,6 @@ const components: Array<SidebarSectionType | SidebarLinkType> = [
     links: sidebarLinks.skeletonComponents,
     title: 'Skeleton Components',
   },
-  ...sidebarLinks.unassigned,
   {
     type: 'section',
     links: sidebarLinks.deprecatedComponents,
@@ -95,25 +96,19 @@ export function Sidebar({ currentPage = '/' }: Props) {
           <>
             {currentPage.includes('guidelines') && (
               <SidebarSection
-                title="Guidelines"
                 links={sidebarLinks.guidelines}
                 currentPage={currentPage}
               />
             )}
             {currentPage.includes('tokens') && (
               <SidebarSection
-                title="Tokens"
                 links={sidebarLinks.tokens}
                 currentPage={currentPage}
               />
             )}
             {currentPage.includes('components') && (
               <>
-                <SidebarSection
-                  title="Components"
-                  links={components}
-                  currentPage={currentPage}
-                />
+                <SidebarSection links={components} currentPage={currentPage} />
                 <SidebarSection
                   title="Utils"
                   links={sidebarLinks.utils}

--- a/packages/website/components/SidebarLink.tsx
+++ b/packages/website/components/SidebarLink.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css, cx } from 'emotion';
 import Link from 'next/link';
 import tokens from '@contentful/f36-tokens';
-import { List, Flex } from '@contentful/f36-components';
+import { List, Flex, Subheading } from '@contentful/f36-components';
 import { ChevronDownIcon } from '@contentful/f36-icons';
 import { ExternalLinkIcon } from '@contentful/f36-icons';
 
@@ -53,12 +53,14 @@ export function SidebarSectionButton(props: {
     <List.Item>
       <Flex
         alignItems="center"
-        justifyContent="space-between"
         className={cx([titleStyles.clickable, titleStyles.sidebarItem])}
         role="button"
         onClick={props.onClick}
       >
-        <span>{props.children}</span>
+        <Subheading marginBottom="none" marginRight="spacingXs">
+          <span>{props.children}</span>
+        </Subheading>
+
         <ChevronDownIcon
           variant="muted"
           className={!props.isOpen ? titleStyles.closedIcon : ''}

--- a/packages/website/components/SidebarLink.tsx
+++ b/packages/website/components/SidebarLink.tsx
@@ -58,7 +58,7 @@ export function SidebarSectionButton(props: {
         onClick={props.onClick}
       >
         <Subheading marginBottom="none" marginRight="spacingXs">
-          <span>{props.children}</span>
+          {props.children}
         </Subheading>
 
         <ChevronDownIcon

--- a/packages/website/components/SidebarSection.tsx
+++ b/packages/website/components/SidebarSection.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
-import { List, SectionHeading } from '@contentful/f36-components';
+import { List, Subheading } from '@contentful/f36-components';
 
 import { SidebarLink, SidebarSectionButton } from './SidebarLink';
 
@@ -19,8 +19,6 @@ const styles = {
   }),
   sectionTitle: css({
     padding: `${tokens.spacingXs} ${tokens.spacingM}`,
-    fontSize: tokens.fontSizeM,
-    lineHeight: tokens.lineHeightM,
     letterSpacing: 'initial',
   }),
 };
@@ -30,12 +28,12 @@ const isLinkActive = (href, currentPage) =>
 
 export type SidebarLinkType = { title: string; slug: string; type: 'link' };
 export type SidebarSectionType = {
-  title: string;
+  title?: string;
   links: SidebarLinkType[];
   type: 'section';
 };
 interface SidebarSectionProps {
-  title: string;
+  title?: string;
   links: Array<SidebarLinkType | SidebarSectionType>;
   currentPage: string;
 }
@@ -45,7 +43,7 @@ function SidebarSubsection({
   links = [],
   currentPage,
 }: {
-  title: string;
+  title?: string;
   links: SidebarLinkType[];
   currentPage: string;
 }) {
@@ -53,14 +51,17 @@ function SidebarSubsection({
 
   return (
     <List className={styles.sublist}>
-      <SidebarSectionButton
-        isOpen={isOpen}
-        onClick={() => {
-          setIsOpen((open) => !open);
-        }}
-      >
-        {title}
-      </SidebarSectionButton>
+      {title && (
+        <SidebarSectionButton
+          isOpen={isOpen}
+          onClick={() => {
+            setIsOpen((open) => !open);
+          }}
+        >
+          {title}
+        </SidebarSectionButton>
+      )}
+
       {isOpen
         ? links.map((link) => {
             return (
@@ -86,9 +87,11 @@ export function SidebarSection({
 }: SidebarSectionProps) {
   return (
     <List className={styles.list}>
-      <SectionHeading className={styles.sectionTitle} marginBottom="none">
-        {title}
-      </SectionHeading>
+      {title && (
+        <Subheading className={styles.sectionTitle} marginBottom="none">
+          {title}
+        </Subheading>
+      )}
       {links.map((link) => {
         if (link.type === 'section') {
           return (

--- a/packages/website/components/Topbar.tsx
+++ b/packages/website/components/Topbar.tsx
@@ -3,14 +3,14 @@ import tokens from '@contentful/f36-tokens';
 import { Subheading, Flex } from '@contentful/f36-components';
 import { css } from 'emotion';
 import Link from 'next/link';
-import { DocSearch } from './DocSearch';
+// import { DocSearch } from './DocSearch';
 
 export const TopbarHeight = '70px';
 
 const styles = {
   header: css`
     display: grid;
-    grid-template-columns: 320px auto 320px;
+    grid-template-columns: 3fr 7fr 2fr;
     background-color: ${tokens.colorWhite};
     color: ${tokens.blue700};
     padding: 0 ${tokens.spacingXl};
@@ -126,16 +126,26 @@ export const Topbar = () => (
               </a>
             </Link>
           </li>
+          <li className={styles.navListItem}>
+            <a
+              className={styles.navListLink}
+              href="https://v3.f36.contentful.com/"
+            >
+              <Subheading className={styles.navListLink} marginBottom="none">
+                v3
+              </Subheading>
+            </a>
+          </li>
         </ul>
       </nav>
     </div>
-    <Flex alignItems="center">
+    {/* <Flex alignItems="center">
       <DocSearch />
       <Flex padding="spacingXs">
         <a className={styles.navListLink} href="https://v3.f36.contentful.com/">
           v3
         </a>
       </Flex>
-    </Flex>
+    </Flex> */}
   </header>
 );

--- a/packages/website/components/Topbar.tsx
+++ b/packages/website/components/Topbar.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import tokens from '@contentful/f36-tokens';
-import { Subheading, Flex } from '@contentful/f36-components';
+import { Text, Flex } from '@contentful/f36-components';
 import { css } from 'emotion';
 import Link from 'next/link';
+// DocSearch will be resintroduced as soon as we fix issue with Algolia
 // import { DocSearch } from './DocSearch';
 
 export const TopbarHeight = '70px';
@@ -44,7 +45,7 @@ const styles = {
     display: flex;
   `,
   navListItem: css`
-    margin-left: ${tokens.spacingXl};
+    margin-right: ${tokens.spacingXl};
     font-size: ${tokens.fontSizeL};
   `,
   navListLink: css`
@@ -93,48 +94,85 @@ export const Topbar = () => (
           <li className={styles.navListItem}>
             <Link href="/" passHref>
               <a className={styles.logoLink} href="/">
-                <Subheading className={styles.navListLink} marginBottom="none">
+                <Text
+                  fontSize="fontSizeL"
+                  lineHeight="lineHeightL"
+                  fontWeight="fontWeightDemiBold"
+                  as="span"
+                  className={styles.navListLink}
+                  marginBottom="none"
+                >
                   Introduction
-                </Subheading>
+                </Text>
               </a>
             </Link>
           </li>
           <li className={styles.navListItem}>
             <Link href="/guidelines/accessibility" passHref>
               <a className={styles.logoLink} href="/guidelines/accessibility">
-                <Subheading className={styles.navListLink} marginBottom="none">
+                <Text
+                  fontSize="fontSizeL"
+                  lineHeight="lineHeightL"
+                  fontWeight="fontWeightDemiBold"
+                  as="span"
+                  className={styles.navListLink}
+                  marginBottom="none"
+                >
                   Guidelines
-                </Subheading>
+                </Text>
               </a>
             </Link>
           </li>
           <li className={styles.navListItem}>
             <Link href="/tokens/color-system" passHref>
               <a className={styles.logoLink} href="/tokens/color-system">
-                <Subheading className={styles.navListLink} marginBottom="none">
+                <Text
+                  fontSize="fontSizeL"
+                  lineHeight="lineHeightL"
+                  fontWeight="fontWeightDemiBold"
+                  as="span"
+                  className={styles.navListLink}
+                  marginBottom="none"
+                >
                   Tokens
-                </Subheading>
+                </Text>
               </a>
             </Link>
           </li>
           <li className={styles.navListItem}>
             <Link href="/components/box" passHref>
               <a className={styles.logoLink} href="/components/box">
-                <Subheading className={styles.navListLink} marginBottom="none">
+                <Text
+                  fontSize="fontSizeL"
+                  lineHeight="lineHeightL"
+                  fontWeight="fontWeightDemiBold"
+                  as="span"
+                  className={styles.navListLink}
+                  marginBottom="none"
+                >
                   Components
-                </Subheading>
+                </Text>
               </a>
             </Link>
           </li>
           <li className={styles.navListItem}>
-            <a
-              className={styles.navListLink}
-              href="https://v3.f36.contentful.com/"
-            >
-              <Subheading className={styles.navListLink} marginBottom="none">
-                v3
-              </Subheading>
-            </a>
+            <Link href="https://v3.f36.contentful.com/" passHref>
+              <a
+                className={styles.navListLink}
+                href="https://v3.f36.contentful.com/"
+              >
+                <Text
+                  fontSize="fontSizeL"
+                  lineHeight="lineHeightL"
+                  fontWeight="fontWeightDemiBold"
+                  as="span"
+                  className={styles.navListLink}
+                  marginBottom="none"
+                >
+                  v3
+                </Text>
+              </a>
+            </Link>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
First step:
 - disable search
 - align typography in the side nav to the design
 - align columns for sidebar and topbar
 
 In the next PR
  - alphabetical order in the sidebar navigation