### PR TITLE
refactor: add displayName to components

### DIFF
--- a/packages/components/asset/src/Asset.tsx
+++ b/packages/components/asset/src/Asset.tsx
@@ -36,15 +36,18 @@ export interface AssetProps extends CommonProps {
   type?: AssetType;
 }
 
-export function Asset({
-  className,
-  src,
-  status,
-  testId = 'cf-ui-asset',
-  title,
-  type = 'image',
-  ...otherProps
-}: AssetProps) {
+function _Asset(
+  {
+    className,
+    src,
+    status,
+    testId = 'cf-ui-asset',
+    title,
+    type = 'image',
+    ...otherProps
+  }: AssetProps,
+  ref: React.Ref<any>,
+) {
   const styles = getAssetStyles();
   const isImage = src && src !== '' && type === 'image';
 
@@ -55,6 +58,7 @@ export function Asset({
     <Box
       className={cx(styles.relative, className)}
       testId={testId}
+      ref={ref}
       {...otherProps}
     >
       {showPreview ? (
@@ -104,4 +108,6 @@ export function Asset({
   );
 }
 
-Asset.displayName = 'Asset';
+_Asset.displayName = 'Asset';
+
+export const Asset = React.forwardRef(_Asset);

--- a/packages/components/asset/src/Asset.tsx
+++ b/packages/components/asset/src/Asset.tsx
@@ -103,3 +103,5 @@ export function Asset({
     </Box>
   );
 }
+
+Asset.displayName = 'Asset';

--- a/packages/components/asset/src/AssetIcon/AssetIcon.tsx
+++ b/packages/components/asset/src/AssetIcon/AssetIcon.tsx
@@ -65,3 +65,5 @@ export function AssetIcon({
       return <ArchiveIcon {...props} />;
   }
 }
+
+AssetIcon.displayName = 'AssetIcon';

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -345,6 +345,8 @@ function _Autocomplete<ItemType>(
   );
 }
 
+_Autocomplete.displayName = 'Autocomplete';
+
 const ListItemLoadingState = () => {
   return (
     <SkeletonContainer svgHeight={16}>

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -345,8 +345,6 @@ function _Autocomplete<ItemType>(
   );
 }
 
-_Autocomplete.displayName = 'Autocomplete';
-
 const ListItemLoadingState = () => {
   return (
     <SkeletonContainer svgHeight={16}>

--- a/packages/components/autocomplete/src/AutocompleteItems.tsx
+++ b/packages/components/autocomplete/src/AutocompleteItems.tsx
@@ -63,6 +63,8 @@ export function AutocompleteItems<ItemType>(
   );
 }
 
+AutocompleteItems.displayName = 'AutocompleteItems';
+
 function HighlightedItem({
   item,
   inputValue,
@@ -80,3 +82,5 @@ function HighlightedItem({
     </>
   );
 }
+
+HighlightedItem.displayName = 'HighlightedItem';

--- a/packages/components/badge/src/EntityStatusBadge/EntityStatusBadge.tsx
+++ b/packages/components/badge/src/EntityStatusBadge/EntityStatusBadge.tsx
@@ -33,6 +33,8 @@ function EntityStatusBadge(
   );
 }
 
+EntityStatusBadge.displayName = 'EntityStatusBadge';
+
 const _EntityStatusBadge = React.forwardRef<
   HTMLDivElement,
   ExpandProps<EntityStatusBadgeProps>

--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -128,6 +128,8 @@ function _Button<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
   );
 }
 
+_Button.displayName = 'Button';
+
 /**
  * @description: Buttons communicate the action that will occur when the user clicks it
  */

--- a/packages/components/button/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/button/src/ButtonGroup/ButtonGroup.tsx
@@ -56,4 +56,6 @@ function _ButtonGroup(
   );
 }
 
+_ButtonGroup.displayName = 'ButtonGroup';
+
 export const ButtonGroup = React.forwardRef(_ButtonGroup);

--- a/packages/components/button/src/IconButton/IconButton.tsx
+++ b/packages/components/button/src/IconButton/IconButton.tsx
@@ -46,6 +46,8 @@ function _IconButton<
   );
 }
 
+_IconButton.displayName = 'IconButton';
+
 export const IconButton: PolymorphicComponent<
   ExpandProps<IconButtonInternalProps>,
   typeof ICON_BUTTON_DEFAULT_TAG,

--- a/packages/components/button/src/ToggleButton/ToggleButton.tsx
+++ b/packages/components/button/src/ToggleButton/ToggleButton.tsx
@@ -79,4 +79,6 @@ function _ToggleButton(props: ExpandProps<ToggleButtonProps>, ref) {
   );
 }
 
+_ToggleButton.displayName = 'ToggleButton';
+
 export const ToggleButton = React.forwardRef(_ToggleButton);

--- a/packages/components/card/src/BaseCard/BaseCard.tsx
+++ b/packages/components/card/src/BaseCard/BaseCard.tsx
@@ -206,6 +206,8 @@ function _BaseCard<E extends React.ElementType = typeof BASE_CARD_DEFAULT_TAG>(
   );
 }
 
+_BaseCard.displayName = 'BaseCard';
+
 export const BaseCard: PolymorphicComponent<
   BaseCardInternalProps,
   typeof BASE_CARD_DEFAULT_TAG

--- a/packages/components/card/src/BaseCard/DefaultCardHeader.tsx
+++ b/packages/components/card/src/BaseCard/DefaultCardHeader.tsx
@@ -82,3 +82,5 @@ export function DefaultCardHeader(
     </Flex>
   );
 }
