### PR TITLE
feat: build to es6

### DIFF
--- a/.changeset/few-schools-develop.md
+++ b/.changeset/few-schools-develop.md
@@ -1,0 +1,5 @@
+---
+@contentful/f36-components: minor
+---
+
+Update tsup.config.ts

--- a/.changeset/few-schools-develop.md
+++ b/.changeset/few-schools-develop.md
@@ -2,4 +2,4 @@
 @contentful/f36-components: minor
 ---
 
-Update tsup.config.ts
+- Build to ES6

--- a/.changeset/few-schools-develop.md
+++ b/.changeset/few-schools-develop.md
@@ -1,5 +1,5 @@
 ---
-@contentful/f36-components: minor
+'@contentful/f36-components': minor
 ---
 
 - Build to ES6

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
   minify: true,
   platform: 'browser',
   sourcemap: true,
-  target: 'es2020',
+  target: 'es6',
   treeshake: true,
 });


### PR DESCRIPTION
# Purpose of PR

Target ES6 instead of ES2020 because react-scripts doesn't support nullish coalescing operator, even though all our targeted platforms do.