### PR TITLE
fix: allow unique IDs for collapse component

### DIFF
--- a/packages/components/collapse/src/Collapse.tsx
+++ b/packages/components/collapse/src/Collapse.tsx
@@ -16,6 +16,10 @@ interface CollapseInternalProps extends CommonProps {
    * string for additional classNames
    */
   className?: string;
+  /**
+   * A unique id of the collapse component
+   */
+  id?: string;
 }
 
 export type CollapseProps = PropsWithHTMLElement<CollapseInternalProps, 'div'>;


### PR DESCRIPTION
# Purpose of PR

Currently the `Collapse` component typescript interface does not allow `id` to be set with a prop.

Even though in the story file of the `Collapse` component an ID has been set: https://github.com/contentful/forma-36/blob/050169cac56863191c0dd8a564300d595605b710/packages/components/collapse/stories/Collapse.stories.tsx#L39

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
