### PR TITLE
docs: add storybook link

### DIFF
--- a/packages/components/button/src/Button/README.mdx
+++ b/packages/components/button/src/Button/README.mdx
@@ -6,6 +6,7 @@ section: 'buttonComponents'
 slug: /components/button/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/button'
 typescript: ./Button.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-button--basic'
 ---
 
 Buttons communicate the action that will occur when the user clicks them.

--- a/packages/components/button/src/ButtonGroup/README.mdx
+++ b/packages/components/button/src/ButtonGroup/README.mdx
@@ -6,6 +6,7 @@ section: 'buttonComponents'
 slug: /components/button-group/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/button/src/ButtonGroup'
 typescript: ./ButtonGroup.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-button-buttongroup--basic'
 ---
 
 `ButtonGroup` should be used to group buttons whose actions are related, with an option to merge them together or split them with an equal amount of free space.

--- a/packages/components/button/src/IconButton/README.mdx
+++ b/packages/components/button/src/IconButton/README.mdx
@@ -6,6 +6,7 @@ section: 'buttonComponents'
 slug: /components/icon-button/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/button/src/IconButton'
 typescript: ./IconButton.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-button-iconbutton--basic'
 ---
 
 `IconButton` composes the [Button](../components/button) component except that it renders only an icon.

--- a/packages/components/button/src/ToggleButton/README.mdx
+++ b/packages/components/button/src/ToggleButton/README.mdx
@@ -6,6 +6,7 @@ section: 'buttonComponents'
 slug: /components/toggle-button/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/button/src/ToggleButton'
 typescript: ./ToggleButton.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-button-togglebutton--basic'
 ---
 
 `ToggleButton` allows users to toggle a selection on or off, for example switching between two states or modes.

--- a/packages/components/card/src/AssetCard/README.mdx
+++ b/packages/components/card/src/AssetCard/README.mdx
@@ -4,6 +4,7 @@ slug: /components/asset-card/
 section: 'cardComponents'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/card/src/AssetCard'
 typescript: ./AssetCard.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-card-assetcard--default'
 ---
 
 import { Heading, Stack, TextLink } from '@contentful/f36-components';

--- a/packages/components/card/src/EntryCard/README.mdx
+++ b/packages/components/card/src/EntryCard/README.mdx
@@ -4,6 +4,7 @@ slug: /components/entry-card/
 section: 'cardComponents'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/card/src/EntryCard'
 typescript: ./EntryCard.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-card-entrycard--default'
 ---
 
 import { Heading, Stack, TextLink } from '@contentful/f36-components';

--- a/packages/components/card/src/InlineEntryCard/README.mdx
+++ b/packages/components/card/src/InlineEntryCard/README.mdx
@@ -4,6 +4,7 @@ slug: /components/inline-entry-card/
 section: 'cardComponents'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/card/src/InlineEntryCard/'
 typescript: ./InlineEntryCard.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-card-inlineentrycard--default'
 ---
 
 import { Heading, Stack, TextLink } from '@contentful/f36-components';

--- a/packages/components/collapse/README.mdx
+++ b/packages/components/collapse/README.mdx
@@ -3,6 +3,7 @@ title: 'Collapse'
 slug: /animations/collapse/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/collapse'
 typescript: ./src/Collapse.tsx,
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/animation-collapse--basic'
 ---
 
 import { Button, Text } from '@contentful/f36-components';

--- a/packages/components/copybutton/README.mdx
+++ b/packages/components/copybutton/README.mdx
@@ -6,6 +6,7 @@ section: 'buttonComponents'
 slug: /components/copy-button/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/copybutton'
 typescript: ./src/CopyButton.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-copybutton--default'
 ---
 
 The `CopyButton` is a styled button that copies text into the user's clipboard.

