### PR TITLE
build: remove assignees from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,7 +3,6 @@ name: "\U0001F41B Bug Report"
 about: Spotted a bug? Add a report to help us improve Forma 36
 title: "\U0001F41B Bug - "
 labels: bug, needs triage
-assignees: m10l, burakukula, mshaaban0, gui-santos, denkristoffer, Lelith
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/component-feedback.md
+++ b/.github/ISSUE_TEMPLATE/component-feedback.md
@@ -3,7 +3,6 @@ name: "\U0001F4AC Give feedback on a component"
 about: Give us a feedback to help us improve Forma 36
 title: "\U0001F4AC Feedback - "
 labels: needs triage
-assignees: m10l, burakukula, mshaaban0, gui-santos, denkristoffer, Lelith
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -3,7 +3,6 @@ name: "\U0001F4A1 Proposal"
 about: Want to extend an existing component or contribute an entirely new one? Send us a proposal
 title: "\U0001F4A1 Proposal - "
 labels: needs review, needs triage, proposal
-assignees: domarku, m10l, burakukula, mshaaban0, gui-santos, denkristoffer, Lelith
 ---
 
 <!--


### PR DESCRIPTION
# Purpose of PR

Get rid of assignees from issue templates, I think it's clear we're not keeping them up to date and maybe we don't need them? 🙂 