### PR TITLE
docs: add changesets usage to contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ We use storybook with our react component library to develop components. You can
 
 ## Commits & releases
 
-Use `yarn commit`. This uses the [Commitzen](https://github.com/commitizen/cz-cli) CLI to create a conventional commit message based on your changes. CI is setup to release all new commits on the main branch.
+Use `yarn commit`. This uses the [Commitzen](https://github.com/commitizen/cz-cli) CLI to create a conventional commit message based on your changes. CI is setup to release all new commits on the main branch that contains a new [changeset](https://github.com/changesets/changesets).
 
 ## Testing with your own project locally
 

--- a/packages/website/content/contributing.mdx
+++ b/packages/website/content/contributing.mdx
@@ -44,6 +44,9 @@ and our [Code Style Guide](https://github.com/contentful/forma-36/blob/main/docs
 Once the code is ready, open a Pull Request in our repository.
 The Pull Request template provides more information on what to include in your request.
 
+Don't forget to include a changeset on your Pull Request if you want a new version to be released.
+You can do that by running `yarn changeset`. Read more about [changesets](https://github.com/changesets/changesets)
+
 ### Step 4: Code & Design Review
 
 We will review both the code and the design changes (if you have any).
@@ -52,7 +55,7 @@ During this step we just want to make sure the solution is maintainable and scal
 ### Step 5: Merge the changes to the main branch
 
 After the Pull Request is approved, you can merge the code to the main branch
-and it will automatically publish a new version of Forma 36 with your changes.
+and it will automatically publish a new version of Forma 36 with your changes if you added a changeset.
 
 ## Bugs & Light contributions
 


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

Updating `Commits & Release` section on Readme and `Contributing Guide` as we now use changeset and only release new versions of packages that contain a changeset with the new version and notes