### PR TITLE
fix: keep topbar and sidebar navigation for deprecated, utils and integrations

### DIFF
--- a/packages/website/components/Sidebar.tsx
+++ b/packages/website/components/Sidebar.tsx
@@ -84,7 +84,9 @@ export function Sidebar({ currentPage = '/' }: Props) {
   // TODO: unify this logic with the one in the Topbar
   const isGuidelines = currentPage.includes('/guidelines');
   const isTokens = currentPage.includes('/tokens');
-  const isComponents = currentPage.includes('/components');
+  const isComponents =
+    currentPage.includes('/components') ||
+    currentPage.includes('/deprecated-components');
   const isIntroduction = !isGuidelines && !isTokens && !isComponents;
 
   return (

--- a/packages/website/components/Sidebar.tsx
+++ b/packages/website/components/Sidebar.tsx
@@ -5,6 +5,10 @@ import tokens from '@contentful/f36-tokens';
 import { Grid } from '@contentful/f36-components';
 
 import {
+  useCurrentLocation,
+  WEBSITE_SECTION,
+} from '../hooks/useCurrentLocation';
+import {
   SidebarSection,
   SidebarSectionType,
   SidebarLinkType,
@@ -81,13 +85,7 @@ const components: Array<SidebarSectionType | SidebarLinkType> = [
 export function Sidebar({ currentPage = '/' }: Props) {
   const componentsSorted = sortBy(components, ['title']);
 
-  // TODO: unify this logic with the one in the Topbar
-  const isGuidelines = currentPage.includes('/guidelines');
-  const isTokens = currentPage.includes('/tokens');
-  const isComponents =
-    currentPage.includes('/components') ||
-    currentPage.includes('/deprecated-components');
-  const isIntroduction = !isGuidelines && !isTokens && !isComponents;
+  const { activeSection } = useCurrentLocation(currentPage);
 
   return (
     <Grid.Item
@@ -96,7 +94,7 @@ export function Sidebar({ currentPage = '/' }: Props) {
       aria-label="Main Navigation"
       className={styles.nav}
     >
-      {isIntroduction && (
+      {activeSection === WEBSITE_SECTION.INTRODUCTION && (
         <>
           <SidebarSection
             links={[
@@ -132,18 +130,18 @@ export function Sidebar({ currentPage = '/' }: Props) {
         </>
       )}
 
-      {isGuidelines && (
+      {activeSection === WEBSITE_SECTION.GUIDELINES && (
         <SidebarSection
           links={sidebarLinks.guidelines}
           currentPage={currentPage}
         />
       )}
 
-      {isTokens && (
+      {activeSection === WEBSITE_SECTION.TOKENS && (
         <SidebarSection links={sidebarLinks.tokens} currentPage={currentPage} />
       )}
 
-      {isComponents && (
+      {activeSection === WEBSITE_SECTION.COMPONENTS && (
         <>
           <SidebarSection links={componentsSorted} currentPage={currentPage} />
           <SidebarSection

--- a/packages/website/components/Topbar/Topbar.tsx
+++ b/packages/website/components/Topbar/Topbar.tsx
@@ -51,7 +51,9 @@ export function Topbar({ currentPage }: TopbarProps) {
   // TODO: unify this logic with the one in the Sidebar
   const isGuidelines = currentPage.includes('/guidelines');
   const isTokens = currentPage.includes('/tokens');
-  const isComponents = currentPage.includes('/components');
+  const isComponents =
+    currentPage.includes('/components') ||
+    currentPage.includes('/deprecated-components');
   const isIntroduction = !isGuidelines && !isTokens && !isComponents;
 
   return (

--- a/packages/website/components/Topbar/Topbar.tsx
+++ b/packages/website/components/Topbar/Topbar.tsx
@@ -10,6 +10,10 @@ import {
 } from '../../utils/getGridStyles';
 import { DocSearch } from '../DocSearch';
 
+import {
+  useCurrentLocation,
+  WEBSITE_SECTION,
+} from '../../hooks/useCurrentLocation';
 import { TopbarLink } from './TopbarLink';
 import { TopbarLogo } from './TopbarLogo';
 import { VersionSwitch } from './VersionSwitch';
@@ -47,14 +51,7 @@ interface TopbarProps {
 
 export function Topbar({ currentPage }: TopbarProps) {
   const gridStyles = getGridStyles();
-
-  // TODO: unify this logic with the one in the Sidebar
-  const isGuidelines = currentPage.includes('/guidelines');
-  const isTokens = currentPage.includes('/tokens');
-  const isComponents =
-    currentPage.includes('/components') ||
-    currentPage.includes('/deprecated-components');
-  const isIntroduction = !isGuidelines && !isTokens && !isComponents;
+  const { activeSection } = useCurrentLocation(currentPage);
 
   return (
     <Grid.Item
@@ -85,28 +82,28 @@ export function Topbar({ currentPage }: TopbarProps) {
               <TopbarLink
                 href="/"
                 label="Introduction"
-                isActive={isIntroduction}
+                isActive={activeSection === WEBSITE_SECTION.INTRODUCTION}
               />
             </List.Item>
             <List.Item>
               <TopbarLink
                 href="/guidelines/accessibility"
                 label="Guidelines"
-                isActive={isGuidelines}
+                isActive={activeSection === WEBSITE_SECTION.GUIDELINES}
               />
             </List.Item>
             <List.Item>
               <TopbarLink
                 href="/tokens/color-system"
                 label="Tokens"
-                isActive={isTokens}
+                isActive={activeSection === WEBSITE_SECTION.TOKENS}
               />
             </List.Item>
             <List.Item>
               <TopbarLink
                 href="/components/accordion"
                 label="Components"
-                isActive={isComponents}
+                isActive={activeSection === WEBSITE_SECTION.COMPONENTS}
               />
             </List.Item>
           </List>

--- a/packages/website/hooks/useCurrentLocation.ts
+++ b/packages/website/hooks/useCurrentLocation.ts
@@ -15,20 +15,20 @@ export const useCurrentLocation = (currentPage: string) => {
     currentPage.includes('/integrations');
 
   if (isComponents) {
-    return { activeSection: WEBSITE_SECTION.COMPONENTS, currentPage };
+    return { activeSection: WEBSITE_SECTION.COMPONENTS };
   }
 
   const isGuidelines = currentPage.includes('/guidelines');
 
   if (isGuidelines) {
-    return { activeSection: WEBSITE_SECTION.GUIDELINES, currentPage };
+    return { activeSection: WEBSITE_SECTION.GUIDELINES };
   }
 
   const isTokens = currentPage.includes('/tokens');
 
   if (isTokens) {
-    return { activeSection: WEBSITE_SECTION.TOKENS, currentPage };
+    return { activeSection: WEBSITE_SECTION.TOKENS };
   }
 
-  return { activeSection: WEBSITE_SECTION.INTRODUCTION, currentPage };
+  return { activeSection: WEBSITE_SECTION.INTRODUCTION };
 };

--- a/packages/website/hooks/useCurrentLocation.ts
+++ b/packages/website/hooks/useCurrentLocation.ts
@@ -1,0 +1,34 @@
+export enum WEBSITE_SECTION {
+  INTRODUCTION = 'INTRODUCTION',
+  GUIDELINES = 'GUIDELINES',
+  TOKENS = 'TOKENS',
+  COMPONENTS = 'COMPONENTS',
+}
+
+export const useCurrentLocation = (currentPage: string) => {
+  // Since there are more pages in the Components' section,
+  // let's try to match the currentPage with it first so we can return early most of the time
+  const isComponents =
+    currentPage.includes('/components') ||
+    currentPage.includes('/deprecated-components') ||
+    currentPage.includes('/utils') ||
+    currentPage.includes('/integrations');
+
+  if (isComponents) {
+    return { activeSection: WEBSITE_SECTION.COMPONENTS, currentPage };
+  }
+
+  const isGuidelines = currentPage.includes('/guidelines');
+
+  if (isGuidelines) {
+    return { activeSection: WEBSITE_SECTION.GUIDELINES, currentPage };
+  }
+
+  const isTokens = currentPage.includes('/tokens');
+
+  if (isTokens) {
+    return { activeSection: WEBSITE_SECTION.TOKENS, currentPage };
+  }
+
+  return { activeSection: WEBSITE_SECTION.INTRODUCTION, currentPage };
+};


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Currently, if you go to a deprecated component documentation, the website renders the Introduction's sidebar and it marks "Introduction" as active in the topbar

This happens because the slug of a deprecated component is "/deprecated-components/dropdown"

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
