### PR TITLE
feat: make native tooltip title optional []

### DIFF
--- a/packages/components/pill/src/Pill.tsx
+++ b/packages/components/pill/src/Pill.tsx
@@ -15,6 +15,12 @@ export type PillInternalProps = CommonProps & {
    * Text that will be shown on the pill
    */
   label: string;
+
+  /**
+   * A boolean that tells if the label should be used as a native tooltip title
+   * @default true
+   */
+  useLabelAsTitle?: boolean;
   /**
    * Function that handles when the close icon is clicked. Close icon visibility depends on if this property is set.
    */
@@ -43,6 +49,7 @@ export const Pill = React.forwardRef<HTMLDivElement, ExpandProps<PillProps>>(
       onClose,
       testId = 'cf-ui-pill',
       onDrag,
+      useLabelAsTitle = true,
       className,
       dragHandleComponent,
       variant = 'idle',
@@ -67,7 +74,7 @@ export const Pill = React.forwardRef<HTMLDivElement, ExpandProps<PillProps>>(
               <DragIcon className={styles.icon} variant="muted" />
             </span>
           ))}
-        <span title={label} className={styles.label}>
+        <span title={useLabelAsTitle ? label : null} className={styles.label}>
           {label}
         </span>
         {onClose && (

--- a/packages/components/pill/stories/Pill.stories.tsx
+++ b/packages/components/pill/stories/Pill.stories.tsx
@@ -16,6 +16,7 @@ export default {
   argTypes: {
     label: { control: { type: 'text' } },
     className: { control: { disable: true } },
+    useLabelAsTitle: { control: 'boolean' },
     testId: { control: { disable: true } },
     onClose: { control: { disable: true } },
     onDrag: { control: { disable: true } },
@@ -25,7 +26,7 @@ export default {
 } as Meta;
 
 export const basic: Story<PillInternalProps> = (args) => (
-  <Pill label={args.label} />
+  <Pill label={args.label} useLabelAsTitle={args.useLabelAsTitle} />
 );
 
 basic.args = { label: 'example.user@contentful.com' };
@@ -39,13 +40,25 @@ export const Overview: Story<PillInternalProps> = (args) => (
 
       <Flex flexDirection="row" marginBottom="spacingM">
         <Box marginRight="spacingXs">
-          <Pill label="Idle" variant="idle" />
+          <Pill
+            label="Idle"
+            variant="idle"
+            useLabelAsTitle={args.useLabelAsTitle}
+          />
         </Box>
         <Box marginRight="spacingXs">
-          <Pill label="Active" variant="active" />
+          <Pill
+            label="Active"
+            variant="active"
+            useLabelAsTitle={args.useLabelAsTitle}
+          />
         </Box>
         <Box marginRight="spacingXs">
-          <Pill label="Deleted" variant="deleted" />
+          <Pill
+            label="Deleted"
+            variant="deleted"
+            useLabelAsTitle={args.useLabelAsTitle}
+          />
         </Box>
       </Flex>
     </Flex>
@@ -56,13 +69,28 @@ export const Overview: Story<PillInternalProps> = (args) => (
 
       <Flex flexDirection="row" marginBottom="spacingM">
         <Box marginRight="spacingXs">
-          <Pill label="Idle" variant="idle" onClose={args.onClose} />
+          <Pill
+            label="Idle"
+            variant="idle"
+            onClose={args.onClose}
+            useLabelAsTitle={args.useLabelAsTitle}
+          />
         </Box>
         <Box marginRight="spacingXs">
-          <Pill label="Active" variant="active" onClose={args.onClose} />
+          <Pill
+            label="Active"
+            variant="active"
+            onClose={args.onClose}
+            useLabelAsTitle={args.useLabelAsTitle}
+          />
         </Box>
         <Box marginRight="spacingXs">
-          <Pill label="Deleted" variant="deleted" onClose={args.onClose} />
+          <Pill
+            label="Deleted"
+            variant="deleted"
+            onClose={args.onClose}
+            useLabelAsTitle={args.useLabelAsTitle}
+          />
         </Box>
       </Flex>
     </Flex>
@@ -73,13 +101,28 @@ export const Overview: Story<PillInternalProps> = (args) => (
 
       <Flex flexDirection="row" marginBottom="spacingM">
         <Box marginRight="spacingXs">
-          <Pill label="Idle" variant="idle" onDrag={args.onDrag} />
+          <Pill
+            label="Idle"
+            variant="idle"
+            onDrag={args.onDrag}
+            useLabelAsTitle={args.useLabelAsTitle}
+          />
         </Box>
         <Box marginRight="spacingXs">
-          <Pill label="Active" variant="active" onDrag={args.onDrag} />
+          <Pill
+            label="Active"
+            variant="active"
+            onDrag={args.onDrag}
+            useLabelAsTitle={args.useLabelAsTitle}
+          />
         </Box>
         <Box marginRight="spacingXs">
-          <Pill label="Deleted" variant="deleted" onDrag={args.onDrag} />
+          <Pill
+            label="Deleted"
+            variant="deleted"
+            onDrag={args.onDrag}
+            useLabelAsTitle={args.useLabelAsTitle}
+          />
         </Box>
       </Flex>
     </Flex>
@@ -95,6 +138,7 @@ export const Overview: Story<PillInternalProps> = (args) => (
             variant="idle"
             onDrag={args.onDrag}
             onClose={args.onClose}
+            useLabelAsTitle={args.useLabelAsTitle}
           />
         </Box>
         <Box marginRight="spacingXs">
@@ -103,6 +147,7 @@ export const Overview: Story<PillInternalProps> = (args) => (
             variant="active"
             onDrag={args.onDrag}
             onClose={args.onClose}
+            useLabelAsTitle={args.useLabelAsTitle}
           />
         </Box>
         <Box marginRight="spacingXs">
@@ -111,6 +156,7 @@ export const Overview: Story<PillInternalProps> = (args) => (
             variant="deleted"
             onDrag={args.onDrag}
             onClose={args.onClose}
+            useLabelAsTitle={args.useLabelAsTitle}
           />
         </Box>
       </Flex>
@@ -127,6 +173,7 @@ export const Overview: Story<PillInternalProps> = (args) => (
             variant="idle"
             onDrag={args.onDrag}
             dragHandleComponent={args.dragHandleComponent}
+            useLabelAsTitle={args.useLabelAsTitle}
           />
         </Box>
         <Box marginRight="spacingXs">
@@ -135,6 +182,7 @@ export const Overview: Story<PillInternalProps> = (args) => (
             variant="active"
             onDrag={args.onDrag}
             dragHandleComponent={args.dragHandleComponent}
+            useLabelAsTitle={args.useLabelAsTitle}
           />
         </Box>
         <Box marginRight="spacingXs">
@@ -143,6 +191,7 @@ export const Overview: Story<PillInternalProps> = (args) => (
             variant="deleted"
             onDrag={args.onDrag}
             dragHandleComponent={args.dragHandleComponent}
+            useLabelAsTitle={args.useLabelAsTitle}
           />
         </Box>
       </Flex>
@@ -159,6 +208,7 @@ export const Overview: Story<PillInternalProps> = (args) => (
             variant="idle"
             onDrag={args.onDrag}
             dragHandleComponent={args.dragHandleComponent}
+            useLabelAsTitle={args.useLabelAsTitle}
             onClose={args.onClose}
           />
         </Box>
@@ -168,6 +218,7 @@ export const Overview: Story<PillInternalProps> = (args) => (
             variant="active"
             onDrag={args.onDrag}
             dragHandleComponent={args.dragHandleComponent}
+            useLabelAsTitle={args.useLabelAsTitle}
             onClose={args.onClose}
           />
         </Box>
@@ -177,6 +228,7 @@ export const Overview: Story<PillInternalProps> = (args) => (
             variant="deleted"
             onDrag={args.onDrag}
             dragHandleComponent={args.dragHandleComponent}
+            useLabelAsTitle={args.useLabelAsTitle}
             onClose={args.onClose}
           />
         </Box>


### PR DESCRIPTION
# Purpose of PR

Make the [title tooltip](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) optional in the `<Pill />` component 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