--- a/packages/components/datetime/src/DateTime/README.mdx
+++ b/packages/components/datetime/src/DateTime/README.mdx
@@ -4,6 +4,7 @@ slug: /components/datetime/
 section: 'dateComponents'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/datetime'
 typescript: ./src/DateTime.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-datetime--basic'
 ---
 
 In `@contentful/f36-datetime`, there are two components (`DateTime` and `RelativeDateTime`) that will return a date following our guidelines.

--- a/packages/components/drag-handle/README.mdx
+++ b/packages/components/drag-handle/README.mdx
@@ -4,6 +4,7 @@ type: 'component'
 slug: /components/drag-handle/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/drag-handle'
 typescript: ./src/DragHandle.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-draghandle--default'
 ---
 
 import { Heading, Stack, TextLink } from '@contentful/f36-components';

--- a/packages/components/forms/src/Radio/README.mdx
+++ b/packages/components/forms/src/Radio/README.mdx
@@ -6,6 +6,7 @@ section: 'formComponents'
 slug: /components/radio/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/forms/src/Radio'
 typescript: ./Radio.tsx,./RadioGroup.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/form-elements-radio--basic'
 ---
 
 `Radio` is a form component, that shows a radio input with its label. It is used to allow users to choose single option from the list.

--- a/packages/components/forms/src/TextInput/README.mdx
+++ b/packages/components/forms/src/TextInput/README.mdx
@@ -6,6 +6,7 @@ section: 'formComponents'
 slug: /components/text-input/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/forms/src/TextInput'
 typescript: ./TextInput.tsx,./input-group/InputGroup.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/form-elements-textinput--basic'
 ---
 
 `TextInput` is a form component, that allows users to input text or numbers and should be used in a form context.

--- a/packages/components/forms/src/Textarea/README.mdx
+++ b/packages/components/forms/src/Textarea/README.mdx
@@ -6,6 +6,7 @@ section: 'formComponents'
 slug: /components/textarea/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/forms/src/Textarea'
 typescript: ./Textarea.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/form-elements-textarea--basic'
 ---
 
 `Textarea` is a form component that allows the user to enter a sizeable amount of multi-line plain text.

--- a/packages/components/menu/README.mdx
+++ b/packages/components/menu/README.mdx
@@ -3,6 +3,7 @@ title: 'Menu'
 slug: /components/menu/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/menu'
 typescript: ./src/Menu.tsx,./src/MenuItem/MenuItem.tsx,./src/MenuList/MenuList.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-menu--basic'
 ---
 
 Menu is a component that offers a list of choices to the user, such as a set of actions or links.

--- a/packages/components/modal/src/ModalConfirm/README.mdx
+++ b/packages/components/modal/src/ModalConfirm/README.mdx
@@ -6,6 +6,7 @@ section: 'modalComponents'
 slug: /components/modal-confirm/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/modal/src'
 typescript: ./ModalConfirm.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-modal-modalconfirm--basic'
 ---
 
 `ModalConfirm` is a convenience wrapper on top of [Modal]. It is intended to use for showing confirmation dialogs.

--- a/packages/components/modal/src/README.mdx
+++ b/packages/components/modal/src/README.mdx
@@ -6,6 +6,7 @@ section: 'modalComponents'
 slug: /components/modal/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/modal/src'
 typescript: ./Modal.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-modal--basic'
 ---
 
 `Modal` appears on top of the main content and moves the system into a special mode requiring user interaction. It blocks interaction with the main content until an action is taken.

--- a/packages/components/notification/README.mdx
+++ b/packages/components/notification/README.mdx
@@ -5,6 +5,7 @@ status: 'stable'
 slug: /components/notification/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/notification'
 typescript: ./src/Notification.tsx,./src/NotificationItem/NotificationItem.tsx,./src/NotificationItem/NotificationItemContainer.tsx,./src/NotificationsManager/NotificationsManager.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-notification--basic'
 ---
 
 `Notification` gives an immediate feedback about an action triggered or experienced by an user.

