### PR TITLE
fix(Collapse): make it clickable after first expansion

### DIFF
--- a/packages/components/collapse/src/Collapse.tsx
+++ b/packages/components/collapse/src/Collapse.tsx
@@ -65,6 +65,7 @@ export const Collapse = ({
         } else {
           // Overwrite none display to see expanding transition
           current.style.setProperty('display', 'block');
+          current.style.removeProperty('pointer-events');
         }
         // Calculate panel height after removing none display
         const fromHeight = isExpanded ? '0px' : getPanelContentHeight();


### PR DESCRIPTION
# Purpose of PR

My former PR introduced a bug where the expanded region was not clickable after expanding for the first time. I'll now remove the `pointer-events` property properly.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
