### PR TITLE
feat: Info variant for Notification

### DIFF
--- a/.changeset/shaggy-fireants-deliver.md
+++ b/.changeset/shaggy-fireants-deliver.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-notification': minor
+---
+
+Add 'info' variant to 'Notification' component

--- a/packages/components/notification/examples/NotificationIntentsExample.tsx
+++ b/packages/components/notification/examples/NotificationIntentsExample.tsx
@@ -22,6 +22,12 @@ export default function NotificationIntentsExample() {
       >
         Show warning notification
       </Button>
+      <Button
+        variant="primary"
+        onClick={() => Notification.info('This is an info notification')}
+      >
+        Show info notification
+      </Button>
     </Stack>
   );
 }

--- a/packages/components/notification/src/Notification.tsx
+++ b/packages/components/notification/src/Notification.tsx
@@ -87,6 +87,7 @@ export const Notification: {
   success: ExternalShowAction<Promise<NotificationProps>>;
   error: ExternalShowAction<Promise<NotificationProps>>;
   warning: ExternalShowAction<Promise<NotificationProps>>;
+  info: ExternalShowAction<Promise<NotificationProps>>;
   close: CloseAction<Promise<void>>;
   closeAll: CloseAllAction<Promise<void>>;
   setPlacement: SetPlacementAction<Promise<void>>;
@@ -95,6 +96,7 @@ export const Notification: {
   success: afterInit<NotificationProps>(show('positive')),
   error: afterInit<NotificationProps>(show('negative')),
   warning: afterInit<NotificationProps>(show('warning')),
+  info: afterInit<NotificationProps>(show('primary')),
   close: afterInit<void>((id: string | number) => {
     if (internalAPI.close) {
       return internalAPI.close(id);

--- a/packages/components/notification/src/NotificationItem/NotificationItem.styles.ts
+++ b/packages/components/notification/src/NotificationItem/NotificationItem.styles.ts
@@ -7,6 +7,7 @@ const variantColors = {
   positive: tokens.green600,
   negative: tokens.red600,
   warning: tokens.orange400,
+  primary: tokens.blue600,
 };
 
 const getWrapperStyle = ({ variant }) =>

--- a/packages/components/notification/src/NotificationItem/NotificationItem.tsx
+++ b/packages/components/notification/src/NotificationItem/NotificationItem.tsx
@@ -5,6 +5,7 @@ import {
   ErrorCircleIcon,
   WarningIcon,
   CloseIcon,
+  InfoCircleIcon,
 } from '@contentful/f36-icons';
 
 import { Button } from '@contentful/f36-button';
@@ -65,12 +66,14 @@ const _NotificationItem = (props: ExpandProps<NotificationItemProps>, ref) => {
     positive: <CheckCircleIcon variant={variant} size={iconSize} />,
     warning: <WarningIcon variant={variant} size={iconSize} />,
     negative: <ErrorCircleIcon variant={variant} size={iconSize} />,
+    primary: <InfoCircleIcon variant={variant} size={iconSize} />,
   };
 
   const intents = {
     positive: 'success',
     warning: 'warning',
     negative: 'error',
+    primary: 'info',
   };
 
   return (

--- a/packages/components/notification/src/types.ts
+++ b/packages/components/notification/src/types.ts
@@ -5,4 +5,8 @@ export interface NotificationCta {
   textLinkProps: Partial<TextLinkProps>;
 }
 
-export type NotificationVariant = 'positive' | 'negative' | 'warning';
+export type NotificationVariant =
+  | 'positive'
+  | 'negative'
+  | 'warning'
+  | 'primary';

--- a/packages/components/notification/stories/Notification.stories.tsx
+++ b/packages/components/notification/stories/Notification.stories.tsx
@@ -75,6 +75,16 @@ export const WithButtons = ({ notificationText, duration, ...args }) => {
             show warning
           </Button>
           <Button
+            variant="primary"
+            onClick={() =>
+              Notification.info(`${notificationText} ${getUniqueNumber()}`, {
+                duration,
+              })
+            }
+          >
+            show info
+          </Button>
+          <Button
             variant="secondary"
             onClick={() =>
               Notification.warning('Notification that should not be repeated', {


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

We are looking to push a notification to users that simply elicits general information. The current Notification component only supports a success, warning, and error state at the moment.

This PR looks to resolve the issue brought up in proposal #2140 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
