### PR TITLE
fix: change collapse url and create animation components section

### DIFF
--- a/packages/components/collapse/README.mdx
+++ b/packages/components/collapse/README.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Collapse'
-slug: /animations/collapse/
+slug: /components/collapse/
+section: 'animationComponents'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/collapse'
 typescript: ./src/Collapse.tsx,
 storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/animation-collapse--basic'

--- a/packages/website/components/Sidebar.tsx
+++ b/packages/website/components/Sidebar.tsx
@@ -35,6 +35,11 @@ const components: Array<SidebarSectionType | SidebarLinkType> = [
 
   {
     type: 'section',
+    links: sidebarLinks.animationComponents,
+    title: 'Animation Components',
+  },
+  {
+    type: 'section',
     links: sidebarLinks.layoutComponents,
     title: 'Layout Components',
   },

--- a/packages/website/utils/sidebarLinks.json
+++ b/packages/website/utils/sidebarLinks.json
@@ -17,10 +17,6 @@
       "slug": "/components/badge/"
     },
     {
-      "title": "Collapse",
-      "slug": "/animations/collapse/"
-    },
-    {
       "title": "DragHandle",
       "slug": "/components/drag-handle/"
     },
@@ -87,6 +83,12 @@
     {
       "title": "Workbench",
       "slug": "/components/workbench/"
+    }
+  ],
+  "animationComponents": [
+    {
+      "title": "Collapse",
+      "slug": "/components/collapse/"
     }
   ],
   "buttonComponents": [


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

![Screenshot 2022-01-26 at 14 53 31](https://user-images.githubusercontent.com/6597467/151175741-929171dc-c0ab-4d1c-8b9d-09e3f0593e90.png)


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
