### PR TITLE
feat: xlarge size for Icon

### DIFF
--- a/.changeset/tasty-cougars-sin.md
+++ b/.changeset/tasty-cougars-sin.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-icon': minor
+---
+
+feat: adding xlarge icon size

--- a/packages/components/icon/examples/IconSizesExample.tsx
+++ b/packages/components/icon/examples/IconSizesExample.tsx
@@ -17,6 +17,9 @@ export default function IconSizesExample() {
       <Flex alignItems="center">
         <CalendarIcon size="large" /> <Text>Large</Text>
       </Flex>
+      <Flex alignItems="center">
+        <CalendarIcon size="xlarge" /> <Text>Large</Text>
+      </Flex>
     </Stack>
   );
 }

--- a/packages/components/icon/src/Icon.tsx
+++ b/packages/components/icon/src/Icon.tsx
@@ -20,7 +20,7 @@ const ICON_DEFAULT_TAG = 'svg';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type IconComponent = ExoticComponent<any> | ComponentType<any>;
 
-export type IconSize = 'large' | 'medium' | 'small' | 'tiny';
+export type IconSize = 'xlarge' | 'large' | 'medium' | 'small' | 'tiny';
 
 export type IconVariant =
   | 'negative'
@@ -32,6 +32,10 @@ export type IconVariant =
   | 'white';
 
 const sizes: { [key in IconSize]: { [key in 'height' | 'width']: string } } = {
+  xlarge: {
+    height: '48px',
+    width: '48px',
+  },
   large: {
     height: '32px',
     width: '32px',

--- a/packages/components/icon/stories/Icon.stories.tsx
+++ b/packages/components/icon/stories/Icon.stories.tsx
@@ -55,7 +55,7 @@ const CustomIcon = (props: IconInternalProps) => (
 );
 
 export const Overview: Story = () => {
-  const sizes = ['large', 'medium', 'small', 'tiny'];
+  const sizes = ['xlarge', 'large', 'medium', 'small', 'tiny'];
 
   return (
     <Fragment>


### PR DESCRIPTION
In order to be able to provide xlarge size icon for ProductIcons,I would like to extend the Icon sizes, since we use it under the hood in experience-components package. WDYT?