### PR TITLE
docs: move skeleton components docs to new format

### DIFF
--- a/packages/components/skeleton/examples/SkeletonDisplayTextBasicExample.tsx
+++ b/packages/components/skeleton/examples/SkeletonDisplayTextBasicExample.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import {
+  SkeletonContainer,
+  SkeletonDisplayText,
+} from '@contentful/f36-components';
+
+export default function SkeletonContainerDifferentSpeedExample() {
+  return (
+    <SkeletonContainer>
+      <SkeletonDisplayText />
+    </SkeletonContainer>
+  );
+}

--- a/packages/components/skeleton/examples/SkeletonDisplayTextCompositionExample.tsx
+++ b/packages/components/skeleton/examples/SkeletonDisplayTextCompositionExample.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import {
+  SkeletonContainer,
+  SkeletonDisplayText,
+  SkeletonBodyText,
+} from '@contentful/f36-components';
+
+export default function SkeletonDisplayTextCompositionExample() {
+  return (
+    <SkeletonContainer>
+      <SkeletonDisplayText />
+      <SkeletonBodyText offsetTop={37} numberOfLines={5} />
+      {/**
+       * The offsetTop value is the height of the DisplayText
+       * plus 16px (gap between the two skeletons)
+       */}
+    </SkeletonContainer>
+  );
+}

--- a/packages/components/skeleton/examples/SkeletonImageBasicExample.tsx
+++ b/packages/components/skeleton/examples/SkeletonImageBasicExample.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { SkeletonContainer, SkeletonImage } from '@contentful/f36-components';
+
+export default function SkeletonImageBasicExample() {
+  return (
+    <SkeletonContainer>
+      <SkeletonImage />
+    </SkeletonContainer>
+  );
+}

--- a/packages/components/skeleton/examples/SkeletonImageDimensionsExample.tsx
+++ b/packages/components/skeleton/examples/SkeletonImageDimensionsExample.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { SkeletonContainer, SkeletonImage } from '@contentful/f36-components';
+
+export default function SkeletonImageDimensionsExample() {
+  return (
+    <SkeletonContainer>
+      <SkeletonImage />
+      <SkeletonImage width={100} height={35} offsetTop={78} />
+      {/**
+       * The offsetTop value is the height of the first SkeletonImage
+       * plus 8px (gap between the two skeletons)
+       */}
+    </SkeletonContainer>
+  );
+}

--- a/packages/components/skeleton/examples/SkeletonImageRoundExample.tsx
+++ b/packages/components/skeleton/examples/SkeletonImageRoundExample.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { SkeletonContainer, SkeletonImage } from '@contentful/f36-components';
+
+export default function SkeletonImageRoundExample() {
+  return (
+    <SkeletonContainer>
+      <SkeletonImage radiusX={100} radiusY={100} />
+    </SkeletonContainer>
+  );
+}

--- a/packages/components/skeleton/examples/SkeletonRowBasicExample.tsx
+++ b/packages/components/skeleton/examples/SkeletonRowBasicExample.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Table, SkeletonRow } from '@contentful/f36-components';
+
+export default function SkeletonRowBasicExample() {
+  return (
+    <Table>
+      <Table.Head>
+        <Table.Row>
+          <Table.Cell>Name</Table.Cell>
+          <Table.Cell>Email</Table.Cell>
+          <Table.Cell>Address</Table.Cell>
+          <Table.Cell>Postcode</Table.Cell>
+          <Table.Cell>City</Table.Cell>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <SkeletonRow rowCount={5} columnCount={5} />
+      </Table.Body>
+    </Table>
+  );
+}

--- a/packages/components/skeleton/src/SkeletonBodyText/README.mdx
+++ b/packages/components/skeleton/src/SkeletonBodyText/README.mdx
@@ -19,9 +19,10 @@ import { SkeletonBodyText } from '@contentful/f36-skeleton';
 
 ## Examples
 
-- Each `SkeletonBodyText` needs to be wrapped by a SkeletonContainer component
-- Use the `numberOfLines` prop to determine how many lines you want to render.
-  We advise using a value that matches the number of lines the text will have after loading.
+Each `SkeletonBodyText` needs to be wrapped by a SkeletonContainer component.
+
+Use the `numberOfLines` prop to determine how many lines you want to render.
+We advise using a value that matches the number of lines the text will have after loading.
 
 ### Basic usage
 

--- a/packages/components/skeleton/src/SkeletonBodyText/README.mdx
+++ b/packages/components/skeleton/src/SkeletonBodyText/README.mdx
@@ -1,38 +1,33 @@
 ---
 title: 'SkeletonBodyText'
-type: 'component'
-status: 'stable'
 section: 'skeletonComponents'
 slug: /components/skeleton/skeleton-body-text/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/skeleton'
-storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-skeleton-skeletonbodytext--default'
+storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-skeleton-skeletonbodytext'
 typescript: ./SkeletonBodyText.tsx
 ---
 
