### PR TITLE
fix(workbench-header): support undefined icon prop

### DIFF
--- a/.changeset/chatty-tips-run.md
+++ b/.changeset/chatty-tips-run.md
@@ -1,5 +1,5 @@
 ---
-"@contentful/f36-workbench": patch
+'@contentful/f36-workbench': patch
 ---
 
 fix(workbench-header): support undefined icon prop

--- a/.changeset/chatty-tips-run.md
+++ b/.changeset/chatty-tips-run.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-workbench": patch
+---
+
+fix(workbench-header): support undefined icon prop

--- a/packages/components/workbench/src/WorkbenchHeader/WorkbenchHeader.tsx
+++ b/packages/components/workbench/src/WorkbenchHeader/WorkbenchHeader.tsx
@@ -34,7 +34,8 @@ export function WorkbenchHeader({
 }: WorkbenchHeaderProps) {
   const hasBackButton = Boolean(onBack);
   const styles = getWorkbenchHeaderStyles(hasBackButton);
-  const iconComponent = isValidElement(Icon) ? Icon : <Icon />;
+  const iconComponent =
+    Icon === undefined ? null : isValidElement(Icon) ? Icon : <Icon />;
 
   return (
     <header


### PR DESCRIPTION
# Purpose of PR

The `WorkbenchHeader` doesn't require the `icon` prop, but the current implementation tries to render a JSX element from the prop even when it's undefined. This PR fixes it by explicitly checking for `undefined` first.