### PR TITLE
fix(Badge): disable newlines

### DIFF
--- a/packages/components/badge/src/Badge/Badge.styles.ts
+++ b/packages/components/badge/src/Badge/Badge.styles.ts
@@ -79,6 +79,7 @@ export const getBadgeStyles = ({
     letterSpacing:
       '0.06rem' /*move to tokens or update wide letter spacing token*/,
     borderRadius: `${tokens.borderRadiusSmall}`,
+    whiteSpace: 'nowrap',
     ...variantToStyles({ variant }),
     ...sizeToStyles({ size }),
   });

--- a/packages/components/badge/src/Badge/Badge.styles.ts
+++ b/packages/components/badge/src/Badge/Badge.styles.ts
@@ -80,6 +80,8 @@ export const getBadgeStyles = ({
       '0.06rem' /*move to tokens or update wide letter spacing token*/,
     borderRadius: `${tokens.borderRadiusSmall}`,
     whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
     ...variantToStyles({ variant }),
     ...sizeToStyles({ size }),
   });

--- a/packages/components/badge/stories/Badge.stories.tsx
+++ b/packages/components/badge/stories/Badge.stories.tsx
@@ -102,5 +102,20 @@ export const Overview = () => (
         </Badge>
       </Flex>
     </Flex>
+
+    <SectionHeading as="h3" marginBottom="spacingS">
+      Text Overflow
+    </SectionHeading>
+
+    <Flex marginBottom="spacingM" alignItems="center">
+      <Flex marginRight="spacingS" style={{ maxWidth: '6rem' }}>
+        <Badge variant="primary">Lorem Ipsum Dolor Sit Amet</Badge>
+      </Flex>
+      <Flex marginRight="spacingS" style={{ maxWidth: '6rem' }}>
+        <Badge variant="primary" size="small">
+          Lorem Ipsum Dolor Sit Amet
+        </Badge>
+      </Flex>
+    </Flex>
   </>
 );


### PR DESCRIPTION
# Purpose of PR

We have an example where there is not much space for the badge. Still, the text in the badge should never break the word for a new line.

![image](https://user-images.githubusercontent.com/9327071/153576062-34e89c0b-64f1-4e34-9b60-8942b9b67145.png)


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
