### PR TITLE
build: build ESM to JS file - legacy output

### DIFF
--- a/.changeset/pretty-weeks-complain.md
+++ b/.changeset/pretty-weeks-complain.md
@@ -1,0 +1,32 @@
+---
+"@contentful/f36-accordion": patch
+"@contentful/f36-asset": patch
+"@contentful/f36-autocomplete": patch
+"@contentful/f36-badge": patch
+"@contentful/f36-button": patch
+"@contentful/f36-card": patch
+"@contentful/f36-collapse": patch
+"@contentful/f36-copybutton": patch
+"@contentful/f36-datepicker": patch
+"@contentful/f36-datetime": patch
+"@contentful/f36-drag-handle": patch
+"@contentful/f36-entity-list": patch
+"@contentful/f36-forms": patch
+"@contentful/f36-icon": patch
+"@contentful/f36-icons": patch
+"@contentful/f36-list": patch
+"@contentful/f36-menu": patch
+"@contentful/f36-modal": patch
+"@contentful/f36-note": patch
+"@contentful/f36-notification": patch
+"@contentful/f36-pagination": patch
+"@contentful/f36-pill": patch
+"@contentful/f36-popover": patch
+"@contentful/f36-skeleton": patch
+"@contentful/f36-spinner": patch
+"@contentful/f36-table": patch
+"@contentful/f36-tabs": patch
+---
+
+build: build ESM to JS file - legacy output
+fix(notification): use type imports

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -10,6 +10,6 @@ module.exports = [
     import: '*',
     limit: '3.2 s',
     name: 'Module',
-    path: './packages/forma-36-react-components/dist/index.mjs',
+    path: './packages/forma-36-react-components/dist/esm/index.js',
   },
 ];

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/asset/package.json
+++ b/packages/components/asset/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/autocomplete/package.json
+++ b/packages/components/autocomplete/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/badge/package.json
+++ b/packages/components/badge/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -24,7 +24,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -30,7 +30,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/collapse/package.json
+++ b/packages/components/collapse/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/copybutton/package.json
+++ b/packages/components/copybutton/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/datepicker/package.json
+++ b/packages/components/datepicker/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/datetime/package.json
+++ b/packages/components/datetime/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/drag-handle/package.json
+++ b/packages/components/drag-handle/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/entity-list/package.json
+++ b/packages/components/entity-list/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/forms/package.json
+++ b/packages/components/forms/package.json
@@ -21,7 +21,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/icons/package.json
+++ b/packages/components/icons/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/list/package.json
+++ b/packages/components/list/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -25,7 +25,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/note/package.json
+++ b/packages/components/note/package.json
@@ -26,7 +26,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/notification/package.json
+++ b/packages/components/notification/package.json
@@ -26,7 +26,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/notification/src/Notification.tsx
+++ b/packages/components/notification/src/Notification.tsx
@@ -12,7 +12,7 @@ import {
   NotificationProps,
   Placement,
 } from './NotificationsManager';
-import { NotificationVariant, NotificationCta } from './types';
+import type { NotificationVariant, NotificationCta } from './types';
 
 export interface NotificationsAPI {
   success: ShowAction<Notification>;

--- a/packages/components/notification/src/NotificationsManager/NotificationsManager.tsx
+++ b/packages/components/notification/src/NotificationsManager/NotificationsManager.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { cx } from 'emotion';
 
 import { useAsyncState } from './useAsyncState';
-import { NotificationCta, NotificationVariant } from '../types';
+import type { NotificationCta, NotificationVariant } from '../types';
 import { NotificationItemContainer } from '../NotificationItem';
 import { getStyles } from './NotificationsManager.styles';
 

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/pill/package.json
+++ b/packages/components/pill/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/skeleton/package.json
+++ b/packages/components/skeleton/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/table/package.json
+++ b/packages/components/table/package.json
@@ -19,7 +19,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/text-link/package.json
+++ b/packages/components/text-link/package.json
@@ -19,7 +19,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/typography/package.json
+++ b/packages/components/typography/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/utils/package.json
+++ b/packages/components/utils/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/components/workbench/package.json
+++ b/packages/components/workbench/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.js",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "browserslist": "extends @contentful/browserslist-config",

--- a/packages/f36-docs-utils/package.json
+++ b/packages/f36-docs-utils/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "browserslist": "extends @contentful/browserslist-config",

--- a/packages/forma-36-react-components/package.json
+++ b/packages/forma-36-react-components/package.json
@@ -4,7 +4,7 @@
   "version": "4.19.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "module": "dist/index.mjs",
+  "module": "dist/index.module.js",
   "license": "MIT",
   "files": [
     "dist"

--- a/scripts/lint-packages.js
+++ b/scripts/lint-packages.js
@@ -51,8 +51,8 @@ for (const pkg of packages) {
   );
   softAssert(json.module, `${pkg} did not have "module"`);
   softAssert(
-    json.module.endsWith('.mjs'),
-    `${pkg}#module should be a .mjs file but got "${json.module}"`,
+    json.module.endsWith('esm/index.js'),
+    `${pkg}#module should be a separate .js file but got "${json.module}"`,
   );
   softAssert(json.source, `${pkg} did not have "source"`);
   softAssert.equal(

--- a/scripts/plop-templates/package/package.json.hbs
+++ b/scripts/plop-templates/package/package.json.hbs
@@ -19,7 +19,7 @@
     "dist"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   entryPoints: ['src/index.ts'],
   external: ['react', 'react-dom', '@contentful/f36-*'],
   format: ['cjs', 'esm'],
+  legacyOutput: true,
   minify: true,
   platform: 'browser',
   sourcemap: true,


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

- Build ESM to .js instead of .mjs until we're ready for .mjs files – Includes upgrading create-react-app to v5, and same for Webpack.
- fix(notification): use type imports