### PR TITLE
fix(global-styles): remove min-height on body

### DIFF
--- a/packages/core/src/GlobalStyles/GlobalStyles.tsx
+++ b/packages/core/src/GlobalStyles/GlobalStyles.tsx
@@ -30,7 +30,6 @@ const cssReset = css`
 
   /* Set core body defaults */
   body {
-    min-height: 100vh;
     text-rendering: optimizeSpeed;
     line-height: 1.5;
   }


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Removes `min-height` on `body` in our CSS reset. Necessary for app SDK resizing to work.