### PR TITLE
feat: update react-day-picker to fix some minor issues, pin the version

### DIFF
--- a/packages/components/datepicker/package.json
+++ b/packages/components/datepicker/package.json
@@ -16,7 +16,7 @@
     "@contentful/f36-tokens": "^4.0.0",
     "emotion": "^10.0.17",
     "date-fns": "^2.28.0",
-    "react-day-picker": "8.2.1",
+    "react-day-picker": "^8.2.1",
     "react-focus-lock": "^2.9.1"
   },
   "peerDependencies": {

--- a/packages/components/datepicker/package.json
+++ b/packages/components/datepicker/package.json
@@ -16,7 +16,7 @@
     "@contentful/f36-tokens": "^4.0.0",
     "emotion": "^10.0.17",
     "date-fns": "^2.28.0",
-    "react-day-picker": "^8.0.7",
+    "react-day-picker": "8.2.1",
     "react-focus-lock": "^2.9.1"
   },
   "peerDependencies": {

--- a/packages/components/datepicker/src/Calendar/Calendar.styles.ts
+++ b/packages/components/datepicker/src/Calendar/Calendar.styles.ts
@@ -196,6 +196,7 @@ export const getStyles = (): ClassNames => {
       fontWeight: tokens.fontWeightDemiBold,
       textAlign: 'center',
       height: '32px',
+      color: tokens.gray600,
     }),
 
     tbody: css({

--- a/packages/components/datepicker/src/Calendar/Calendar.styles.ts
+++ b/packages/components/datepicker/src/Calendar/Calendar.styles.ts
@@ -36,7 +36,7 @@ export const getStyles = (): ClassNames => {
       cursor: 'pointer',
       color: tokens.gray900,
 
-      '&[aria-disabled="true"]': {
+      '&.rdp-day_disabled': {
         color: tokens.gray400,
         pointerEvents: 'none',
       },
@@ -52,7 +52,7 @@ export const getStyles = (): ClassNames => {
         backgroundColor: tokens.gray200,
       },
 
-      '&.rdp-day_selected:not([aria-disabled="true"])': {
+      '&.rdp-day_selected:not(.rdp-day_disabled)': {
         backgroundColor: tokens.blue600,
         color: tokens.colorWhite,
         fontWeight: tokens.fontWeightDemiBold,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2972,22 +2972,6 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-callback-ref" "0.1.0"
 
-"@reach/auto-id@0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.16.0.tgz#dfabc3227844e8c04f8e6e45203a8e14a8edbaed"
-  integrity sha512-5ssbeP5bCkM39uVsfQCwBBL+KT8YColdnMN5/Eto6Rj7929ql95R3HZUOkKIvj7mgPtEb60BLQxd1P3o6cjbmg==
-  dependencies:
-    "@reach/utils" "0.16.0"
-    tslib "^2.3.0"
-
-"@reach/utils@0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.16.0.tgz#5b0777cf16a7cab1ddd4728d5d02762df0ba84ce"
-  integrity sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==
-  dependencies:
-    tiny-warning "^1.0.3"
-    tslib "^2.3.0"
-
 "@react-hook/intersection-observer@^3.1.1":
   version "3.1.1"
   resolved "https://registry.npmjs.org/@react-hook/intersection-observer/-/intersection-observer-3.1.1.tgz"
@@ -18315,12 +18299,10 @@ react-copy-to-clipboard@^5.1.0:
     copy-to-clipboard "^3.3.1"
     prop-types "^15.8.1"
 
-react-day-picker@^8.0.7:
-  version "8.0.7"
-  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-8.0.7.tgz#6f2fb98b33a6f7e1a4e03d557bd78fffeb21ccda"
-  integrity sha512-isrLVhWpfdsxtG8YarHh5c0erL5aV1nrfolR/yK3KGTUqb7UGiCFnleBSH/Bv45tNpC2CZNFne01dsQEiocjYw==
-  dependencies:
-    "@reach/auto-id" "0.16.0"
+react-day-picker@8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-8.2.1.tgz#43f57ebe65dd8a90ccbb9d192eee899d67f79087"
+  integrity sha512-zFCi2IP7UbwcOM26mqYVE1vcuVC2sw/WY+QfC0AKitwRLkxMjC/o/KSzl8ia0+N3XQb38aoNcXnuH7d17QOSOw==
 
 react-devtools-inline@4.4.0:
   version "4.4.0"


### PR DESCRIPTION
# Purpose of PR

- update react-day-picker to fix some minor issues (for example before it was possible to focus disabled days with keyboard navigation )
- pin `react-day-picker` version to prevent breaking changes in styles
