### PR TITLE
refactor(autocomplete): add prop to force showing the empty list when focused

### DIFF
--- a/packages/components/autocomplete/src/Autocomplete.styles.ts
+++ b/packages/components/autocomplete/src/Autocomplete.styles.ts
@@ -61,4 +61,7 @@ export const getAutocompleteStyles = (listMaxHeight: number) => ({
   highlighted: css({
     backgroundColor: tokens.gray100,
   }),
+  hidden: css({
+    display: 'none',
+  }),
 });

--- a/packages/components/autocomplete/src/Autocomplete.test.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.test.tsx
@@ -163,6 +163,24 @@ describe('Autocomplete', () => {
       });
     });
 
+    it('should show the empty list if showEmptyList is true', async () => {
+      const noMatchesMessage = 'No matches found';
+
+      renderComponent({ items: [], showEmptyList: true, noMatchesMessage });
+      const input = screen.getByTestId('cf-autocomplete-input');
+      // Container should exist but not visible
+      expect(screen.getByTestId('cf-autocomplete-container')).not.toBeVisible();
+
+      // focus on input to open the list
+      fireEvent.focus(input);
+
+      // Should be visible after clicking on the input
+      await waitFor(() => {
+        expect(screen.getByTestId('cf-autocomplete-container')).toBeVisible();
+        expect(screen.getByText(noMatchesMessage)).toBeVisible();
+      });
+    });
+
     it('is not showing the container when the list has 0 items and there is no input value', async () => {
       renderComponent({ items: [] });
 

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -384,6 +384,8 @@ function _Autocomplete<ItemType>(
               )}
           </Popover.Content>
         ) : (
+          // We need to render an empty hidden div, so we can pass the menuProps or downshift will show a warning about it
+          // https://github.com/downshift-js/downshift/issues/1167#issuecomment-1088022842
           <div {...menuProps} className={cx(styles.hidden)} />
         )}
       </Popover>

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -93,6 +93,11 @@ export interface AutocompleteProps<ItemType>
    */
   placeholder?: string;
   /**
+   * Defines if the list should be shown even if empty, when input is focused
+   * @default false
+   */
+  showEmptyList?: boolean;
+  /**
    * A message that will be shown when it is not possible to find any option that matches the input value
    * @default "No matches"
    */
@@ -155,6 +160,7 @@ function _Autocomplete<ItemType>(
     isDisabled,
     isRequired,
     isReadOnly,
+    showEmptyList,
     noMatchesMessage = 'No matches found',
     placeholder = 'Search',
     inputRef,
@@ -312,7 +318,7 @@ function _Autocomplete<ItemType>(
           </div>
         </Popover.Trigger>
 
-        {(items.length > 0 || inputValue.length > 0) && (
+        {items.length > 0 || inputValue.length > 0 || showEmptyList ? (
           <Popover.Content
             {...menuProps}
             ref={mergeRefs(menuProps.ref, listRef)}
@@ -377,6 +383,8 @@ function _Autocomplete<ItemType>(
                 />
               )}
           </Popover.Content>
+        ) : (
+          <div {...menuProps} className={cx(styles.hidden)} />
         )}
       </Popover>
     </div>


### PR DESCRIPTION
# Purpose of PR

Add prop to force showing the list when focused, even if empty and no search value is set.
Instead of not rendering, we render a empty hidden div to pass the ref to it to avoid downshift error messages, for more context see [here](https://github.com/downshift-js/downshift/issues/1167#issuecomment-1088022842)

