### PR TITLE
chore: export formatRelativeDateTime function from datetime package []

### DIFF
--- a/packages/components/datetime/src/index.ts
+++ b/packages/components/datetime/src/index.ts
@@ -2,4 +2,8 @@ export { DateTime } from './DateTime/DateTime';
 export type { DateTimeProps } from './DateTime/DateTime';
 export { RelativeDateTime } from './RelativeDateTime/RelativeDateTime';
 export type { RelativeDateTimeProps } from './RelativeDateTime/RelativeDateTime';
-export { formatDateAndTime, formatMachineReadableDateTime } from './utils';
+export {
+  formatDateAndTime,
+  formatMachineReadableDateTime,
+  formatRelativeDateTime,
+} from './utils';


### PR DESCRIPTION
# Purpose of PR

We use `RelativeDateTime` component in our app, but for testing `formatRelativeDateTime` is useful, while not exported publicly

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
