### PR TITLE
fix: enable keeping the dropdown open after select

### DIFF
--- a/packages/components/autocomplete/examples/AutocompleteMultiSelectionExample.tsx
+++ b/packages/components/autocomplete/examples/AutocompleteMultiSelectionExample.tsx
@@ -37,6 +37,7 @@ export default function AutocompleteMultiSelectionExample() {
         renderItem={(item) => item.name}
         // When this prop is `true`, it will clean the TextInput after an option is selected
         clearAfterSelect
+        closeAfterSelect={false}
       />
 
       <span>

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -76,6 +76,11 @@ export interface AutocompleteProps<ItemType>
    */
   clearAfterSelect?: boolean;
   /**
+   * If this is set to `true` the dropdown menu will stay open after the select
+   * @default false
+   */
+  closeAfterSelect?: boolean;
+  /**
    * This is the value will be passed to the `placeholder` prop of the input.
    * @default "Search"
    */
@@ -130,6 +135,7 @@ function _Autocomplete<ItemType>(
     id,
     className,
     clearAfterSelect = false,
+    closeAfterSelect = true,
     defaultValue = '',
     selectedItem,
     items,
@@ -217,6 +223,9 @@ function _Autocomplete<ItemType>(
           }
           if (clearAfterSelect) {
             handleInputValueChange('');
+          }
+          if (!closeAfterSelect) {
+            toggleMenu();
           }
           break;
         default:

--- a/packages/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -272,6 +272,7 @@ export const MultipleSelection = (args: AutocompleteProps<Produce>) => {
         itemToString={(item) => item.name}
         renderItem={(item) => item.name}
         clearAfterSelect
+        closeAfterSelect={false}
       />
 
       <span>


### PR DESCRIPTION
Issue description:
For multi-selects,clicking again on the input did not open the drawer again, because the element was still in focus. Which makes sense from the keyboards perspective. So improve the UX around multi-selects allow to keep the dropdown open after selection. 