### PR TITLE
feat: improve codemod

### DIFF
--- a/packages/forma-36-codemod/README.md
+++ b/packages/forma-36-codemod/README.md
@@ -53,62 +53,122 @@ f36-codemod <transform> <path> [...options]
 Converts usage of deprecated color tokens with the correct new token.
 eg. `tokens.colorElementMid` to `tokens.gray300`.
 
-#### `v4-text-link`
+#### `v4-asset-card`
 
-Migrates `TextLink` component from Forma@v3 to Forma@v4
+Migrate AssetCard components from v3 to v4
 
 #### `v4-badge`
 
-Migrates `Tag` component from Forma@v3 to `Badge` component from Forma@v4
-
-#### `v4-note`
-
-Migrates `Note` component from Forma@v3 to Forma@v4
-
-#### `v4-flex`
-
-Migrates `Flex` component from Forma@v3 to Forma@v4
-
-#### `v4-list`
-
-Migrates `List` component from Forma@v3 to Forma@v4
-
-#### `v4-pill`
-
-Migrates `Pill` component from Forma@v3 to Forma@v4
+Converts Tag component from Forma v3 to Badge component from v4
 
 #### `v4-button`
 
-Migrates `Button` component from Forma@v3 to Forma@v4
+Converts Button component from Forma v3 to v4
 
-#### `v4-tooltip`
+#### `v4-card`
 
-Migrates `Tooltip` component from Forma@v3 to Forma@v4
+Converts Card component from Forma v3 to v4
+
+#### `v4-checkbox`
+
+Converts CheckboxField component from Forma v3 to v4 Checkbox
+
+#### `v4-clean-css`
+
+Removes the imports for v3 css files
 
 #### `v4-entity-list`
 
 Converts EntityList components from Forma v3 to v4
 
-#### `v4-text-field`
-
-Migrates `TextField` component from Forma@v3 to Forma@v4
-
-#### `v4-notification`
-
-Migrate Notification component from v3 to v4
-
-#### `v4-asset-card`
-
-Migrate AssetCard components from v3 to v4
-
 #### `v4-entry-card`
 
-Migrate EntryCard components from v3 to v4
+Migrate Entry components from v3 to v4
+
+#### `v4-flex`
+
+Converts Flex component from Forma v3 to v4
+
+#### `v4-form`
+
+Converts Form component from Forma v3 to v4
+
+#### `v4-grid`
+
+Converts Grid components from Forma v3 to v4
 
 #### `v4-helptext`
 
 Migrates HelpText components outside form from v3 to v4
 
+#### `v4-icon`
+
+Converts Icon component from Forma v3 to v4
+
+#### `v4-icon-button`
+
+Converts IconButton component from Forma v3 to v4
+
 #### `v4-inline-entry-card`
 
 Converts InlineEntryCard from Forma v3 to v4
+
+#### `v4-list`
+
+Converts List component from Forma v3 to v4
+
+#### `v4-modal`
+
+Converts Modal, ModalConfirm and ModalLauncher components from Forma v3 to v4
+
+#### `v4-note`
+
+Converts Note component from Forma v3 to v4
+
+#### `v4-notification`
+
+Migrate Notification component from v3 to v4
+
+#### `v4-pill`
+
+Converts Pill component from Forma v3 to v4
+
+#### `v4-radio`
+
+Converts RadioButton and RadioButtonField components from Forma v3 to v4
+
+#### `v4-select`
+
+Converts Select components from Forma v3 to v4
+
+#### `v4-skeleton`
+
+Converts Skeleton components from Forma v3 to v4
+
+#### `v4-spinner`
+
+Converts Spinner component from Forma v3 to v4
+
+#### `v4-table`
+
+Converts Table components from Forma v3 to v4
+
+#### `v4-text-field`
+
+Converts TextField components from Forma v3 to v4
+
+#### `v4-text-inputs`
+
+Converts TextInput and Textarea components from Forma v3 to v4
+
+#### `v4-text-link`
+
+Converts TextLink component from Forma v3 to v4
+
+#### `v4-tooltip`
+
+Converts Tooltip component from Forma v3 to v4
+
+#### `v4-typography`
+
+Converts all typography components from Forma v3 to v4

--- a/packages/forma-36-codemod/bin/cli.js
+++ b/packages/forma-36-codemod/bin/cli.js
@@ -101,12 +101,13 @@ function run() {
       help: `
     Usage
       $ npx @contentful/f36-codemod <transform> <path> <...options>
-        transform        Currently only color-tokens-to-new-tokens.
+        transform        Check all included transformers on https://github.com/contentful/forma-36/tree/master/packages/forma-36-codemod#included-transforms.
         path             Files or directory to transform. Can be a glob like src/**.test.js
     Options
       --force            Bypass Git repository safety checks and forcibly run codemods
       --dry              Dry run (no changes are made to files)
       --print            Print transformed files to your terminal
+      --parser           Which parser to be used: babel or tsx
       --jscodeshift      (Advanced) Pass options directly to jscodeshift
     `,
     },
