### PR TITLE
fix(counter): make counter work for initial values

### DIFF
--- a/packages/components/forms/examples/FormControlCharacterCountExample.tsx
+++ b/packages/components/forms/examples/FormControlCharacterCountExample.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { FormControl, TextInput, Grid } from '@contentful/f36-components';
 
 export default function FormControlCharacterCountExample() {
-  const limit = 10;
+  const limit = 20;
   return (
     <FormControl>
       <FormControl.Label isRequired>Name</FormControl.Label>
-      <TextInput maxLength={limit} />
+      <TextInput defaultValue="Initial value" maxLength={limit} />
       <Grid columns="auto 80px">
         <FormControl.HelpText>
           Name should be no longer than {limit} characters

--- a/packages/components/forms/src/TextInput/TextInput.tsx
+++ b/packages/components/forms/src/TextInput/TextInput.tsx
@@ -40,8 +40,9 @@ export const _TextInput = (
   useEffect(() => {
     if (maxLength !== undefined && typeof setMaxLength === 'function') {
       setMaxLength(maxLength);
+      setInputValue(value ?? defaultValue ?? '');
     }
-  }, [maxLength, setMaxLength]);
+  }, [maxLength, setMaxLength, setInputValue, defaultValue, value]);
 
   const handleOnChange = (event) => {
     if (typeof setInputValue === 'function') {

--- a/packages/components/forms/src/Textarea/Textarea.tsx
+++ b/packages/components/forms/src/Textarea/Textarea.tsx
@@ -7,10 +7,13 @@ import { useFormControl } from '../FormControl/FormControlContext';
 import { getStyles } from './Textarea.styles';
 import { ExpandProps } from '@contentful/f36-core';
 
-export type TextareaProps = Omit<
-  BaseInputProps<'textarea'>,
-  'as' | 'type' | 'size'
->;
+export interface TextareaProps
+  extends Omit<BaseInputProps<'textarea'>, 'as' | 'type' | 'size'> {
+  /**
+   * Set's default value for textarea
+   */
+  defaultValue?: string;
+}
 
 const _Textarea = (
   {
@@ -24,6 +27,8 @@ const _Textarea = (
     id,
     resize = 'vertical',
     maxLength,
+    value,
+    defaultValue,
     ...otherProps
   }: ExpandProps<TextareaProps>,
   ref: React.Ref<HTMLTextAreaElement>,
@@ -47,8 +52,9 @@ const _Textarea = (
   useEffect(() => {
     if (maxLength !== undefined && typeof setMaxLength === 'function') {
       setMaxLength(maxLength);
+      setInputValue(value ?? defaultValue ?? '');
     }
-  }, [maxLength, setMaxLength]);
+  }, [defaultValue, maxLength, setInputValue, setMaxLength, value]);
 
   const handleOnChange = (event) => {
     if (typeof setInputValue === 'function') {
@@ -61,6 +67,8 @@ const _Textarea = (
     <BaseInput
       {...otherProps}
       {...formProps}
+      defaultValue={defaultValue}
+      value={value}
       testId={testId}
       as="textarea"
       ref={ref}

--- a/packages/components/forms/stories/FormControl.stories.tsx
+++ b/packages/components/forms/stories/FormControl.stories.tsx
@@ -153,7 +153,7 @@ export const WithCharactersCount = (args: FormControlInternalProps) => {
     <>
       <FormControl {...args}>
         <FormControl.Label isRequired>Name</FormControl.Label>
-        <TextInput maxLength={10} />
+        <TextInput defaultValue="test" maxLength={10} />
         <Flex justifyContent="space-between">
           <FormControl.HelpText>
             Please enter your first name
@@ -167,7 +167,7 @@ export const WithCharactersCount = (args: FormControlInternalProps) => {
       </FormControl>
       <FormControl {...args}>
         <FormControl.Label isRequired>Name</FormControl.Label>
-        <Textarea maxLength={10} />
+        <Textarea defaultValue="Some text" maxLength={50} />
         <Flex justifyContent="space-between">
           <FormControl.HelpText>
             Please enter your first name


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Make Counter work with initial values, if either `value` or `defaultValue` prop is passed to the inputs.

closes #1826

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
