### PR TITLE
fix(button): only wrap text children in overflow wrapper

### DIFF
--- a/.changeset/witty-kids-swim.md
+++ b/.changeset/witty-kids-swim.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-button": patch
+---
+
+fix(button): only wrap text children in overflow wrapper

--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -82,11 +82,12 @@ function _Button<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
   const commonContent = (
     <>
       {startIcon && iconContent(startIcon)}
-      {children && (
-        <Box as="span" display="block" className={styles.buttonContent}>
-          {children}
-        </Box>
-      )}
+      {children &&
+        (typeof children === 'string' || typeof children === 'number') && (
+          <Box as="div" className={styles.buttonContent}>
+            {children}
+          </Box>
+        )}
       {endIcon && iconContent(endIcon)}
       {isLoading && (
         <Box


### PR DESCRIPTION
# Purpose of PR

We have to be a bit careful about this one. I'd like to get rid of this extra wrapper element for non-text `children`, but I don't know if someone is using e.g. a `<Text />` component to wrap their button value out there...