### PR TITLE
fix: remove min-height from GlobalStyles

### DIFF
--- a/packages/core/src/GlobalStyles/GlobalStyles.tsx
+++ b/packages/core/src/GlobalStyles/GlobalStyles.tsx
@@ -22,7 +22,6 @@ export const GlobalStyles = ({
           border: 0;
           box-sizing: border-box;
           margin: 0;
-          min-height: 100%;
           padding: 0;
         }
 


### PR DESCRIPTION
# Purpose of PR

- Remove min-height from GlobalStyles. Because it breaks the auto resizer of our App SDK in the iframes.