+
+DefaultCardHeader.displayName = 'DefaultCardHeader';

--- a/packages/components/card/src/Card/Card.tsx
+++ b/packages/components/card/src/Card/Card.tsx
@@ -77,6 +77,8 @@ function _Card<E extends React.ElementType = typeof BASE_CARD_DEFAULT_TAG>(
   );
 }
 
+_Card.displayName = 'Card';
+
 export const Card: PolymorphicComponent<
   ExpandProps<CardInternalProps>,
   typeof BASE_CARD_DEFAULT_TAG

--- a/packages/components/card/src/EntryCard/EntryCard.tsx
+++ b/packages/components/card/src/EntryCard/EntryCard.tsx
@@ -42,6 +42,8 @@ function EntryCardTitle({ title }: { title?: string }) {
   );
 }
 
+EntryCardTitle.displayName = 'EntryCardTitle';
+
 function EntryCardDescription({
   description,
   size,
@@ -61,6 +63,8 @@ function EntryCardDescription({
     </Paragraph>
   );
 }
+
+EntryCardDescription.displayName = 'EntryCardDescription';
 
 function _EntryCard<
   E extends React.ElementType = typeof ENTRY_CARD_DEFAULT_TAG
@@ -115,6 +119,8 @@ function _EntryCard<
     </BaseCard>
   );
 }
+
+_EntryCard.displayName = 'EntryCard';
 
 export const EntryCard: PolymorphicComponent<
   ExpandProps<EntryCardInternalProps>,

--- a/packages/components/copybutton/src/CopyButton.tsx
+++ b/packages/components/copybutton/src/CopyButton.tsx
@@ -119,4 +119,6 @@ function _CopyButton(
   );
 }
 
+_CopyButton.displayName = 'CopyButton';
+
 export const CopyButton = React.forwardRef(_CopyButton);

--- a/packages/components/entity-list/src/EntityList.tsx
+++ b/packages/components/entity-list/src/EntityList.tsx
@@ -26,4 +26,6 @@ function _EntityList(
   );
 }
 
+_EntityList.displayName = 'EntityList';
+
 export const EntityList = React.forwardRef(_EntityList);

--- a/packages/components/entity-list/src/EntityListItem/EntityListItem.tsx
+++ b/packages/components/entity-list/src/EntityListItem/EntityListItem.tsx
@@ -271,3 +271,5 @@ export function EntityListItem({
     </li>
   );
 }