@@ -134,7 +135,9 @@ function run() {
   ) {
     console.error('Invalid transform choice, pick one of:');
     console.error(
-      inquirerChoices.TRANSFORMS_CHOICES.map((x) => '- ' + x.value).join('\n'),
+      inquirerChoices.TRANSFORMS_CHOICES.filter((x) => x.value)
+        .map((x) => '- ' + x.value)
+        .join('\n'),
     );
     process.exit(1);
   }

--- a/packages/forma-36-codemod/bin/inquirer-choices.js
+++ b/packages/forma-36-codemod/bin/inquirer-choices.js
@@ -33,13 +33,7 @@ const SETUP_CHOICES = [
   },
 ];
 
-const TRANSFORMS_CHOICES = [
-  {
-    name:
-      'color-tokens-to-new-tokens: Converts deprecated color tokens to the new ones',
-    value: 'color-tokens-to-new-tokens',
-  },
-  new inquirer.Separator(),
+const V4_CODEMODS = [
   {
     name: 'v4-text-link: Converts TextLink component from Forma v3 to v4',
     value: 'v4-text-link',
@@ -168,6 +162,16 @@ const TRANSFORMS_CHOICES = [
     value: 'v4-clean-css',
   },
   // Add extra codemods - do not remove
+].sort((a, b) => (a.value < b.value ? -1 : 1));
+
+const TRANSFORMS_CHOICES = [
+  {
+    name:
+      'color-tokens-to-new-tokens: Converts deprecated color tokens to the new ones',
+    value: 'color-tokens-to-new-tokens',
+  },
+  new inquirer.Separator(),
+  ...V4_CODEMODS,
 ];
 
 module.exports = {

--- a/packages/forma-36-codemod/transforms/v4-checkbox.js
+++ b/packages/forma-36-codemod/transforms/v4-checkbox.js
@@ -5,6 +5,7 @@ const {
   createComponent,
   addImport,
   renameProperties,
+  getChildren,
 } = require('../utils');
 const { getFormaImport, shouldSkipUpdateImport } = require('../utils/config');
 
@@ -70,18 +71,11 @@ module.exports = function checkboxFieldCodemod(file, api) {
         ...commonProps,
       ].filter((prop) => prop);
 
-      const getChildren = (prop) => {
-        if (!prop) return [];
-        return prop.value.type === 'JSXExpressionContainer'
-          ? [prop.value]
-          : [j.jsxText(prop.value.value)];
-      };
-
       const Checkbox = createComponent({
         j,
         componentName: 'Checkbox',
         props: checkboxProps,
-        children: getChildren(labelText),
+        children: getChildren({ prop: labelText, j }),
       });
 
       const ValidationMesage =
@@ -89,7 +83,7 @@ module.exports = function checkboxFieldCodemod(file, api) {
         createComponent({
           j,
           componentName: 'FormControl.ValidationMessage',
-          children: getChildren(validationMessage),
+          children: getChildren({ prop: validationMessage, j }),
         });
 
       const FormControlContent = [Checkbox, ValidationMesage].reduce(

--- a/packages/forma-36-codemod/transforms/v4-radio.js
+++ b/packages/forma-36-codemod/transforms/v4-radio.js
@@ -8,6 +8,7 @@ const {
   changeComponentName,
   changeProperties,
   deleteProperty,
+  getChildren,
 } = require('../utils');
 const { getFormaImport, shouldSkipUpdateImport } = require('../utils/config');
 const { pipe } = require('./common/pipe');
@@ -114,13 +115,6 @@ function radioButtonFieldCodemod(file, api) {
         ['testId', 'className'].includes(attributes.name?.name),
       );
 
-      const getChildren = (prop) => {
-        if (!prop) return [];
-        return prop.value.type === 'JSXExpressionContainer'
-          ? [prop.value]
-          : [j.jsxText(prop.value.value)];
-      };
-
       const radioProps = [
         !validationMessage ? id : null,
         helpText,
@@ -136,7 +130,7 @@ function radioButtonFieldCodemod(file, api) {
         j,
         componentName: 'Radio',
         props: radioProps,
-        children: getChildren(labelText),
+        children: getChildren({ prop: labelText, j }),
       });
 
       const ValidationMesage =
@@ -144,7 +138,7 @@ function radioButtonFieldCodemod(file, api) {
         createComponent({
           j,
           componentName: 'FormControl.ValidationMessage',
-          children: getChildren(validationMessage),
+          children: getChildren({ prop: validationMessage, j }),
         });
 
       const FormControlContent = [Radio, ValidationMesage].reduce(

--- a/packages/forma-36-codemod/transforms/v4-select.js
+++ b/packages/forma-36-codemod/transforms/v4-select.js
@@ -9,6 +9,7 @@ const {
   changeComponentName,
   changeProperties,
   deleteProperty,
+  getChildren,
 } = require('../utils');
 const { getFormaImport, shouldSkipUpdateImport } = require('../utils/config');
 const { pipe } = require('./common/pipe');
@@ -108,17 +109,10 @@ function selectFieldCodemod(file, api) {
         ['testId', 'className'].includes(attributes.name?.name),
       );
 
-      const getChildren = (prop) => {
-        if (!prop) return [];
-        return prop.value.type === 'JSXExpressionContainer'
-          ? [prop.value]
-          : [j.jsxText(prop.value.value)];
-      };
-
       const Label = createComponent({
         j,
         componentName: 'FormControl.Label',
-        children: getChildren(labelText),
+        children: getChildren({ prop: labelText, j }),
       });
 
       const HelpText =
@@ -126,7 +120,7 @@ function selectFieldCodemod(file, api) {
         createComponent({
           j,
           componentName: 'FormControl.HelpText',
-          children: getChildren(helpText),
+          children: getChildren({ prop: helpText, j }),
         });
 
       const ValidationMesage =
@@ -134,7 +128,7 @@ function selectFieldCodemod(file, api) {
         createComponent({
           j,
           componentName: 'FormControl.ValidationMessage',
-          children: getChildren(validationMessage),
+          children: getChildren({ prop: validationMessage, j }),
         });
 
       const selectProps = [value, ...handlerProps].filter((prop) => prop);

--- a/packages/forma-36-codemod/transforms/v4-text-field.js
+++ b/packages/forma-36-codemod/transforms/v4-text-field.js
@@ -6,6 +6,7 @@ const {
   getProperty,
   removeComponentImport,
   renameProperties,
+  getChildren,
 } = require('../utils');
 const { getFormaImport, shouldSkipUpdateImport } = require('../utils/config');
 const { isConditionalExpression } = require('../utils/updateTernaryValues');
@@ -92,14 +93,7 @@ function textFieldCodemod(file, api) {
       const Label = createComponent({
         j,
         componentName: 'FormControl.Label',
-        children: [
-          labelText.value.type === 'StringLiteral' ||
-          labelText.value.type === 'Literal'
-            ? j.jsxText(labelText.value.value)
-            : j.jsxExpressionContainer(
-                j.identifier(labelText.value.expression.name),
-              ),
-        ],
+        children: getChildren({ prop: labelText, j }),
       });
 
       const TextInput = createComponent({
@@ -131,14 +125,7 @@ function textFieldCodemod(file, api) {
         HelpText = createComponent({
           j,
           componentName: 'FormControl.HelpText',
-          children: [
-            helpText.value.type === 'StringLiteral' ||
-            helpText.value.type === 'Literal'
-              ? j.jsxText(helpText.value.value)
-              : j.jsxExpressionContainer(
-                  j.identifier(helpText.value.expression.name),
-                ),
-          ],
+          children: getChildren({ prop: helpText, j }),
         });
       }
 

--- a/packages/forma-36-codemod/utils/deleteProperty.js
+++ b/packages/forma-36-codemod/utils/deleteProperty.js
@@ -3,6 +3,6 @@ module.exports.deleteProperty = function deleteProperty(
   { propertyName },
 ) {
   return attributes.filter((attribute) => {
-    return attribute.name.name !== propertyName;
+    return attribute.name?.name !== propertyName;
   });
 };

--- a/packages/forma-36-codemod/utils/getChildren.js
+++ b/packages/forma-36-codemod/utils/getChildren.js
@@ -1,0 +1,12 @@
+/**
+ * Returns the prop value on correct format to be used as children.
+ * @param {*} param.prop - prop to extract the value from
+ * @param {*} param.j - Instance of jscodeshift to use
+ * @returns Value to be passed to children when creating component
+ */
+module.exports.getChildren = function getChildren({ prop, j }) {
+  if (!prop) return [];
+  return prop.value.type === 'JSXExpressionContainer'
+    ? [prop.value]
+    : [j.jsxText(prop.value.value)];
+};

--- a/packages/forma-36-codemod/utils/index.js
+++ b/packages/forma-36-codemod/utils/index.js
@@ -14,6 +14,7 @@ const { changeComponentName } = require('./changeComponentName');
 const { updateTernaryValues } = require('./updateTernaryValues');
 const { warningMessage } = require('./warningMessage');
 const { createComponent } = require('./createComponent');
+const { getChildren } = require('./getChildren');
 
 module.exports = {
   getComponentLocalName,
@@ -33,4 +34,5 @@ module.exports = {
   updateTernaryValues,
   warningMessage,
   createComponent,
+  getChildren,
 };


### PR DESCRIPTION
Fix issue when trying to get value from prop and turning into children.

This didn't work because if the prop  was set as `labelText={foo.bar}`, the `jsxExpressionContainer` would expect a `ExpressionMember` and not an `Identifier`.
```js
children: [
          labelText.value.type === 'StringLiteral' ||
          labelText.value.type === 'Literal'
            ? j.jsxText(labelText.value.value)
            : j.jsxExpressionContainer(
                j.identifier(labelText.value.expression.name),
              ),
        ],
```


With the `getChildren` function, if the value of the prop is a `JSXExpressionContainer` we just pass that value down to the children, and if it's a `Literal` we wrap with `JSXText`.

----

Also made the list of transformers alphabetically ordered and added missing transformers to the Readme