### PR TITLE
fix(workbench): don't render null children

### DIFF
--- a/packages/components/workbench/src/Workbench.tsx
+++ b/packages/components/workbench/src/Workbench.tsx
@@ -17,17 +17,16 @@ function _Workbench(
   const header: React.ReactNode[] = [];
   const content: React.ReactNode[] = [];
 
-  React.Children.forEach(
-    children,
-    // eslint-disable-next-line
-    (child: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  React.Children.forEach<any>(children, (child) => {
+    if (child) {
       if (child.type?.displayName === 'WorkbenchHeader') {
         header.push(child);
       } else {
         content.push(child);
       }
-    },
-  );
+    }
+  });
 
   return (
     <div


### PR DESCRIPTION
# Purpose of PR

Follow-up to #1831.

Workbench is rendering null children which throws an error.