### PR TITLE
style: fix autocomplete input with button styling [HOMER-856]

### DIFF
--- a/packages/components/autocomplete/src/Autocomplete.styles.ts
+++ b/packages/components/autocomplete/src/Autocomplete.styles.ts
@@ -10,7 +10,7 @@ export const getAutocompleteStyles = (listMaxHeight: number) => ({
     position: 'relative',
   }),
   inputField: css({
-    paddingRight: '32px',
+    paddingRight: tokens.spacingXl,
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   }),

--- a/packages/components/autocomplete/src/Autocomplete.styles.ts
+++ b/packages/components/autocomplete/src/Autocomplete.styles.ts
@@ -9,12 +9,18 @@ export const getAutocompleteStyles = (listMaxHeight: number) => ({
   combobox: css({
     position: 'relative',
   }),
+  inputField: css({
+    paddingRight: '32px',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  }),
   toggleButton: css({
     position: 'absolute',
-    top: '4px',
-    right: '4px',
+    top: '1px',
+    right: '1px',
     zIndex: 1,
     padding: tokens.spacing2Xs,
+    height: '38px',
   }),
   content: css({
     overflow: 'auto',

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -246,6 +246,7 @@ function _Autocomplete<ItemType>(
         <Popover.Trigger>
           <div {...comboboxProps} className={styles.combobox}>
             <TextInput
+              className={styles.inputField}
               {...inputProps}
               onFocus={() => {
                 if (!isOpen) {

--- a/packages/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -81,7 +81,7 @@ export const Basic = (args: AutocompleteProps<string>) => {
 
   return (
     <Stack
-      style={{ minWidth: '300px' }}
+      style={{ width: '150px' }}
       flexDirection="column"
       spacing="spacingM"
       alignItems="start"


### PR DESCRIPTION
### Description
This fixes the styling of the autocomplete input. 
- input placeholder and typed in text was flowing underneath the icon button
- the icon button was having too much spacing around and so it did not look as integrated part of the autocomplete input.

**Before**
<img width="131" alt="before_hover" src="https://user-images.githubusercontent.com/1789174/168011932-8defd010-a66b-4967-9301-b24e8f3b8082.png">
Too much space around the button makes it look hovering weird and distached from the input field, instead of beeing part of it

<img width="107" alt="before_long_inputtext" src="https://user-images.githubusercontent.com/1789174/168012018-e26d7378-eb08-46a1-a7f3-04732bf6f9e4.png">
Long input texts would overflow underneath the X button and look broken

<img width="161" alt="before_clearstate" src="https://user-images.githubusercontent.com/1789174/168012082-cde3e4a3-a413-4fc9-80e2-82cf4f92d224.png">
long input texts would just dissapear undernath the button and be cut off.

**After**
<img width="131" alt="after_dropdown" src="https://user-images.githubusercontent.com/1789174/168012271-b84558fb-9576-4ebf-af4d-aea2d2ce1cd8.png">
Button is now tucked fitting into the input field with no visual space

<img width="127" alt="after_clearstate" src="https://user-images.githubusercontent.com/1789174/168012412-41970062-960d-4c84-850a-8fea08e6cfad.png">
Long selections and palceholders get overflown via ellipsis


<img width="135" alt="after_long_inputtext" src="https://user-images.githubusercontent.com/1789174/168012219-0dd3726a-fa5f-4764-95fb-10d0404c86e3.png">
Long input texts stop before the button
