### PR TITLE
fix: call window.location.assign in prod

### DIFF
--- a/packages/website/components/DocSearch.tsx
+++ b/packages/website/components/DocSearch.tsx
@@ -22,6 +22,8 @@ export const DocSearch = () => {
             if (process.env.NODE_ENV !== 'production') {
               const path = suggestion.url.replace(/.*\.com/, '');
               window.location.assign(`${window.location.origin}${path}`);
+            } else {
+              window.location.assign(suggestion.url);
             }
           },
         });


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

I think that's the problem, but we can only test in production since we are already calling that function in non-production environments

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
