### PR TITLE
chore: update operations-per-run on stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,6 +23,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 30
         days-before-close: -1
+        operations-per-run: 300
         stale-issue-message: 'Marking issue as stale since there was no acitivty for 30 days'
         stale-pr-message: 'Marking pull request as stale since there was no acitivty for 30 days'
         stale-issue-label: 'stale'


### PR DESCRIPTION
# Purpose of PR

The stale action hit the default operations-per-run before going through all issues and PRs, this increase is to be sure that it runs in all of them