### PR TITLE
[Proposal] feat: navigation links states

### DIFF
--- a/packages/website/components/Layout.tsx
+++ b/packages/website/components/Layout.tsx
@@ -41,7 +41,7 @@ export function Layout({ children, currentPage }: Props) {
       columnGap="none"
     >
       <Grid.Item area="topbar">
-        <Topbar />
+        <Topbar currentPage={currentPage} />
       </Grid.Item>
 
       <Grid.Item area="sidemenu" className={styles.sidebarItem}>

--- a/packages/website/components/LayoutFullSize.tsx
+++ b/packages/website/components/LayoutFullSize.tsx
@@ -37,7 +37,7 @@ function Main({ children }: Props) {
 export function LayoutFullSize({ children, currentPage }: Props) {
   return (
     <Flex className={styles.root} flexDirection="column">
-      <Topbar />
+      <Topbar currentPage={currentPage} />
 
       {/* Unique key for each page, so scroll position is not preserved when opening a new page */}
       <Main key={currentPage} currentPage={currentPage}>

--- a/packages/website/components/SidebarLink.tsx
+++ b/packages/website/components/SidebarLink.tsx
@@ -20,13 +20,16 @@ export const getSectionTitleStyles = (isActive = false, indent = 1) => {
       lineHeight: `${tokens.lineHeightM}`,
     }),
     clickable: css({
-      textDecoration: 'none',
       cursor: 'pointer',
-      color: isActive ? tokens.colorWhite : tokens.gray900,
-      backgroundColor: isActive ? tokens.colorPrimary : 'transparent',
+      color: isActive ? tokens.blue700 : tokens.gray900,
+      fontWeight: isActive
+        ? tokens.fontWeightDemiBold
+        : tokens.fontWeightNormal,
+      textDecoration: isActive ? 'underline' : 'none',
+      backgroundColor: 'transparent',
       transition: `background-color ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}`,
       '&:hover': {
-        backgroundColor: isActive ? tokens.colorPrimary : tokens.gray200,
+        textDecoration: 'underline',
       },
     }),
     closedIcon: css({

--- a/packages/website/components/TableOfContent.tsx
+++ b/packages/website/components/TableOfContent.tsx
@@ -16,6 +16,7 @@ const styles = {
   sidebarNavItemActive: css({
     color: tokens.blue700,
     fontWeight: 'bold',
+    textDecoration: 'underline',
   }),
   secondLevelMargin: css({
     marginLeft: tokens.spacingM,

--- a/packages/website/components/TableOfContent.tsx
+++ b/packages/website/components/TableOfContent.tsx
@@ -15,7 +15,7 @@ const styles = {
   }),
   sidebarNavItemActive: css({
     color: tokens.blue700,
-    fontWeight: 'bold',
+    fontWeight: tokens.fontWeightDemiBold,
     textDecoration: 'underline',
   }),
   secondLevelMargin: css({

--- a/packages/website/components/Topbar.tsx
+++ b/packages/website/components/Topbar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import tokens from '@contentful/f36-tokens';
 import { Text, Flex } from '@contentful/f36-components';
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import Link from 'next/link';
 
 import { DocSearch } from './DocSearch';
@@ -33,14 +33,18 @@ const styles = {
       fontSize: tokens.fontSizeL,
     },
   }),
-  navListLink: css`
-    color: ${tokens.gray900};
-    text-decoration: none;
+  navListLink: css({
+    color: tokens.gray900,
+    textDecoration: 'none',
 
-    &:hover {
-      color: ${tokens.gray700};
-    }
-  `,
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  }),
+  active: css({
+    color: tokens.blue700,
+    textDecoration: 'underline',
+  }),
 };
 
 const Logo = () => (
@@ -62,57 +66,84 @@ const Logo = () => (
   </svg>
 );
 
-export const Topbar = () => (
-  <header className={styles.header}>
-    <Flex flexGrow={1}>
-      <Link href="/" passHref>
-        <a className={styles.logoLink} href="/">
-          <Logo />
-          <Text
-            fontSize="fontSizeXl"
-            fontWeight="fontWeightDemiBold"
-            fontColor="blue700"
-            marginLeft="spacingL"
-          >
-            Forma 36
-          </Text>
-        </a>
-      </Link>
-    </Flex>
+interface TopbarProps {
+  currentPage: string;
+}
 
-    <Flex as="nav" alignItems="center">
-      <ul className={styles.navList}>
-        <li>
-          <TopbarLink href="/" label="Introduction" />
-        </li>
-        <li>
-          <TopbarLink href="/guidelines/accessibility" label="Guidelines" />
-        </li>
-        <li>
-          <TopbarLink href="/tokens/color-system" label="Tokens" />
-        </li>
-        <li>
-          <TopbarLink href="/components/box" label="Components" />
-        </li>
-      </ul>
-    </Flex>
+export const Topbar = ({ currentPage }: TopbarProps) => {
+  const isGuidelines = currentPage.includes('/guidelines');
+  const isTokens = currentPage.includes('/tokens');
+  const isComponents = currentPage.includes('/components');
+  const isIntroduction = !isGuidelines && !isTokens && !isComponents;
 
-    <Flex alignItems="center">
-      <DocSearch />
-      <TopbarLink href="https://v3.f36.contentful.com/" label="v3" />
-    </Flex>
-  </header>
-);
+  return (
+    <header className={styles.header}>
+      <Flex flexGrow={1}>
+        <Link href="/" passHref>
+          <a className={styles.logoLink} href="/">
+            <Logo />
+            <Text
+              fontSize="fontSizeXl"
+              fontWeight="fontWeightDemiBold"
+              fontColor="blue700"
+              marginLeft="spacingL"
+            >
+              Forma 36
+            </Text>
+          </a>
+        </Link>
+      </Flex>
 
-function TopbarLink({ href, label }) {
+      <Flex as="nav" alignItems="center">
+        <ul className={styles.navList}>
+          <li>
+            <TopbarLink
+              href="/"
+              label="Introduction"
+              isActive={isIntroduction}
+            />
+          </li>
+          <li>
+            <TopbarLink
+              href="/guidelines/accessibility"
+              label="Guidelines"
+              isActive={isGuidelines}
+            />
+          </li>
+          <li>
+            <TopbarLink
+              href="/tokens/color-system"
+              label="Tokens"
+              isActive={isTokens}
+            />
+          </li>
+          <li>
+            <TopbarLink
+              href="/components/box"
+              label="Components"
+              isActive={isComponents}
+            />
+          </li>
+        </ul>
+      </Flex>
+
+      <Flex alignItems="center">
+        <DocSearch />
+        <TopbarLink href="https://v3.f36.contentful.com/" label="v3" />
+      </Flex>
+    </header>
+  );
+};
+
+function TopbarLink({ href, label, isActive = false }) {
   return (
     <Link href={href} passHref>
       <Text
+        as="a"
+        className={cx(styles.navListLink, { [styles.active]: isActive })}
         fontSize="fontSizeL"
         lineHeight="lineHeightL"
         fontWeight="fontWeightDemiBold"
-        as="a"
-        className={styles.navListLink}
         marginBottom="none"
       >
         {label}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This is just a proposal to start a discussion on how we can align these states until @domarku designs the final version of them

I basically tried to align all the navigation links to follow our TextLink styles:
- hover: the link gets underlined
- active: the link gets bold and underline

![Screenshot 2022-01-17 at 11 59 20](https://user-images.githubusercontent.com/6597467/149758322-ca810d45-cbf7-461f-82c7-4e1cfe4343fb.png)

### Hover state in sidebar
![hover_sidebar](https://user-images.githubusercontent.com/6597467/149758336-f496ce08-5f7f-4227-b870-7ef6a52e6e05.gif)

### Hover in ToC
![hover_toc](https://user-images.githubusercontent.com/6597467/149758340-040b9f3a-07ca-4283-ac0d-53502d2ea491.gif)

### Hover in Topbar
![hover_topbar](https://user-images.githubusercontent.com/6597467/149758344-202535b3-a67d-4cfd-8178-a7d506a537bc.gif)



## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
