### PR TITLE
chore: remove beta flag

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@contentful/f36-accordion": "4.10.5",


### PR DESCRIPTION
# Purpose of PR

Revert back to normal releases and move beta after merging to a new `beta` branch
