### PR TITLE
feat: by default render Popover only when it's open

### DIFF
--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -223,6 +223,7 @@ function _Autocomplete<ItemType>(
         usePortal={usePortal}
         isOpen={isOpen}
         isFullWidth={listWidth === 'full'}
+        renderOnlyWhenOpen={false}
         // This is necessary, otherwise the focus will change from the input to the Popover
         // and the user won't be able to type in the input
         // eslint-disable-next-line jsx-a11y/no-autofocus

--- a/packages/components/menu/src/Menu.test.tsx
+++ b/packages/components/menu/src/Menu.test.tsx
@@ -290,89 +290,88 @@ describe('Menu', function () {
       );
 
     it('should open submenu if item with submenu clicked', async () => {
-      const { getByTestId } = renderMenuWithSubMenu();
+      const { queryByTestId } = renderMenuWithSubMenu();
 
       await waitFor(() => {
-        expect(getByTestId('menu')).toBeVisible();
-        expect(getByTestId('submenu')).not.toBeVisible();
+        expect(queryByTestId('menu')).toBeInTheDocument();
+        expect(queryByTestId('submenu')).not.toBeInTheDocument();
       });
 
       await act(async () => {
-        userEvent.click(getByTestId('second-item'));
+        userEvent.click(queryByTestId('second-item'));
       });
 
       await waitFor(() => {
-        expect(getByTestId('submenu')).toBeVisible();
+        expect(queryByTestId('submenu')).toBeInTheDocument();
       });
     });
 
     it('should open submenu if item with submenu is hovered and close when its unhovered', async () => {
-      const { getByTestId } = renderMenuWithSubMenu();
+      const { queryByTestId } = renderMenuWithSubMenu();
 
       await waitFor(() => {
-        expect(getByTestId('menu')).toBeVisible();
-        expect(getByTestId('submenu')).not.toBeVisible();
-      });
-
-      await act(async () => {
-        userEvent.hover(getByTestId('second-item'));
-      });
-      await waitFor(() => {
-        expect(getByTestId('submenu')).toBeVisible();
+        expect(queryByTestId('menu')).toBeInTheDocument();
+        expect(queryByTestId('submenu')).not.toBeInTheDocument();
       });
 
       await act(async () => {
-        userEvent.unhover(getByTestId('second-item'));
+        userEvent.hover(queryByTestId('second-item'));
       });
       await waitFor(() => {
-        expect(getByTestId('submenu')).not.toBeVisible();
+        expect(queryByTestId('submenu')).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        userEvent.unhover(queryByTestId('second-item'));
+      });
+      await waitFor(() => {
+        expect(queryByTestId('submenu')).not.toBeInTheDocument();
       });
     });
 
     it('should open submenu if ArrowRight clicked on item with submenu', async () => {
-      const { getByTestId } = renderMenuWithSubMenu();
+      const { queryByTestId } = renderMenuWithSubMenu();
 
       await waitFor(() => {
-        expect(getByTestId('menu')).toBeVisible();
-        expect(getByTestId('submenu')).not.toBeVisible();
+        expect(queryByTestId('menu')).toBeInTheDocument();
+        expect(queryByTestId('submenu')).not.toBeInTheDocument();
       });
 
       await act(async () => {
-        fireEvent.keyDown(getByTestId('second-item'), {
+        fireEvent.keyDown(queryByTestId('second-item'), {
           key: 'ArrowRight',
         });
       });
       await waitFor(() => {
-        expect(getByTestId('submenu')).toBeVisible();
+        expect(queryByTestId('submenu')).toBeInTheDocument();
       });
     });
 
     it('should close submenu if ArrowLeft clicked on any item in submenu', async () => {
-      const { getByTestId } = renderMenuWithSubMenu();
+      const { queryByTestId } = renderMenuWithSubMenu();
 
       await waitFor(() => {
-        expect(getByTestId('menu')).toBeVisible();
-        expect(getByTestId('submenu')).not.toBeVisible();
+        expect(queryByTestId('menu')).toBeInTheDocument();
       });
 
       // open a submenu first
       await act(async () => {
-        fireEvent.keyDown(getByTestId('second-item'), {
+        fireEvent.keyDown(queryByTestId('second-item'), {
           key: 'ArrowRight',
         });
       });
       // verify it's open
       await waitFor(() => {
-        expect(getByTestId('submenu')).toBeVisible();
+        expect(queryByTestId('submenu')).toBeInTheDocument();
       });
 
       await act(async () => {
-        fireEvent.keyDown(getByTestId('submenu-item-2'), {
+        fireEvent.keyDown(queryByTestId('submenu-item-2'), {
           key: 'ArrowLeft',
         });
       });
       await waitFor(() => {
-        expect(getByTestId('submenu')).not.toBeVisible();
+        expect(queryByTestId('submenu')).not.toBeInTheDocument();
       });
     });
   });

--- a/packages/components/popover/src/Popover.test.tsx
+++ b/packages/components/popover/src/Popover.test.tsx
@@ -194,6 +194,38 @@ describe('Popover', function () {
     });
   });
 
+  it('popover should NOT be rendered in the DOM by default (when renderOnlyWhenOpen=true)', async () => {
+    render(
+      <Popover>
+        <Popover.Trigger>
+          <Button>Toggle</Button>
+        </Popover.Trigger>
+        <Popover.Content>This is the content.</Popover.Content>
+      </Popover>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('cf-ui-popover-content'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('popover should be rendered in the DOM when renderOnlyWhenOpen=false', async () => {
+    render(
+      <Popover renderOnlyWhenOpen={false}>
+        <Popover.Trigger>
+          <Button>Toggle</Button>
+        </Popover.Trigger>
+        <Popover.Content>This is the content.</Popover.Content>
+      </Popover>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('cf-ui-popover-content')).toBeInTheDocument();
+    });
+  });
+
   it('has no a11y issues', async () => {
     const { container } = render(
       <Popover isOpen={true}>

--- a/packages/components/popover/src/Popover.tsx
+++ b/packages/components/popover/src/Popover.tsx
@@ -95,6 +95,14 @@ export interface PopoverProps {
    * @default [1, 4]
    */
   offset?: [number, number];
+
+  /**
+   * Defines if popover should be rendered in the DOM only when it's open
+   * or all the time (after the component has been mounted)
+   *
+   * @default true
+   */
+  renderOnlyWhenOpen?: boolean;
 }
 
 export function Popover(props: ExpandProps<PopoverProps>) {
@@ -111,6 +119,7 @@ export function Popover(props: ExpandProps<PopoverProps>) {
     autoFocus = true,
     id,
     offset = [1, 4],
+    renderOnlyWhenOpen = true,
   } = props;
 
   const [triggerElement, setTriggerElement] = useState<HTMLElement | null>(
@@ -178,6 +187,7 @@ export function Popover(props: ExpandProps<PopoverProps>) {
     () => ({
       isOpen,
       usePortal,
+      renderOnlyWhenOpen,
       getTriggerProps: (_ref = null) => ({
         ref: mergeRefs(setTriggerElement, _ref),
         ['aria-expanded']: Boolean(isOpen),
@@ -228,6 +238,7 @@ export function Popover(props: ExpandProps<PopoverProps>) {
     }),
     [
       isOpen,
+      renderOnlyWhenOpen,
       popperAttributes,
       popperStyles,
       usePortal,

--- a/packages/components/popover/src/PopoverContent/PopoverContent.tsx
+++ b/packages/components/popover/src/PopoverContent/PopoverContent.tsx
@@ -26,7 +26,12 @@ const _PopoverContent = (props: ExpandProps<PopoverContentProps>, ref) => {
     role = 'dialog',
     ...otherProps
   } = props;
-  const { isOpen, getPopoverProps, usePortal } = usePopoverContext();
+  const {
+    isOpen,
+    renderOnlyWhenOpen,
+    getPopoverProps,
+    usePortal,
+  } = usePopoverContext();
 
   const styles = getPopoverContentStyles(isOpen);
 
@@ -45,6 +50,10 @@ const _PopoverContent = (props: ExpandProps<PopoverContentProps>, ref) => {
       {children}
     </div>
   );
+
+  if (renderOnlyWhenOpen && !isOpen) {
+    return null;
+  }
 
   return usePortal ? <Portal>{content}</Portal> : content;
 };

--- a/packages/components/popover/src/PopoverContext.ts
+++ b/packages/components/popover/src/PopoverContext.ts
@@ -3,6 +3,7 @@ import React, { HTMLProps } from 'react';
 export type PopoverContextType = {
   isOpen: boolean;
   usePortal: boolean;
+  renderOnlyWhenOpen: boolean;
   getPopoverProps: (
     _props: HTMLProps<HTMLDivElement>,
     _ref: React.Ref<HTMLDivElement>,


### PR DESCRIPTION
# Purpose of PR

- Rollback the logic when Popover is rendered in the DOM only when it's open and make it a default behavior. 
But with the option to turn it off.  Because there is a problem with our `Autocomplete` and Downshift library if the popover is not initially rendered. See the error below and more details in the [related PR](https://github.com/contentful/forma-36/pull/1355)

![image](https://user-images.githubusercontent.com/10744462/153006580-e8e0c836-bce1-4142-a595-e3d29932d428.png)