+
+EntityListItem.displayName = 'EntityListItem';

--- a/packages/components/forms/src/BaseCheckbox/BaseCheckbox.tsx
+++ b/packages/components/forms/src/BaseCheckbox/BaseCheckbox.tsx
@@ -150,4 +150,6 @@ function _BaseCheckbox(
   );
 }
 
+_BaseCheckbox.displayName = 'BaseCheckbox';
+
 export const BaseCheckbox = React.forwardRef(_BaseCheckbox);

--- a/packages/components/forms/src/BaseInput/BaseInput.tsx
+++ b/packages/components/forms/src/BaseInput/BaseInput.tsx
@@ -147,6 +147,8 @@ function _BaseInput<E extends React.ElementType = typeof INPUT_DEFAULT_TAG>(
   return inputContent();
 }
 
+_BaseInput.displayName = 'BaseInput';
+
 export const BaseInput: PolymorphicComponent<
   ExpandProps<BaseInputInternalProps>,
   typeof INPUT_DEFAULT_TAG,

--- a/packages/components/forms/src/Form/Form.tsx
+++ b/packages/components/forms/src/Form/Form.tsx
@@ -38,4 +38,6 @@ function _Form(
   );
 }
 
+_Form.displayName = 'Form';
+
 export const Form = forwardRef(_Form);

--- a/packages/components/forms/src/FormControl/FormControl.tsx
+++ b/packages/components/forms/src/FormControl/FormControl.tsx
@@ -77,6 +77,8 @@ function _FormControl<
   );
 }
 
+_FormControl.displayName = 'FormControl';
+
 export const FormControl: PolymorphicComponent<
   ExpandProps<FormControlInternalProps>,
   typeof FORM_CONTROL_DEFAULT_TAG

--- a/packages/components/forms/src/FormLabel/FormLabel.tsx
+++ b/packages/components/forms/src/FormLabel/FormLabel.tsx
@@ -91,6 +91,8 @@ function _FormLabel<
   );
 }
 
+_FormLabel.displayName = 'FormLabel';
+
 export const FormLabel: PolymorphicComponent<
   ExpandProps<FormLabelInternalProps>,
   typeof FORM_LABEL_DEFAULT_TAG

--- a/packages/components/icon/src/Icon.tsx
+++ b/packages/components/icon/src/Icon.tsx
@@ -161,8 +161,6 @@ export function _Icon<E extends React.ElementType = IconComponent>(
   );
 }
 
-_Icon.displayName = 'Icon';
-
 export const Icon: PolymorphicComponent<
   ExpandProps<IconInternalProps>,
   typeof ICON_DEFAULT_TAG,

--- a/packages/components/icon/src/Icon.tsx
+++ b/packages/components/icon/src/Icon.tsx
@@ -161,6 +161,8 @@ export function _Icon<E extends React.ElementType = IconComponent>(
   );
 }
 
+_Icon.displayName = 'Icon';
+
 export const Icon: PolymorphicComponent<
   ExpandProps<IconInternalProps>,
   typeof ICON_DEFAULT_TAG,

--- a/packages/components/list/src/List.tsx
+++ b/packages/components/list/src/List.tsx
@@ -52,6 +52,8 @@ function _List<E extends React.ElementType = typeof LIST_DEFAULT_TAG>(
   );
 }
 
+_List.displayName = 'List';
+
 export const List: PolymorphicComponent<
   ExpandProps<ListInternalProps>,
   typeof LIST_DEFAULT_TAG

--- a/packages/components/list/src/ListItem/ListItem.tsx
+++ b/packages/components/list/src/ListItem/ListItem.tsx
@@ -37,3 +37,5 @@ export function ListItem({
     </li>
   );
 }
+
+ListItem.displayName = 'ListItem';

