### PR TITLE
fix(autocomplete): use onSelectItemChange instead of onStateChange

### DIFF
--- a/.changeset/early-laws-run.md
+++ b/.changeset/early-laws-run.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-autocomplete': minor
+---
+
+fix Autocomplete onSelectItem trigger

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -220,13 +220,13 @@ function _Autocomplete<ItemType>(
         handleInputValueChange(inputValue);
       }
     },
-    onStateChange: ({ type, selectedItem }) => {
+    onSelectedItemChange: (changes) => {
+      onSelectItem(changes.selectedItem);
+    },
+    onStateChange: ({ type }) => {
       switch (type) {
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick:
-          if (selectedItem) {
-            onSelectItem(selectedItem);
-          }
           if (clearAfterSelect) {
             handleInputValueChange('');
           }


### PR DESCRIPTION
# Purpose of PR

@Silhoue 

> Hello, I’m trying to fire onSelectItem on the Autocomplete component on every click but it seems to work with a static items array, and not with React state. [Playground](https://f36.contentful.com/playground?code=N4Igxg9gJgpiBcICWBbADhATgFwAQCUYBDMPAM0whVwHJNjSaBuAHQDtUMddhcBBAK7YIkdABsY2GABpcAZWwkA1rIAKRTEQDmmtAAtcAX1wUqtAAKQ2U62QFiA9GQDMANgC0ojGxjWAzszs7DAAHlx4sGRE9uQCbKRIEGz8QiJUaBJSALIxSHIwEglJAKIhROIwABQAlDzsuLgODrgAKkR+SvC4qkhgSrgsIC2aAG4FuABGYhBag7jYAO69MPUDyY3N2HpIfrgLWEp+q1Z+eEhSKLsAvLgA2qsNvGzlMF00w0RjYrgAQtNaNFkSCgbwAjDQjNIHjxcM8UK9aAAxJBsZ7xGC-f6A3DAt4AJghhlWAF1WOsmvNtrsoBAYH42DRsKsKSc8LdzjBLrI-JIAJIXPzE3A3QgkbAAOgEPIURCklXu5Oaj1hLzeHy+mJm2NxtHBkOZSphcIRNGRqKI6M1AKBINoBKMBtwxOqZIajvcHvcxySpzuPMKUig-M5fm5knyAZgQYFQpFDAlUpgMrlt2drtwrNwegtUAkEZgpGD1BulX9BcDRdqVwAfHV1g1cDzsPnSFGi35KpU0PQRsmYFXa7dxcPuzBe4opGHI9HOc7VoYyat6NgBJhkpVoQAeGV9EwSEIAESQ9CKbCug0gYgEKDYcyIYiQWjY7fPIFOGiZIGr0Iam8Ewi8TIVnrBsGg5S4rmAcC-CJEDQKSFtsCLSDszYXMkwKcsi1g0DQPAloIAUTAUS0SDKnAgccQucVjRw3CBmweg0JgTBkOAciLko8CaJeOj6LACQND4MgpEwRCfwbASIB5YTRMQyCojEHk+IbBxvzg3BNwmTA1IkrSdPU+j9N0jTjMM3CzL0vw0AtcyjPUTQdCIfRq0QqN4E3BwHO0XQ9Dsiz7H8+jgDLVsZ0ucUUGcztwKBZiQkojcNKMh9cCUGAAE9IO44FDGrKDqNozyHyC3DqmqFTQM8wK9IcazbK3BwdyUcyXXYWCQEMIA)

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
