### PR TITLE
fix(card): don't omit withDragHandle type

### DIFF
--- a/packages/components/card/examples/Card/WithCustomDragHandle.tsx
+++ b/packages/components/card/examples/Card/WithCustomDragHandle.tsx
@@ -41,7 +41,7 @@ export default function WithCustomDragHandle() {
   const SortableCard = SortableElement(({ label }) => {
     return (
       <Card
-        dragHandleRender={() => <SortableDragHandle item={label} />}
+        dragHandleRender={() => <SortableDragHandle />}
         padding="none"
         withDragHandle
       >

--- a/packages/components/card/examples/Card/WithCustomDragHandle.tsx
+++ b/packages/components/card/examples/Card/WithCustomDragHandle.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Box, Card, DragHandle, Flex } from '@contentful/f36-components';
+import { css } from 'emotion';
+import {
+  SortableContainer,
+  SortableElement,
+  SortableHandle,
+} from 'react-sortable-hoc';
+import arrayMove from 'array-move';
+
+export default function WithCustomDragHandle() {
+  const styles = {
+    dragHandle: css({
+      alignSelf: 'stretch',
+    }),
+  };
+  const [items, updateItems] = React.useState([
+    'Tech',
+    'News',
+    'CMS',
+    'Contentful',
+  ]);
+
+  const swapItems = React.useCallback(
+    ({ oldIndex, newIndex }) => {
+      // `arrayMove` is imported from 'array-move'
+      const newItems = arrayMove(items, oldIndex, newIndex);
+      updateItems(newItems);
+    },
+    [items],
+  );
+
+  const SortableList = SortableContainer((props) => (
+    <Flex flexDirection="column">{props.children}</Flex>
+  ));
+
+  const SortableDragHandle = SortableHandle(() => (
+    <DragHandle as="button" className={styles.dragHandle} label="Move card" />
+  ));
+
+  const SortableCard = SortableElement(({ label }) => {
+    return (
+      <Card
+        dragHandleRender={() => <SortableDragHandle item={label} />}
+        padding="none"
+        withDragHandle
+      >
+        <Box padding="spacingM">{label}</Box>
+      </Card>
+    );
+  });
+
+  return (
+    <SortableList
+      useDragHandle
+      axis="y"
+      distance={10}
+      onSortEnd={({ oldIndex, newIndex }) => {
+        swapItems({ oldIndex, newIndex });
+      }}
+      shouldCancelStart={(event) => {
+        const interactiveElements = ['INPUT', 'TEXTAREA', 'SELECT', 'OPTION'];
+
+        if (interactiveElements.indexOf(event.target.tagName) !== -1) {
+          return true;
+        }
+
+        return false;
+      }}
+    >
+      {items.map((item, index) => (
+        <SortableCard key={item} index={index} label={item} />
+      ))}
+    </SortableList>
+  );
+}

--- a/packages/components/card/src/BaseCard/BaseCard.types.ts
+++ b/packages/components/card/src/BaseCard/BaseCard.types.ts
@@ -4,8 +4,27 @@ import type { CommonProps, MarginProps } from '@contentful/f36-core';
 
 export type CardElement = 'a' | 'article' | 'button' | 'div' | 'fieldset';
 
+export type BaseCardDragHandleProps = {
+  /**
+   * Render the component with a drag handle
+   */
+  withDragHandle?: boolean;
+  /**
+   * Applies dragging styles to the card and drag handle
+   */
+  isDragging?: boolean;
+  /**
+   * Custom drag handle renderer. Useful, when integrating cards with drag-n-drop libraries
+   */
+  dragHandleRender?: (props: {
+    isDragging?: boolean;
+    drag: React.ReactElement;
+  }) => React.ReactElement;
+};
+
 export type BaseCardInternalProps = CommonProps &
-  MarginProps & {
+  MarginProps &
+  BaseCardDragHandleProps & {
     /**
      * An array of Menu elements used to render an actions menu
      */
@@ -52,10 +71,6 @@ export type BaseCardInternalProps = CommonProps &
      */
     onClick?: MouseEventHandler<HTMLElement>;
     /**
-     * Applies dragging styles to the card and drag handle
-     */
-    isDragging?: boolean;
-    /**
      * Applies hover styles to the card
      */
     isHovered?: boolean;
@@ -71,18 +86,6 @@ export type BaseCardInternalProps = CommonProps &
      * Type of the entity represented by the card. Shown in the header of the card
      */
     type?: string;
-    /**
-     * Render the component with a drag handle
-     */
-    withDragHandle?: boolean;
-    /**
-     * Custom drag handle renderer. Useful, when integrating cards with drag-n-drop libraries
-     */
-    dragHandleRender?: (props: {
-      isDragging?: boolean;
-      drag: React.ReactElement;
-    }) => React.ReactElement;
-
     /**
      * Loading state for the component - when true will display loading feedback to the user
      */

--- a/packages/components/card/src/Card/Card.tsx
+++ b/packages/components/card/src/Card/Card.tsx
@@ -13,9 +13,9 @@ import type { BaseCardInternalProps } from '../BaseCard/BaseCard.types';
 import { CardActions } from '../BaseCard/CardActions';
 import { getCardStyles } from './Card.styles';
 
-export type CardInternalProps = Omit<
+type BaseProps = Omit<
   BaseCardInternalProps,
-  'header' | 'ref' | 'type'
+  'header' | 'withDragHandle' | 'ref' | 'src' | 'type'
 > & {
   /**
    * Padding size to apply to the component
@@ -24,6 +24,11 @@ export type CardInternalProps = Omit<
    */
   padding?: 'default' | 'large' | 'none';
 };
+
+type BasePropsWithDragHandle = BaseProps &
+  Pick<BaseCardInternalProps, 'withDragHandle'> & { padding: 'none' };
+
+export type CardInternalProps = BaseProps | BasePropsWithDragHandle;
 
 export type CardProps<
   E extends React.ElementType = typeof BASE_CARD_DEFAULT_TAG

--- a/packages/components/card/src/Card/Card.tsx
+++ b/packages/components/card/src/Card/Card.tsx
@@ -15,7 +15,7 @@ import { getCardStyles } from './Card.styles';
 
 export type CardInternalProps = Omit<
   BaseCardInternalProps,
-  'header' | 'ref' | 'type' | 'withDragHandle'
+  'header' | 'ref' | 'type'
 > & {
   /**
    * Padding size to apply to the component

--- a/packages/components/card/src/Card/Card.tsx
+++ b/packages/components/card/src/Card/Card.tsx
@@ -25,7 +25,7 @@ type BaseProps = Omit<
   padding?: 'default' | 'large' | 'none';
 };
 
-type BasePropsWithDragHandle = BaseProps &
+type BasePropsWithDragHandle = Omit<BaseProps, 'padding'> &
   Pick<BaseCardInternalProps, 'withDragHandle'> & { padding: 'none' };
 
 export type CardInternalProps = BaseProps | BasePropsWithDragHandle;

--- a/packages/components/card/src/Card/README.mdx
+++ b/packages/components/card/src/Card/README.mdx
@@ -49,6 +49,14 @@ Optionally, the user can pass a `target` prop to control how the link should be 
 
 ```
 
+### With a custom drag handle
+
+When using the `withDragHandle` prop on the Card, you can also pass a custom drag handle render function. This is useful for more advanced use cases such as supporting keyboard navigation, where you would want to handle key events on the drag handle component. When using a custom drag handle, you should pass `padding="none"` to the `Card` to make sure the drag handle does not render inside the Card's content.
+
+```jsx file=../../examples/Card/WithCustomDragHandle.tsx
+
+```
+
 ## Props (API reference)
 
 <PropsTable of="Card" />

--- a/packages/components/card/src/InlineEntryCard/InlineEntryCard.tsx
+++ b/packages/components/card/src/InlineEntryCard/InlineEntryCard.tsx
@@ -4,6 +4,7 @@ import { Tooltip } from '@contentful/f36-tooltip';
 import { Text } from '@contentful/f36-typography';
 
 import { BaseCard } from '../BaseCard/BaseCard';
+import type { BaseCardDragHandleProps } from '../BaseCard/BaseCard.types';
 import type { EntryCardInternalProps } from '../EntryCard/EntryCard.types';
 import { getInlineEntryCardStyles } from './InlineEntryCard.styles';
 import { CardActions } from '../BaseCard/CardActions';
@@ -12,7 +13,7 @@ import { SkeletonBodyText, SkeletonContainer } from '@contentful/f36-skeleton';
 
 export type InlineEntryCardInternalProps = Omit<
   EntryCardInternalProps,
-  'icon' | 'withDragHandle' | 'ref' | 'src' | 'type'
+  'icon' | 'ref' | 'src' | 'type' | keyof BaseCardDragHandleProps
 >;
 
 export type InlineEntryCardProps = InlineEntryCardInternalProps;

--- a/packages/components/card/stories/Card.stories.tsx
+++ b/packages/components/card/stories/Card.stories.tsx
@@ -22,7 +22,7 @@ export default {
   parameters: {
     propTypes: Card['__docgenInfo'],
   },
-  title: 'Components/Card/Card',
+  title: 'Components/Card',
   decorators: [
     (Story) => (
       <Flex flexDirection="column" style={{ maxWidth: '500px' }}>

--- a/packages/components/card/stories/Card.stories.tsx
+++ b/packages/components/card/stories/Card.stories.tsx
@@ -22,7 +22,7 @@ export default {
   parameters: {
     propTypes: Card['__docgenInfo'],
   },
-  title: 'Components/Card',
+  title: 'Components/Card/Card',
   decorators: [
     (Story) => (
       <Flex flexDirection="column" style={{ maxWidth: '500px' }}>

--- a/packages/components/drag-handle/src/DragHandle.styles.ts
+++ b/packages/components/drag-handle/src/DragHandle.styles.ts
@@ -36,8 +36,17 @@ export const getStyles = () => ({
         position: 'relative',
         transition: `background-color ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}`,
         width: tokens.spacingL,
-        '&:hover, &:focus': {
-          backgroundColor: tokens.colorElementLight,
+        '&:hover': {
+          backgroundColor: tokens.gray200,
+        },
+        '&:focus': {
+          boxShadow: tokens.glowPrimary,
+        },
+        '&:focus:not(:focus-visible)': {
+          boxShadow: 'unset',
+        },
+        '&:focus-visible': {
+          boxShadow: tokens.glowPrimary,
         },
       }),
       (isActive || isFocused || isHovered) &&

--- a/packages/components/drag-handle/src/DragHandle.tsx
+++ b/packages/components/drag-handle/src/DragHandle.tsx
@@ -1,17 +1,31 @@
-import React, {
-  forwardRef,
-  useCallback,
-  useState,
-  FocusEventHandler,
-  MouseEventHandler,
-} from 'react';
+import React, { useCallback, useState } from 'react';
+import type { FocusEventHandler, MouseEventHandler } from 'react';
 import { cx } from 'emotion';
-import type { PropsWithHTMLElement } from '@contentful/f36-core';
+import type {
+  PolymorphicComponent,
+  PolymorphicProps,
+} from '@contentful/f36-core';
 import type { CommonProps, ExpandProps } from '@contentful/f36-core';
 import { DragIcon } from '@contentful/f36-icons';
 import { getStyles } from './DragHandle.styles';
 
-export type DragHandleInternalProps = CommonProps & {
+// We use div instead of a button because react-sortable-hoc lib cancels sorting if the event target is button.
+//
+// The other alternative way to fix it was to pass a custom `shouldCancelStart` callback,
+// in every place where we use this component with react-sortable-hoc.
+// (the custom callback with all the logic from default callback, but without button event cancelation).
+// So we decided that just changing it to the div, as it was in v3, is a better fix.
+//
+// default shouldCancelStart callback:
+// https://github.com/clauderic/react-sortable-hoc/blob/d94ba3cc67cfc7d6d460b585e7723bdb50015e53/src/SortableContainer/defaultShouldCancelStart.js
+const DRAG_HANDLE_DEFAULT_TAG = 'div';
+
+export interface DragHandleInternalProps extends CommonProps {
+  /**
+   * The element used for the root node
+   * @default div
+   */
+  as?: 'button' | 'div';
   /**
    * Applies styling for when the component is actively being dragged by
    * the user
@@ -34,114 +48,107 @@ export type DragHandleInternalProps = CommonProps & {
    * Set type button for div element
    */
   type?: string;
-};
+}
 
-export type DragHandleProps = PropsWithHTMLElement<
-  DragHandleInternalProps,
-  'div'
->;
+export type DragHandleProps<
+  E extends React.ElementType = typeof DRAG_HANDLE_DEFAULT_TAG
+> = PolymorphicProps<DragHandleInternalProps, E>;
 
-export const DragHandle = forwardRef<
-  HTMLDivElement,
-  ExpandProps<DragHandleProps>
+function _DragHandle<
+  E extends React.ElementType = typeof DRAG_HANDLE_DEFAULT_TAG
 >(
-  (
-    {
-      className,
-      isActive,
-      isFocused: isFocusedProp,
-      isHovered: isHoveredProp,
-      label,
-      onBlur,
-      onFocus,
-      onMouseEnter,
-      onMouseLeave,
-      testId = 'cf-ui-drag-handle',
-      style,
-      ...otherProps
+  props: DragHandleProps<E>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  forwardedRef: React.Ref<any>,
+) {
+  const styles = getStyles();
+  const {
+    as = DRAG_HANDLE_DEFAULT_TAG,
+    className,
+    isActive,
+    isFocused: isFocusedProp,
+    isHovered: isHoveredProp,
+    label,
+    onBlur,
+    onFocus,
+    onMouseEnter,
+    onMouseLeave,
+    testId = 'cf-ui-drag-handle',
+    style,
+    ...otherProps
+  } = props;
+  const [isFocused, setisFocused] = useState(isFocusedProp);
+  const [isHovered, setisHovered] = useState(isHoveredProp);
+
+  const handleFocus = useCallback<FocusEventHandler<E>>(
+    (event) => {
+      setisFocused(true);
+
+      if (onFocus) {
+        onFocus(event);
+      }
     },
-    forwardedRef,
-  ) => {
-    const styles = getStyles();
-    const [isFocused, setisFocused] = useState(isFocusedProp);
-    const [isHovered, setisHovered] = useState(isHoveredProp);
+    [onFocus],
+  );
 
-    const handleFocus = useCallback<FocusEventHandler<HTMLDivElement>>(
-      (event) => {
-        setisFocused(true);
+  const handleBlur = useCallback<FocusEventHandler<E>>(
+    (event) => {
+      setisFocused(false);
 
-        if (onFocus) {
-          onFocus(event);
-        }
-      },
-      [onFocus],
-    );
+      if (onBlur) {
+        onBlur(event);
+      }
+    },
+    [onBlur],
+  );
 
-    const handleBlur = useCallback<FocusEventHandler<HTMLDivElement>>(
-      (event) => {
-        setisFocused(false);
+  const handleMouseEnter = useCallback<MouseEventHandler<E>>(
+    (event) => {
+      setisHovered(true);
 
-        if (onBlur) {
-          onBlur(event);
-        }
-      },
-      [onBlur],
-    );
+      if (onMouseEnter) {
+        onMouseEnter(event);
+      }
+    },
+    [onMouseEnter],
+  );
 
-    const handleMouseEnter = useCallback<MouseEventHandler<HTMLDivElement>>(
-      (event) => {
-        setisHovered(true);
+  const handleMouseLeave = useCallback<MouseEventHandler<E>>(
+    (event) => {
+      setisHovered(false);
 
-        if (onMouseEnter) {
-          onMouseEnter(event);
-        }
-      },
-      [onMouseEnter],
-    );
+      if (onMouseLeave) {
+        onMouseLeave(event);
+      }
+    },
+    [onMouseLeave],
+  );
 
-    const handleMouseLeave = useCallback<MouseEventHandler<HTMLDivElement>>(
-      (event) => {
-        setisHovered(false);
+  const Element: React.ElementType = as;
 
-        if (onMouseLeave) {
-          onMouseLeave(event);
-        }
-      },
-      [onMouseLeave],
-    );
+  return (
+    <Element
+      role="button"
+      tabIndex={0}
+      {...otherProps}
+      className={cx(styles.root({ isActive, isFocused, isHovered }), className)}
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      data-test-id={testId}
+      ref={forwardedRef}
+      style={style}
+      type={as === 'button' ? 'button' : undefined}
+    >
+      <DragIcon variant="muted" />
+      <span className={styles.label}>{label}</span>
+    </Element>
+  );
+}
 
-    return (
-      // We use div instead of a button because react-sortable-hoc lib cancels sorting if the event target is button.
-      //
-      // The other alternative way to fix it was to pass a custom `shouldCancelStart` callback,
-      // in every place where we use this component with react-sortable-hoc.
-      // (the custom callback with all the logic from default callback, but without button event cancelation).
-      // So we decided that just changing it to the div, as it was in v3, is a better fix.
-      //
-      // default shouldCancelStart callback:
-      // https://github.com/clauderic/react-sortable-hoc/blob/d94ba3cc67cfc7d6d460b585e7723bdb50015e53/src/SortableContainer/defaultShouldCancelStart.js
-      <div
-        role="button"
-        tabIndex={0}
-        type="button"
-        {...otherProps}
-        className={cx(
-          styles.root({ isActive, isFocused, isHovered }),
-          className,
-        )}
-        onBlur={handleBlur}
-        onFocus={handleFocus}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-        data-test-id={testId}
-        ref={forwardedRef}
-        style={style}
-      >
-        <DragIcon variant="muted" />
-        <span className={styles.label}>{label}</span>
-      </div>
-    );
-  },
-);
-
-DragHandle.displayName = 'DragHandle';
+export const DragHandle: PolymorphicComponent<
+  ExpandProps<DragHandleInternalProps>,
+  typeof DRAG_HANDLE_DEFAULT_TAG,
+  'disabled'
+> = React.forwardRef(_DragHandle);

--- a/packages/components/drag-handle/src/DragHandle.tsx
+++ b/packages/components/drag-handle/src/DragHandle.tsx
@@ -62,9 +62,7 @@ export type DragHandleProps<
 
 function _DragHandle<E extends ElementType = typeof DRAG_HANDLE_DEFAULT_TAG>(
   props: DragHandleProps<E>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ref: Ref<any>, // Ref<ElementRef<E>>,
-  // forwardedRef: Ref<HTMLButtonElement> | Ref<HTMLDivElement>,
+  ref: Ref<any>,
 ) {
   const styles = getStyles();
   const {

--- a/packages/components/drag-handle/src/DragHandle.tsx
+++ b/packages/components/drag-handle/src/DragHandle.tsx
@@ -1,5 +1,11 @@
 import React, { useCallback, useState } from 'react';
-import type { FocusEventHandler, MouseEventHandler } from 'react';
+import type {
+  ElementRef,
+  ElementType,
+  FocusEventHandler,
+  MouseEventHandler,
+  Ref,
+} from 'react';
 import { cx } from 'emotion';
 import type {
   PolymorphicComponent,
@@ -51,15 +57,14 @@ export interface DragHandleInternalProps extends CommonProps {
 }
 
 export type DragHandleProps<
-  E extends React.ElementType = typeof DRAG_HANDLE_DEFAULT_TAG
+  E extends ElementType = typeof DRAG_HANDLE_DEFAULT_TAG
 > = PolymorphicProps<DragHandleInternalProps, E>;
 
-function _DragHandle<
-  E extends React.ElementType = typeof DRAG_HANDLE_DEFAULT_TAG
->(
+function _DragHandle<E extends ElementType = typeof DRAG_HANDLE_DEFAULT_TAG>(
   props: DragHandleProps<E>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  forwardedRef: React.Ref<any>,
+  ref: Ref<any>, // Ref<ElementRef<E>>,
+  // forwardedRef: Ref<HTMLButtonElement> | Ref<HTMLDivElement>,
 ) {
   const styles = getStyles();
   const {
@@ -80,7 +85,7 @@ function _DragHandle<
   const [isFocused, setisFocused] = useState(isFocusedProp);
   const [isHovered, setisHovered] = useState(isHoveredProp);
 
-  const handleFocus = useCallback<FocusEventHandler<E>>(
+  const handleFocus = useCallback<FocusEventHandler<HTMLElement>>(
     (event) => {
       setisFocused(true);
 
@@ -91,7 +96,7 @@ function _DragHandle<
     [onFocus],
   );
 
-  const handleBlur = useCallback<FocusEventHandler<E>>(
+  const handleBlur = useCallback<FocusEventHandler<HTMLElement>>(
     (event) => {
       setisFocused(false);
 
@@ -102,7 +107,7 @@ function _DragHandle<
     [onBlur],
   );
 
-  const handleMouseEnter = useCallback<MouseEventHandler<E>>(
+  const handleMouseEnter = useCallback<MouseEventHandler<HTMLElement>>(
     (event) => {
       setisHovered(true);
 
@@ -113,7 +118,7 @@ function _DragHandle<
     [onMouseEnter],
   );
 
-  const handleMouseLeave = useCallback<MouseEventHandler<E>>(
+  const handleMouseLeave = useCallback<MouseEventHandler<HTMLElement>>(
     (event) => {
       setisHovered(false);
 
@@ -124,26 +129,31 @@ function _DragHandle<
     [onMouseLeave],
   );
 
-  const Element: React.ElementType = as;
+  const commonProps = {
+    className: cx(styles.root({ isActive, isFocused, isHovered }), className),
+    'data-test-id': testId,
+    onBlur: handleBlur,
+    onFocus: handleFocus,
+    onMouseEnter: handleMouseEnter,
+    onMouseLeave: handleMouseLeave,
+    ref,
+    style,
+  };
+
+  if (as === 'div') {
+    return (
+      <div {...otherProps} {...commonProps} role="button" tabIndex={0}>
+        <DragIcon variant="muted" />
+        <span className={styles.label}>{label}</span>
+      </div>
+    );
+  }
 
   return (
-    <Element
-      role="button"
-      tabIndex={0}
-      {...otherProps}
-      className={cx(styles.root({ isActive, isFocused, isHovered }), className)}
-      onBlur={handleBlur}
-      onFocus={handleFocus}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      data-test-id={testId}
-      ref={forwardedRef}
-      style={style}
-      type={as === 'button' ? 'button' : undefined}
-    >
+    <button {...otherProps} {...commonProps} type="button">
       <DragIcon variant="muted" />
       <span className={styles.label}>{label}</span>
-    </Element>
+    </button>
   );
 }
 

--- a/packages/components/drag-handle/src/DragHandle.tsx
+++ b/packages/components/drag-handle/src/DragHandle.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import type {
-  ElementRef,
+  /* ElementRef, */
   ElementType,
   FocusEventHandler,
   MouseEventHandler,

--- a/packages/components/text-link/src/TextLink.tsx
+++ b/packages/components/text-link/src/TextLink.tsx
@@ -10,7 +10,7 @@ import type {
 import { styles } from './TextLink.styles';
 import { TextLinkVariant } from './types';
 
-const TEX_LINK_DEFAULT_TAG = 'a';
+const TEXT_LINK_DEFAULT_TAG = 'a';
 
 interface TextLinkInternalProps extends CommonProps {
   children?: React.ReactNode;
@@ -41,10 +41,10 @@ interface TextLinkInternalProps extends CommonProps {
 }
 
 export type TextLinkProps<
-  E extends React.ElementType = typeof TEX_LINK_DEFAULT_TAG
+  E extends React.ElementType = typeof TEXT_LINK_DEFAULT_TAG
 > = PolymorphicProps<TextLinkInternalProps, E, 'disabled'>;
 
-function _TextLink<E extends React.ElementType = typeof TEX_LINK_DEFAULT_TAG>(
+function _TextLink<E extends React.ElementType = typeof TEXT_LINK_DEFAULT_TAG>(
   props: TextLinkProps<E>,
   ref: React.Ref<any>,
 ) {
@@ -57,7 +57,7 @@ function _TextLink<E extends React.ElementType = typeof TEX_LINK_DEFAULT_TAG>(
     icon,
     alignIcon = 'start',
     isDisabled,
-    as = TEX_LINK_DEFAULT_TAG,
+    as = TEXT_LINK_DEFAULT_TAG,
     ...otherProps
   } = props;
 
@@ -129,6 +129,6 @@ _TextLink.displayName = 'TextLink';
 
 export const TextLink: PolymorphicComponent<
   ExpandProps<TextLinkInternalProps>,
-  typeof TEX_LINK_DEFAULT_TAG,
+  typeof TEXT_LINK_DEFAULT_TAG,
   'disabled'
 > = React.forwardRef(_TextLink);


### PR DESCRIPTION
# Purpose of PR

Reinstates the `withDragHandle` boolean on `Card` component. This prop is required to be able to use `dragHandleRender`.