### PR TITLE
docs: add beta installation instructions

### DIFF
--- a/packages/components/datepicker/README.mdx
+++ b/packages/components/datepicker/README.mdx
@@ -15,6 +15,18 @@ The Datepicker component combines text input, and calendar in dropdown.
 
 Use Datepicker to ask user's for date input in forms, modals, or filtering.
 
+## Install beta package
+
+```bash static=true
+npm install @contentful/f36-datepicker@beta
+```
+
+For yarn:
+
+```bash static=true
+yarn add @contentful/f36-datepicker@beta
+```
+
 ## Import
 
 ```jsx static=true

--- a/packages/components/datepicker/src/Calendar/README.mdx
+++ b/packages/components/datepicker/src/Calendar/README.mdx
@@ -15,6 +15,18 @@ At Contentful calendar is used to ask user's input to set, edit, or view schedul
 
 The component is built on top of React Day Picker, see full documentation: https://react-day-picker.js.org/
 
+## Install beta package
+
+```bash static=true
+npm install @contentful/f36-datepicker@beta
+```
+
+For yarn:
+
+```bash static=true
+yarn add @contentful/f36-datepicker@beta
+```
+
 ## Import
 
 ```jsx static=true

--- a/packages/website/components/PageContent/PageContentHeader.tsx
+++ b/packages/website/components/PageContent/PageContentHeader.tsx
@@ -103,11 +103,11 @@ export function PageContentHeader({
             title={`${isAlpha ? 'Alpha' : 'Beta'} component`}
           >
             {isAlpha
-              ? `${title} component is ready to use but may have some bugs. Use in
-              production software with caution.`
-              : `${title} component is subject to major changes and is for
+              ? `${title} component is subject to major changes and is for
               experimentation purposes only. Not recommended for use in production
-              software.`}
+              software.`
+              : `${title} component is ready to use but may have some bugs. Use in
+              production software with caution.`}
           </Note>
         </Flex>
       )}


### PR DESCRIPTION
# Purpose of PR

Add installation instructions to docs for beta packages:

- https://forma-36-git-docs-beta-package-install.colorfuldemo.com/components/calendar
- https://forma-36-git-docs-beta-package-install.colorfuldemo.com/components/datepicker