### PR TITLE
fix(checkbox): allow passing HTML attributes to input

### DIFF
--- a/packages/components/forms/src/BaseCheckbox/types.ts
+++ b/packages/components/forms/src/BaseCheckbox/types.ts
@@ -1,4 +1,8 @@
-import type { ChangeEventHandler, ComponentProps } from 'react';
+import type {
+  ChangeEventHandler,
+  ComponentPropsWithoutRef,
+  HTMLAttributes,
+} from 'react';
 import type { BaseInputInternalProps } from '../BaseInput/types';
 
 export type checkboxTypes = 'checkbox' | 'radio' | 'switch';
@@ -31,7 +35,9 @@ export interface BaseCheckboxInternalProps
   /**
    * Additional props that are passed to the input element
    */
-  inputProps?: Partial<ComponentProps<'input'>>;
+  inputProps?: Partial<
+    HTMLAttributes<HTMLInputElement> & ComponentPropsWithoutRef<'input'>
+  >;
   /**
    * Value to be set as aria-label if not passing a children
    */


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR should allow passing HTML attributes to the checkbox input through `inputProps`. This is necessary to be able to set a `data-test-id`.

We could also use common props to allow setting `testId` prop, but I think this is overkill since we're dealing with the raw HTML element anyway.