### PR TITLE
fix: allow children to be passed to InlineEntryCard

### DIFF
--- a/packages/components/card/examples/InlineEntryCard/BasicInlineEntryCardExample.tsx
+++ b/packages/components/card/examples/InlineEntryCard/BasicInlineEntryCardExample.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { InlineEntryCard, MenuItem } from '@contentful/f36-components';
+
+export default function BasicInlineEntryCardExample() {
+  return (
+    <>
+      <InlineEntryCard
+        actions={[
+          <MenuItem key="copy">Copy</MenuItem>,
+          <MenuItem key="delete">Delete</MenuItem>,
+        ]}
+        status="published"
+        title="Published Entry Title"
+      >
+        Published entry body
+      </InlineEntryCard>
+      <InlineEntryCard
+        actions={[
+          <MenuItem key="copy">Copy</MenuItem>,
+          <MenuItem key="delete">Delete</MenuItem>,
+        ]}
+        status="new"
+        title="New Entry Title"
+      >
+        New entry body
+      </InlineEntryCard>
+      <InlineEntryCard
+        actions={[
+          <MenuItem key="copy">Copy</MenuItem>,
+          <MenuItem key="delete">Delete</MenuItem>,
+        ]}
+        status="draft"
+        title="Draft Entry Title"
+      >
+        Draft entry body
+      </InlineEntryCard>
+      <InlineEntryCard
+        actions={[
+          <MenuItem key="copy">Copy</MenuItem>,
+          <MenuItem key="delete">Delete</MenuItem>,
+        ]}
+        status="deleted"
+        title="Deleted Entry Title"
+      >
+        Deleted entry body
+      </InlineEntryCard>
+      <InlineEntryCard
+        actions={[
+          <MenuItem key="copy">Copy</MenuItem>,
+          <MenuItem key="delete">Delete</MenuItem>,
+        ]}
+        status="changed"
+        title="Changed Entry Title"
+      >
+        Changed entry body
+      </InlineEntryCard>
+      <InlineEntryCard
+        actions={[
+          <MenuItem key="copy">Copy</MenuItem>,
+          <MenuItem key="delete">Delete</MenuItem>,
+        ]}
+        status="archived"
+        title="Archived Entry Title"
+      >
+        Archived entry body
+      </InlineEntryCard>
+    </>
+  );
+}

--- a/packages/components/card/examples/InlineEntryCard/InlineEntryCardInTextExample.tsx
+++ b/packages/components/card/examples/InlineEntryCard/InlineEntryCardInTextExample.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Text, InlineEntryCard, MenuItem } from '@contentful/f36-components';
+
+export default function InlineEntryCardInTextExample() {
+  return (
+    <Text>
+      Macbeth (/məkˈbɛθ/, full title The Tragedie of Macbeth) is a tragedy by{' '}
+      <InlineEntryCard
+        actions={[
+          <MenuItem key="copy">Copy</MenuItem>,
+          <MenuItem key="delete">Delete</MenuItem>,
+        ]}
+        status="published"
+        title="Author: William Shakespeare"
+      >
+        William Shakespeare
+      </InlineEntryCard>
+      . It is thought to have been first performed in 1606.[a] It dramatises the
+      damaging physical and psychological effects of political ambition on those
+      who seek power. Of all the plays that Shakespeare wrote during the reign
+      of James I, Macbeth most clearly reflects his relationship with King
+      James, patron of Shakespeare’s acting company.[1] It was first published
+      in the Folio of 1623, possibly from a prompt book, and is Shakespeare’s
+      shortest tragedy
+    </Text>
+  );
+}

--- a/packages/components/card/examples/InlineEntryCard/InlineEntryCardWithActionsExample.tsx
+++ b/packages/components/card/examples/InlineEntryCard/InlineEntryCardWithActionsExample.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { InlineEntryCard, MenuItem } from '@contentful/f36-components';
+
+export default function InlineEntryCardWithActionsExample() {
+  const handleEditAction = () => console.log('handleEditAction');
+  const handleUnpublishAction = () => console.log('handleUnpublishAction');
+  const handleCopyAction = () => console.log('handleCopyAction');
+  const handleDeleteAction = () => console.log('handleDeleteAction');
+
+  return (
+    <InlineEntryCard
+      actions={[
+        <MenuItem key="edit" onClick={handleEditAction}>
+          Edit
+        </MenuItem>,
+        <MenuItem key="unpublish" onClick={handleUnpublishAction}>
+          Unpublish
+        </MenuItem>,
+        <MenuItem key="copy" onClick={handleCopyAction}>
+          Copy
+        </MenuItem>,
+        <MenuItem key="delete" onClick={handleDeleteAction}>
+          Delete
+        </MenuItem>,
+      ]}
+      status="published"
+      title="Forma 36 Entry Title"
+    >
+      Forma 36 entry body
+    </InlineEntryCard>
+  );
+}

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -17,6 +17,7 @@
     "@contentful/f36-menu": "^4.2.2",
     "@contentful/f36-skeleton": "^4.1.1",
     "@contentful/f36-tokens": "^4.0.0",
