### PR TITLE
fix: clunky close animation of the modal component

### DIFF
--- a/packages/components/modal/src/Modal.styles.ts
+++ b/packages/components/modal/src/Modal.styles.ts
@@ -10,10 +10,7 @@ export function getModalStyles(props: {
 }) {
   const modal = cx(
     css({
-      transition: `opacity ${tokens.transitionDurationLong} ${tokens.transitionEasingDefault}, transform ${tokens.transitionDurationDefault} ${tokens.transitionEasingCubicBezier}`,
-      opacity: '0.5',
       margin: tokens.spacing2Xl,
-      transform: 'scale(0.85)',
       backgroundColor: tokens.colorWhite,
       borderRadius: tokens.borderRadiusMedium,
       boxShadow: tokens.boxShadowHeavy,
@@ -55,6 +52,8 @@ export function getModalStyles(props: {
           margin: '0 auto',
           textAlign: 'left',
           outline: 'none',
+          transform: 'scale(0.85)',
+          transition: `transform ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}`,
         }),
         props.size === 'zen'
           ? css({
@@ -64,16 +63,10 @@ export function getModalStyles(props: {
           : null,
       ),
       afterOpen: css({
-        '[data-modal-root]': {
-          transform: 'scale(1)',
-          opacity: '1',
-        },
+        transform: 'scale(1)',
       }),
       beforeClose: css({
-        '[data-modal-root]': {
-          opacity: '0.5',
-          transform: 'scale(0.85)',
-        },
+        transform: 'scale(0.85)',
       }),
     },
     modalOverlay: {
@@ -102,7 +95,7 @@ export function getModalStyles(props: {
           : null,
       ),
       afterOpen: css({
-        opacity: '1 !important',
+        opacity: 1,
       }),
       beforeClose: css({
         opacity: 0,

--- a/packages/components/modal/src/Modal.tsx
+++ b/packages/components/modal/src/Modal.tsx
@@ -181,22 +181,22 @@ export function Modal({
       shouldFocusAfterRender
       shouldReturnFocusAfterClose
       portalClassName={styles.portal}
-      className={{
-        base: styles.base.root,
-        afterOpen: styles.base.afterOpen,
-        beforeClose: styles.base.beforeClose,
-      }}
       style={{
         content: {
           top: position === 'center' ? 0 : topOffset,
         },
+      }}
+      className={{
+        base: styles.base.root,
+        afterOpen: styles.base.afterOpen,
+        beforeClose: styles.base.beforeClose,
       }}
       overlayClassName={{
         base: styles.modalOverlay.root,
         afterOpen: styles.modalOverlay.afterOpen,
         beforeClose: styles.modalOverlay.beforeClose,
       }}
-      closeTimeoutMS={300}
+      closeTimeoutMS={200}
       contentRef={(ref) => {
         contentRef.current = ref;
       }}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

There is a bug in the close animation of our modals, look:

![modal_animation_bug](https://user-images.githubusercontent.com/6597467/157475245-808df732-77e2-4f42-9371-c5434c482a43.gif)

This PR fixes it:

![modal_animation_fix](https://user-images.githubusercontent.com/6597467/157475300-0a47ef61-99be-4371-bc9b-c2ce3ab4a014.gif)


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
