### PR TITLE
fix: add button margin reset on GlobalStyles

### DIFF
--- a/.changeset/honest-teachers-smile.md
+++ b/.changeset/honest-teachers-smile.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-core': patch
+---
+
+fix: add button margin reset on GlobalStyles

--- a/packages/core/src/GlobalStyles/GlobalStyles.tsx
+++ b/packages/core/src/GlobalStyles/GlobalStyles.tsx
@@ -4,6 +4,7 @@ import tokens from '@contentful/f36-tokens';
 
 const cssReset = css`
   /* Remove default margin */
+  /* Button has default margin in some browsers, like safari */
   body,
   h1,
   h2,
@@ -13,7 +14,8 @@ const cssReset = css`
   figure,
   blockquote,
   dl,
-  dd {
+  dd,
+  button {
     margin: 0;
   }
 


### PR DESCRIPTION
# Purpose of PR
Safari has a default margin set to `2` on buttons, we reset all buttons to have no margin, to fix issues with spacing

**Before:**
![image](https://user-images.githubusercontent.com/1071799/190144325-b4766644-c6e8-4e3a-8c7d-3839d0513166.png)

**After:**
<img width="732" alt="image" src="https://user-images.githubusercontent.com/1071799/190144486-36e739b5-3629-453f-acff-d0209aa93b02.png">
