### PR TITLE
fix: make remove-stale run on PRs too

### DIFF
--- a/.github/workflows/remove-stale.yml
+++ b/.github/workflows/remove-stale.yml
@@ -19,5 +19,5 @@ jobs:
         run: gh issue edit $ISSUE --remove-label $LABEL
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE: ${{ github.event.issue.html_url }}
+          ISSUE: ${{ github.event.issue.number }}
           LABEL: 'stale'

--- a/.github/workflows/remove-stale.yml
+++ b/.github/workflows/remove-stale.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   remove_stale:
-
+    if: contains(github.event.issue.labels.*.name, 'stale')
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
# Purpose of PR

Make the remove-stale action work on PRs and only run when the stale label is present