### PR TITLE
chore: add action to remove stale label when there is a new comment

### DIFF
--- a/.github/workflows/remove-stale.yml
+++ b/.github/workflows/remove-stale.yml
@@ -1,0 +1,23 @@
+# This workflow removes the stale label from PRs and issues when a new comment is created
+#
+name: Remove stale label
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  remove_stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Remove stale label
+        run: gh issue edit $ISSUE --remove-label $LABEL
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.html_url }}
+          LABEL: 'stale'


### PR DESCRIPTION
# Purpose of PR

Add action to remove stale label from PRs/issues when a new comment is created on it.