### PR TITLE
fix: display none has negative impact on svgs used inside a collapse 

### DIFF
--- a/.changeset/forty-experts-hug.md
+++ b/.changeset/forty-experts-hug.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-collapse': patch
+---
+
+Fix negative side effect for svgs

--- a/package-lock.json
+++ b/package-lock.json
@@ -37879,14 +37879,14 @@
     },
     "packages/components/accordion": {
       "name": "@contentful/f36-accordion",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-collapse": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -37895,14 +37895,14 @@
     },
     "packages/components/asset": {
       "name": "@contentful/f36-asset",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -37911,18 +37911,18 @@
     },
     "packages/components/autocomplete": {
       "name": "@contentful/f36-autocomplete",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
+        "@contentful/f36-utils": "^4.21.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       },
@@ -37932,15 +37932,15 @@
     },
     "packages/components/badge": {
       "name": "@contentful/f36-badge",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^4.21.0"
+        "@contentful/f36-typography": "^4.21.3"
       },
       "peerDependencies": {
         "react": ">=16.8"
@@ -37948,17 +37948,17 @@
     },
     "packages/components/button": {
       "name": "@contentful/f36-button",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-spinner": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-spinner": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0"
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3"
       },
       "peerDependencies": {
         "react": ">=16.8"
@@ -37966,21 +37966,21 @@
     },
     "packages/components/card": {
       "name": "@contentful/f36-card",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-asset": "^4.21.0",
-        "@contentful/f36-badge": "^4.21.0",
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-drag-handle": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-menu": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
+        "@contentful/f36-asset": "^4.21.3",
+        "@contentful/f36-badge": "^4.21.3",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-drag-handle": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-menu": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -37990,10 +37990,10 @@
     },
     "packages/components/collapse": {
       "name": "@contentful/f36-collapse",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -38003,13 +38003,13 @@
     },
     "packages/components/copybutton": {
       "name": "@contentful/f36-copybutton",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
         "emotion": "^10.0.17",
         "react-copy-to-clipboard": "^5.1.0"
       },
