### PR TITLE
fix(base-checkbox): explicitly allow data-test-id on HTML element

### DIFF
--- a/.changeset/wet-cats-visit.md
+++ b/.changeset/wet-cats-visit.md
@@ -1,5 +1,5 @@
 ---
-"@contentful/f36-forms": patch
+'@contentful/f36-forms': patch
 ---
 
 fix(base-checkbox): explicitly allow data-test-id on HTML element

--- a/.changeset/wet-cats-visit.md
+++ b/.changeset/wet-cats-visit.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-forms": patch
+---
+
+fix(base-checkbox): explicitly allow data-test-id on HTML element

--- a/packages/components/forms/src/BaseCheckbox/types.ts
+++ b/packages/components/forms/src/BaseCheckbox/types.ts
@@ -35,9 +35,9 @@ export interface BaseCheckboxInternalProps
   /**
    * Additional props that are passed to the input element
    */
-  inputProps?: Partial<
-    HTMLAttributes<HTMLInputElement> & ComponentPropsWithoutRef<'input'>
-  >;
+  inputProps?: Partial<ComponentPropsWithoutRef<'input'>> & {
+    'data-test-id'?: string;
+  };
   /**
    * Value to be set as aria-label if not passing a children
    */

--- a/packages/components/forms/src/BaseCheckbox/types.ts
+++ b/packages/components/forms/src/BaseCheckbox/types.ts
@@ -1,8 +1,4 @@
-import type {
-  ChangeEventHandler,
-  ComponentPropsWithoutRef,
-  HTMLAttributes,
-} from 'react';
+import type { ChangeEventHandler, ComponentPropsWithoutRef } from 'react';
 import type { BaseInputInternalProps } from '../BaseInput/types';
 
 export type checkboxTypes = 'checkbox' | 'radio' | 'switch';


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

I can't get the types to allow `data-test-id` so this PR sets it explicitly.