### PR TITLE
chore(deps): update typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "semver": "^7.3.5",
     "style-loader": "^2.0.0",
     "turbo": "^1.0.6",
-    "typescript": "4.2.3"
+    "typescript": "4.7.3"
   },
   "engines": {
     "node": ">=14.15.0",

--- a/packages/components/accordion/src/Accordion.test.tsx
+++ b/packages/components/accordion/src/Accordion.test.tsx
@@ -5,12 +5,16 @@ import { axe } from '@/scripts/test/axeHelper';
 
 import { Accordion } from '.';
 
-jest.mock('@contentful/f36-core', () => ({
-  ...jest.requireActual('@contentful/f36-core'),
-  useId: () => {
-    return 'id';
-  },
-}));
+jest.mock('@contentful/f36-core', () => {
+  const actual = jest.requireActual('@contentful/f36-core');
+
+  return {
+    ...actual,
+    useId: () => {
+      return 'id';
+    },
+  };
+});
 
 describe('Accordion', () => {
   it('opens the accordion panel when the header is clicked', () => {

--- a/packages/components/modal/src/ModalConfirm/ModalConfirm.tsx
+++ b/packages/components/modal/src/ModalConfirm/ModalConfirm.tsx
@@ -79,7 +79,8 @@ export interface ModalConfirmProps {
   /**
    * Optional property to set initial focus
    */
-  initialFocusRef?: React.RefObject<HTMLElement>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- we don't know the type of element to give initial focus
+  initialFocusRef?: React.RefObject<any>;
 
   testId?: string;
   confirmTestId?: string;

--- a/packages/components/tooltip/src/Tooltip.test.tsx
+++ b/packages/components/tooltip/src/Tooltip.test.tsx
@@ -10,9 +10,7 @@ jest.mock('@contentful/f36-core', () => {
 
   return {
     ...actual,
-    useId: () => {
-      return 'id';
-    },
+    useId: (id) => id,
   };
 });
 

--- a/packages/components/tooltip/src/Tooltip.test.tsx
+++ b/packages/components/tooltip/src/Tooltip.test.tsx
@@ -5,10 +5,16 @@ import { axe } from '@/scripts/test/axeHelper';
 
 import { Tooltip } from './Tooltip';
 
-jest.mock('@contentful/f36-core', () => ({
-  ...jest.requireActual('@contentful/f36-core'),
-  useId: (id) => id,
-}));
+jest.mock('@contentful/f36-core', () => {
+  const actual = jest.requireActual('@contentful/f36-core');
+
+  return {
+    ...actual,
+    useId: () => {
+      return 'id';
+    },
+  };
+});
 
 describe('Tooltip', () => {
   it('does not render the component if no mouseover event on child', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22243,10 +22243,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.2.3:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz"
-  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+typescript@4.7.3:
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
+  integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
 
 typescript@^4.1.3, typescript@^4.4.3:
   version "4.6.2"


### PR DESCRIPTION
Next.js expects TypeScript version 4.3.2 or above. This upgrade also gives us some cool features like `type` imports in named imports, so that we don't have to split component and type imports.