### PR TITLE
feat(button): allow icon variant for transparent buttons

### DIFF
--- a/.changeset/eleven-turkeys-press.md
+++ b/.changeset/eleven-turkeys-press.md
@@ -1,0 +1,7 @@
+---
+"@contentful/f36-button": patch
+"@contentful/f36-datepicker": patch
+---
+
+feat(button): allow icon variant for transparent buttons
+fix(datepicker): change calendar button icon variant

--- a/packages/components/button/examples/ButtonWithIconExample.tsx
+++ b/packages/components/button/examples/ButtonWithIconExample.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import { Button, Stack } from '@contentful/f36-components';
-import { PlusIcon, ChevronDownIcon } from '@contentful/f36-icons';
+import { PlusIcon, ChevronDownIcon, SettingsIcon } from '@contentful/f36-icons';
 
 export default function ButtonWithIconExample() {
   return (
     <Stack>
-      <Button startIcon={<PlusIcon />}>Add</Button>
+      <Button startIcon={<PlusIcon />} variant="primary">
+        Add
+      </Button>
       <Button endIcon={<ChevronDownIcon />}>Menu</Button>
+      <Button
+        startIcon={<SettingsIcon variant="muted" />}
+        variant="transparent"
+      >
+        Settings
+      </Button>
     </Stack>
   );
 }

--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -70,9 +70,10 @@ function _Button<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
         >
           {React.cloneElement(icon, {
             size: icon.props.size ?? `${size === 'large' ? 'medium' : 'small'}`,
-            // we want to allow variants for icons, only for the transparent IconButton
+            // we want to allow variants for icons for transparent buttons
             variant:
-              (!children && icon.props.variant) || defaultIconColor[variant],
+              (variant === 'transparent' && icon.props.variant) ||
+              defaultIconColor[variant],
           })}
         </Flex>
       )

--- a/packages/components/button/src/Button/README.mdx
+++ b/packages/components/button/src/Button/README.mdx
@@ -72,7 +72,7 @@ You can add an icon by providing the following props:
 - `startIcon` - adds icon to the left side of the button
 - `endIcon` - adds icon to the right side of the button
 
-The `variant` prop of the icon is automatically adjusted based on the `variant` of the button. If you are using a button with `variant="transparent"` you can also override the icon variant manually.
+The `variant` prop of the icon is automatically adjusted based on the `variant` of the button. If you are using a button with `variant="transparent"` you can also set the icon variant manually.
 
 ```jsx file=../../examples/ButtonWithIconExample.tsx
 

--- a/packages/components/button/src/Button/README.mdx
+++ b/packages/components/button/src/Button/README.mdx
@@ -72,6 +72,8 @@ You can add an icon by providing the following props:
 - `startIcon` - adds icon to the left side of the button
 - `endIcon` - adds icon to the right side of the button
 
+The `variant` prop of the icon is automatically adjusted based on the `variant` of the button. If you are using a button with `variant="transparent"` you can also override the icon variant manually.
+
 ```jsx file=../../examples/ButtonWithIconExample.tsx
 
 ```

--- a/packages/components/datepicker/src/Datepicker.tsx
+++ b/packages/components/datepicker/src/Datepicker.tsx
@@ -225,7 +225,7 @@ const DatepickerTrigger = React.forwardRef<
       <IconButton
         aria-label="Use calendar"
         variant="secondary"
-        icon={<CalendarIcon aria-label="calendar" variant="muted" />}
+        icon={<CalendarIcon aria-label="calendar" />}
         onClick={onTriggerClick}
         isDisabled={isDisabled}
         testId="cf-ui-datepicker-button"


### PR DESCRIPTION
# Purpose of PR

This PR allows you to set an icon variant for buttons with `variant="transparent"`.

It also fixes a bug with the icon button: We previously allowed setting `variant` for all icon buttons, even the other variants. This is now fixed to only allow `variant="transparent"` just like the regular button.