### PR TITLE
fix(Text): truncated styles

### DIFF
--- a/packages/components/typography/src/Text/Text.tsx
+++ b/packages/components/typography/src/Text/Text.tsx
@@ -34,6 +34,7 @@ function truncatedStyle() {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
+    maxWidth: '100%',
   });
 }
 


### PR DESCRIPTION
# Purpose of PR

Fix text truncation styles

**Before**
<img width="944" alt="Screenshot 2022-09-12 at 16 31 17" src="https://user-images.githubusercontent.com/6163988/189680898-0a45b88e-fae8-40c3-b56c-3d71642d84fd.png">


**After**
<img width="748" alt="Screenshot 2022-09-12 at 16 31 35" src="https://user-images.githubusercontent.com/6163988/189680980-90e47a36-99a6-4a2d-9698-92d93380cf32.png">

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
