### PR TITLE
refactor(baseinput): Remove zIndex logic when input is disabled or invalid

### DIFF
--- a/packages/components/forms/src/BaseInput/BaseInput.styles.ts
+++ b/packages/components/forms/src/BaseInput/BaseInput.styles.ts
@@ -22,8 +22,6 @@ const getStyles = ({ as, isDisabled, isInvalid, size, resize }) => ({
     position: 'relative',
     display: 'flex',
     width: '100%',
-    zIndex:
-      isInvalid || isDisabled ? tokens.zIndexDefault + 1 : tokens.zIndexDefault,
   }),
   input: css({
     outline: 'none',
@@ -40,8 +38,6 @@ const getStyles = ({ as, isDisabled, isInvalid, size, resize }) => ({
     margin: 0,
     cursor: isDisabled ? 'not-allowed' : 'auto',
     width: '100%',
-    zIndex:
-      isInvalid || isDisabled ? tokens.zIndexDefault + 1 : tokens.zIndexDefault,
 
     // if the input is a textarea, the resize prop is applied and size should be ignored
     ...(as === 'textarea' ? { resize } : getSizeStyles({ size })),


### PR DESCRIPTION
Remove zIndex logic when input `isInvalid` or `isDisabled` to avoid tooltip being overlapped.