### PR TITLE
docs(Calendar): remove beta package install instructions

### DIFF
--- a/packages/components/datepicker/src/Calendar/README.mdx
+++ b/packages/components/datepicker/src/Calendar/README.mdx
@@ -15,18 +15,6 @@ At Contentful calendar is used to ask user's input to set, edit, or view schedul
 
 The component is built on top of React Day Picker, see full documentation: https://react-day-picker.js.org/
 
-## Install beta package
-
-```bash static=true
-npm install @contentful/f36-datepicker@beta
-```
-
-For yarn:
-
-```bash static=true
-yarn add @contentful/f36-datepicker@beta
-```
-
 ## Import
 
 ```jsx static=true


### PR DESCRIPTION
# Purpose of PR

Removes the beta installation instructions


<img width="778" alt="Screenshot 2022-09-14 at 14 24 44" src="https://user-images.githubusercontent.com/6163988/190152700-7280773b-81af-4784-9364-e0e486d815ca.png">
