### PR TITLE
fix(button): enforce color properties with !important

### DIFF
--- a/packages/components/button/src/Button/Button.styles.ts
+++ b/packages/components/button/src/Button/Button.styles.ts
@@ -24,6 +24,8 @@ const variantToStyles = (variant: ButtonVariant): CSSObject => {
   switch (variant) {
     case 'primary':
       return {
+        // !important is a temporary necessity until we get rid of legacy styles
+        // in the web app. See https://github.com/contentful/forma-36/pull/1856
         color: `${tokens.colorWhite} !important`,
         backgroundColor: tokens.blue500,
         borderColor: tokens.blue500,

--- a/packages/components/button/src/Button/Button.styles.ts
+++ b/packages/components/button/src/Button/Button.styles.ts
@@ -24,13 +24,12 @@ const variantToStyles = (variant: ButtonVariant): CSSObject => {
   switch (variant) {
     case 'primary':
       return {
-        color: tokens.colorWhite,
+        color: `${tokens.colorWhite} !important`,
         backgroundColor: tokens.blue500,
         borderColor: tokens.blue500,
         '&:hover': {
           backgroundColor: tokens.blue600,
           borderColor: tokens.blue600,
-          color: tokens.colorWhite,
         },
         '&:active': variantActiveStyles(variant),
         '&:focus': {
@@ -40,12 +39,11 @@ const variantToStyles = (variant: ButtonVariant): CSSObject => {
       };
     case 'secondary':
       return {
-        color: tokens.gray900,
+        color: `${tokens.gray900} !important`,
         backgroundColor: tokens.colorWhite,
         borderColor: tokens.gray300,
         '&:hover': {
           backgroundColor: tokens.gray100,
-          color: tokens.gray900,
         },
         '&:active': variantActiveStyles(variant),
         '&:focus': {
@@ -54,13 +52,12 @@ const variantToStyles = (variant: ButtonVariant): CSSObject => {
       };
     case 'positive':
       return {
-        color: tokens.colorWhite,
+        color: `${tokens.colorWhite} !important`,
         backgroundColor: tokens.colorPositive,
         borderColor: tokens.colorPositive,
         '&:hover': {
           backgroundColor: tokens.green600,
           borderColor: tokens.green600,
-          color: tokens.colorWhite,
         },
         '&:active': variantActiveStyles(variant),
         '&:focus': {
@@ -70,13 +67,12 @@ const variantToStyles = (variant: ButtonVariant): CSSObject => {
       };
     case 'negative':
       return {
-        color: tokens.colorWhite,
+        color: `${tokens.colorWhite} !important`,
         backgroundColor: tokens.red600,
         borderColor: tokens.red600,
         '&:hover': {
           backgroundColor: tokens.red700,
           borderColor: tokens.red700,
-          color: tokens.colorWhite,
         },
         '&:active': variantActiveStyles(variant),
         '&:focus': {
@@ -86,13 +82,13 @@ const variantToStyles = (variant: ButtonVariant): CSSObject => {
       };
     case 'transparent':
       return {
-        color: tokens.gray800,
+        color: `${tokens.gray800} !important`,
         background: `none`,
         borderColor: `transparent`,
         boxShadow: `none`,
         '&:hover': {
           backgroundColor: tokens.gray100,
-          color: tokens.gray900,
+          color: `${tokens.gray900} !important`,
         },
         '&:active': variantActiveStyles(variant),
         '&:focus': {


### PR DESCRIPTION
# Purpose of PR

Sets `color: ... !important`on buttons.

Yes, this is bad form, but currently buttons that are rendered `as="a"` are rendered with the wrong colours because of `a:link` and `a:hover` styling in our legacy CSS. This is a suggested temporary fix until we can get rid of legacy styles.

See also #1848 for a similar selector issue albeit with a different reason.