+    "@contentful/f36-tooltip": "^4.1.1",
     "@contentful/f36-typography": "^4.1.1",
     "emotion": "^10.0.17",
     "truncate": "^2.0.1"

--- a/packages/components/card/src/EntryCard/EntryCard.types.ts
+++ b/packages/components/card/src/EntryCard/EntryCard.types.ts
@@ -10,7 +10,7 @@ export type EntryCardInternalProps = Omit<
   'badge' | 'header' | 'padding' | 'ref' | 'type' | 'title'
 > & {
   /**
-   * The title of the entry, it will be used as the value for the native HTML attribute "title"
+   * The title of the entry, it will be used as the value for the tooltip
    */
   title?: string;
   /**

--- a/packages/components/card/src/EntryCard/EntryCard.types.ts
+++ b/packages/components/card/src/EntryCard/EntryCard.types.ts
@@ -10,7 +10,7 @@ export type EntryCardInternalProps = Omit<
   'badge' | 'header' | 'padding' | 'ref' | 'type' | 'title'
 > & {
   /**
-   * The title of the entry
+   * The title of the entry, it will be used as the value for the native HTML attribute "title"
    */
   title?: string;
   /**

--- a/packages/components/card/src/InlineEntryCard/InlineEntryCard.tsx
+++ b/packages/components/card/src/InlineEntryCard/InlineEntryCard.tsx
@@ -11,7 +11,7 @@ import { SkeletonBodyText, SkeletonContainer } from '@contentful/f36-skeleton';
 
 export type InlineEntryCardInternalProps = Omit<
   EntryCardInternalProps,
-  'children' | 'icon' | 'withDragHandle' | 'ref' | 'src' | 'type'
+  'icon' | 'withDragHandle' | 'ref' | 'src' | 'type'
 >;
 
 export type InlineEntryCardProps = InlineEntryCardInternalProps;
@@ -19,6 +19,7 @@ export type InlineEntryCardProps = InlineEntryCardInternalProps;
 export const InlineEntryCard = ({
   actions,
   className,
+  children,
   status,
   title,
   isLoading,
@@ -50,8 +51,9 @@ export const InlineEntryCard = ({
       className={cx(styles.root({ status }), className)}
       header={header}
       testId={testId}
+      title={title}
     >
-      <Text>{title}</Text>
+      {children || <Text>{title}</Text>}
     </BaseCard>
   );
 };

--- a/packages/components/card/src/InlineEntryCard/InlineEntryCard.tsx
+++ b/packages/components/card/src/InlineEntryCard/InlineEntryCard.tsx
@@ -46,7 +46,6 @@ export const InlineEntryCard = ({
     );
   }
 
-  console.log({ title, children });
 
   return (
     <Tooltip placement="bottom" content={title}>

--- a/packages/components/card/src/InlineEntryCard/InlineEntryCard.tsx
+++ b/packages/components/card/src/InlineEntryCard/InlineEntryCard.tsx
@@ -46,7 +46,6 @@ export const InlineEntryCard = ({
     );
   }
 
-
   return (
     <Tooltip placement="bottom" content={title}>
       <BaseCard

--- a/packages/components/card/src/InlineEntryCard/InlineEntryCard.tsx
+++ b/packages/components/card/src/InlineEntryCard/InlineEntryCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { cx } from 'emotion';
+import { Tooltip } from '@contentful/f36-tooltip';
 import { Text } from '@contentful/f36-typography';
 
 import { BaseCard } from '../BaseCard/BaseCard';
@@ -45,15 +46,18 @@ export const InlineEntryCard = ({
     );
   }
 
+  console.log({ title, children });
+
   return (
-    <BaseCard
-      {...otherProps}
-      className={cx(styles.root({ status }), className)}
-      header={header}
-      testId={testId}
-      title={title}
-    >
-      {children || <Text>{title}</Text>}
-    </BaseCard>
+    <Tooltip placement="bottom" content={title}>
+      <BaseCard
+        {...otherProps}
+        className={cx(styles.root({ status }), className)}
+        header={header}
+        testId={testId}
+      >
+        {children || <Text>{title}</Text>}
+      </BaseCard>
+    </Tooltip>
   );
 };

--- a/packages/components/card/src/InlineEntryCard/README.mdx
+++ b/packages/components/card/src/InlineEntryCard/README.mdx
@@ -3,19 +3,18 @@ title: 'InlineEntryCard'
 slug: /components/inline-entry-card/
 section: 'cardComponents'
 github: 'https://github.com/contentful/forma-36/tree/master/packages/components/card/src/InlineEntryCard/'
-typescript: ./InlineEntryCard.tsx
 storybook: 'https://v4-f36-storybook.netlify.app/?path=/story/components-card-inlineentrycard--default'
+typescript: ./InlineEntryCard.tsx
 ---
 
-import { Heading, Stack, TextLink } from '@contentful/f36-components';
-import { ExternalLinkIcon } from '@contentful/f36-icons';
-
-`InlineEntryCard` should be used to represent links to Entries, similar `EntryCard`. But `InlineEntryCard` is used as an inline-block.
+Display links to entries inline.
 
 ## Import
 
 ```jsx static=true
 import { InlineEntryCard } from '@contentful/f36-components';
+// or
+import { InlineEntryCard } from '@contentful/f36-card';
 ```
 
 ## Examples
@@ -24,141 +23,24 @@ import { InlineEntryCard } from '@contentful/f36-components';
 
 Here are `InlineEntryCard` components used with all possible `status` variants.
 
-```jsx
-<>
-  <InlineEntryCard
-    actions={[
-      <MenuItem key="copy">Copy</MenuItem>,
-      <MenuItem key="delete">Delete</MenuItem>,
-    ]}
-    status="published"
-    title="Published Entry Title"
-  />
-  <InlineEntryCard
-    actions={[
-      <MenuItem key="copy">Copy</MenuItem>,
-      <MenuItem key="delete">Delete</MenuItem>,
-    ]}
-    status="new"
-    title="New Entry Title"
-  />
-  <InlineEntryCard
-    actions={[
-      <MenuItem key="copy">Copy</MenuItem>,
-      <MenuItem key="delete">Delete</MenuItem>,
-    ]}
-    status="draft"
-    title="Draft Entry Title"
-  />
-  <InlineEntryCard
-    actions={[
-      <MenuItem key="copy">Copy</MenuItem>,
-      <MenuItem key="delete">Delete</MenuItem>,
-    ]}
-    status="deleted"
-    title="Deleted Entry Title"
-  />
-  <InlineEntryCard
-    actions={[
-      <MenuItem key="copy">Copy</MenuItem>,
-      <MenuItem key="delete">Delete</MenuItem>,
-    ]}
-    status="changed"
-    title="Changed Entry Title"
-  />
-  <InlineEntryCard
-    actions={[
-      <MenuItem key="copy">Copy</MenuItem>,
-      <MenuItem key="delete">Delete</MenuItem>,
-    ]}
-    status="archived"
-    title="Archived Entry Title"
-  />
-</>
+```jsx file=../../examples/InlineEntryCard/BasicInlineEntryCardExample.tsx
+
 ```
 
 ### Usage with various actions
 
-`actions` prop takes an array of `MenuItem` elements. You can learn more about `MenuItem` component on [`Menu` documentation page](/components/menu).
+The `actions` prop takes an array of `MenuItem` elements. You can learn more about `MenuItem` component on [`Menu` documentation page](/components/menu).
 
-```jsx
-() => {
-  const handleEditAction = () => console.log('handleEditAction');
-  const handleUnpublishAction = () => console.log('handleUnpublishAction');
-  const handleCopyAction = () => console.log('handleCopyAction');
-  const handleDeleteAction = () => console.log('handleDeleteAction');
+```jsx file=../../examples/InlineEntryCard/InlineEntryCardWithActionsExample.tsx
 
-  return (
-    <InlineEntryCard
-      actions={[
-        <MenuItem key="edit" onClick={handleEditAction}>
-          Edit
-        </MenuItem>,
-        <MenuItem key="unpublish" onClick={handleUnpublishAction}>
-          Unpublish
-        </MenuItem>,
-        <MenuItem key="copy" onClick={handleCopyAction}>
-          Copy
-        </MenuItem>,
-        <MenuItem key="delete" onClick={handleDeleteAction}>
-          Delete
-        </MenuItem>,
-      ]}
-      status="published"
-      title="Forma 36 Entry Title"
-    />
-  );
-};
 ```
 
 ### Usage inline in text
 
-`InlineEntryCard` is mainly for using it in text editors, to represent links to other entries.
+```jsx file=../../examples/InlineEntryCard/InlineEntryCardInTextExample.tsx
 
-```jsx
-<Text>
-  Fusce a odio pharetra, porta justo vel, maximus ex. In pellentesque a orci et
-  pretium. Praesent libero lorem, gravida eu pulvinar id, eleifend a sapien.
-  <InlineEntryCard
-    actions={[
-      <MenuItem key="copy">Copy</MenuItem>,
-      <MenuItem key="delete">Delete</MenuItem>,
-    ]}
-    status="published"
-    title="Published Entry Title"
-  />
-  Nulla a ultrices nulla, vel blandit sapien. Etiam eget massa dui. Fusce id
-  nisl quam. Integer nec mi arcu. Nullam lacinia est lectus, a euismod purus
-  eleifend id. Fusce a odio pharetra, porta justo vel, maximus ex. In
-  pellentesque a orci et pretium. Praesent libero lorem, gravida eu pulvinar id,
-  eleifend a sapien.
-  <InlineEntryCard
-    actions={[
-      <MenuItem key="copy">Copy</MenuItem>,
-      <MenuItem key="delete">Delete</MenuItem>,
-    ]}
-    status="new"
-    title="New Entry Title"
-  />
-  Nulla a ultrices nulla, vel blandit sapien. Etiam eget massa dui. Fusce id
-  nisl quam. Integer nec mi arcu. Nullam lacinia est lectus, a euismod purus
-  eleifend id.
-</Text>
 ```
 
-<Stack justifyContent="space-between" marginTop="spacing2Xl" marginBottom="spacingL">
-  <Heading id="props-api-reference" as="h2" marginTop="none" marginBottom="none">
-    Props (API reference)
-  </Heading>
-
-  <TextLink
-    href="https://v4-f36-storybook.netlify.app/?path=/story/components-card-inlineentrycard--default"
-    target="_blank"
-    alignIcon="end"
-    icon={<ExternalLinkIcon />}
-  >
-    Open in Storybook
-  </TextLink>
-</Stack>
+## Props (API reference)
 
 <PropsTable of="InlineEntryCard" />

--- a/packages/components/card/stories/InlineEntryCard.stories.tsx
+++ b/packages/components/card/stories/InlineEntryCard.stories.tsx
@@ -23,21 +23,19 @@ export default {
 
 export const Default: Story<InlineEntryCardProps> = (args) => {
   return (
-    <Text>
-      Fusce a odio pharetra, porta justo vel, maximus ex. In pellentesque a orci
-      et pretium. Praesent libero lorem, gravida eu pulvinar id, eleifend a
-      sapien. &nbsp;
-      <InlineEntryCard {...args} />
-      &nbsp; Nulla a ultrices nulla, vel blandit sapien. Etiam eget massa dui.
-      Fusce id nisl quam. Integer nec mi arcu. Nullam lacinia est lectus, a
-      euismod purus eleifend id. Fusce a odio pharetra, porta justo vel, maximus
-      ex. In pellentesque a orci et pretium. Praesent libero lorem, gravida eu
-      pulvinar id, eleifend a sapien. &nbsp;
-      <InlineEntryCard {...args} />
-      &nbsp; Nulla a ultrices nulla, vel blandit sapien. Etiam eget massa dui.
-      Fusce id nisl quam. Integer nec mi arcu. Nullam lacinia est lectus, a
-      euismod purus eleifend id.
-    </Text>
+    <Flex style={{ maxWidth: '600px' }}>
+      <Text>
+        Macbeth (/məkˈbɛθ/, full title The Tragedie of Macbeth) is a tragedy by{' '}
+        <InlineEntryCard {...args} />. It is thought to have been first
+        performed in 1606.[a] It dramatises the damaging physical and
+        psychological effects of political ambition on those who seek power. Of
+        all the plays that Shakespeare wrote during the reign of James I,
+        Macbeth most clearly reflects his relationship with King James, patron
+        of Shakespeare’s acting company.[1] It was first published in the Folio
+        of 1623, possibly from a prompt book, and is Shakespeare’s shortest
+        tragedy
+      </Text>
+    </Flex>
   );
 };
 
@@ -47,7 +45,35 @@ Default.args = {
     <MenuItem key="delete">Delete</MenuItem>,
   ],
   status: 'published',
-  title: 'Closer',
+  title: 'Author: William Shakespeare',
+  children: 'William Shakespeare',
+};
+
+export const WithOnlyTitle: Story<InlineEntryCardProps> = (args) => {
+  return (
+    <Flex style={{ maxWidth: '600px' }}>
+      <Text>
+        Macbeth (/məkˈbɛθ/, full title The Tragedie of Macbeth) is a tragedy by{' '}
+        <InlineEntryCard {...args} />. It is thought to have been first
+        performed in 1606.[a] It dramatises the damaging physical and
+        psychological effects of political ambition on those who seek power. Of
+        all the plays that Shakespeare wrote during the reign of James I,
+        Macbeth most clearly reflects his relationship with King James, patron
+        of Shakespeare’s acting company.[1] It was first published in the Folio
+        of 1623, possibly from a prompt book, and is Shakespeare’s shortest
+        tragedy
+      </Text>
+    </Flex>
+  );
+};
+
+WithOnlyTitle.args = {
+  actions: [
+    <MenuItem key="copy">Copy</MenuItem>,
+    <MenuItem key="delete">Delete</MenuItem>,
+  ],
+  status: 'published',
+  title: 'Author: William Shakespeare',
 };
 
 export const WithLoadingState: Story<InlineEntryCardProps> = (args) => {
@@ -71,7 +97,12 @@ export const Overview: Story<InlineEntryCardProps> = () => {
             Inline
           </SectionHeading>
 
-          <InlineEntryCard status="published" title="Forma 36" />
+          <InlineEntryCard
+            status="published"
+            title="Author: William Shakespeare"
+          >
+            William Shakespeare
+          </InlineEntryCard>
         </Flex>
 
         <Flex
@@ -83,7 +114,13 @@ export const Overview: Story<InlineEntryCardProps> = () => {
             Hover
           </SectionHeading>
 
-          <InlineEntryCard isHovered status="archived" title="Forma 36" />
+          <InlineEntryCard
+            isHovered
+            status="archived"
+            title="Author: William Shakespeare"
+          >
+            William Shakespeare
+          </InlineEntryCard>
         </Flex>
 
         <Flex
@@ -95,7 +132,13 @@ export const Overview: Story<InlineEntryCardProps> = () => {
             Selected
           </SectionHeading>
 
-          <InlineEntryCard isSelected status="deleted" title="Forma 36" />
+          <InlineEntryCard
+            isSelected
+            status="deleted"
+            title="Author: William Shakespeare"
+          >
+            William Shakespeare
+          </InlineEntryCard>
         </Flex>
       </Flex>
     </>

--- a/packages/components/card/stories/InlineEntryCard.stories.tsx
+++ b/packages/components/card/stories/InlineEntryCard.stories.tsx
@@ -76,6 +76,33 @@ WithOnlyTitle.args = {
   title: 'Author: William Shakespeare',
 };
 
+export const WithNoTitle: Story<InlineEntryCardProps> = (args) => {
+  return (
+    <Flex style={{ maxWidth: '600px' }}>
+      <Text>
+        Macbeth (/məkˈbɛθ/, full title The Tragedie of Macbeth) is a tragedy by{' '}
+        <InlineEntryCard {...args} />. It is thought to have been first
+        performed in 1606.[a] It dramatises the damaging physical and
+        psychological effects of political ambition on those who seek power. Of
+        all the plays that Shakespeare wrote during the reign of James I,
+        Macbeth most clearly reflects his relationship with King James, patron
+        of Shakespeare’s acting company.[1] It was first published in the Folio
+        of 1623, possibly from a prompt book, and is Shakespeare’s shortest
+        tragedy
+      </Text>
+    </Flex>
+  );
+};
+
+WithNoTitle.args = {
+  actions: [
+    <MenuItem key="copy">Copy</MenuItem>,
+    <MenuItem key="delete">Delete</MenuItem>,
+  ],
+  status: 'published',
+  children: 'William Shakespeare',
+};
+
 export const WithLoadingState: Story<InlineEntryCardProps> = (args) => {
   return <InlineEntryCard {...args} />;
 };


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

![Screenshot 2022-02-14 at 15 09 55](https://user-images.githubusercontent.com/6597467/153879721-11782d10-ec4c-4241-a6d2-2c6ea71c035a.png)

We've made a mistake in the past. I think we assumed the `InlineEntryCard` only needed `title`, but because of that we created a bug in Rich Text editor where the title is being rendered as the content of the card:

![image](https://user-images.githubusercontent.com/6597467/153611243-099dd564-7acd-409d-8c95-e42494ad9263.png)

The title was supposed to be a prop to just render the native HTML tooltip, so now I updated it to show our Tooltip (see first image)

This PR fixes the bug and updates the documentation

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