--- a/packages/components/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/components/menu/src/MenuItem/MenuItem.tsx
@@ -63,6 +63,8 @@ function _MenuItem<E extends React.ElementType = typeof MENU_ITEM_DEFAULT_TAG>(
   );
 }
 
+_MenuItem.displayName = 'MenuItem';
+
 export const MenuItem: PolymorphicComponent<
   ExpandProps<MenuItemInternalProps>,
   typeof MENU_ITEM_DEFAULT_TAG

--- a/packages/components/modal/src/Modal.tsx
+++ b/packages/components/modal/src/Modal.tsx
@@ -216,3 +216,5 @@ export function Modal({
     </ReactModal>
   );
 }
+
+Modal.displayName = 'Modal';

--- a/packages/components/modal/src/ModalConfirm/ModalConfirm.tsx
+++ b/packages/components/modal/src/ModalConfirm/ModalConfirm.tsx
@@ -164,3 +164,5 @@ export function ModalConfirm({
     </Modal>
   );
 }
+
+ModalConfirm.displayName = 'ModalConfirm';

--- a/packages/components/modal/src/ModalContent/ModalContent.tsx
+++ b/packages/components/modal/src/ModalContent/ModalContent.tsx
@@ -31,3 +31,5 @@ export function ModalContent({
     </Box>
   );
 }
+
+ModalContent.displayName = 'ModalContent';

--- a/packages/components/modal/src/ModalControls/ModalControls.tsx
+++ b/packages/components/modal/src/ModalControls/ModalControls.tsx
@@ -35,3 +35,5 @@ export function ModalControls({
     </Flex>
   );
 }
+
+ModalControls.displayName = 'ModalControls';

--- a/packages/components/modal/src/ModalHeader/ModalHeader.tsx
+++ b/packages/components/modal/src/ModalHeader/ModalHeader.tsx
@@ -54,3 +54,5 @@ export function ModalHeader({
     </Flex>
   );
 }
+
+ModalHeader.displayName = 'ModalHeader';

--- a/packages/components/notification/src/NotificationItem/NotificationItemContainer.tsx
+++ b/packages/components/notification/src/NotificationItem/NotificationItemContainer.tsx
@@ -22,6 +22,7 @@ export class NotificationItemContainer extends Component<
   NotificationItemContainerState
 > {
   static defaultProps = defaultProps;
+  displayName: 'NotificationItemContainer';
 
   timer: number | null = null;
 
@@ -105,5 +106,3 @@ export class NotificationItemContainer extends Component<
     );
   }
 }
-
-NotificationItemContainer.displayName = 'NotificationItemContainer';

--- a/packages/components/notification/src/NotificationItem/NotificationItemContainer.tsx
+++ b/packages/components/notification/src/NotificationItem/NotificationItemContainer.tsx
@@ -105,3 +105,5 @@ export class NotificationItemContainer extends Component<
     );
   }
 }
+
+NotificationItemContainer.displayName = 'NotificationItemContainer';

--- a/packages/components/notification/src/NotificationsManager/NotificationsManager.tsx
+++ b/packages/components/notification/src/NotificationsManager/NotificationsManager.tsx
@@ -187,3 +187,5 @@ export function NotificationsManager({
     </div>
   );
 }
+
+NotificationsManager.displayName = 'NotificationsManager';

--- a/packages/components/pagination/src/Pagination.tsx
+++ b/packages/components/pagination/src/Pagination.tsx
@@ -142,4 +142,6 @@ function _Pagination(props: PaginationProps, ref: React.Ref<HTMLDivElement>) {
   );
 }
 
+_Pagination.displayName = 'Pagination';
+
 export const Pagination = React.forwardRef(_Pagination);

--- a/packages/components/skeleton/src/SkeletonContainer/SkeletonContainer.tsx
+++ b/packages/components/skeleton/src/SkeletonContainer/SkeletonContainer.tsx
@@ -149,3 +149,5 @@ export function SkeletonContainer({
     </Box>
   );
 }
+
+SkeletonContainer.displayName = 'SkeletonContainer';

