### PR TITLE
fix: focus styles for Popover content in safari

### DIFF
--- a/packages/components/popover/src/PopoverContent/PopoverContent.styles.ts
+++ b/packages/components/popover/src/PopoverContent/PopoverContent.styles.ts
@@ -10,10 +10,11 @@ export const getPopoverContentStyles = (isOpen: boolean) => ({
     boxShadow: tokens.boxShadowDefault,
     zIndex: tokens.zIndexDropdown,
     '&:focus': {
+      boxShadow: tokens.glowPrimary,
       outline: 'none',
     },
-    '&:focus-visible': {
-      boxShadow: tokens.glowPrimary,
+    '&:focus:not(:focus-visible)': {
+      boxShadow: tokens.boxShadowDefault,
     },
   }),
 });


### PR DESCRIPTION
# Purpose of PR

- reintroduce `Popover` content focus styles for Safari browser