### PR TITLE
fix: broken types

### DIFF
--- a/.changeset/breezy-buttons-grin.md
+++ b/.changeset/breezy-buttons-grin.md
@@ -1,0 +1,6 @@
+---
+"@contentful/f36-asset": patch
+"@contentful/f36-typography": patch
+---
+
+Fix issue with types being generated wrongly

--- a/packages/components/asset/src/AssetIcon/AssetIcon.tsx
+++ b/packages/components/asset/src/AssetIcon/AssetIcon.tsx
@@ -26,12 +26,12 @@ export interface AssetIconProps
 /**
  * Renders only the Illustration that would represent this asset's type
  */
-export function AssetIcon({
+export const AssetIcon = ({
   type = 'archive',
   className,
   testId = 'cf-ui-asset-icon',
   ...otherProps
-}: AssetIconProps) {
+}: AssetIconProps) => {
   const styles = getAssetIconStyles();
   const props = {
     ...otherProps,
@@ -64,6 +64,6 @@ export function AssetIcon({
     default:
       return <ArchiveIcon {...props} />;
   }
-}
+};
 
 AssetIcon.displayName = 'AssetIcon';

--- a/packages/components/typography/src/Typography.tsx
+++ b/packages/components/typography/src/Typography.tsx
@@ -7,13 +7,13 @@ export interface TypographyProps {
 /**
  * @deprecated
  */
-export function Typography(props: TypographyProps) {
+export const Typography = (props: TypographyProps) => {
   useEffect(() => {
     console.warn(
       'Forma 36: Typography component is deprecated. You can safely remove it from your components.',
     );
   }, []);
   return <>{props.children}</>;
-}
+};
 
 Typography.displayName = 'Typography';


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Same as https://github.com/contentful/forma-36/pull/2008 just for `AssetIcon` and `Typography`

Previously only types with `declare export namespace` were fixed. In these cases there is a comment between `declare` and  `export namespace`.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