@@ -38019,16 +38019,16 @@
     },
     "packages/components/datepicker": {
       "name": "@contentful/f36-datepicker",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.3.5",
@@ -38053,10 +38053,10 @@
     },
     "packages/components/datetime": {
       "name": "@contentful/f36-datetime",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -38067,11 +38067,11 @@
     },
     "packages/components/drag-handle": {
       "name": "@contentful/f36-drag-handle",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -38081,19 +38081,19 @@
     },
     "packages/components/entity-list": {
       "name": "@contentful/f36-entity-list",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-badge": "^4.21.0",
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-drag-handle": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-menu": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
+        "@contentful/f36-badge": "^4.21.3",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-drag-handle": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-menu": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -38102,13 +38102,13 @@
     },
     "packages/components/forms": {
       "name": "@contentful/f36-forms",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
@@ -38121,10 +38121,10 @@
     },
     "packages/components/icon": {
       "name": "@contentful/f36-icon",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -38137,11 +38137,11 @@
     },
     "packages/components/icons": {
       "name": "@contentful/f36-icons",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -38151,10 +38151,10 @@
     },
     "packages/components/list": {
       "name": "@contentful/f36-list",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -38164,15 +38164,15 @@
     },
     "packages/components/menu": {
       "name": "@contentful/f36-menu",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
+        "@contentful/f36-utils": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -38181,14 +38181,14 @@
     },
     "packages/components/modal": {
       "name": "@contentful/f36-modal",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "@types/react-modal": "^3.12.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.14.3"
@@ -38225,15 +38225,15 @@
     },
     "packages/components/note": {
       "name": "@contentful/f36-note",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
@@ -38245,15 +38245,15 @@
     },
     "packages/components/notification": {
       "name": "@contentful/f36-notification",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-text-link": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-text-link": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "@swc/helpers": "^0.4.2",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -38265,15 +38265,15 @@
     },
     "packages/components/pagination": {
       "name": "@contentful/f36-pagination",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -38282,14 +38282,14 @@
     },
     "packages/components/pill": {
       "name": "@contentful/f36-pill",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -38298,12 +38298,12 @@
     },
     "packages/components/popover": {
       "name": "@contentful/f36-popover",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-utils": "^4.21.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
@@ -38314,11 +38314,11 @@
     },
     "packages/components/skeleton": {
       "name": "@contentful/f36-skeleton",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-table": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-table": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -38328,15 +38328,15 @@
     },
     "packages/components/spinner": {
       "name": "@contentful/f36-spinner",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^4.21.0"
+        "@contentful/f36-typography": "^4.21.3"
       },
       "peerDependencies": {
         "react": ">=16.8"
@@ -38344,10 +38344,10 @@
     },
     "packages/components/table": {
       "name": "@contentful/f36-table",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -38357,10 +38357,10 @@
     },
     "packages/components/tabs": {
       "name": "@contentful/f36-tabs",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "@radix-ui/react-tabs": "0.1.1",
         "emotion": "^10.0.17"
@@ -38371,10 +38371,10 @@
     },
     "packages/components/text-link": {
       "name": "@contentful/f36-text-link",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -38384,12 +38384,12 @@
     },
     "packages/components/tooltip": {
       "name": "@contentful/f36-tooltip",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-utils": "^4.21.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
@@ -38401,10 +38401,10 @@
     },
     "packages/components/typography": {
       "name": "@contentful/f36-typography",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -38414,7 +38414,7 @@
     },
     "packages/components/utils": {
       "name": "@contentful/f36-utils",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
         "emotion": "^10.0.17"
@@ -38443,7 +38443,7 @@
     },
     "packages/core": {
       "name": "@contentful/f36-core",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.1",
@@ -38729,42 +38729,42 @@
     },
     "packages/forma-36-react-components": {
       "name": "@contentful/f36-components",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.21.0",
-        "@contentful/f36-asset": "^4.21.0",
-        "@contentful/f36-autocomplete": "^4.21.0",
-        "@contentful/f36-badge": "^4.21.0",
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-card": "^4.21.0",
-        "@contentful/f36-collapse": "^4.21.0",
-        "@contentful/f36-copybutton": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-datepicker": "^4.21.0",
-        "@contentful/f36-datetime": "^4.21.0",
-        "@contentful/f36-drag-handle": "^4.21.0",
-        "@contentful/f36-entity-list": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-list": "^4.21.0",
-        "@contentful/f36-menu": "^4.21.0",
-        "@contentful/f36-modal": "^4.21.0",
-        "@contentful/f36-note": "^4.21.0",
-        "@contentful/f36-notification": "^4.21.0",
-        "@contentful/f36-pagination": "^4.21.0",
-        "@contentful/f36-pill": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
-        "@contentful/f36-spinner": "^4.21.0",
-        "@contentful/f36-table": "^4.21.0",
-        "@contentful/f36-tabs": "^4.21.0",
-        "@contentful/f36-text-link": "^4.21.0",
+        "@contentful/f36-accordion": "^4.21.3",
+        "@contentful/f36-asset": "^4.21.3",
+        "@contentful/f36-autocomplete": "^4.21.3",
+        "@contentful/f36-badge": "^4.21.3",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-card": "^4.21.3",
+        "@contentful/f36-collapse": "^4.21.3",
+        "@contentful/f36-copybutton": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-datepicker": "^4.21.3",
+        "@contentful/f36-datetime": "^4.21.3",
+        "@contentful/f36-drag-handle": "^4.21.3",
+        "@contentful/f36-entity-list": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-list": "^4.21.3",
+        "@contentful/f36-menu": "^4.21.3",
+        "@contentful/f36-modal": "^4.21.3",
+        "@contentful/f36-note": "^4.21.3",
+        "@contentful/f36-notification": "^4.21.3",
+        "@contentful/f36-pagination": "^4.21.3",
+        "@contentful/f36-pill": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
+        "@contentful/f36-spinner": "^4.21.3",
+        "@contentful/f36-table": "^4.21.3",
+        "@contentful/f36-tabs": "^4.21.3",
+        "@contentful/f36-text-link": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
-        "@contentful/f36-typography": "^4.21.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
+        "@contentful/f36-typography": "^4.21.3",
+        "@contentful/f36-utils": "^4.21.3",
         "@types/react": "16.14.22",
         "@types/react-dom": "16.9.14"
       },
