### PR TITLE
feat(modal): add 'overlayProps' to Modal component

### DIFF
--- a/.changeset/wild-shrimps-confess.md
+++ b/.changeset/wild-shrimps-confess.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-modal': minor
+---
+
+Add 'overlayProps' to Modal component

--- a/packages/components/modal/src/Modal.styles.ts
+++ b/packages/components/modal/src/Modal.styles.ts
@@ -8,6 +8,7 @@ export function getModalStyles(props: {
   position: ModalProps['position'];
   allowHeightOverflow?: boolean;
   className?: string;
+  overlayClassName?: string;
 }) {
   const modal = cx(
     css({
@@ -94,6 +95,7 @@ export function getModalStyles(props: {
               justifyContent: 'center',
             })
           : null,
+        props.overlayClassName,
       ),
       afterOpen: css({
         opacity: 1,

--- a/packages/components/modal/src/Modal.tsx
+++ b/packages/components/modal/src/Modal.tsx
@@ -73,6 +73,11 @@ export interface ModalProps extends CommonProps {
   allowHeightOverflow?: boolean;
 
   /**
+   * Optional props to override overlay behaviour
+   */
+  overlayProps?: Pick<CommonProps, 'className' | 'style'>;
+
+  /**
    * Optional props to override ModalHeader behaviour
    */
   modalHeaderProps?: Partial<ModalHeaderProps>;
@@ -135,6 +140,7 @@ export const Modal = ({
     size,
     allowHeightOverflow,
     className: otherProps.className,
+    overlayClassName: otherProps.overlayProps?.className,
   });
 
   React.useEffect(() => {
@@ -184,6 +190,7 @@ export const Modal = ({
         content: {
           top: position === 'center' ? 0 : topOffset,
         },
+        overlay: otherProps.overlayProps?.style,
       }}
       className={{
         base: styles.base.root,


### PR DESCRIPTION
# Purpose of PR

Add a way to style the Modal backdrop

This PR looks to resolve the issue brought up in proposal #2166

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
