### PR TITLE
feat: allow react nodes in title of note

### DIFF
--- a/packages/components/note/src/Note.tsx
+++ b/packages/components/note/src/Note.tsx
@@ -36,7 +36,7 @@ export type NoteInternalProps = CommonProps & {
   /**
    * Sets title in the Note
    */
-  title?: string;
+  title?: React.ReactNode;
   /**
    * Children of Note
    */


### PR DESCRIPTION
# Purpose of PR

In the note component I want to be able to set other components next to the title. For example the badge component.
This required a simple typescript change.

![Screenshot 2022-01-19 at 10 06 29](https://user-images.githubusercontent.com/22968325/150098749-33eec120-cfa3-4f39-89b1-e9104dab2ed2.png)

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are not required
- [x] Tests are passing
- [x] Storybook stories are not required
- [x] Usage notes are not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
