### PR TITLE
fix: playground datepicker dependency version

### DIFF
--- a/packages/website/components/Playground/SandpackRenderer.tsx
+++ b/packages/website/components/Playground/SandpackRenderer.tsx
@@ -60,7 +60,7 @@ export function SandpackRenderer({
           'react-dom': '^17.0.0',
           'react-scripts': '^4.0.0',
           '@contentful/f36-components': '^4.0.0',
-          '@contentful/f36-datepicker': '^4.0.0-beta', // Remove when not in beta
+          '@contentful/f36-datepicker': '^4.1.0-beta.0', //TODO: Remove when not in beta
           '@contentful/f36-tokens': '^4.0.0',
           '@contentful/f36-icons': '^4.0.0',
           emotion: '^10.0.17',


### PR DESCRIPTION
# Purpose of PR

Fixes playground error

<img width="2560" alt="Screenshot 2022-07-06 at 19 15 10" src="https://user-images.githubusercontent.com/6163988/177606880-ab85eefe-e2c2-40c0-bbf2-d36de32d7b06.png">