-## How to use SkeletonBodyText
-
 Use the `SkeletonBodyText` component to simulate bodies of text with multiple lines whenever loading asynchronous data.
 
-### Import
+## Import
 
-```js static=true
+```jsx static=true
 import { SkeletonBodyText } from '@contentful/f36-components';
 // or
 import { SkeletonBodyText } from '@contentful/f36-skeleton';
 ```
 
-## Code examples
-
-```jsx
-<SkeletonContainer>
-  <SkeletonBodyText numberOfLines={4} />
-</SkeletonContainer>
-```
-
-## Best practices
+## Examples
 
 - Each `SkeletonBodyText` needs to be wrapped by a SkeletonContainer component
-- Use the `numberOfLines` prop to determine how many lines you want to render. We advise using a value that matches the number of lines the text will have after loading.
+- Use the `numberOfLines` prop to determine how many lines you want to render.
+  We advise using a value that matches the number of lines the text will have after loading.
+
+### Basic usage
+
+```jsx file=../../examples/SkeletonContainerBasicExample.tsx
+
+```
 
 ## Props (API reference)
 

--- a/packages/components/skeleton/src/SkeletonBodyText/README.mdx
+++ b/packages/components/skeleton/src/SkeletonBodyText/README.mdx
@@ -29,6 +29,12 @@ import { SkeletonBodyText } from '@contentful/f36-skeleton';
 
 ```
 
+### Composition with other skeletons
+
+```jsx file=../../examples/SkeletonDisplayTextCompositionExample.tsx
+
+```
+
 ## Props (API reference)
 
 <PropsTable of="SkeletonBodyText" />

--- a/packages/components/skeleton/src/SkeletonDisplayText/README.mdx
+++ b/packages/components/skeleton/src/SkeletonDisplayText/README.mdx
@@ -19,8 +19,8 @@ import { SkeletonDisplayText } from '@contentful/f36-skeleton';
 
 ## Examples
 
-- Each `SkeletonDisplayText` needs to be wrapped by a `SkeletonContainer` component
-- Only use it to mimic headings and titles, for normal text we recommend using SkeletonBodyText.
+Each `SkeletonDisplayText` needs to be wrapped by a `SkeletonContainer` component.
+Only use it to mimic headings and titles, for normal text we recommend using [SkeletonBodyText](/components/skeleton/skeleton-body-text).
 
 ### Basic usage
 

--- a/packages/components/skeleton/src/SkeletonDisplayText/README.mdx
+++ b/packages/components/skeleton/src/SkeletonDisplayText/README.mdx
@@ -1,7 +1,5 @@
 ---
 title: 'SkeletonDisplayText'
-type: 'component'
-status: 'stable'
 section: 'skeletonComponents'
 slug: /components/skeleton/skeleton-display-text/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/skeleton'
@@ -9,30 +7,32 @@ storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-skeleto
 typescript: ./SkeletonDisplayText.tsx
 ---
 
-## How to use SkeletonDisplayText
-
 Use the `SkeletonDisplayText` component to simulate headings, subheadings or titles whenever loading asynchronous data.
 
-### Import
+## Import
 
-```js static=true
+```jsx static=true
 import { SkeletonDisplayText } from '@contentful/f36-components';
 // or
 import { SkeletonDisplayText } from '@contentful/f36-skeleton';
 ```
 
-## Code examples
-
-```jsx
-<SkeletonContainer>
-  <SkeletonDisplayText />
-</SkeletonContainer>
-```
-
-## Best practices
+## Examples
 
 - Each `SkeletonDisplayText` needs to be wrapped by a `SkeletonContainer` component
 - Only use it to mimic headings and titles, for normal text we recommend using SkeletonBodyText.
+
+### Basic usage
+
+```jsx file=../../examples/SkeletonDisplayTextBasicExample.tsx
+
+```
+
+### Composition with other skeletons
+
+```jsx file=../../examples/SkeletonDisplayTextCompositionExample.tsx
+
+```
 
 ## Props (API reference)
 

--- a/packages/components/skeleton/src/SkeletonImage/README.mdx
+++ b/packages/components/skeleton/src/SkeletonImage/README.mdx
@@ -1,7 +1,5 @@
 ---
 title: 'SkeletonImage'
-type: 'component'
-status: 'stable'
 section: 'skeletonComponents'
 slug: /components/skeleton/skeleton-image/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/skeleton'
@@ -9,55 +7,44 @@ storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-skeleto
 typescript: ./SkeletonImage.tsx
 ---
 
-## How to use SkeletonImage
-
 Use the `SkeletonImage` component to simulate images, illustrations, avatars or icons whenever loading asynchronous data.
 
-### Import
+## Import
 
-```js static=true
+```jsx static=true
 import { SkeletonImage } from '@contentful/f36-components';
 // or
 import { SkeletonImage } from '@contentful/f36-skeleton';
 ```
 
-## Code examples
+## Examples
 
