### PR TITLE
fix(menu-item): keyboard-only focus style

### DIFF
--- a/.changeset/two-squids-fly.md
+++ b/.changeset/two-squids-fly.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix(menu-item): keyboard-only focus style

--- a/.changeset/two-squids-fly.md
+++ b/.changeset/two-squids-fly.md
@@ -1,5 +1,5 @@
 ---
-"@contentful/f36-menu": patch
+'@contentful/f36-menu': patch
 ---
 
 Keyboard-only focus style

--- a/.changeset/two-squids-fly.md
+++ b/.changeset/two-squids-fly.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+"@contentful/f36-menu": patch
 ---
 
-fix(menu-item): keyboard-only focus style
+Keyboard-only focus style

--- a/packages/components/menu/src/MenuItem/MenuItem.styles.ts
+++ b/packages/components/menu/src/MenuItem/MenuItem.styles.ts
@@ -32,6 +32,14 @@ export const getMenuItemStyles = () => {
         // just to make boxShadow with rounded corners
         borderRadius: tokens.borderRadiusMedium,
       },
+      '&:focus:not(:focus-visible)': {
+        boxShadow: 'unset',
+        borderRadius: 'unset',
+      },
+      '&:focus-visible': {
+        boxShadow: `inset ${tokens.glowPrimary}`,
+        borderRadius: tokens.borderRadiusMedium,
+      },
       '&:active': {
         backgroundColor: tokens.gray200,
       },


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Makes MenuItem focus styling keyboard-only.