### PR TITLE
chore: add function to use NPM_TOKEN on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,9 @@ jobs:
           command: yarn changeset version
       - run:
           name: Publish packages and create releases
-          command: yarn run changeset:publish
+          command: |
+            npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+            yarn run changeset:publish
 
   changelog:
     docker:

--- a/scripts/changesets/generate-releases.js
+++ b/scripts/changesets/generate-releases.js
@@ -54,20 +54,11 @@ const getReleasedPackages = async (csOutput, pkgs) => {
   }, []);
 };
 
-function setNpmToken() {
-  const env = process.env;
-  const registry = '//registry.npmjs.org/';
-  childProcess.execSync(
-    `npm config set ${registry}:_authToken=${env.NPM_TOKEN}`,
-  );
-}
-
 async function main() {
   const env = process.env;
   const octokit = new Octokit({
     auth: `token ${env.GITHUB_TOKEN}`,
   });
-  setNpmToken();
 
   // Run changesets publish and get stdout
   const csOutput = childProcess.execSync('yarn changeset publish').toString();

--- a/scripts/changesets/generate-releases.js
+++ b/scripts/changesets/generate-releases.js
@@ -54,11 +54,20 @@ const getReleasedPackages = async (csOutput, pkgs) => {
   }, []);
 };
 
+function setNpmToken() {
+  const env = process.env;
+  const registry = '//registry.npmjs.org/';
+  childProcess.execSync(
+    `npm config set ${registry}:_authToken=${env.NPM_TOKEN}`,
+  );
+}
+
 async function main() {
   const env = process.env;
   const octokit = new Octokit({
     auth: `token ${env.GITHUB_TOKEN}`,
   });
+  setNpmToken();
 
   // Run changesets publish and get stdout
   const csOutput = childProcess.execSync('yarn changeset publish').toString();


### PR DESCRIPTION
# Purpose of PR

Publishing to npm is failing on CI asking that the user should be logged into NPM.
We are adding a function to use NPM_TOKEN on the CI to avoid this problem