### PR TITLE
feat: allow passing custom icons to autocomplete

### DIFF
--- a/.changeset/fifty-apples-suffer.md
+++ b/.changeset/fifty-apples-suffer.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-autocomplete": minor
+---
+
+feat: allow passing custom icons to autocomplete

--- a/packages/components/autocomplete/README.mdx
+++ b/packages/components/autocomplete/README.mdx
@@ -96,6 +96,14 @@ In order to use proper form validation you need to be able to control the actual
 
 ```
 
+### Custom icon
+
+Pass a custom icon to the text input
+
+```jsx file=./examples/CustomIcon.tsx
+
+```
+
 ## Props (API reference)
 
 <PropsTable of="Autocomplete" />

--- a/packages/components/autocomplete/README.mdx
+++ b/packages/components/autocomplete/README.mdx
@@ -98,7 +98,7 @@ In order to use proper form validation you need to be able to control the actual
 
 ### Custom icon
 
-Pass a custom icon to the text input
+Pass a custom icon to the text input, example: to indicate a search input
 
 ```jsx file=./examples/CustomIcon.tsx
 

--- a/packages/components/autocomplete/examples/CustomIcon.tsx
+++ b/packages/components/autocomplete/examples/CustomIcon.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Autocomplete, Stack, Paragraph } from '@contentful/f36-components';
+import { SearchIcon } from '@contentful/f36-icons';
+
+export default function AutocompleteBasicUsageExample() {
+  const spaces = [
+    'Travel Blog',
+    'Finnance Blog',
+    'Fitness App',
+    'News Website',
+    'eCommerce Catalogue',
+    'Photo Gallery',
+  ];
+
+  // This `useState` is going to store the selected "space" so we can show it in the UI
+  const [selectedSpace, setSelectedSpace] = React.useState();
+  const [filteredItems, setFilteredItems] = React.useState(spaces);
+
+  // We filter the "spaces" array by the inputValue
+  // we use 'toLowerCase()' to make the search case insensitive
+  const handleInputValueChange = (value) => {
+    const newFilteredItems = spaces.filter((item) =>
+      item.toLowerCase().includes(value.toLowerCase()),
+    );
+    setFilteredItems(newFilteredItems);
+  };
+
+  // This function will be called once the user selects an item in the list of options
+  const handleSelectItem = (item) => {
+    setSelectedSpace(item);
+  };
+
+  return (
+    <Stack flexDirection="column" alignItems="start">
+      <Autocomplete
+        items={filteredItems}
+        icon={<SearchIcon variant="muted" />}
+        onInputValueChange={handleInputValueChange}
+        onSelectItem={handleSelectItem}
+      />
+
+      <Paragraph>
+        Selected space: <b>{selectedSpace}</b>
+      </Paragraph>
+    </Stack>
+  );
+}

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -39,6 +39,11 @@ export interface AutocompleteProps<ItemType>
   items: ItemType[] | GenericGroupType<ItemType>[];
 
   /**
+   * Set a custom icon for the text input
+   */
+  icon?: React.ReactElement;
+
+  /**
    * Tells if the item is a object with groups
    */
   isGrouped?: boolean;
@@ -142,6 +147,7 @@ function _Autocomplete<ItemType>(
     onInputValueChange,
     onSelectItem,
     renderItem,
+    icon = <ChevronDownIcon variant="muted" />,
     itemToString = (item: ItemType) => (item as unknown) as string,
     isInvalid,
     isDisabled,
@@ -287,16 +293,10 @@ function _Autocomplete<ItemType>(
             <IconButton
               {...toggleProps}
               ref={mergeRefs(toggleProps.ref, toggleRef)}
-              aria-label="toggle menu"
+              aria-label={inputValue ? 'Clear' : 'Show list'}
               className={styles.toggleButton}
               variant="transparent"
-              icon={
-                inputValue ? (
-                  <CloseIcon aria-label="Clear" variant="muted" />
-                ) : (
-                  <ChevronDownIcon aria-label="Show list" variant="muted" />
-                )
-              }
+              icon={inputValue ? <CloseIcon variant="muted" /> : icon}
               onClick={() => {
                 if (inputValue) {
                   handleInputValueChange('');


### PR DESCRIPTION
# Purpose of PR

Allow passing custom icons to Autocomplete component


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Usage notes are added
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