--- a/packages/components/skeleton/src/SkeletonDisplayText/SkeletonDisplayText.tsx
+++ b/packages/components/skeleton/src/SkeletonDisplayText/SkeletonDisplayText.tsx
@@ -26,3 +26,5 @@ export function SkeletonDisplayText({
     />
   );
 }
+
+SkeletonDisplayText.displayName = 'SkeletonDisplayText';

--- a/packages/components/skeleton/src/SkeletonImage/SkeletonImage.tsx
+++ b/packages/components/skeleton/src/SkeletonImage/SkeletonImage.tsx
@@ -35,3 +35,5 @@ export function SkeletonImage({
     />
   );
 }
+
+SkeletonImage.displayName = 'SkeletonImage';

--- a/packages/components/skeleton/src/SkeletonText/SkeletonText.tsx
+++ b/packages/components/skeleton/src/SkeletonText/SkeletonText.tsx
@@ -68,3 +68,5 @@ export function SkeletonText({
     </React.Fragment>
   );
 }
+
+SkeletonText.displayName = 'SkeletonText';

--- a/packages/components/table/src/TableBody.tsx
+++ b/packages/components/table/src/TableBody.tsx
@@ -16,10 +16,7 @@ export type TableBodyProps = PropsWithHTMLElement<
   'tbody'
 >;
 
-export const TableBody = forwardRef<
-  HTMLTableSectionElement,
-  ExpandProps<TableBodyProps>
->(function TableBody(
+function _TableBody(
   { className, children, testId = 'cf-ui-table-body', ...otherProps },
   forwardedRef,
 ) {
@@ -34,4 +31,11 @@ export const TableBody = forwardRef<
       {children}
     </Box>
   );
-});
+}
+
+_TableBody.displayName = 'TableBody';
+
+export const TableBody = forwardRef<
+  HTMLTableSectionElement,
+  ExpandProps<TableBodyProps>
+>(_TableBody);

--- a/packages/components/text-link/src/TextLink.tsx
+++ b/packages/components/text-link/src/TextLink.tsx
@@ -125,6 +125,8 @@ function _TextLink<E extends React.ElementType = typeof TEX_LINK_DEFAULT_TAG>(
   );
 }
 
+_TextLink.displayName = 'TextLink';
+
 export const TextLink: PolymorphicComponent<
   ExpandProps<TextLinkInternalProps>,
   typeof TEX_LINK_DEFAULT_TAG,

--- a/packages/components/typography/src/DisplayText/DisplayText.tsx
+++ b/packages/components/typography/src/DisplayText/DisplayText.tsx
@@ -59,6 +59,8 @@ function _DisplayText<
   );
 }
 
+_DisplayText.displayName = 'DisplayText';
+
 export const DisplayText: PolymorphicComponent<
   ExpandProps<DisplayTextInternalProps>,
   typeof DISPLAY_TEXT_DEFAULT_TAG

--- a/packages/components/typography/src/Heading/Heading.tsx
+++ b/packages/components/typography/src/Heading/Heading.tsx
@@ -44,6 +44,8 @@ function _Heading<E extends React.ElementType = typeof HEADING_DEFAULT_TAG>(
   );
 }
 
+_Heading.displayName = 'Heading';
+
 export const Heading: PolymorphicComponent<
   ExpandProps<HeadingInternalProps>,
   typeof HEADING_DEFAULT_TAG

--- a/packages/components/typography/src/SectionHeading/SectionHeading.tsx
+++ b/packages/components/typography/src/SectionHeading/SectionHeading.tsx
@@ -58,6 +58,8 @@ function _SectionHeading<
   );
 }
 
+_SectionHeading.displayName = 'SectionHeading';
+
 export const SectionHeading: PolymorphicComponent<
   ExpandProps<SectionHeadingInternalProps>,
   typeof SECTION_HEADING_DEFAULT_TAG

