### PR TITLE
fix: fix badge alignment

### DIFF
--- a/packages/components/badge/src/Badge/Badge.styles.ts
+++ b/packages/components/badge/src/Badge/Badge.styles.ts
@@ -82,6 +82,7 @@ export const getBadgeStyles = ({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+    verticalAlign: 'middle',
     ...variantToStyles({ variant }),
     ...sizeToStyles({ size }),
   });


### PR DESCRIPTION
Before:
<img width="198" alt="Screenshot 2022-02-23 at 14 34 05" src="https://user-images.githubusercontent.com/4272331/155329821-b25d10d0-c8a8-494f-a559-1141b231e71c.png">
After:
<img width="181" alt="Screenshot 2022-02-23 at 14 35 31" src="https://user-images.githubusercontent.com/4272331/155329893-121f8dee-80cc-4eab-bed9-02dbb8218317.png">

