### PR TITLE
chore: bump popper version

### DIFF
--- a/.changeset/mean-stingrays-add.md
+++ b/.changeset/mean-stingrays-add.md
@@ -1,0 +1,6 @@
+---
+'@contentful/f36-popover': patch
+'@contentful/f36-tooltip': patch
+---
+
+bump popper version

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -10,9 +10,9 @@
     "@contentful/f36-core": "^4.10.2",
     "@contentful/f36-tokens": "^4.0.1",
     "@contentful/f36-utils": "^4.10.2",
-    "@popperjs/core": "^2.4.4",
+    "@popperjs/core": "^2.11.5",
     "emotion": "^10.0.17",
-    "react-popper": "^2.2.3"
+    "react-popper": "^2.3.0"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/components/popover/src/Popover.tsx
+++ b/packages/components/popover/src/Popover.tsx
@@ -132,7 +132,7 @@ export function Popover(props: ExpandProps<PopoverProps>) {
 
   const {
     attributes: popperAttributes,
-    forceUpdate,
+    update,
     styles: popperStyles,
   } = usePopper(triggerElement, popoverElement, {
     placement,
@@ -169,10 +169,13 @@ export function Popover(props: ExpandProps<PopoverProps>) {
   }, [isOpen, popoverElement]);
 
   useEffect(() => {
-    if (isOpen && forceUpdate) {
-      forceUpdate();
-    }
-  }, [isOpen, forceUpdate]);
+    const updatePosition = async () => {
+      if (isOpen && update) {
+        await update();
+      }
+    };
+    updatePosition();
+  }, [isOpen, update]);
 
   const popoverGeneratedId = useId(null, 'popover-content');
   const popoverId = id || popoverGeneratedId;

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -10,10 +10,10 @@
     "@contentful/f36-core": "^4.10.2",
     "@contentful/f36-tokens": "^4.0.1",
     "@contentful/f36-utils": "^4.10.2",
-    "@popperjs/core": "^2.4.4",
+    "@popperjs/core": "^2.11.5",
     "csstype": "^3.0.5",
     "emotion": "^10.0.17",
-    "react-popper": "^2.2.3"
+    "react-popper": "^2.3.0"
   },
   "peerDependencies": {
     "react": ">=16.8"

--- a/packages/components/tooltip/src/Tooltip.tsx
+++ b/packages/components/tooltip/src/Tooltip.tsx
@@ -122,7 +122,7 @@ export const Tooltip = ({
   const elementRef = useRef(null);
   const popperRef = useRef(null);
   const [arrowRef, setArrowRef] = useState<HTMLSpanElement | null>(null);
-  const { styles: popperStyles, attributes, forceUpdate } = usePopper(
+  const { styles: popperStyles, attributes, update } = usePopper(
     elementRef.current,
     popperRef.current,
     {
@@ -147,10 +147,13 @@ export const Tooltip = ({
 
   // necessary to update tooltip position in case the content is being updated
   useEffect(() => {
-    if (forceUpdate !== null) {
-      forceUpdate();
-    }
-  }, [content, forceUpdate]);
+    const updatePosition = async () => {
+      if (update !== null) {
+        await update();
+      }
+    };
+    updatePosition();
+  }, [content, update]);
 
   const [isHoveringTarget, setIsHoveringTarget] = useState(false);
   const [isHoveringContent, setIsHoveringContent] = useState(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3697,7 +3697,12 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
-"@popperjs/core@^2.4.4", "@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
+"@popperjs/core@^2.11.5":
+  version "2.11.5"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
+  integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
+
+"@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
   version "2.9.3"
   resolved "https://registry.npmjs.org/@popperjs/core/-/core-2.9.3.tgz"
   integrity sha512-xDu17cEfh7Kid/d95kB6tZsLOmSWKCZKtprnhVepjsSaCij+lM3mItSJDuuHDMbCWTh8Ejmebwb+KONcCJ0eXQ==
@@ -20558,10 +20563,18 @@ react-popper-tooltip@^3.1.1:
     "@popperjs/core" "^2.5.4"
     react-popper "^2.2.4"
 
-react-popper@^2.2.3, react-popper@^2.2.4:
+react-popper@^2.2.4:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
   integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
+
+react-popper@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
+  integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

* Bump version of popper to latest
* Update from `forceUpdate` to `update` to avoid flushSync errors