### PR TITLE
fix: add local zIndex scope for buttonGroup

### DIFF
--- a/.changeset/plenty-moles-watch.md
+++ b/.changeset/plenty-moles-watch.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-button': minor
+---
+
+add stacking context for ButtonGroup component. It should fix the bug when the buttons is stacking not within the ButtonGroup’s context, but within the context of the parent element (because the ButtonGroup itself didn't create a stacking context)

--- a/.changeset/plenty-moles-watch.md
+++ b/.changeset/plenty-moles-watch.md
@@ -1,5 +1,0 @@
----
-'@contentful/f36-button': minor
----
-
-add stacking context for ButtonGroup component. It should fix the bug when the buttons is stacking not within the ButtonGroup’s context, but within the context of the parent element (because the ButtonGroup itself didn't create a stacking context)

--- a/.changeset/six-cameras-bow.md
+++ b/.changeset/six-cameras-bow.md
@@ -1,0 +1,6 @@
+---
+'@contentful/f36-button': minor
+'@contentful/f36-forms': minor
+---
+
+Add stacking context for the ButtonGroup and InputGroup components. It should fix the bug when the group elements are stacking not within the Group’s context, but within the context of the parent element (because the ButtonGroup/InputGroup itself didn't create a stacking context)

--- a/packages/components/button/src/ButtonGroup/ButtonGroup.styles.ts
+++ b/packages/components/button/src/ButtonGroup/ButtonGroup.styles.ts
@@ -55,6 +55,7 @@ const getDividerStyle = (withDivider: boolean): CSSObject => {
 export default ({ withDivider }: GetStyleArguments) => ({
   buttonGroup: css({
     display: 'inline-flex',
+    position: 'relative',
   }),
   groupContent: css(getGroupContentStyle({ withDivider })),
 });

--- a/packages/components/forms/src/TextInput/input-group/InputGroup.styles.ts
+++ b/packages/components/forms/src/TextInput/input-group/InputGroup.styles.ts
@@ -4,10 +4,10 @@ import type { GetStyleArguments } from './types';
 
 const getInputGroupStyle = ({ spacing }) => {
   if (spacing !== 'none') {
-    return {};
+    return;
   }
 
-  return {
+  return css({
     position: 'relative',
 
     '& button, & input': {
@@ -32,9 +32,9 @@ const getInputGroupStyle = ({ spacing }) => {
         zIndex: tokens.zIndexDefault + 1,
       },
     },
-  };
+  });
 };
 
 export default ({ spacing }: GetStyleArguments) => ({
-  inputGroup: css(getInputGroupStyle({ spacing })),
+  inputGroup: getInputGroupStyle({ spacing }),
 });

--- a/packages/components/forms/src/TextInput/input-group/InputGroup.styles.ts
+++ b/packages/components/forms/src/TextInput/input-group/InputGroup.styles.ts
@@ -8,6 +8,8 @@ const getInputGroupStyle = ({ spacing }) => {
   }
 
   return {
+    position: 'relative',
+
     '& button, & input': {
       borderRadius: '0 !important',
     },


### PR DESCRIPTION
# Purpose of PR

- Add stacking context for the ButtonGroup and InputGroup components. It should fix the bug when the group elements are stacking not within the Group’s context, but within the context of the parent element (because the ButtonGroup/InputGroup itself didn't create a stacking context)
