### PR TITLE
fix: avoid shrinking the switch input to not cut if off [HOMER-1216]

### DIFF
--- a/packages/components/forms/src/BaseCheckbox/GhostCheckbox.styles.ts
+++ b/packages/components/forms/src/BaseCheckbox/GhostCheckbox.styles.ts
@@ -98,6 +98,7 @@ const getSwitchStyles = ({ isDisabled, size }) => {
     borderRadius: tokens.borderRadiusSmall,
     justifyContent: 'space-around',
     position: 'relative',
+    flexShrink: 0,
     '&:before': {
       background: tokens.colorWhite,
       borderRadius: `calc(${tokens.borderRadiusSmall}/2)`,


### PR DESCRIPTION
# Purpose of PR

As soon as the width of the component is limited and the description includes a line wrap, the switch input will be cut off.

<img width="227" alt="Screen Shot 2022-09-01 at 11 59 58" src="https://user-images.githubusercontent.com/9327071/187887780-23dc5186-23e2-4e2b-a0b4-7138acbc70b0.png">

Using the flex-shrink property, we tell the flexbox never to shrink this part but only the text block.
<img width="239" alt="Screen Shot 2022-09-01 at 12 00 42" src="https://user-images.githubusercontent.com/9327071/187887901-df33bdfb-17dd-4f15-b2dd-becfbb935524.png">

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