--- a/packages/components/text-link/README.mdx
+++ b/packages/components/text-link/README.mdx
@@ -5,6 +5,7 @@ status: 'stable'
 slug: /components/text-link/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/text-link'
 typescript: ./src/TextLink.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-textlink--basic'
 ---
 
 `TextLink` communicates actions and links to URLs.

--- a/packages/components/typography/src/DisplayText/README.mdx
+++ b/packages/components/typography/src/DisplayText/README.mdx
@@ -6,6 +6,7 @@ section: 'typographyComponents'
 slug: /components/display-text/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/typography/src'
 typescript: ./DisplayText.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/typography-displaytext--basic'
 ---
 
 `DisplayText` is used to display text in special scenarios - example usages of `DisplayText` include empty states, promotional/featured items, etc.

--- a/packages/components/typography/src/Heading/README.mdx
+++ b/packages/components/typography/src/Heading/README.mdx
@@ -6,6 +6,7 @@ section: 'typographyComponents'
 slug: /components/heading/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/typography/src'
 typescript: ./Heading.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/typography-heading--basic'
 ---
 
 `Heading` is intended to be used to define the title of the page. They are displayed as `h1` by default. Accessibility requires having just one `h1` tag on the page. Keep that in mind during the implementation.

--- a/packages/components/typography/src/Paragraph/README.mdx
+++ b/packages/components/typography/src/Paragraph/README.mdx
@@ -6,6 +6,7 @@ section: 'typographyComponents'
 slug: /components/paragraph/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/typography/src'
 typescript: ./Paragraph.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/typography-paragraph--basic'
 ---
 
 `Paragraph` component is rendered as `<p>` and with default bottom margin of `spacingM` (`1rem`) applied. It is one of the most commonly used typography components.

--- a/packages/components/typography/src/SectionHeading/README.mdx
+++ b/packages/components/typography/src/SectionHeading/README.mdx
@@ -6,6 +6,7 @@ section: 'typographyComponents'
 slug: /components/section-heading/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/typography/src'
 typescript: ./SectionHeading.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/typography-sectionheading--basic'
 ---
 
 `SectionHeading` is intended to be used as a title for each section. SectionHeading are very important for accessibility, as they help to make copy more easily scannable and guides a user through your content. When using screen readers, it finds sections in your copy based on your heading hierarchy.

--- a/packages/components/typography/src/Subheading/README.mdx
+++ b/packages/components/typography/src/Subheading/README.mdx
@@ -6,6 +6,7 @@ section: 'typographyComponents'
 slug: /components/subheading/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/typography/src'
 typescript: ./Subheading.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/typography-subheading--basic'
 ---
 
 `Subheading` is intended to be used as a heading for copy nested within a section. For example: a subheading under Contact may be Address or Phone number.

--- a/packages/components/typography/src/Text/README.mdx
+++ b/packages/components/typography/src/Text/README.mdx
@@ -6,6 +6,7 @@ section: 'typographyComponents'
 slug: /components/text/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/typography/src'
 typescript: ./Text.tsx
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/typography-text--basic'
 ---
 
 `Text` is a basic typography component. It will be displayed as a `span` element by default with a default font family, font color, font size and letter spacing.

--- a/packages/website/components/CustomHeading2.tsx
+++ b/packages/website/components/CustomHeading2.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { TextLink, Stack, Heading } from '@contentful/f36-components';
+
+import { ExternalLinkIcon } from '@contentful/f36-icons';
+import { useFrontMatterContext } from '../utils/frontMatterContext';
+
+const PROPS_TITLE = 'Props (API reference)';
+
+interface CustomHeading2Props {
+  children: string;
+}
+
+export const CustomHeading2 = (props: CustomHeading2Props) => {
+  const { storybook } = useFrontMatterContext() ?? {};
+
+  if (props.children.includes(PROPS_TITLE)) {
+    return (
+      <Stack
+        justifyContent="space-between"
+        marginTop="spacing2Xl"
+        marginBottom="spacingM"
+      >
+        <Heading as="h2" marginTop="none" marginBottom="none" {...props} />
+
+        <TextLink
+          href={storybook}
+          target="_blank"
+          alignIcon="end"
+          icon={<ExternalLinkIcon />}
+        >
+          Open in Storybook
+        </TextLink>
+      </Stack>
+    );
+  }
+
+  return <Heading as="h2" marginTop="spacing2Xl" {...props} />;
+};

