### PR TITLE
docs: fix Menu a11y section

### DIFF
--- a/packages/components/menu/README.mdx
+++ b/packages/components/menu/README.mdx
@@ -132,7 +132,7 @@ but you can redefine them on any submenu by passing those props directly to that
 
 ## Accessibility
 
-- When the menu is opened, focus is moved to the first menu item. If you set `autoFocus`to `false`, it will not move the focus.
+- When the menu is opened, focus is moved to the first menu item. Or to the one that has `isInitiallyFocused` prop set to `true`.
 - When the menu is closed, focus returned back to the trigger element.
 - You can use arrow keys (`ArrowUp` and `ArrowDown`) to navigate through menu items.
 - When the menu is open, click on `Esc` key will close the popover. If you set `closeOnEsc` to `false`, it will not close.


### PR DESCRIPTION
`Menu` doesn't provide a prop for disabling `autoFocus`. It's made in such a way for a11y purposes. 
Only `Popover` component has it.