@@ -42073,12 +42073,12 @@
       "version": "1.0.0",
       "dependencies": {
         "@codesandbox/sandpack-react": "0.18.1",
-        "@contentful/f36-components": "^4.21.0",
+        "@contentful/f36-components": "^4.21.3",
         "@contentful/f36-docs-utils": "^4.0.1",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-utils": "^4.21.3",
         "@contentful/rich-text-react-renderer": "^15.11.1",
         "@emotion/core": "^10.0.17",
         "@mdx-js/loader": "^1.6.22",
@@ -44908,37 +44908,37 @@
     "@contentful/f36-accordion": {
       "version": "file:packages/components/accordion",
       "requires": {
-        "@contentful/f36-collapse": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-collapse": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
       "version": "file:packages/components/asset",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
       "version": "file:packages/components/autocomplete",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
+        "@contentful/f36-utils": "^4.21.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
@@ -44946,19 +44946,19 @@
     "@contentful/f36-badge": {
       "version": "file:packages/components/badge",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
       "version": "file:packages/components/button",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-spinner": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-spinner": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -44966,18 +44966,18 @@
     "@contentful/f36-card": {
       "version": "file:packages/components/card",
       "requires": {
-        "@contentful/f36-asset": "^4.21.0",
-        "@contentful/f36-badge": "^4.21.0",
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-drag-handle": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-menu": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
+        "@contentful/f36-asset": "^4.21.3",
+        "@contentful/f36-badge": "^4.21.3",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-drag-handle": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-menu": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
@@ -45134,7 +45134,7 @@
     "@contentful/f36-collapse": {
       "version": "file:packages/components/collapse",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -45142,39 +45142,39 @@
     "@contentful/f36-components": {
       "version": "file:packages/forma-36-react-components",
       "requires": {
-        "@contentful/f36-accordion": "^4.21.0",
-        "@contentful/f36-asset": "^4.21.0",
-        "@contentful/f36-autocomplete": "^4.21.0",
-        "@contentful/f36-badge": "^4.21.0",
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-card": "^4.21.0",
-        "@contentful/f36-collapse": "^4.21.0",
-        "@contentful/f36-copybutton": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-datepicker": "^4.21.0",
-        "@contentful/f36-datetime": "^4.21.0",
-        "@contentful/f36-drag-handle": "^4.21.0",
-        "@contentful/f36-entity-list": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-list": "^4.21.0",
-        "@contentful/f36-menu": "^4.21.0",
-        "@contentful/f36-modal": "^4.21.0",
-        "@contentful/f36-note": "^4.21.0",
-        "@contentful/f36-notification": "^4.21.0",
-        "@contentful/f36-pagination": "^4.21.0",
-        "@contentful/f36-pill": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
-        "@contentful/f36-spinner": "^4.21.0",
-        "@contentful/f36-table": "^4.21.0",
-        "@contentful/f36-tabs": "^4.21.0",
-        "@contentful/f36-text-link": "^4.21.0",
+        "@contentful/f36-accordion": "^4.21.3",
+        "@contentful/f36-asset": "^4.21.3",
+        "@contentful/f36-autocomplete": "^4.21.3",
+        "@contentful/f36-badge": "^4.21.3",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-card": "^4.21.3",
+        "@contentful/f36-collapse": "^4.21.3",
+        "@contentful/f36-copybutton": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-datepicker": "^4.21.3",
+        "@contentful/f36-datetime": "^4.21.3",
+        "@contentful/f36-drag-handle": "^4.21.3",
+        "@contentful/f36-entity-list": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-list": "^4.21.3",
+        "@contentful/f36-menu": "^4.21.3",
+        "@contentful/f36-modal": "^4.21.3",
+        "@contentful/f36-note": "^4.21.3",
+        "@contentful/f36-notification": "^4.21.3",
+        "@contentful/f36-pagination": "^4.21.3",
+        "@contentful/f36-pill": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
+        "@contentful/f36-spinner": "^4.21.3",
+        "@contentful/f36-table": "^4.21.3",
+        "@contentful/f36-tabs": "^4.21.3",
+        "@contentful/f36-text-link": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
-        "@contentful/f36-typography": "^4.21.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
+        "@contentful/f36-typography": "^4.21.3",
+        "@contentful/f36-utils": "^4.21.3",
         "@types/react": "16.14.22",
         "@types/react-dom": "16.9.14",
         "microbundle": "^0.15.1",
@@ -47479,10 +47479,10 @@
     "@contentful/f36-copybutton": {
       "version": "file:packages/components/copybutton",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
         "emotion": "^10.0.17",
         "react-copy-to-clipboard": "^5.1.0"
       }
@@ -47515,13 +47515,13 @@
     "@contentful/f36-datepicker": {
       "version": "file:packages/components/datepicker",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.3.5",
@@ -47539,7 +47539,7 @@
     "@contentful/f36-datetime": {
       "version": "file:packages/components/datetime",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -47557,8 +47557,8 @@
     "@contentful/f36-drag-handle": {
       "version": "file:packages/components/drag-handle",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47566,26 +47566,26 @@
     "@contentful/f36-entity-list": {
       "version": "file:packages/components/entity-list",
       "requires": {
-        "@contentful/f36-badge": "^4.21.0",
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-drag-handle": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-menu": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
+        "@contentful/f36-badge": "^4.21.3",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-drag-handle": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-menu": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
       "version": "file:packages/components/forms",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17",
         "formik": "^2.2.9",
         "react-hook-form": "^7.15.0"
@@ -47594,7 +47594,7 @@
     "@contentful/f36-icon": {
       "version": "file:packages/components/icon",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17",
         "react-icons": "^4.4.0"
@@ -47603,8 +47603,8 @@
     "@contentful/f36-icons": {
       "version": "file:packages/components/icons",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47612,7 +47612,7 @@
     "@contentful/f36-list": {
       "version": "file:packages/components/list",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47620,23 +47620,23 @@
     "@contentful/f36-menu": {
       "version": "file:packages/components/menu",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
+        "@contentful/f36-utils": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
       "version": "file:packages/components/modal",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "@types/react-modal": "^3.12.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.14.3"
@@ -47663,12 +47663,12 @@
     "@contentful/f36-note": {
       "version": "file:packages/components/note",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "@emotion/serialize": "^0.11.15",
         "emotion": "^10.0.17"
       }
@@ -47676,12 +47676,12 @@
     "@contentful/f36-notification": {
       "version": "file:packages/components/notification",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-text-link": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-text-link": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "@swc/helpers": "^0.4.2",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -47690,32 +47690,32 @@
     "@contentful/f36-pagination": {
       "version": "file:packages/components/pagination",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
       "version": "file:packages/components/pill",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
       "version": "file:packages/components/popover",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-utils": "^4.21.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
@@ -47724,8 +47724,8 @@
     "@contentful/f36-skeleton": {
       "version": "file:packages/components/skeleton",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-table": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-table": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47733,16 +47733,16 @@
     "@contentful/f36-spinner": {
       "version": "file:packages/components/spinner",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
       "version": "file:packages/components/table",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47750,7 +47750,7 @@
     "@contentful/f36-tabs": {
       "version": "file:packages/components/tabs",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "@radix-ui/react-tabs": "0.1.1",
         "emotion": "^10.0.17"
@@ -47759,7 +47759,7 @@
     "@contentful/f36-text-link": {
       "version": "file:packages/components/text-link",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47803,9 +47803,9 @@
     "@contentful/f36-tooltip": {
       "version": "file:packages/components/tooltip",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-utils": "^4.21.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
@@ -47815,7 +47815,7 @@
     "@contentful/f36-typography": {
       "version": "file:packages/components/typography",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47830,12 +47830,12 @@
       "version": "file:packages/website",
       "requires": {
         "@codesandbox/sandpack-react": "0.18.1",
-        "@contentful/f36-components": "^4.21.0",
+        "@contentful/f36-components": "^4.21.3",
         "@contentful/f36-docs-utils": "^4.0.1",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-utils": "^4.21.3",
         "@contentful/rich-text-react-renderer": "^15.11.1",
         "@contentful/rich-text-types": "^15.11.1",
         "@emotion/babel-preset-css-prop": "^10.2.1",

--- a/packages/components/collapse/src/Collapse.styles.ts
+++ b/packages/components/collapse/src/Collapse.styles.ts
@@ -9,6 +9,7 @@ export const getCollapseStyles = ({ className }: { className?: string }) => {
         overflow: 'hidden',
         height: 0,
         visibility: 'hidden',
+        display: 'block',
         transition: `height ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}, padding ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}`,
       }),
       className,

--- a/packages/components/collapse/src/Collapse.styles.ts
+++ b/packages/components/collapse/src/Collapse.styles.ts
@@ -8,7 +8,7 @@ export const getCollapseStyles = ({ className }: { className?: string }) => {
         boxSizing: 'border-box',
         overflow: 'hidden',
         height: 0,
-        display: 'none',
+        visibility: 'hidden',
         transition: `height ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}, padding ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}`,
       }),
       className,

--- a/packages/components/collapse/src/Collapse.tsx
+++ b/packages/components/collapse/src/Collapse.tsx
@@ -55,7 +55,7 @@ export const Collapse = ({
           current.style.setProperty('height', 'auto');
         } else {
           current.style.removeProperty('pointer-events');
-          current.style.setProperty('display', 'none');
+          current.style.setProperty('visibility', 'hidden');
         }
       }
     };
@@ -68,7 +68,7 @@ export const Collapse = ({
           current.style.setProperty('pointer-events', 'none');
         } else {
           // Overwrite none display to see expanding transition
-          current.style.setProperty('display', 'block');
+          current.style.setProperty('visibility', 'visible');
           current.style.removeProperty('pointer-events');
         }
         // Calculate panel height after removing none display


### PR DESCRIPTION
# Purpose of PR
This is a side-effect fix.

I have multiple collapsable containers using this collapse animation. Inside of these containers i have a colorful svg icon with a gradient in several of them.

Every time the first container that has the icon gets collapsed, the gradient disappears. [This is a known chromium bug since almost 10 years now](https://bugs.chromium.org/p/chromium/issues/detail?id=258029) The issue exists not only in chrome but also in firefox (it was also in webkit, but safari fixed it at some point)

What happens is, that the reference all of the svg files have to the gradient (via id) always points to its first defintion. When this first svg is now set to display:none this defintion stops to exist for all following instances of the same svg in the page.

The simplest to achieve fix is: do not use display:none but visibility:hidden to hide the content.

If there are no objections or other reasons why display:none is the important rule, please let me know and we can think about other solutions.

Maybe its also worth checking again the proposal here https://github.com/contentful/forma-36/issues/2043
