### PR TITLE
chore: bump version to force publishing new version

### DIFF
--- a/.changeset/loud-birds-wave.md
+++ b/.changeset/loud-birds-wave.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-components': patch
+---
+
+Version bump to force publishing new version

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "scripts": {
-    "build": "turbo run build",
+    "build": "turbo run build --force",
     "chromatic": "chromatic --project-token=vn1cd01txe --exit-zero-on-changes --storybook-build-dir ./dist-storybook",
     "commit": "git-cz",
     "commitmsg": "validate-commit-msg",


### PR DESCRIPTION
# Purpose of PR

Force build always building from source, not using cache, to prevent old versions being mistakenly published