### PR TITLE
fix: remove exports key from package.json

### DIFF
--- a/.changeset/sharp-meals-brush.md
+++ b/.changeset/sharp-meals-brush.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-components": patch
+---
+
+fix: remove exports key from package.json

--- a/packages/forma-36-react-components/package.json
+++ b/packages/forma-36-react-components/package.json
@@ -5,7 +5,6 @@
   "main": "dist/f36-components.umd.js",
   "types": "dist/index.d.ts",
   "module": "./dist/f36-components.module.js",
-  "exports": "./dist/f36-components.modern.js",
   "license": "MIT",
   "files": [
     "dist"


### PR DESCRIPTION
# Purpose of PR

Fixes import issues in non-module environments by removing the `exports` key from `package.json`. This key currently makes build tools ignore all builds other than the `modern` one.

We're not using this key correctly so I've opted for removing it, but we can always add it back with a more robust configuration similar to this one, which I found in `acorn`:

```json
  "exports": {
    ".": [
      {
        "import": "./dist/acorn.mjs",
        "require": "./dist/acorn.js",
        "default": "./dist/acorn.js"
      },
      "./dist/acorn.js"
    ],
    "./package.json": "./package.json"
  },
```