--- a/packages/components/typography/src/Subheading/Subheading.tsx
+++ b/packages/components/typography/src/Subheading/Subheading.tsx
@@ -44,6 +44,8 @@ function _Subheading<
   );
 }
 
+_Subheading.displayName = 'Subheading';
+
 export const Subheading: PolymorphicComponent<
   ExpandProps<SubheadingInternalProps>,
   typeof SUBHEADING_DEFAULT_TAG

--- a/packages/components/typography/src/Text/Text.tsx
+++ b/packages/components/typography/src/Text/Text.tsx
@@ -91,6 +91,8 @@ function _Text<E extends React.ElementType = typeof TEXT_DEFAULT_TAG>(
   );
 }
 
+_Text.displayName = 'Text';
+
 export const Text: PolymorphicComponent<
   ExpandProps<TextInternalProps>,
   typeof TEXT_DEFAULT_TAG

--- a/packages/components/typography/src/Typography.tsx
+++ b/packages/components/typography/src/Typography.tsx
@@ -15,3 +15,5 @@ export function Typography(props: TypographyProps) {
   }, []);
   return <>{props.children}</>;
 }
+
+Typography.displayName = 'Typography';

--- a/packages/components/workbench/src/Workbench.tsx
+++ b/packages/components/workbench/src/Workbench.tsx
@@ -41,6 +41,8 @@ function _Workbench(
   );
 }
 
+_Workbench.displayName = 'Workbench';
+
 /**
  * The Workbench assembles the outer app shell which defines regions to structure content and interactions
  */

--- a/packages/core/src/Box/Box.tsx
+++ b/packages/core/src/Box/Box.tsx
@@ -92,6 +92,8 @@ function _Box<E extends React.ElementType = typeof BOX_DEFAULT_TAG>(
   );
 }
 
+_Box.displayName = 'Box';
+
 export const Box: PolymorphicComponent<
   ExpandProps<BoxInternalProps>,
   typeof BOX_DEFAULT_TAG

--- a/packages/core/src/Flex/Flex.tsx
+++ b/packages/core/src/Flex/Flex.tsx
@@ -145,6 +145,8 @@ function _Flex<E extends React.ElementType = typeof FLEX_DEFAULT_TAG>(
   );
 }
 
+_Flex.displayName = 'Flex';
+
 export const Flex: PolymorphicComponent<
   ExpandProps<FlexInternalProps>,
   typeof FLEX_DEFAULT_TAG

--- a/packages/core/src/Grid/Grid.tsx
+++ b/packages/core/src/Grid/Grid.tsx
@@ -100,6 +100,8 @@ function _Grid<E extends React.ElementType = typeof GRID_DEFAULT_TAG>(
   );
 }
 
+_Grid.displayName = 'Grid';
+
 export const Grid: PolymorphicComponent<
   ExpandProps<GridInternalProps>,
   typeof GRID_DEFAULT_TAG

--- a/packages/core/src/Grid/GridItem/GridItem.tsx
+++ b/packages/core/src/Grid/GridItem/GridItem.tsx
@@ -82,6 +82,8 @@ function _GridItem<E extends React.ElementType = typeof GRID_ITEM_DEFAULT_TAG>(
   );
 }
 
+_GridItem.displayName = 'GridItem';
+
 export const GridItem: PolymorphicComponent<
   GridItemInternalProps,
   typeof GRID_ITEM_DEFAULT_TAG

--- a/packages/core/src/Stack/Stack.tsx
+++ b/packages/core/src/Stack/Stack.tsx
@@ -57,6 +57,8 @@ function _Stack<E extends React.ElementType = typeof STACK_DEFAULT_TAG>(
   );
 }
 
+_Stack.displayName = 'Stack';
+
 export const Stack: PolymorphicComponent<
   ExpandProps<StackInternalProps>,
   typeof STACK_DEFAULT_TAG


### PR DESCRIPTION
Adds displayName to component so `react-dev-tools` shows a readable name for the components.


PS: I may have missed some, as I used a script to add the `displayName`.