### PR TITLE
fix(text-link): fix vertical alignment when icon aligned to start

### DIFF
--- a/.changeset/great-houses-brake.md
+++ b/.changeset/great-houses-brake.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-text-link': patch
+---
+
+Fix vertical alignment when icon is aligned at start

--- a/packages/components/text-link/src/TextLink.styles.ts
+++ b/packages/components/text-link/src/TextLink.styles.ts
@@ -76,6 +76,7 @@ const textLink = ({
     opacity: isDisabled ? 0.5 : 1,
     ...variantToStyles(variant),
     outline: 'none',
+    verticalAlign: 'bottom',
     '&:focus, &:focus-visible, &:hover': {
       textDecoration: isDisabled ? 'none' : 'underline',
     },

--- a/packages/components/text-link/stories/TextLink.stories.tsx
+++ b/packages/components/text-link/stories/TextLink.stories.tsx
@@ -64,7 +64,12 @@ export const UsedWithText = () => {
         Brandenburg
       </TextLink>
       , and contiguous with{' '}
-      <TextLink href="https://www.wikiwand.com/en/Potsdam" target="_blank">
+      <TextLink
+        href="https://www.wikiwand.com/en/Potsdam"
+        icon={<Icon as={icons.ExternalLinkIcon} />}
+        alignIcon="start"
+        target="_blank"
+      >
         Potsdam
       </TextLink>
       , Brandenburg’s capital. The two cities are at the center of the


### PR DESCRIPTION
# Purpose of PR

Add vertical-align fix issue when icon was aligned to start.

Closes #2266