### PR TITLE
chore: bump datepicker version to `4.1.0-beta.3`

### DIFF
--- a/packages/components/datepicker/package.json
+++ b/packages/components/datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-datepicker",
-  "version": "4.1.0",
+  "version": "4.1.0-beta.3",
   "description": "Forma 36: Datepicker component",
   "scripts": {
     "build": "parcel build"

--- a/packages/website/components/Playground/SandpackRenderer.tsx
+++ b/packages/website/components/Playground/SandpackRenderer.tsx
@@ -60,7 +60,7 @@ export function SandpackRenderer({
           'react-dom': '^17.0.0',
           'react-scripts': '^4.0.0',
           '@contentful/f36-components': '^4.0.0',
-          '@contentful/f36-datepicker': '^4.1.0-beta.0', //TODO: Remove when not in beta
+          '@contentful/f36-datepicker': 'beta', //TODO: Remove when not in beta
           '@contentful/f36-tokens': '^4.0.0',
           '@contentful/f36-icons': '^4.0.0',
           emotion: '^10.0.17',

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -12,7 +12,7 @@
     "@codesandbox/sandpack-react": "0.18.1",
     "@contentful/f36-components": "^4.11.0",
     "@contentful/f36-core": "^4.11.0",
-    "@contentful/f36-datepicker": "^4.1.0",
+    "@contentful/f36-datepicker": "beta",
     "@contentful/f36-docs-utils": "^4.0.1",
     "@contentful/f36-icon": "^4.11.0",
     "@contentful/f36-icons": "^4.11.0",


### PR DESCRIPTION
# Purpose of PR

bump datepicker version to `4.1.0-beta.3`
