### PR TITLE
fix: allows all native HTML values to type prop of an input

### DIFF
--- a/packages/components/forms/src/BaseInput/types.ts
+++ b/packages/components/forms/src/BaseInput/types.ts
@@ -23,11 +23,6 @@ export interface BaseInputInternalProps extends CommonProps {
    */
   name?: string;
   /**
-   * Set the type of the input
-   * @default text
-   */
-  type?: 'text' | 'email' | 'file' | 'number' | 'password' | 'search' | 'url';
-  /**
    * Applies disabled styles
    * @default false
    */


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

We were overwriting the default values for the `type` property of an input and because of that TS was complaining when you did something like `<TextInput type="date" />`

This will close https://github.com/contentful/forma-36/issues/1769

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
