### PR TITLE
fix: flash sync error in DropDown and Tooltip

### DIFF
--- a/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
+++ b/packages/forma-36-react-components/src/components/Dropdown/Dropdown.tsx
@@ -181,7 +181,7 @@ export function Dropdown({
   const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   const [isOpen, setIsOpen] = useState(isOpenProp);
   const placement = mapPositionTypeToPlacement(position);
-  const { attributes, forceUpdate, styles: popperStyles } = usePopper(
+  const { attributes, update, styles: popperStyles } = usePopper(
     referenceElement,
     popperElement,
     {
@@ -218,10 +218,13 @@ export function Dropdown({
   }, [isOpenProp]);
 
   useEffect(() => {
-    if (forceUpdate) {
-      forceUpdate();
-    }
-  }, [children, forceUpdate]);
+    const updatePosition = async () => {
+      if (update !== null) {
+        await update();
+      }
+    };
+    updatePosition();
+  }, [children, update]);
 
   const openSubmenu = (isOpen: boolean) => {
     if (submenuToggleLabel) {

--- a/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/forma-36-react-components/src/components/Tooltip/Tooltip.tsx
@@ -110,7 +110,7 @@ export const Tooltip = ({
   const elementRef = useRef(null);
   const popperRef = useRef(null);
   const [arrowRef, setArrowRef] = useState<HTMLSpanElement | null>(null);
-  const { styles: popperStyles, attributes, forceUpdate } = usePopper(
+  const { styles: popperStyles, attributes, update } = usePopper(
     elementRef.current,
     popperRef.current,
     {
@@ -135,10 +135,13 @@ export const Tooltip = ({
 
   // necessary to update tooltip position in case the content is being updated
   useEffect(() => {
-    if (forceUpdate !== null) {
-      forceUpdate();
-    }
-  }, [content, forceUpdate]);
+    const updatePosition = async () => {
+      if (update !== null) {
+        await update();
+      }
+    };
+    updatePosition();
+  }, [content, update]);
 
   const [isHoveringTarget, setIsHoveringTarget] = useState(false);
   const [isHoveringContent, setIsHoveringContent] = useState(false);


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Fix react error in `DropDown` and `ToolTip` component where we were still using `forceUpdate` from `popperjs`

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
