### PR TITLE
fix: playground top bar

### DIFF
--- a/packages/website/components/Playground/PlaygroundTopBar.tsx
+++ b/packages/website/components/Playground/PlaygroundTopBar.tsx
@@ -14,6 +14,7 @@ const styles = {
     paddingLeft: tokens.spacingXl,
     borderBottom: `1px solid ${tokens.gray300}`,
     overflow: 'hidden',
+    flexShrink: 0,
   }),
   tooltipWrapper: css({
     height: '100%',


### PR DESCRIPTION
# Purpose of PR

- Fix the case when the playground subheader is collapsed because of the code area that is bigger than the page height.
![image](https://user-images.githubusercontent.com/10744462/152993824-e36b1b04-4105-4881-af52-224c89763425.png)
