### PR TITLE
fix: handling of zIndex on TextInput.Group

### DIFF
--- a/.changeset/smooth-students-watch.md
+++ b/.changeset/smooth-students-watch.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-forms': patch
+---
+
+fix zIndex handling on TextInput.Group

--- a/packages/components/forms/src/BaseInput/BaseInput.styles.ts
+++ b/packages/components/forms/src/BaseInput/BaseInput.styles.ts
@@ -17,11 +17,18 @@ const getSizeStyles = ({ size }): CSSObject => {
   };
 };
 
+const getZIndex = ({
+  isDisabled,
+  isInvalid,
+  zIndexBase = tokens.zIndexDefault,
+}) => (isDisabled || isInvalid ? zIndexBase + 1 : zIndexBase);
+
 const getStyles = ({ as, isDisabled, isInvalid, size, resize }) => ({
   rootComponentWithIcon: css({
     position: 'relative',
     display: 'flex',
     width: '100%',
+    zIndex: getZIndex({ isDisabled, isInvalid }),
   }),
   input: css({
     outline: 'none',
@@ -38,6 +45,7 @@ const getStyles = ({ as, isDisabled, isInvalid, size, resize }) => ({
     margin: 0,
     cursor: isDisabled ? 'not-allowed' : 'auto',
     width: '100%',
+    zIndex: getZIndex({ isDisabled, isInvalid }),
 
     // if the input is a textarea, the resize prop is applied and size should be ignored
     ...(as === 'textarea' ? { resize } : getSizeStyles({ size })),

--- a/packages/components/forms/src/TextInput/input-group/InputGroup.styles.ts
+++ b/packages/components/forms/src/TextInput/input-group/InputGroup.styles.ts
@@ -15,7 +15,6 @@ const getInputGroupStyle = ({ spacing }) => {
     },
     '& > *': {
       marginRight: '-1px !important',
-      zIndex: tokens.zIndexDefault,
       '&:not(:focus), & button:not(:focus)': {
         boxShadow: 'none !important',
       },
@@ -28,8 +27,8 @@ const getInputGroupStyle = ({ spacing }) => {
         borderTopRightRadius: `${tokens.borderRadiusMedium} !important`,
         marginRight: '0 !important',
       },
-      '&:focus, &:focus-within, &:hover': {
-        zIndex: tokens.zIndexTooltip + 1,
+      '&:focus, &:focus-within': {
+        zIndex: tokens.zIndexDefault + 1,
       },
     },
   });

--- a/packages/components/forms/src/TextInput/input-group/InputGroup.styles.ts
+++ b/packages/components/forms/src/TextInput/input-group/InputGroup.styles.ts
@@ -28,8 +28,8 @@ const getInputGroupStyle = ({ spacing }) => {
         borderTopRightRadius: `${tokens.borderRadiusMedium} !important`,
         marginRight: '0 !important',
       },
-      '&:focus, &:focus-within': {
-        zIndex: tokens.zIndexDefault + 1,
+      '&:focus, &:focus-within, &:hover': {
+        zIndex: tokens.zIndexTooltip + 1,
       },
     },
   });

--- a/packages/components/forms/stories/InputGroup.stories.tsx
+++ b/packages/components/forms/stories/InputGroup.stories.tsx
@@ -5,6 +5,7 @@ import { SectionHeading } from '@contentful/f36-typography';
 import { Tooltip } from '@contentful/f36-tooltip';
 import { Flex } from '@contentful/f36-core';
 import { TextInput, InputGroupProps } from '../src';
+import { CopyButton } from '@contentful/f36-copybutton';
 
 export default {
   title: 'Form Elements/InputGroup',
@@ -163,7 +164,7 @@ export const Overview = () => {
       <SectionHeading as="h3" marginBottom="spacingS">
         With button wrapped in tooltip
       </SectionHeading>
-      <Flex marginBottom="spacingM" fullWidth>
+      <Flex marginBottom="spacingL" fullWidth>
         <TextInput.Group>
           <TextInput
             aria-label="Text Input"
@@ -177,6 +178,33 @@ export const Overview = () => {
               aria-label="Lock"
             />
           </Tooltip>
+        </TextInput.Group>
+      </Flex>
+      <SectionHeading as="h3" marginBottom="spacingS">
+        With copy button
+      </SectionHeading>
+      <Flex marginBottom="spacingM" fullWidth>
+        <TextInput.Group>
+          <TextInput value="Some value" />
+          <CopyButton value="Some value" />
+        </TextInput.Group>
+      </Flex>
+      <Flex marginBottom="spacingM" fullWidth>
+        <TextInput.Group>
+          <TextInput isInvalid value="Some value" />
+          <CopyButton value="Some value" />
+        </TextInput.Group>
+      </Flex>
+      <Flex marginBottom="spacingM" fullWidth>
+        <TextInput.Group>
+          <TextInput isDisabled value="Some value" />
+          <CopyButton value="Some value" />
+        </TextInput.Group>
+      </Flex>
+      <Flex marginBottom="spacingM" fullWidth>
+        <TextInput.Group>
+          <TextInput isDisabled isInvalid value="Some value" />
+          <CopyButton value="Some value" />
         </TextInput.Group>
       </Flex>
     </Flex>


### PR DESCRIPTION
# Purpose of PR

Fixes handling of zIndex on TextInput.Group, by giving `invalid` and `disabled` inputs a higher value, but if an element inside the group is `hovered` or `focused`, it gets an higher z-index in case it has a tooltip, it's not overlapped by the input itself (refer to #1857)

closes #1978 

> ~~**Known issues**~~
> ~~since we are changing the z-index in multiple places, some overlaps may happen:~~
> ~~If the input is focused~~
> ~~<img width="355" alt="image" src="https://user-images.githubusercontent.com/1071799/191037429-75e3cfb7-3aee-4371-b197-69167ee2ee62.png">~~
> ~~And then the button with a tooltip is hovered, it will appear like this~~
> ~~<img width="355" alt="image" src="https://user-images.githubusercontent.com/1071799/191037533-9e71bc39-a265-4194-90fd-cb2d2684ceac.png">~~
>
> ~~@fabe FYI~~

By removing the base z-index of all children elements on the InputGroup, and only updating the z-index of the input when it's invalid or disabled, seems to solve the issue:
<img width="360" alt="image" src="https://user-images.githubusercontent.com/1071799/191264388-ebd9b015-a69d-4256-a7f2-e9435fdf181c.png">

You can check it on [Storybook](https://5fd1dda724cc620021ace8c5-gfctmvkyiq.chromatic.com/?path=/story/form-elements-inputgroup--overview)

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
