### PR TITLE
fix(button-group): pass className prop to spaced group

### DIFF
--- a/packages/components/button/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/button/src/ButtonGroup/ButtonGroup.tsx
@@ -21,6 +21,7 @@ function _ButtonGroup(
   if (variant === 'spaced') {
     return (
       <Stack
+        className={className}
         isInline
         flexDirection="row"
         testId={testId}


### PR DESCRIPTION
# Purpose of PR

ButtonGroup currently doesn't pass given `className` to the group when `variant="spaced"`