--- a/packages/website/components/CustomHeading2.tsx
+++ b/packages/website/components/CustomHeading2.tsx
@@ -13,7 +13,7 @@ interface CustomHeading2Props {
 export const CustomHeading2 = (props: CustomHeading2Props) => {
   const { storybook } = useFrontMatterContext() ?? {};
 
-  if (props.children.includes(PROPS_TITLE)) {
+  if (props.children.includes(PROPS_TITLE) && storybook) {
     return (
       <Stack
         justifyContent="space-between"

--- a/packages/website/components/MdxRenderer.tsx
+++ b/packages/website/components/MdxRenderer.tsx
@@ -7,10 +7,10 @@ import { MdxComponents } from '../mdx-components';
 import { ComponentSource } from './LiveEditor/ComponentSource';
 import { StaticSource } from './LiveEditor/StaticSource';
 import tokens from '@contentful/f36-tokens';
+import { CustomHeading2 } from './CustomHeading2';
 
 const {
   DisplayText,
-  Heading,
   Subheading,
   Paragraph,
   TextLink,
@@ -22,7 +22,8 @@ const {
 /* eslint-disable @next/next/no-img-element */
 const components = {
   h1: (props) => <DisplayText as="h1" {...props} />,
-  h2: (props) => <Heading as="h2" marginTop="spacing2Xl" {...props} />,
+  // to cover a specific case with "Props (API reference)"
+  h2: CustomHeading2,
   h3: (props) => <Subheading as="h3" marginTop="spacingXl" {...props} />,
   h4: (props) => <Subheading as="h4" {...props} />,
   h5: (props) => <Subheading as="h5" {...props} />,

--- a/packages/website/pages/[...slug].tsx
+++ b/packages/website/pages/[...slug].tsx
@@ -19,6 +19,7 @@ import { getMdxPaths, getMdxSourceBySlug } from '../utils/content';
 import { getPropsMetadata, transformToc } from '../utils/propsMeta';
 import { getTableOfContents } from '../utils/mdx-utils';
 import { HeadingType } from '../components/TableOfContent';
+import { FrontMatterContextProvider } from '../utils/frontMatterContext';
 
 type ComponentPageProps = {
   source: MDXRemoteSerializeResult;
@@ -47,7 +48,9 @@ export default function ComponentPage({
 
       <PageContent frontMatter={frontMatter} headings={headings}>
         <PropsContextProvider value={{ ...propsMetadata }}>
-          <MdxRenderer source={source} />
+          <FrontMatterContextProvider value={frontMatter}>
+            <MdxRenderer source={source} />
+          </FrontMatterContextProvider>
         </PropsContextProvider>
       </PageContent>
     </>

--- a/packages/website/types.ts
+++ b/packages/website/types.ts
@@ -7,4 +7,5 @@ export interface FrontMatter {
   title: string;
   type?: string;
   typescript?: string;
+  storybook?: string;
 }

--- a/packages/website/utils/frontMatterContext.ts
+++ b/packages/website/utils/frontMatterContext.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+import type { FrontMatter } from '../types';
+
+const FrontMatterContext = React.createContext<FrontMatter | undefined>(
+  undefined,
+);
+
+export const useFrontMatterContext = () => {
+  return React.useContext(FrontMatterContext);
+};
+
+export const FrontMatterContextProvider = FrontMatterContext.Provider;


### PR DESCRIPTION
- add a storybook link for Props Table heading
- return back all the components docs storybook links in front matter