### PR TITLE
fix: menu item focus styles

### DIFF
--- a/packages/components/menu/src/MenuItem/MenuItem.styles.ts
+++ b/packages/components/menu/src/MenuItem/MenuItem.styles.ts
@@ -24,8 +24,13 @@ export const getMenuItemStyles = () => {
       textDecoration: 'none',
       color: tokens.gray800,
 
-      '&:focus, &:hover': {
+      '&:hover': {
         backgroundColor: tokens.gray100,
+      },
+      '&:focus': {
+        boxShadow: `inset ${tokens.glowPrimary}`,
+        // just to make boxShadow with rounded corners
+        borderRadius: tokens.borderRadiusMedium,
       },
       '&:active': {
         backgroundColor: tokens.gray200,


### PR DESCRIPTION
# Purpose of PR

- Make Menu item `hover` state styles different from `focus` state.

@domarku pls take a look 🖼