### PR TITLE
docs: add link to changelog page and rename changelog to what's new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
-title: Changelog
-slug: '/changelog'
+title: What's new
+slug: '/whats-new'
 section: 'intro'
 ---
 

--- a/packages/website/components/Footer.tsx
+++ b/packages/website/components/Footer.tsx
@@ -44,6 +44,7 @@ export function Footer() {
             href="https://forms.gle/qC7LLbiy4CcF5HPLA"
             label="Give us feedback"
           />
+          <FooterLink isExternal={false} href="/whats-new" label="What's new" />
         </Flex>
 
         <Flex flexDirection="column" alignItems="flex-start" gap="spacingM">

--- a/packages/website/content/changelog.mdx
+++ b/packages/website/content/changelog.mdx
@@ -1,6 +1,6 @@
 ---
-title: Changelog
-slug: '/changelog'
+title: What's new
+slug: '/whats-new'
 section: 'intro'
 ---
 

--- a/packages/website/utils/sidebarLinks.json
+++ b/packages/website/utils/sidebarLinks.json
@@ -290,6 +290,10 @@
     {
       "title": "Getting started",
       "slug": "/getting-started"
+    },
+    {
+      "title": "What's new",
+      "slug": "/whats-new"
     }
   ],
   "forma36Version3": [


### PR DESCRIPTION
Add link on the Footer of documentation website to the `What's new` page.
The table of content is generated automatically, if will appear when we have a new entry on the file.