### PR TITLE
Style: Update Background color on hover for td

### DIFF
--- a/packages/forma-36-react-components/src/components/Table/TableCell/TableCell.css
+++ b/packages/forma-36-react-components/src/components/Table/TableCell/TableCell.css
@@ -23,10 +23,6 @@
   vertical-align: top;
 }
 
-tr:hover td:not(.TableCell--head) {
-  background-color: var(--color-element-lightest);
-}
-
 .TableRow--selected .TableCell {
   background-color: var(--color-blue-lightest);
 }


### PR DESCRIPTION
# Purpose of PR
Background colour should not change while hovering on the table

<img width="396" align="center" alt="image" src="https://user-images.githubusercontent.com/83456083/180150570-6e9aad7f-e93a-4118-acc0-f6c9c401c8e8.png">


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
