### PR TITLE
docs: use placeholder images from placeholder.pics

### DIFF
--- a/packages/components/asset/src/Asset.test.tsx
+++ b/packages/components/asset/src/Asset.test.tsx
@@ -8,7 +8,7 @@ describe('with type=image', () => {
   it('renders the component as a preview', () => {
     const { container } = render(
       <Asset
-        src="https://via.placeholder.com/200x300"
+        src="https://placeholder.pics/svg/200x300"
         title="Image of a cat"
         className="extra-class-name"
         type="image"
@@ -22,7 +22,7 @@ describe('with type=image', () => {
   it('renders the component as a standard asset with status=archived', () => {
     const { container } = render(
       <Asset
-        src="https://via.placeholder.com/200x300"
+        src="https://placeholder.pics/svg/200x300"
         title="Image of a cat"
         className="extra-class-name"
         type="image"
@@ -38,7 +38,7 @@ describe('with type=image', () => {
 it('has no a11y issues', async () => {
   const { container } = render(
     <Asset
-      src="https://via.placeholder.com/200x300"
+      src="https://placeholder.pics/svg/200x300"
       title="picture of a cat"
     />,
   );

--- a/packages/components/asset/stories/Asset.stories.tsx
+++ b/packages/components/asset/stories/Asset.stories.tsx
@@ -12,7 +12,7 @@ export default {
     className: { control: { disable: true } },
     src: {
       control: 'text',
-      defaultValue: 'https://via.placeholder.com/200x300',
+      defaultValue: 'https://placeholder.pics/svg/200x300',
     },
     status: {
       control: {
@@ -59,19 +59,22 @@ export const Overview: Story<AssetProps> = () => (
       <Flex marginBottom="spacingS">
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">published</Text>
-          <Asset status="published" src="https://via.placeholder.com/200x300" />
+          <Asset
+            status="published"
+            src="https://placeholder.pics/svg/200x300"
+          />
         </Flex>
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">draft</Text>
-          <Asset status="draft" src="https://via.placeholder.com/200x300" />
+          <Asset status="draft" src="https://placeholder.pics/svg/200x300" />
         </Flex>
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">changed</Text>
-          <Asset status="changed" src="https://via.placeholder.com/200x300" />
+          <Asset status="changed" src="https://placeholder.pics/svg/200x300" />
         </Flex>
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">archived (should not show image)</Text>
-          <Asset status="archived" src="https://via.placeholder.com/200x300" />
+          <Asset status="archived" src="https://placeholder.pics/svg/200x300" />
         </Flex>
       </Flex>
     </Flex>
@@ -83,46 +86,49 @@ export const Overview: Story<AssetProps> = () => (
       <Flex marginBottom="spacingS">
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">image</Text>
-          <Asset type="image" src="https://via.placeholder.com/200x300" />
+          <Asset type="image" src="https://placeholder.pics/svg/200x300" />
         </Flex>
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">archive</Text>
-          <Asset type="archive" src="https://via.placeholder.com/200x300" />
+          <Asset type="archive" src="https://placeholder.pics/svg/200x300" />
         </Flex>
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">audio</Text>
-          <Asset type="audio" src="https://via.placeholder.com/200x300" />
+          <Asset type="audio" src="https://placeholder.pics/svg/200x300" />
         </Flex>
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">code</Text>
-          <Asset type="code" src="https://via.placeholder.com/200x300" />
+          <Asset type="code" src="https://placeholder.pics/svg/200x300" />
         </Flex>
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">markup</Text>
-          <Asset type="markup" src="https://via.placeholder.com/200x300" />
+          <Asset type="markup" src="https://placeholder.pics/svg/200x300" />
         </Flex>
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">pdf</Text>
-          <Asset type="pdf" src="https://via.placeholder.com/200x300" />
+          <Asset type="pdf" src="https://placeholder.pics/svg/200x300" />
         </Flex>
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">plaintext</Text>
-          <Asset type="plaintext" src="https://via.placeholder.com/200x300" />
+          <Asset type="plaintext" src="https://placeholder.pics/svg/200x300" />
         </Flex>
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">presentation</Text>
           <Asset
             type="presentation"
-            src="https://via.placeholder.com/200x300"
+            src="https://placeholder.pics/svg/200x300"
           />
         </Flex>
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">spreadsheet</Text>
-          <Asset type="spreadsheet" src="https://via.placeholder.com/200x300" />
+          <Asset
+            type="spreadsheet"
+            src="https://placeholder.pics/svg/200x300"
+          />
         </Flex>
         <Flex flexDirection="column" marginRight="spacingS">
           <Text as="p">video</Text>
-          <Asset type="video" src="https://via.placeholder.com/200x300" />
+          <Asset type="video" src="https://placeholder.pics/svg/200x300" />
         </Flex>
       </Flex>
     </Flex>

--- a/packages/components/card/stories/AssetCard.stories.tsx
+++ b/packages/components/card/stories/AssetCard.stories.tsx
@@ -42,7 +42,7 @@ export const Default: Story<Args> = (args) => {
 Default.args = {
   status: 'published',
   type: 'image',
-  src: 'https://via.placeholder.com/200x300',
+  src: 'https://placeholder.pics/svg/200x300',
   title: 'Asset title',
 };
 
@@ -74,7 +74,7 @@ export const Overview: Story<Args> = () => {
 
           <AssetCard
             icon={<Icon as={icons.ClockIcon} />}
-            src="https://via.placeholder.com/200x300"
+            src="https://placeholder.pics/svg/200x300"
             title="Asset title"
             type="image"
           />
@@ -88,7 +88,7 @@ export const Overview: Story<Args> = () => {
           <AssetCard
             actions={actions}
             isHovered
-            src="https://via.placeholder.com/200x300"
+            src="https://placeholder.pics/svg/200x300"
             title="Asset title"
             type="image"
           />
@@ -101,7 +101,7 @@ export const Overview: Story<Args> = () => {
 
           <AssetCard
             isSelected
-            src="https://via.placeholder.com/200x300"
+            src="https://placeholder.pics/svg/200x300"
             title="Asset title"
             type="image"
           />
@@ -121,7 +121,7 @@ export const Overview: Story<Args> = () => {
           <AssetCard
             icon={<Icon as={icons.ClockIcon} />}
             size="small"
-            src="https://via.placeholder.com/200x300"
+            src="https://placeholder.pics/svg/200x300"
             title="Asset title"
             type="image"
           />
@@ -136,7 +136,7 @@ export const Overview: Story<Args> = () => {
             actions={actions}
             isHovered
             size="small"
-            src="https://via.placeholder.com/200x300"
+            src="https://placeholder.pics/svg/200x300"
             title="Asset title"
             type="image"
           />
@@ -150,7 +150,7 @@ export const Overview: Story<Args> = () => {
           <AssetCard
             isSelected
             size="small"
-            src="https://via.placeholder.com/200x300"
+            src="https://placeholder.pics/svg/200x300"
             title="Asset title"
             type="image"
           />
@@ -175,7 +175,7 @@ export const DifferentImageSizes: Story<Args> = () => {
 
           <AssetCard
             icon={<Icon as={icons.ClockIcon} />}
-            src="https://via.placeholder.com/200x300"
+            src="https://placeholder.pics/svg/200x300"
             title="Asset title"
             type="image"
           />
@@ -188,7 +188,7 @@ export const DifferentImageSizes: Story<Args> = () => {
 
           <AssetCard
             icon={<Icon as={icons.ClockIcon} />}
-            src="https://via.placeholder.com/200x600"
+            src="https://placeholder.pics/svg/200x600"
             title="Asset title"
             type="image"
           />
@@ -201,7 +201,7 @@ export const DifferentImageSizes: Story<Args> = () => {
 
           <AssetCard
             icon={<Icon as={icons.ClockIcon} />}
-            src="https://via.placeholder.com/800x200"
+            src="https://placeholder.pics/svg/800x200"
             title="Asset title"
             type="image"
           />
@@ -221,7 +221,7 @@ export const DifferentImageSizes: Story<Args> = () => {
           <AssetCard
             icon={<Icon as={icons.ClockIcon} />}
             size="small"
-            src="https://via.placeholder.com/200x300"
+            src="https://placeholder.pics/svg/200x300"
             title="Asset title"
             type="image"
           />
@@ -235,7 +235,7 @@ export const DifferentImageSizes: Story<Args> = () => {
           <AssetCard
             actions={actions}
             size="small"
-            src="https://via.placeholder.com/200x600"
+            src="https://placeholder.pics/svg/200x600"
             title="Asset title"
             type="image"
           />
@@ -248,7 +248,7 @@ export const DifferentImageSizes: Story<Args> = () => {
 
           <AssetCard
             size="small"
-            src="https://via.placeholder.com/800x200"
+            src="https://placeholder.pics/svg/800x200"
             title="Asset title"
             type="image"
           />
@@ -262,7 +262,7 @@ export const DifferentImageSizes: Story<Args> = () => {
       <Box style={{ width: '500px' }} marginBottom="spacingS">
         <AssetCard
           icon={<Icon as={icons.ClockIcon} />}
-          src="https://via.placeholder.com/800x200"
+          src="https://placeholder.pics/svg/800x200"
           title="Asset title"
           type="image"
         />
@@ -271,7 +271,7 @@ export const DifferentImageSizes: Story<Args> = () => {
       <Box style={{ width: '500px' }}>
         <AssetCard
           icon={<Icon as={icons.ClockIcon} />}
-          src="https://via.placeholder.com/200x300"
+          src="https://placeholder.pics/svg/200x300"
           title="Asset title"
           type="image"
         />

--- a/packages/components/entity-list/stories/EntityListItem.stories.tsx
+++ b/packages/components/entity-list/stories/EntityListItem.stories.tsx
@@ -31,7 +31,7 @@ Basic.args = {
   title: 'Entity title',
   description: 'Entity description',
   contentType: 'My content type',
-  thumbnailUrl: 'https://via.placeholder.com/400x400',
+  thumbnailUrl: 'https://placeholder.pics/svg/400x400',
   thumbnailAltText: 'My thumbnail text',
   withThumbnail: true,
   entityType: 'entry',

--- a/packages/website/content/deprecated-components/empty-state.mdx
+++ b/packages/website/content/deprecated-components/empty-state.mdx
@@ -17,7 +17,7 @@ You must migrate existing code:
 <EmptyState
   headingProps={{ text: 'Heading' }}
   imageProps={{
-    url: 'https://via.placeholder.com/200x200',
+    url: 'https://placeholder.pics/svg/200x200',
     width: '340px',
     height: '250px',
     description: 'Image descriptionProps',
@@ -34,7 +34,7 @@ to:
 ```tsx
 <Flex flexDirection="column" justifyContent="center" alignItems="center">
   <Flex flexDirection="column" justifyContent="center" alignItems="center">
-    <img src="https://via.placeholder.com/200x200" alt="Illustration" />
+    <img src="https://placeholder.pics/svg/200x200" alt="Illustration" />
     <Subheading marginTop="spacingM" marginBottom="spacingM">
       Heading
     </Subheading>


### PR DESCRIPTION
# Purpose of PR

The current placeholder service isn't working with Chromatic at the moment. I found this one that might be useful instead, although I'm not sure how much load it can handle: https://placeholder.pics/

The service insists on adding a border to the image, which I'm not a fan of. People might confuse it for a border in the library. You can see what it looks like on Chromatic. Thoughts? 