### PR TITLE
refactor(website): hardcode components sidebar to utils and integrations sections

### DIFF
--- a/packages/website/pages/[...slug].tsx
+++ b/packages/website/pages/[...slug].tsx
@@ -150,7 +150,12 @@ export const getStaticProps: GetStaticProps<
   const topbarLinks = await getTopbarLinks();
   let sidebarLinks = (await getSidebarLinksBySectionSlug(section)) ?? [];
 
-  if (section === HARDCODED_WEBSITE_SECTION.COMPONENTS) {
+  const sectionsWithComponentsSidebar: string[] = [
+    HARDCODED_WEBSITE_SECTION.COMPONENTS,
+    HARDCODED_WEBSITE_SECTION.INTEGRATIONS,
+    HARDCODED_WEBSITE_SECTION.UTILS,
+  ];
+  if (sectionsWithComponentsSidebar.includes(section)) {
     sidebarLinks = [
       ...sidebarLinks,
       ...componentSidebarLinks,

--- a/packages/website/types.ts
+++ b/packages/website/types.ts
@@ -17,6 +17,8 @@ export enum HARDCODED_WEBSITE_SECTION {
   PLAYGROUND = 'playground',
   TOKENS = 'tokens',
   WHATS_NEW = 'whats-new',
+  UTILS = 'utils',
+  INTEGRATIONS = 'integrations',
 }
 
 /**


### PR DESCRIPTION
## Purpose of PR

The sections `utils` and `integrations` were missing the sidebar, and it should show the same sidebar as the other components pages, for that we added the sections on the check to render the sidebar.

PS: The cast for `string[]` is because without it, TS was complaining on the `includes(section)` check