### PR TITLE
fix: workbench styles [BAU-944]

### DIFF
--- a/.changeset/pretty-hotels-roll.md
+++ b/.changeset/pretty-hotels-roll.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-workbench': patch
+---
+
+Fix Workbench styles to prevent additional scroll on a page

--- a/packages/components/workbench/src/Workbench.styles.ts
+++ b/packages/components/workbench/src/Workbench.styles.ts
@@ -17,5 +17,6 @@ export const getWorkbenchStyles = () => ({
     height: '100%',
     width: '100%',
     overflow: 'hidden',
+    position: 'relative',
   }),
 });


### PR DESCRIPTION
# Purpose of PR

Fix for the style bug in the Entry Editor when the page body is scrollable, which means that if users use that scroll, the page will look like this
- Too much space in the bottom
- Entry title and Content type disappear

You want to ask why `position: relative` because that's how it works in the prev Workbench version.
