### PR TITLE
fix: close button alignment in Note component

### DIFF
--- a/packages/components/note/src/Note.styles.tsx
+++ b/packages/components/note/src/Note.styles.tsx
@@ -49,10 +49,10 @@ const variantToStyles = (variant: NoteVariant): CSSObject => {
 
 export const getNoteStyles = () => {
   return {
-    container: ({ variant, title }: NoteProps) =>
+    container: ({ variant }: Pick<NoteProps, 'variant'>) =>
       css({
+        position: 'relative',
         borderRadius: tokens.borderRadiusMedium,
-        alignItems: !title ? 'center' : null,
         border: '1px solid',
         ...variantToStyles(variant),
       }),
@@ -60,22 +60,21 @@ export const getNoteStyles = () => {
       color: tokens.gray800,
       fontSize: tokens.fontSizeL,
       lineHeight: tokens.lineHeightL,
-      marginBottom: tokens.spacingXs,
     }),
     description: css({
       color: tokens.gray700,
     }),
-    close: ({ title }: NoteProps) =>
-      css({
-        padding: tokens.spacingXs,
-        marginTop: title ? `-${tokens.spacingXs}` : '0',
-        marginRight: title ? `-${tokens.spacingXs}` : '0',
-        '&:hover, &:active': {
-          backgroundColor: 'transparent',
-        },
-      }),
+    close: css({
+      position: 'absolute',
+      top: tokens.spacingXs,
+      right: tokens.spacingXs,
+      padding: tokens.spacingXs,
+      '&:hover, &:active': {
+        backgroundColor: 'transparent',
+      },
+    }),
     closeIcon: css({
-      color: tokens.gray600,
+      fill: tokens.gray600,
     }),
   };
 };

--- a/packages/components/note/src/Note.tsx
+++ b/packages/components/note/src/Note.tsx
@@ -1,6 +1,6 @@
 import { cx } from 'emotion';
 import React from 'react';
-import { Flex } from '@contentful/f36-core';
+import { Flex, Grid } from '@contentful/f36-core';
 import type {
   CommonProps,
   PropsWithHTMLElement,
@@ -72,31 +72,39 @@ export const Note = React.forwardRef<HTMLElement, ExpandProps<NoteProps>>(
     const styles = getNoteStyles();
 
     return (
-      <Flex
+      <Grid
         {...otherProps}
+        columns={withCloseButton ? 'auto 1fr 24px' : 'auto 1fr'} // 24px is the width of the close button
         as="article"
-        className={cx(styles.container({ variant, title }), className)}
+        className={cx(styles.container({ variant }), className)}
         testId={testId}
         ref={ref}
         padding="spacingM"
-        alignItems="flex-start"
       >
-        <Flex marginRight="spacingS">
-          <Icon
-            as={icons[variant]}
-            variant={variant}
-            size={title ? 'medium' : 'small'}
-          />
-        </Flex>
-        <Flex flexDirection="column" flexGrow={1}>
+        <Icon
+          as={icons[variant]}
+          variant={variant}
+          size={title ? 'medium' : 'small'}
+        />
+        <Flex flexDirection="column">
           {title && (
-            <Heading as="h2" className={styles.title}>
+            <Heading
+              as="h2"
+              className={styles.title}
+              marginBottom={!children ? 'none' : 'spacingS'}
+            >
               {title}
             </Heading>
           )}
-          <Text as="p" lineHeight="lineHeightM" className={styles.description}>
-            {children}
-          </Text>
+          {children && (
+            <Text
+              as="p"
+              lineHeight="lineHeightM"
+              className={styles.description}
+            >
+              {children}
+            </Text>
+          )}
         </Flex>
         {withCloseButton && (
           <Button
@@ -105,10 +113,10 @@ export const Note = React.forwardRef<HTMLElement, ExpandProps<NoteProps>>(
             onClick={onClose}
             testId={`${testId}-close`}
             aria-label="Dismiss"
-            className={styles.close({ title })}
+            className={styles.close}
           />
         )}
-      </Flex>
+      </Grid>
     );
   },
 );

--- a/packages/components/note/src/Note.tsx
+++ b/packages/components/note/src/Note.tsx
@@ -88,7 +88,7 @@ export const Note = React.forwardRef<HTMLElement, ExpandProps<NoteProps>>(
             size={title ? 'medium' : 'small'}
           />
         </Flex>
-        <div>
+        <Flex flexDirection="column" flexGrow={1}>
           {title && (
             <Heading as="h2" className={styles.title}>
               {title}
@@ -97,7 +97,7 @@ export const Note = React.forwardRef<HTMLElement, ExpandProps<NoteProps>>(
           <Text as="p" lineHeight="lineHeightM" className={styles.description}>
             {children}
           </Text>
-        </div>
+        </Flex>
         {withCloseButton && (
           <Button
             variant="transparent"


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

it fixes this case:
![Screenshot 2022-02-25 at 15 58 13](https://user-images.githubusercontent.com/6597467/155743108-a20c9901-96a3-4bae-ae88-f2f70c1c0e38.png)

and this case:
<img width="745" alt="155946791-1c810f8f-75a0-4fea-a277-69aee78037d9" src="https://user-images.githubusercontent.com/6597467/156016755-384759c9-6d80-41e5-82c2-e91023f4b834.png">


This is what I achieved:
![Screenshot 2022-02-28 at 16 59 07](https://user-images.githubusercontent.com/6597467/156016781-03608efe-43ce-42bc-8d95-7f72dd949cda.png)



## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
