### PR TITLE
feat: new property to typography components

### DIFF
--- a/packages/components/card/src/BaseCard/DefaultCardHeader.tsx
+++ b/packages/components/card/src/BaseCard/DefaultCardHeader.tsx
@@ -54,7 +54,11 @@ export function DefaultCardHeader(
   return (
     <Flex className={cx(styles.header, actions && styles.headerWithActions)}>
       <Flex flexGrow={1}>
-        {type && <Text fontColor="gray600" isWordBreak>{type}</Text>}
+        {type && (
+          <Text fontColor="gray600" isWordBreak>
+            {type}
+          </Text>
+        )}
       </Flex>
       {icon && (
         <Flex alignItems="center" marginLeft="spacingXs">

--- a/packages/components/card/src/BaseCard/DefaultCardHeader.tsx
+++ b/packages/components/card/src/BaseCard/DefaultCardHeader.tsx
@@ -54,7 +54,7 @@ export function DefaultCardHeader(
   return (
     <Flex className={cx(styles.header, actions && styles.headerWithActions)}>
       <Flex flexGrow={1}>
-        {type && <Text fontColor="gray600">{type}</Text>}
+        {type && <Text fontColor="gray600" isWordBreak>{type}</Text>}
       </Flex>
       {icon && (
         <Flex alignItems="center" marginLeft="spacingXs">

--- a/packages/components/card/src/EntryCard/EntryCard.styles.ts
+++ b/packages/components/card/src/EntryCard/EntryCard.styles.ts
@@ -25,6 +25,9 @@ export const getEntryCardStyles = () => {
         paddingRight: tokens.spacingM,
       },
     }),
+    wrappedText: css({
+      wordBreak: 'break-word'
+    }),
     header: css({
       borderBottomWidth: 1,
       borderBottomColor: tokens.gray200,

--- a/packages/components/card/src/EntryCard/EntryCard.styles.ts
+++ b/packages/components/card/src/EntryCard/EntryCard.styles.ts
@@ -25,9 +25,6 @@ export const getEntryCardStyles = () => {
         paddingRight: tokens.spacingM,
       },
     }),
-    wrappedText: css({
-      wordBreak: 'break-word'
-    }),
     header: css({
       borderBottomWidth: 1,
       borderBottomColor: tokens.gray200,

--- a/packages/components/card/src/EntryCard/EntryCard.tsx
+++ b/packages/components/card/src/EntryCard/EntryCard.tsx
@@ -22,7 +22,7 @@ export type EntryCardProps<
   E extends React.ElementType = typeof ENTRY_CARD_DEFAULT_TAG
 > = PolymorphicProps<EntryCardInternalProps, E>;
 
-function EntryCardTitle({ title }: { title?: string }) {
+function EntryCardTitle({ title, className }: { title?: string, className?: string }) {
   if (!title) {
     return null;
   }
@@ -35,6 +35,7 @@ function EntryCardTitle({ title }: { title?: string }) {
       testId="title"
       as="h1"
       marginBottom="none"
+      className={className}
     >
       {truncatedTitle}
     </Subheading>
@@ -102,7 +103,7 @@ function _EntryCard<
         flexDirection="row"
       >
         <Flex flexDirection="column" flexGrow={1} gap="spacingS">
-          <EntryCardTitle title={title} />
+          <EntryCardTitle title={title} className={styles.wrappedText} />
           <EntryCardDescription size={size} description={description} />
           {children}
         </Flex>

--- a/packages/components/card/src/EntryCard/EntryCard.tsx
+++ b/packages/components/card/src/EntryCard/EntryCard.tsx
@@ -22,7 +22,7 @@ export type EntryCardProps<
   E extends React.ElementType = typeof ENTRY_CARD_DEFAULT_TAG
 > = PolymorphicProps<EntryCardInternalProps, E>;
 
-function EntryCardTitle({ title, className }: { title?: string, className?: string }) {
+function EntryCardTitle({ title }: { title?: string, className?: string }) {
   if (!title) {
     return null;
   }
@@ -35,7 +35,7 @@ function EntryCardTitle({ title, className }: { title?: string, className?: stri
       testId="title"
       as="h1"
       marginBottom="none"
-      className={className}
+      isWordBreak
     >
       {truncatedTitle}
     </Subheading>
@@ -103,7 +103,7 @@ function _EntryCard<
         flexDirection="row"
       >
         <Flex flexDirection="column" flexGrow={1} gap="spacingS">
-          <EntryCardTitle title={title} className={styles.wrappedText} />
+          <EntryCardTitle title={title} />
           <EntryCardDescription size={size} description={description} />
           {children}
         </Flex>

--- a/packages/components/card/src/EntryCard/EntryCard.tsx
+++ b/packages/components/card/src/EntryCard/EntryCard.tsx
@@ -22,7 +22,7 @@ export type EntryCardProps<
   E extends React.ElementType = typeof ENTRY_CARD_DEFAULT_TAG
 > = PolymorphicProps<EntryCardInternalProps, E>;
 
-function EntryCardTitle({ title }: { title?: string, className?: string }) {
+function EntryCardTitle({ title }: { title?: string }) {
   if (!title) {
     return null;
   }

--- a/packages/components/card/stories/EntryCard.stories.tsx
+++ b/packages/components/card/stories/EntryCard.stories.tsx
@@ -173,7 +173,7 @@ export const Overview: Story<EntryCardProps> = () => {
             Entry card with very long title and description
           </SectionHeading>
             <EntryCard
-              title="verylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitle"
+              title="verylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitle"
               description='verylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescription'
               contentType="Design system"
               withDragHandle

--- a/packages/components/card/stories/EntryCard.stories.tsx
+++ b/packages/components/card/stories/EntryCard.stories.tsx
@@ -167,6 +167,18 @@ export const Overview: Story<EntryCardProps> = () => {
             />
           ))}
         </Flex>
+
+        <Flex flexDirection="column" gap="spacingM">
+          <SectionHeading as="h3" marginBottom="none">
+            Entry card with very long title and description
+          </SectionHeading>
+            <EntryCard
+              title="verylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitle"
+              description='verylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescription'
+              contentType="Design system"
+              withDragHandle
+            />
+        </Flex>
       </Flex>
     </>
   );

--- a/packages/components/card/stories/EntryCard.stories.tsx
+++ b/packages/components/card/stories/EntryCard.stories.tsx
@@ -172,12 +172,12 @@ export const Overview: Story<EntryCardProps> = () => {
           <SectionHeading as="h3" marginBottom="none">
             Entry card with very long title and description
           </SectionHeading>
-            <EntryCard
-              title="verylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitle"
-              description='verylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescription'
-              contentType="Design system"
-              withDragHandle
-            />
+          <EntryCard
+            title="verylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitle"
+            description="verylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescriptionverylongdescription"
+            contentType="Design system"
+            withDragHandle
+          />
         </Flex>
       </Flex>
     </>

--- a/packages/components/typography/src/DisplayText/DisplayText.tsx
+++ b/packages/components/typography/src/DisplayText/DisplayText.tsx
@@ -16,6 +16,7 @@ export interface DisplayTextInternalProps extends CommonProps, MarginProps {
   size?: 'default' | 'large';
   as?: HeadingElement;
   isTruncated?: boolean;
+  isWordBreak?: boolean;
 }
 
 export type DisplayTextProps<

--- a/packages/components/typography/src/Heading/Heading.tsx
+++ b/packages/components/typography/src/Heading/Heading.tsx
@@ -16,6 +16,7 @@ export interface HeadingInternalProps extends CommonProps, MarginProps {
   as?: HeadingElement;
   children?: React.ReactNode;
   isTruncated?: boolean;
+  isWordBreak?: boolean;
 }
 
 export type HeadingProps<

--- a/packages/components/typography/src/Paragraph/Paragraph.tsx
+++ b/packages/components/typography/src/Paragraph/Paragraph.tsx
@@ -11,6 +11,7 @@ export type ParagraphInternalProps = CommonProps &
   MarginProps & {
     children: React.ReactNode;
     isTruncated?: boolean;
+    isWordBreak?: boolean;
   };
 
 export type ParagraphProps = PropsWithHTMLElement<ParagraphInternalProps, 'p'>;

--- a/packages/components/typography/src/SectionHeading/SectionHeading.tsx
+++ b/packages/components/typography/src/SectionHeading/SectionHeading.tsx
@@ -16,6 +16,7 @@ const SECTION_HEADING_DEFAULT_TAG = 'h2';
 export interface SectionHeadingInternalProps extends CommonProps, MarginProps {
   as?: HeadingElement;
   isTruncated?: boolean;
+  isWordBreak?: boolean;
 }
 
 export type SectionHeadingProps<

--- a/packages/components/typography/src/Subheading/Subheading.tsx
+++ b/packages/components/typography/src/Subheading/Subheading.tsx
@@ -14,6 +14,7 @@ const SUBHEADING_DEFAULT_TAG = 'h3';
 export interface SubheadingInternalProps extends CommonProps, MarginProps {
   as?: HeadingElement;
   isTruncated?: boolean;
+  isWordBreak?: boolean;
 }
 
 export type SubheadingProps<

--- a/packages/components/typography/src/Text/Text.tsx
+++ b/packages/components/typography/src/Text/Text.tsx
@@ -39,7 +39,7 @@ function truncatedStyle() {
 
 function wordBreakStyle() {
   return css({
-    wordBreak: 'break-word'
+    wordBreak: 'break-word',
   });
 }
 

--- a/packages/components/typography/src/Text/Text.tsx
+++ b/packages/components/typography/src/Text/Text.tsx
@@ -24,6 +24,7 @@ export interface TextInternalProps extends CommonProps, MarginProps {
   fontWeight?: FontWeightTokens;
   fontColor?: ColorTokens;
   isTruncated?: boolean;
+  isWordBreak?: boolean;
 }
 
 const TEXT_DEFAULT_TAG = 'span';
@@ -33,6 +34,12 @@ function truncatedStyle() {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
+  });
+}
+
+function wordBreakStyle() {
+  return css({
+    wordBreak: 'break-word'
   });
 }
 
@@ -49,6 +56,7 @@ function _Text<E extends React.ElementType = typeof TEXT_DEFAULT_TAG>(
     lineHeight = 'lineHeightM',
     children,
     isTruncated,
+    isWordBreak,
     as,
     className,
     margin = 'none',
@@ -72,6 +80,7 @@ function _Text<E extends React.ElementType = typeof TEXT_DEFAULT_TAG>(
           lineHeight: tokens[lineHeight],
         }),
         isTruncated ? truncatedStyle() : null,
+        isWordBreak ? wordBreakStyle() : null,
         className,
       )}
       margin={margin}


### PR DESCRIPTION
Introducing new prop to typography components to manage cases like this one:

![card-overflow2](https://user-images.githubusercontent.com/4272331/154311216-7002a1fe-cc2f-43b6-9178-295edd8d18df.png)

WDYT?