-```jsx
-<SkeletonContainer>
-  <SkeletonImage />
-</SkeletonContainer>
+Each `SkeletonImage` needs to be wrapped by a `SkeletonContainer` component.
+
+### Basic usage
+
+```jsx file=../../examples/SkeletonImageBasicExample.tsx
+
 ```
 
-## Best practices
+### Setting width and height
 
-- Each `SkeletonImage` needs to be wrapped by a `SkeletonContainer` component.
-- Pass some value to the `width` and `height` props to make the skeleton the same size as the simulated image (default values are 70).
-  You can use the same values a normal `<rect>` tag would accept for [width](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/width#rect) and [height](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/height#rect)
+Pass some value to the `width` and `height` props to make the skeleton the same size as the simulated image (default values are 70).
+You can use the same values a normal `<rect>` tag would accept for [width](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/width#rect)
+and [height](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/height#rect)
 
-```jsx
-<>
-  <SkeletonContainer>
-    <SkeletonImage />
-  </SkeletonContainer>
-  <SkeletonContainer>
-    <SkeletonImage width={100} height={35} />
-  </SkeletonContainer>
-</>
+```jsx file=../../examples/SkeletonImageDimensionsExample.tsx
+
 ```
 
-- Pass some value to the `radiusX` and `radiusY` props to control the roundness of skeleton's corners (default values are 0).
-  You can use the same values a normal `<rect>` tag would accept for [rx](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx#rect) and [ry](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ry#rect)
+### Round skeleton
 
-```jsx
-<>
-  <SkeletonContainer>
-    <SkeletonImage />
-  </SkeletonContainer>
-  <SkeletonContainer>
-    <SkeletonImage radiusX={100} radiusY={100} />
-  </SkeletonContainer>
-</>
+Pass some value to the `radiusX` and `radiusY` props to control the roundness of skeleton's corners (default values are 0).
+You can use the same values a normal `<rect>` tag would accept for [rx](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx#rect)
+and [ry](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ry#rect)
+
+```jsx file=../../examples/SkeletonImageRoundExample.tsx
+
 ```
 
 ## Props (API reference)

--- a/packages/components/skeleton/src/SkeletonRow/README.mdx
+++ b/packages/components/skeleton/src/SkeletonRow/README.mdx
@@ -1,7 +1,5 @@
 ---
 title: 'SkeletonRow'
-type: 'component'
-status: 'stable'
 section: 'skeletonComponents'
 slug: /components/skeleton/skeleton-row/
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/skeleton'
@@ -9,42 +7,28 @@ storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-skeleto
 typescript: ./SkeletonRow.tsx
 ---
 
-## How to use SkeletonRow
-
 Use the `SkeletonRow` component to create a better loading state for your tables whenever they use asynchronous data.
 
-### Import
+## Import
 
-```js static=true
+```jsx static=true
 import { SkeletonRow } from '@contentful/f36-components';
 // or
 import { SkeletonRow } from '@contentful/f36-skeleton';
 ```
 
-## Code examples
+## Examples
 
-```jsx
-<Table>
-  <TableHead>
-    <TableRow>
-      <TableCell>Name</TableCell>
-      <TableCell>Email</TableCell>
-      <TableCell>Address</TableCell>
-      <TableCell>Postcode</TableCell>
-      <TableCell>City</TableCell>
-    </TableRow>
-  </TableHead>
-  <TableBody>
-    <SkeletonRow rowCount={5} columnCount={5} />
-  </TableBody>
-</Table>
+- Pass a value to the `columnCount` prop equal to the number of columns in your table (default value is 5).
+- Pass a value to the `rowCount` prop equal to the number of rows you need.
+- We think that for a better experience this value should match the number of rows that this table usually has when it's first loaded.
+- Only use this component as a child of the TableBody component. The `SkeletonRow` component renders `<tr>` tags, and this HTML tag should always be a child of a `<tbody>` tag.
+
+### Basic usage
+
+```jsx file=../../examples/SkeletonRowBasicExample.tsx
+
 ```
-
-## Best practices
-
-- Pass a value to the `columnCount` prop equal to the number of columns in your table (default value is 5)
-- Pass a value to the `rowCount` prop equal to the number of rows you need. We think that for a better experience this value should match the number of rows that this table usually has when it's first loaded.
-- Only use this component as a child of the TableBody component. The SkeletonRow component renders `<tr>` tags, and this HTML tag should always be a child of a `<tbody>` tag
 
 ## Props (API reference)
 

--- a/scripts/plop-templates/package/v4ComponentDoc.mdx.hbs
+++ b/scripts/plop-templates/package/v4ComponentDoc.mdx.hbs
@@ -6,9 +6,6 @@ storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-{{packa
 typescript: ./src/{{componentName}}.tsx
 ---
 
-import { Heading, Stack, TextLink } from '@contentful/f36-components';
-import { ExternalLinkIcon } from '@contentful/f36-icons';
-
 Short component description covering when it's used.
 (Optional: give a most common example)
 


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This moves all the remaining skeleton components docs to the new format

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
