### PR TITLE
build: ignore generated changesets from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ public
 .next
 packages/**/CHANGELOG.md
 **/__testfixtures__/**
+.changeset/*.md


### PR DESCRIPTION
# Purpose of PR

Excludes generated changeset files from prettier so that they stop failing the CI pipeline