### PR TITLE
fix(togglebutton): fix border when hovering grouped toggle button

### DIFF
--- a/packages/components/button/src/ButtonGroup/ButtonGroup.styles.ts
+++ b/packages/components/button/src/ButtonGroup/ButtonGroup.styles.ts
@@ -19,7 +19,7 @@ const getGroupContentStyle = ({ withDivider }: GetStyleArguments) => {
       borderTopRightRadius: `${tokens.borderRadiusMedium} !important`,
       marginRight: 0,
     },
-    '&:focus, &:hover': {
+    '&:focus': {
       zIndex: tokens.zIndexDefault + 1,
     },
     ...dividerStyle,

--- a/packages/components/button/src/ButtonGroup/ButtonGroup.styles.ts
+++ b/packages/components/button/src/ButtonGroup/ButtonGroup.styles.ts
@@ -19,7 +19,7 @@ const getGroupContentStyle = ({ withDivider }: GetStyleArguments) => {
       borderTopRightRadius: `${tokens.borderRadiusMedium} !important`,
       marginRight: 0,
     },
-    '&:focus': {
+    '&:focus, &:hover': {
       zIndex: tokens.zIndexDefault + 1,
     },
     ...dividerStyle,

--- a/packages/components/button/src/ToggleButton/ToggleButton.styles.ts
+++ b/packages/components/button/src/ToggleButton/ToggleButton.styles.ts
@@ -19,6 +19,7 @@ const getToggleButtonStyle = ({ isActive, isDisabled }: GetStyleArguments) => {
     '&:hover': {
       background: tokens.colorWhite,
       borderColor: isDisabled ? tokens.gray300 : tokens.blue600,
+      zIndex: tokens.zIndexDefault + 1,
     },
     '&&:focus': {
       boxShadow: tokens.glowPrimary,
@@ -28,10 +29,12 @@ const getToggleButtonStyle = ({ isActive, isDisabled }: GetStyleArguments) => {
       ? {
           background: tokens.colorWhite,
           borderColor: tokens.gray300,
+          zIndex: tokens.zIndexDefault + 1,
         }
       : {
           background: tokens.blue100,
           borderColor: tokens.blue600,
+          zIndex: tokens.zIndexDefault + 1,
         },
   };
 


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Fix issue with right border on grouped toggle button when hovering.

You can check it on the [preview](https://forma-36-git-fix-toggle-button-hover-border-contentful-apps.vercel.app/components/toggle-button#grouped) deploy, need to change the `useState(true)` to `useState(false)` on the example.

Fixes #1757

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
