### PR TITLE
fix: align sidebar links to forma 36's logo

### DIFF
--- a/packages/website/components/DocSearch.tsx
+++ b/packages/website/components/DocSearch.tsx
@@ -6,16 +6,15 @@ import { SearchIcon } from '@contentful/f36-icons';
 import { TextInput } from '@contentful/f36-forms';
 
 const styles = {
-  container: css`
-    display: flex;
-    align-items: center;
-    width: 100%;
-    padding: ${tokens.spacingM} ${tokens.spacingM} 0;
-    margin-bottom: ${tokens.spacingM};
-    & .algolia-autocomplete {
-      width: 100%;
-    }
-  `,
+  container: css({
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+    marginRight: tokens.spacingM,
+    '& .algolia-autocomplete': {
+      width: '100%',
+    },
+  }),
 };
 
 export const DocSearch = () => {

--- a/packages/website/components/Sidebar.tsx
+++ b/packages/website/components/Sidebar.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { css } from 'emotion';
 import sortBy from 'lodash.sortby';
 import tokens from '@contentful/f36-tokens';
-import { Flex, List, Box } from '@contentful/f36-components';
+import { Flex } from '@contentful/f36-components';
 
-import { SidebarLink } from './SidebarLink';
 import {
   SidebarSection,
   SidebarSectionType,
@@ -24,9 +23,6 @@ const styles = {
     listStyle: 'none',
   }),
 };
-
-const isLinkActive = (href, currentPage) =>
-  currentPage.replace(/\/$/, '') === href.replace(/\/$/, '');
 
 interface Props {
   currentPage?: string;
@@ -92,65 +88,65 @@ export function Sidebar({ currentPage = '/' }: Props) {
       flexDirection="column"
       className={styles.nav}
     >
-      <List className={styles.list}>
-        {currentPage.includes('guidelines') ||
-        currentPage.includes('tokens') ||
-        currentPage.includes('components') ? (
-          <>
-            {currentPage.includes('guidelines') && (
-              <SidebarSection
-                links={sidebarLinks.guidelines}
-                currentPage={currentPage}
-              />
-            )}
-            {currentPage.includes('tokens') && (
-              <SidebarSection
-                links={sidebarLinks.tokens}
-                currentPage={currentPage}
-              />
-            )}
-            {currentPage.includes('components') && (
-              <>
-                <SidebarSection
-                  links={componentsSorted}
-                  currentPage={currentPage}
-                />
-                <SidebarSection
-                  title="Utils"
-                  links={sidebarLinks.utils}
-                  currentPage={currentPage}
-                />
-                <SidebarSection
-                  title="Integrations"
-                  links={sidebarLinks.integrations}
-                  currentPage={currentPage}
-                />
-              </>
-            )}
-          </>
-        ) : (
-          <>
-            <SidebarLink
-              isActive={isLinkActive('/getting-started', currentPage)}
-              href="/getting-started"
-            >
-              Getting started
-            </SidebarLink>
-            <SidebarLink
-              isActive={isLinkActive('/contributing', currentPage)}
-              href="/contributing"
-            >
-              Contributing to Forma 36
-            </SidebarLink>
-            <Box marginBottom="spacingL" />
+      {currentPage.includes('guidelines') ||
+      currentPage.includes('tokens') ||
+      currentPage.includes('components') ? (
+        <>
+          {currentPage.includes('guidelines') && (
             <SidebarSection
-              title="Forma 36 version 3"
-              links={sidebarLinks.forma36Version3}
+              links={sidebarLinks.guidelines}
               currentPage={currentPage}
             />
-          </>
-        )}
-      </List>
+          )}
+          {currentPage.includes('tokens') && (
+            <SidebarSection
+              links={sidebarLinks.tokens}
+              currentPage={currentPage}
+            />
+          )}
+          {currentPage.includes('components') && (
+            <>
+              <SidebarSection
+                links={componentsSorted}
+                currentPage={currentPage}
+              />
+              <SidebarSection
+                title="Utils"
+                links={sidebarLinks.utils}
+                currentPage={currentPage}
+              />
+              <SidebarSection
+                title="Integrations"
+                links={sidebarLinks.integrations}
+                currentPage={currentPage}
+              />
+            </>
+          )}
+        </>
+      ) : (
+        <>
+          <SidebarSection
+            links={[
+              {
+                title: 'Getting started',
+                slug: '/getting-started',
+                type: 'link',
+              },
+              {
+                title: 'Contributing to Forma 36',
+                slug: '/contributing',
+                type: 'link',
+              },
+            ]}
+            currentPage={currentPage}
+          />
+          <SidebarSection
+            title="Forma 36 version 3"
+            links={sidebarLinks.forma36Version3}
+            currentPage={currentPage}
+          />
+        </>
+      )}
     </Flex>
   );
 }

--- a/packages/website/components/SidebarLink.tsx
+++ b/packages/website/components/SidebarLink.tsx
@@ -10,7 +10,7 @@ export const getSectionTitleStyles = (isActive = false, indent = 1) => {
   return {
     sidebarItem: css({
       padding: `${tokens.spacingXs} ${tokens.spacingM}`,
-      paddingLeft: `calc(${indent} * ${tokens.spacingM})`,
+      paddingLeft: indent === 1 ? tokens.spacingXl : tokens.spacing2Xl,
       fontSize: tokens.fontSizeM,
       lineHeight: tokens.lineHeightM,
     }),

--- a/packages/website/components/SidebarSection.tsx
+++ b/packages/website/components/SidebarSection.tsx
@@ -18,7 +18,7 @@ const styles = {
     userSelect: 'none',
   }),
   sectionTitle: css({
-    padding: `${tokens.spacingXs} ${tokens.spacingM}`,
+    padding: `${tokens.spacingXs} ${tokens.spacingM} ${tokens.spacingXs} ${tokens.spacingXl}`,
     letterSpacing: 'initial',
   }),
 };


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

![Screenshot 2022-01-17 at 15 44 20](https://user-images.githubusercontent.com/6597467/149791825-36fed507-cb98-4413-b90a-2b9e5a9356c3.png)
![Screenshot 2022-01-17 at 15 52 36](https://user-images.githubusercontent.com/6597467/149791830-dc507b2c-70df-4d2a-9ae8-0c40e516d087.png)
![Screenshot 2022-01-17 at 15 52 42](https://user-images.githubusercontent.com/6597467/149791832-bb62105f-23db-4a99-92bd-63659e5a9283.png)
![Screenshot 2022-01-17 at 15 52 49](https://user-images.githubusercontent.com/6597467/149791834-4703b160-ccb3-4857-8bd6-90dd66490895.png)

This PR:
- removes unnecessary list that was wrapping all other list of links in the sidebar
- aligns links in the sidebar to Forma 36's logo like in the designs by @domarku 
- removes padding around DocSearch that was increasing the size of the topbar

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
