### PR TITLE
[WIP] docs: change component overview descriptions

### DIFF
--- a/packages/components/accordion/README.mdx
+++ b/packages/components/accordion/README.mdx
@@ -6,8 +6,9 @@ github: 'https://github.com/contentful/forma-36/tree/main/packages/components/ac
 typescript: ./src/Accordion.tsx,./src/AccordionItem/AccordionItem.tsx
 ---
 
-Accordions are a good way to deliver a large amount of information. An accordion is a list of headers that after being clicked reveal or hide more content related to them.
-The header gives the user a summary of the content and the user decides if they need to see the extended content or not.
+Store longer content in sections users can open one at a time.
+
+Keep the section titles short.
 
 ## Import
 


### PR DESCRIPTION
# Purpose of PR

Change component overview descriptions according to new writing guidelines.
See descriptions here: https://docs.google.com/spreadsheets/d/1bJQEq8EYMQ9jOmY9cJoiBRdsIkmbh2a27o9xO3V1LeY/edit?usp=sharing

### Before

- unnecessarily repeating the component name
- no consistency in overview structure — "Component is...", "Component is used to...", etc
- not concise enough

<img width="1227" alt="Screen Shot 2022-03-15 at 08 32 54" src="https://user-images.githubusercontent.com/7631029/158328377-82a072de-05a4-4c3d-b455-94ecc1020327.png">

### After
- without repeating the name of the component
- following the imperative format of: "Use this component to..."
- concise, optionally with a common pitfall

<img width="1227" alt="Screen Shot 2022-03-15 at 08 33 00" src="https://user-images.githubusercontent.com/7631029/158328395-9e2f3637-2e8d-42f5-9248-63526789ef56.png">



## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
