### PR TITLE
docs: move skeleton container docs to new format

### DIFF
--- a/packages/components/skeleton/examples/SkeletonContainerBasicExample.tsx
+++ b/packages/components/skeleton/examples/SkeletonContainerBasicExample.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import {
+  SkeletonContainer,
+  SkeletonBodyText,
+} from '@contentful/f36-components';
+
+export default function SkeletonContainerBasicExample() {
+  return (
+    <SkeletonContainer>
+      <SkeletonBodyText numberOfLines={4} />
+    </SkeletonContainer>
+  );
+}

--- a/packages/components/skeleton/examples/SkeletonContainerDifferentSpeedExample.tsx
+++ b/packages/components/skeleton/examples/SkeletonContainerDifferentSpeedExample.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import {
+  SkeletonContainer,
+  SkeletonBodyText,
+} from '@contentful/f36-components';
+
+export default function SkeletonContainerDifferentSpeedExample() {
+  return (
+    <SkeletonContainer backgroundColor="blue" speed={1}>
+      <SkeletonBodyText numberOfLines={4} />
+    </SkeletonContainer>
+  );
+}

--- a/packages/components/skeleton/src/SkeletonContainer/README.mdx
+++ b/packages/components/skeleton/src/SkeletonContainer/README.mdx
@@ -1,42 +1,38 @@
 ---
 title: 'SkeletonContainer'
-type: 'component'
-status: 'stable'
-section: 'skeletonComponents'
 slug: /components/skeleton/skeleton-container/
+section: 'skeletonComponents'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/skeleton'
-storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-skeleton-container--default'
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-skeleton-skeletoncontainer'
 typescript: ./SkeletonContainer.tsx
 ---
 
-## How to use SkeletonContainer
+The `SkeletonContainer` component is a wrapper component of the all other skeleton components:
+`SkeletonBodyText`, `SkeletonDisplayText`, `SkeletonImage`, `SkeletonRow`
 
-The `SkeletonContainer` component is a wrapper component of the all other skeleton components: `SkeletonBodyText`, `SkeletonDisplayText`, `SkeletonImage`, `SkeletonRow`
+Use can use properties of `SkeletonContainer` to control color, background color, animation,
+opacity of the skeleton elements that are used inside.
 
-Use can use properties of `SkeletonContainer` to control color, background color, animation, opacity of the skeleton elements that are used inside.
+## Import
 
-### Import
-
-```js static=true
+```jsx static=true
 import { SkeletonContainer } from '@contentful/f36-components';
 // or
 import { SkeletonContainer } from '@contentful/f36-skeleton';
 ```
 
-## Code examples
+## Examples
 
-```jsx
-<SkeletonContainer>
-  <SkeletonBodyText numberOfLines={4} />
-</SkeletonContainer>
+### Basic usage
+
+```jsx file=../../examples/SkeletonContainerBasicExample.tsx
+
 ```
 
-An example with a different color and an increased speed.
+### Different speed and color
 
-```jsx
-<SkeletonContainer backgroundColor="red" speed={1}>
-  <SkeletonBodyText numberOfLines={2} />
-</SkeletonContainer>
+```jsx file=../../examples/SkeletonContainerDifferentSpeedExample.tsx
+
 ```
 
 ## Props (API reference)

--- a/scripts/plop-templates/package/v4ComponentDoc.mdx.hbs
+++ b/scripts/plop-templates/package/v4ComponentDoc.mdx.hbs
@@ -2,6 +2,7 @@
 title: '{{componentName}}'
 slug: /components/{{packageName}}/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/{{packageName}}'
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-{{packageName}}'
 typescript: ./src/{{componentName}}.tsx
 ---
 
@@ -17,6 +18,8 @@ Optional: Most common misuse and what to use instead.
 
 ```jsx static=true
 import { {{componentName}} } from '@contentful/f36-components'
+// or
+import { {{componentName}} } from '@contentful/f36-{{packageName}}'
 ```
 
 ## Examples
@@ -27,24 +30,10 @@ Repeat for every important variant
 
 Optional: Short "when to use" with considerations towards the end user
 
-```jsx
-<{{componentName}}>This is an example</{{componentName}}>
+```jsx file=../examples/{{componentName}}Example.tsx
 ```
 
-<Stack justifyContent="space-between" marginTop="spacing2Xl" marginBottom="spacingL">
-  <Heading id="props-api-reference" as="h2" marginTop="none" marginBottom="none">
-    Props (API reference)
-  </Heading>
-
-  <TextLink
-    href="https://v4-f36-storybook.netlify.app/?path=/story/components-{{packageName}}"
-    target="_blank"
-    alignIcon="end"
-    icon={<ExternalLinkIcon />}
-  >
-    Open in Storybook
-  </TextLink>
-</Stack>
+## Props (API reference)
 
 <PropsTable of="{{componentName}}" />
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20669,6 +20669,11 @@ react-hook-form@^7.15.0:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.15.0.tgz#f6eb3a18ca797d39a5407114db07719d5c55e7fb"
   integrity sha512-UWEkNhcTvA+o/FUZ2RMvpKgxxEg0rJqEjHMDwh3I4TIdHX38TtN8IywyGieqeWLiHEpoNVOuEhLVPZ9/srXUhA==
 
+react-icons@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.3.1.tgz#2fa92aebbbc71f43d2db2ed1aed07361124e91ca"
+  integrity sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==
+
 react-icons@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.2.0.tgz#6dda80c8a8f338ff96a1851424d63083282630d0"


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

It updates `SkeletonContainer` docs

# ACHTUNG ⚠️ 

I ran `yarn install` and it updated yarn.lock
which means we forgot to commit yarn.lock changes after installing `react-icons`
Let's not forget to push changes to the lock file after installing dependencies in the future 🙏  

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
