### PR TITLE
fix: remove default button margin in safari

### DIFF
--- a/.changeset/lucky-baboons-end.md
+++ b/.changeset/lucky-baboons-end.md
@@ -1,0 +1,11 @@
+---
+'@contentful/f36-accordion': patch
+'@contentful/f36-button': patch
+'@contentful/f36-card': patch
+'@contentful/f36-copybutton': patch
+'@contentful/f36-drag-handle': patch
+'@contentful/f36-entity-list': patch
+'@contentful/f36-text-link': patch
+---
+
+fix: remove default margin in safari for buttons

--- a/packages/components/accordion/src/AccordionHeader/AccordionHeader.styles.ts
+++ b/packages/components/accordion/src/AccordionHeader/AccordionHeader.styles.ts
@@ -13,6 +13,7 @@ const getHeaderStyles = ({ align }: StyleProps) =>
       flexDirection: 'row',
       alignItems: 'center',
       border: '0',
+      margin: 0, // remove the default button margin in Safari.
       padding: tokens.spacingM,
       backgroundColor: 'transparent',
       fontFamily: tokens.fontStackPrimary,

--- a/packages/components/button/src/Button/Button.styles.ts
+++ b/packages/components/button/src/Button/Button.styles.ts
@@ -215,6 +215,7 @@ export const getStyles = () => ({
       fontWeight: tokens.fontWeightMedium,
       outline: 'none',
       textDecoration: 'none',
+      margin: 0, // remove the default margin in Safari.
       transition: `background ${tokens.transitionDurationShort} ${tokens.transitionEasingDefault},
         opacity ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault},
         border-color ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}`,

--- a/packages/components/card/src/BaseCard/BaseCard.styles.ts
+++ b/packages/components/card/src/BaseCard/BaseCard.styles.ts
@@ -35,6 +35,7 @@ export const getBaseCardStyles = () => {
         fontWeight: tokens.fontWeightNormal,
         position: 'relative',
         textDecoration: 'none',
+        margin: 0, // remove the default button margin in Safari.
         transition: `border-color ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault},
     box-shadow ${tokens.transitionDurationShort} ${tokens.transitionEasingDefault}`,
 

--- a/packages/components/copybutton/src/CopyButton.styles.ts
+++ b/packages/components/copybutton/src/CopyButton.styles.ts
@@ -20,6 +20,7 @@ export const getStyles = ({ size }) => {
       justifyContent: 'center',
       outline: 'none',
       padding: 0,
+      margin: 0, // remove the default button margin in Safari.
       transition: `background ${tokens.transitionDurationShort} ${tokens.transitionEasingDefault}`,
       width: '100%',
       '&:hover': {

--- a/packages/components/drag-handle/src/DragHandle.styles.ts
+++ b/packages/components/drag-handle/src/DragHandle.styles.ts
@@ -33,6 +33,7 @@ export const getStyles = () => ({
         display: 'flex',
         justifyContent: 'center',
         padding: 0,
+        margin: 0, // remove the default button margin in Safari.
         position: 'relative',
         transition: `background-color ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}`,
         width: tokens.spacingL,

--- a/packages/components/entity-list/src/EntityListItem/EntityListItem.styles.ts
+++ b/packages/components/entity-list/src/EntityListItem/EntityListItem.styles.ts
@@ -27,6 +27,7 @@ export const getEntityListItemStyles = () => ({
     width: '100%',
     minHeight: tokens.spacing3Xl,
     padding: tokens.spacingXs,
+    margin: 0, // remove the default button margin in Safari.
     border: 'none',
     background: 'none',
     textAlign: 'left',

--- a/packages/components/text-link/src/TextLink.styles.ts
+++ b/packages/components/text-link/src/TextLink.styles.ts
@@ -63,6 +63,7 @@ const textLink = ({
     boxSizing: 'border-box',
     border: 0,
     padding: 0,
+    margin: 0, // remove the default button margin in Safari.
     fontFamily: tokens.fontStackPrimary,
     fontSize: tokens.fontSizeM,
     fontWeight: tokens.fontWeightMedium,


### PR DESCRIPTION
By default Safari adds `2px` margin to `button`