### PR TITLE
docs: use correct space character

### DIFF
--- a/packages/website/content/migration-v3-to-v4.mdx
+++ b/packages/website/content/migration-v3-to-v4.mdx
@@ -106,6 +106,6 @@ To migrate your project easily, we provided a codemod for most of the components
 You have successfully upgraded to version 4, so congratulations and welcome to the new version of Forma 36! 🎉🎉🎉
 For any questions or issues, you can:
 
-- Reach out to us on [Github](https://github.com/contentful/forma-36/issues): submit an [issue](https://github.com/contentful/forma-36/issues/new/choose) and we will help you out.
+- Reach out to us on [Github](https://github.com/contentful/forma-36/issues): submit an [issue](https://github.com/contentful/forma-36/issues/new/choose) and we will help you out.
 
 - Join our public community [Slack](https://join.slack.com/t/contentful-community/shared_invite/zt-f2u3vjyq-k2G7wu_ji4~Toywt955Ynw) and ask a question on the #forma36 channel. We are there to help you out!


### PR DESCRIPTION
We are using the wrong space character between "issue" and "and":

![image](https://user-images.githubusercontent.com/4947671/153445785-ade316fc-58da-479d-ae70-22747f76da19.png)
