### PR TITLE
chore: provide defaultMonth prop to Calendar stories [BAU-821]

### DIFF
--- a/packages/components/datepicker/stories/Calendar.stories.tsx
+++ b/packages/components/datepicker/stories/Calendar.stories.tsx
@@ -20,6 +20,7 @@ export const Default: Story<CalendarProps> = (args) => {
       mode="single"
       selected={selectedDay}
       onSelect={setSelectedDay}
+      defaultMonth={selectedDay}
     />
   );
 };
@@ -35,6 +36,7 @@ export const WithMinMaxDate: Story<CalendarProps> = (args) => {
       onSelect={setSelectedDay}
       fromDate={testDate}
       toYear={2025}
+      defaultMonth={selectedDay}
     />
   );
 };
@@ -49,6 +51,7 @@ export const WithMultipleMonths: Story<CalendarProps> = (args) => {
       numberOfMonths={2}
       selected={selectedDay}
       onSelect={setSelectedDay}
+      defaultMonth={selectedDay}
     />
   );
 };

--- a/packages/components/datepicker/stories/Datepicker.stories.tsx
+++ b/packages/components/datepicker/stories/Datepicker.stories.tsx
@@ -45,7 +45,7 @@ export const WithMinMaxDate: Story<DatepickerProps> = (args) => {
 };
 
 export const WithMultipleMonths: Story<DatepickerProps> = (args) => {
-  const [selectedDay, setSelectedDay] = useState<Date>(new Date());
+  const [selectedDay, setSelectedDay] = useState<Date>(testDate);
 
   return (
     <Datepicker


### PR DESCRIPTION
- Now Datepicker/Calendar Storybook stories shouldn't trigger a change on Chromatic every time they run.