### PR TITLE
fix(Notification): break long words into new lines

### DIFF
--- a/packages/components/notification/examples/NotificationIntentsExample.tsx
+++ b/packages/components/notification/examples/NotificationIntentsExample.tsx
@@ -3,7 +3,7 @@ import { Button, Notification, Stack } from '@contentful/f36-components';
 
 export default function NotificationIntentsExample() {
   return (
-    <Stack>
+    <Stack justifyContent="center" flexWrap="wrap">
       <Button
         variant="positive"
         onClick={() => Notification.success('This is a success notification')}

--- a/packages/components/notification/src/NotificationItem/NotificationItem.styles.ts
+++ b/packages/components/notification/src/NotificationItem/NotificationItem.styles.ts
@@ -54,6 +54,7 @@ const titleStyle: CSSObject = {
 const contentStyle: CSSObject = {
   color: tokens.gray700,
   wordBreak: 'break-word',
+  hyphens: 'auto',
   '&:last-child': {
     marginBottom: 0,
   },

--- a/packages/components/notification/src/NotificationItem/NotificationItem.styles.ts
+++ b/packages/components/notification/src/NotificationItem/NotificationItem.styles.ts
@@ -53,6 +53,7 @@ const titleStyle: CSSObject = {
 
 const contentStyle: CSSObject = {
   color: tokens.gray700,
+  wordBreak: 'break-word',
   '&:last-child': {
     marginBottom: 0,
   },


### PR DESCRIPTION
# Purpose of PR

- Long words in notifications bugs the component. hence, we introduce this change to break long words into new lines
- Fix Notifications triggers alignment in docs

**Before**
![image](https://user-images.githubusercontent.com/6163988/190186892-ba26ebc4-1a9b-44e8-b769-e3ad88349dd8.png)

<img width="913" alt="Screenshot 2022-09-14 at 16 45 35" src="https://user-images.githubusercontent.com/6163988/190188211-da30d8d4-bdcd-4a19-8570-36c9e4c8eea0.png">


**After**
<img width="692" alt="Screenshot 2022-09-14 at 16 31 51" src="https://user-images.githubusercontent.com/6163988/190186959-21cab6d5-b89f-4477-923d-170b6a84d800.png">
<img width="746" alt="Screenshot 2022-09-14 at 16 46 23" src="https://user-images.githubusercontent.com/6163988/190188229-9f055d03-d076-424d-b862-d7480ee81ec3.png">

