### PR TITLE
fix: grid examples

### DIFF
--- a/packages/core/src/Grid/examples/BasicGridExample.tsx
+++ b/packages/core/src/Grid/examples/BasicGridExample.tsx
@@ -4,7 +4,12 @@ import tokens from '@contentful/f36-tokens';
 
 export default function BasicGridExample() {
   return (
-    <Grid columns="1fr 2fr" rowGap="spacingM" columnGap="spacingM">
+    <Grid
+      style={{ width: '100%' }}
+      columns="1fr 2fr"
+      rowGap="spacingM"
+      columnGap="spacingM"
+    >
       <Grid.Item style={{ backgroundColor: tokens.gray800, height: '100px' }} />
       <Grid.Item style={{ backgroundColor: tokens.gray800, height: '100px' }} />
       <Grid.Item style={{ backgroundColor: tokens.gray800, height: '100px' }} />

--- a/packages/core/src/Grid/examples/ContentAlignmentGridExample.tsx
+++ b/packages/core/src/Grid/examples/ContentAlignmentGridExample.tsx
@@ -4,7 +4,11 @@ import tokens from '@contentful/f36-tokens';
 
 export default function ContentAlignmentGridExample() {
   return (
-    <Grid columns="250px 250px" justifyContent="space-between">
+    <Grid
+      style={{ width: '100%' }}
+      columns="250px 250px"
+      justifyContent="space-between"
+    >
       <Grid.Item style={{ backgroundColor: tokens.gray700, height: '100px' }} />
       <Grid.Item style={{ backgroundColor: tokens.gray700, height: '100px' }} />
     </Grid>

--- a/packages/core/src/Grid/examples/FrGridExample.tsx
+++ b/packages/core/src/Grid/examples/FrGridExample.tsx
@@ -5,7 +5,7 @@ import tokens from '@contentful/f36-tokens';
 export default function FrGridExample() {
   const border = `1px solid ${tokens.gray700}`;
   return (
-    <Grid columns="1fr 1fr 1fr">
+    <Grid style={{ width: '100%' }} columns="1fr 1fr 1fr">
       <p style={{ border }}>WelcomeToTheAwesomeContentfulGridSystem</p>
       <p style={{ border }}>Contentful</p>
       <p style={{ border }}>Forma 36</p>

--- a/packages/core/src/Grid/examples/RepeatNotationGridExample.tsx
+++ b/packages/core/src/Grid/examples/RepeatNotationGridExample.tsx
@@ -5,7 +5,11 @@ import tokens from '@contentful/f36-tokens';
 export default function RepeatNotationGridExample() {
   return (
     <>
-      <Grid columns="1fr 2fr 1fr 2fr 1fr 2fr" columnGap="spacingM">
+      <Grid
+        style={{ width: '100%' }}
+        columns="1fr 2fr 1fr 2fr 1fr 2fr"
+        columnGap="spacingM"
+      >
         <Grid.Item
           style={{ backgroundColor: tokens.gray800, height: '100px' }}
         />
@@ -27,6 +31,7 @@ export default function RepeatNotationGridExample() {
       </Grid>
 
       <Grid
+        style={{ width: '100%' }}
         columns="repeat(3, 1fr 2fr)"
         columnGap="spacingM"
         marginTop="spacingM"

--- a/packages/core/src/Grid/examples/SpanKeywordGridExample.tsx
+++ b/packages/core/src/Grid/examples/SpanKeywordGridExample.tsx
@@ -4,7 +4,7 @@ import tokens from '@contentful/f36-tokens';
 
 export default function SpanKeywordGridExample() {
   return (
-    <Grid columns={6}>
+    <Grid style={{ width: '100%' }} columns={6}>
       <Grid.Item style={{ backgroundColor: tokens.gray700, height: '100px' }} />
       <Grid.Item
         area="span 4 / span 4"

--- a/packages/website/components/LiveEditor/ComponentSource.tsx
+++ b/packages/website/components/LiveEditor/ComponentSource.tsx
@@ -20,7 +20,6 @@ import { ExternalLinkIcon } from '@contentful/f36-icons';
 import { Flex } from '@contentful/f36-core';
 import { theme } from './theme';
 import { formatSourceCode } from './utils';
-import { useRouter } from 'next/router';
 import * as coder from '../../utils/coder';
 import FocusLock from 'react-focus-lock';
 import {
@@ -143,7 +142,6 @@ export function ComponentSource({
   file?: string;
 }) {
   const [showSource, setShowSource] = useState(true);
-  const router = useRouter();
 
   const handleToggle = () => {
     setShowSource((prevState) => !prevState);

--- a/packages/website/components/LiveEditor/ComponentSource.tsx
+++ b/packages/website/components/LiveEditor/ComponentSource.tsx
@@ -206,15 +206,12 @@ export function ComponentSource({
                   />
                   {isExampleFromFile && (
                     <Button
+                      as="a"
                       className={styles.playgroundButton}
                       endIcon={<ExternalLinkIcon />}
                       size="small"
-                      onClick={() => {
-                        const href = `/playground?code=${coder.encode(
-                          children,
-                        )}`;
-                        router.push(href, href);
-                      }}
+                      href={`/playground?code=${coder.encode(children)}`}
+                      target="_blank"
                     >
                       Open in Playground
                     </Button>


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

The grid examples were not showing up because they didn't have a `width`

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
