### PR TITLE
feat: add React 18 as peer dependencies

### DIFF
--- a/.changeset/sharp-phones-check.md
+++ b/.changeset/sharp-phones-check.md
@@ -3,4 +3,4 @@
 '@contentful/f36-utils': minor
 ---
 
-feat: add React 18 as peer dependencies
+feat: add React 18 as a peer dependency

--- a/.changeset/sharp-phones-check.md
+++ b/.changeset/sharp-phones-check.md
@@ -1,0 +1,6 @@
+---
+'@contentful/f36-component': minor
+'@contentful/f36-utils': minor
+---
+
+feat: add React 18 as peer dependencies

--- a/packages/components/utils/package.json
+++ b/packages/components/utils/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "react": ">=16.8",
-    "react-dom": "^16.8.6 || ^17.0.0"
+    "react-dom": ">=16.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/forma-36-react-components/package.json
+++ b/packages/forma-36-react-components/package.json
@@ -19,8 +19,8 @@
     "semantic-release": "semantic-release"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.0"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "dependencies": {
     "@babel/runtime": "^7.3.4",


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

`utils` and `react-components` did not include React 18 in their peer deps version range

Now, all peer dependencies are now consistent: `react: >= 16.8.0`

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/master/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
