### PR TITLE
fix: workbench header icon alignments

### DIFF
--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -82,7 +82,7 @@ function _Button<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
     <>
       {startIcon && iconContent(startIcon)}
       {children && (
-        <Box as="span" display="inline-flex" className={styles.buttonContent}>
+        <Box as="span" display="block" className={styles.buttonContent}>
           {children}
         </Box>
       )}

--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -82,7 +82,7 @@ function _Button<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
     <>
       {startIcon && iconContent(startIcon)}
       {children && (
-        <Box as="span" display="block" className={styles.buttonContent}>
+        <Box as="span" display="inline-flex" className={styles.buttonContent}>
           {children}
         </Box>
       )}

--- a/packages/components/workbench/src/WorkbenchHeader/WorkbenchHeader.styles.ts
+++ b/packages/components/workbench/src/WorkbenchHeader/WorkbenchHeader.styles.ts
@@ -34,6 +34,9 @@ export const getWorkbenchHeaderStyles = (hasBackButton = false) => ({
     '& svg': {
       fill: tokens.gray400,
     },
+    '&:focus': {
+      boxShadow: `inset ${tokens.glowPrimary}`,
+    },
     // This overwrite is necessary because the transparent button hover and the workbench header have the same bg color
     '&:hover': {
       backgroundColor: tokens.gray200,

--- a/packages/components/workbench/src/WorkbenchHeader/WorkbenchHeader.tsx
+++ b/packages/components/workbench/src/WorkbenchHeader/WorkbenchHeader.tsx
@@ -53,7 +53,11 @@ export const WorkbenchHeader = ({
         </Button>
       )}
 
-      {Icon && <Box marginRight="spacingM">{iconComponent}</Box>}
+      {Icon && (
+        <Box marginRight="spacingM" display="inline-flex">
+          {iconComponent}
+        </Box>
+      )}
 
       {typeof title === 'string' ? (
         <Heading

--- a/packages/components/workbench/src/WorkbenchHeader/WorkbenchHeader.tsx
+++ b/packages/components/workbench/src/WorkbenchHeader/WorkbenchHeader.tsx
@@ -6,7 +6,7 @@ import type { CommonProps } from '@contentful/f36-core';
 import { Heading, Paragraph } from '@contentful/f36-typography';
 import type { IconComponent } from '@contentful/f36-icon';
 import { ChevronLeftIcon } from '@contentful/f36-icons';
-import { Button } from '@contentful/f36-button';
+import { IconButton } from '@contentful/f36-button';
 
 import { getWorkbenchHeaderStyles } from './WorkbenchHeader.styles';
 
@@ -43,14 +43,14 @@ export const WorkbenchHeader = ({
       data-test-id={testId}
     >
       {hasBackButton && (
-        <Button
-          variant="transparent"
+        <IconButton
+          aria-label="Back"
           testId="workbench-back-btn"
+          variant="transparent"
           className={styles.backButton}
           onClick={() => onBack()}
-        >
-          <ChevronLeftIcon aria-label="Back" size="large" variant="muted" />
-        </Button>
+          icon={<ChevronLeftIcon size="large" variant="muted" />}
+        />
       )}
 
       {Icon && (


### PR DESCRIPTION

# Purpose of PR

Align Workbench header icons properly
**Before**
<img width="337" alt="Screenshot 2022-05-12 at 16 40 16" src="https://user-images.githubusercontent.com/6163988/168101690-f339c827-25ef-4b3b-9215-1922a0c48bc3.png">

**After**
<img width="343" alt="Screenshot 2022-05-12 at 16 39 52" src="https://user-images.githubusercontent.com/6163988/168101718-429bfe86-6986-4e57-add4-6387cdf3d6e6.png">


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
