### PR TITLE
fix(codemod): pass the name prop to the Select not FormControl

### DIFF
--- a/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-select.output.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v4/v4-select.output.js
@@ -1,8 +1,8 @@
 import { Select, FormControl } from "@contentful/f36-components";
 
-<FormControl id="select-field" name="select-field" isRequired>
+<FormControl id="select-field" isRequired>
   <FormControl.Label>Select label</FormControl.Label>
-  <Select onChange={() => {}} testId="cf-ui-select-field">
+  <Select name="select-field" onChange={() => {}} testId="cf-ui-select-field">
     <Select.Option value='1'>Option 1</Select.Option>
     <Select.Option value='2'>Option 2</Select.Option>
     <Select.Option value='3'>Option 3</Select.Option>

--- a/packages/forma-36-codemod/transforms/v4-select.js
+++ b/packages/forma-36-codemod/transforms/v4-select.js
@@ -134,10 +134,8 @@ function selectFieldCodemod(file, api) {
           children: getChildren({ prop: validationMessage, j }),
         });
 
-      const selectProps = [value, ...handlerProps].filter((prop) => prop);
-      const formControlProps = [id, name, required, ...commonProps].filter(
-        (p) => p,
-      );
+      const selectProps = [name, value, ...handlerProps].filter((prop) => prop);
+      const formControlProps = [id, required, ...commonProps].filter((p) => p);
 
       // from selectProps
       const selectPropsObj = getProperty(attributes, {


### PR DESCRIPTION
# Purpose of PR

Select codemod was passing the name prop to the FormControl instead of to the Select.