### PR TITLE
ci(circleci): prettier should be executed after files are added

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       - run:
           name: Commit changelogrc
           command: |
-            git add .
+            git add . && yarn run pretty:quick
             git diff --staged --quiet || git commit -m "docs(changelog): add changelogs for $(git rev-parse --short HEAD) [skip ci]" && git push origin ${CIRCLE_BRANCH} --follow-tags
 
   changelog:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,4 +137,3 @@ The Changelog gives an overview of the changes we've made to Forma 36
 **F36 Workbench** `v4.3.9`
 
 - bump packages versions to have consistent versioning
-

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "docs:next:build": "turbo run build:prod --scope=@contentful/f36-website --parallel",
     "docs:next:start-prod": "turbo run start:prod --scope=@contentful/f36-website --parallel",
     "changelog:gen": "node scripts/changesets/changelog-generate.js",
-    "changelog:write": "node scripts/changesets/changelog-write.js && yarn run pretty:quick",
+    "changelog:write": "node scripts/changesets/changelog-write.js",
     "pretty:quick": "yarn pretty-quick --staged --pattern '**/*.*(js|jsx|ts|tsx|md|mdx)'"
   },
   "husky": {

--- a/packages/website/content/changelog.mdx
+++ b/packages/website/content/changelog.mdx
@@ -135,4 +135,3 @@ The Changelog gives an overview of the changes we've made to Forma 36
 **F36 Workbench** `v4.3.9`
 
 - bump packages versions to have consistent versioning
-


### PR DESCRIPTION
- Fix order when prettier is called on CI.
- Fix prettier issues on generated changelog.