### PR TITLE
fix: specify react-dom as peer dependency

### DIFF
--- a/.changeset/rotten-tables-nail.md
+++ b/.changeset/rotten-tables-nail.md
@@ -1,0 +1,29 @@
+---
+"@contentful/f36-core": patch
+"@contentful/f36-docs-utils": patch
+"@contentful/f36-accordion": patch
+"@contentful/f36-asset": patch
+"@contentful/f36-autocomplete": patch
+"@contentful/f36-badge": patch
+"@contentful/f36-button": patch
+"@contentful/f36-card": patch
+"@contentful/f36-collapse": patch
+"@contentful/f36-copybutton": patch
+"@contentful/f36-datepicker": patch
+"@contentful/f36-datetime": patch
+"@contentful/f36-drag-handle": patch
+"@contentful/f36-entity-list": patch
+"@contentful/f36-forms": patch
+"@contentful/f36-icon": patch
+"@contentful/f36-icons": patch
+"@contentful/f36-menu": patch
+"@contentful/f36-note": patch
+"@contentful/f36-pill": patch
+"@contentful/f36-skeleton": patch
+"@contentful/f36-table": patch
+"@contentful/f36-tabs": patch
+"@contentful/f36-tooltip": patch
+"@contentful/f36-workbench": patch
+---
+
+fix: specify react-dom as peer dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -37879,163 +37879,172 @@
     },
     "packages/components/accordion": {
       "name": "@contentful/f36-accordion",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-collapse": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/asset": {
       "name": "@contentful/f36-asset",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/autocomplete": {
       "name": "@contentful/f36-autocomplete",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
+        "@contentful/f36-utils": "^4.21.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/badge": {
       "name": "@contentful/f36-badge",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^4.21.0"
+        "@contentful/f36-typography": "^4.21.3"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/button": {
       "name": "@contentful/f36-button",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-spinner": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-spinner": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0"
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/card": {
       "name": "@contentful/f36-card",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-asset": "^4.21.0",
-        "@contentful/f36-badge": "^4.21.0",
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-drag-handle": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-menu": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
+        "@contentful/f36-asset": "^4.21.3",
+        "@contentful/f36-badge": "^4.21.3",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-drag-handle": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-menu": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/collapse": {
       "name": "@contentful/f36-collapse",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/copybutton": {
       "name": "@contentful/f36-copybutton",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
         "emotion": "^10.0.17",
         "react-copy-to-clipboard": "^5.1.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/datepicker": {
       "name": "@contentful/f36-datepicker",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.3.5",
         "react-focus-lock": "^2.9.1"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/datepicker/node_modules/react-day-picker": {
@@ -38053,62 +38062,65 @@
     },
     "packages/components/datetime": {
       "name": "@contentful/f36-datetime",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/drag-handle": {
       "name": "@contentful/f36-drag-handle",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/entity-list": {
       "name": "@contentful/f36-entity-list",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-badge": "^4.21.0",
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-drag-handle": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-menu": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
+        "@contentful/f36-badge": "^4.21.3",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-drag-handle": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-menu": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/forms": {
       "name": "@contentful/f36-forms",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
@@ -38116,15 +38128,16 @@
         "react-hook-form": "^7.15.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/icon": {
       "name": "@contentful/f36-icon",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -38137,24 +38150,25 @@
     },
     "packages/components/icons": {
       "name": "@contentful/f36-icons",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/list": {
       "name": "@contentful/f36-list",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -38164,31 +38178,32 @@
     },
     "packages/components/menu": {
       "name": "@contentful/f36-menu",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
+        "@contentful/f36-utils": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/modal": {
       "name": "@contentful/f36-modal",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "@types/react-modal": "^3.12.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.14.3"
@@ -38225,35 +38240,36 @@
     },
     "packages/components/note": {
       "name": "@contentful/f36-note",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
         "@emotion/serialize": "^0.11.15"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/notification": {
       "name": "@contentful/f36-notification",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-text-link": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-text-link": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "@swc/helpers": "^0.4.2",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -38265,15 +38281,15 @@
     },
     "packages/components/pagination": {
       "name": "@contentful/f36-pagination",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -38282,28 +38298,29 @@
     },
     "packages/components/pill": {
       "name": "@contentful/f36-pill",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/popover": {
       "name": "@contentful/f36-popover",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-utils": "^4.21.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
@@ -38314,29 +38331,30 @@
     },
     "packages/components/skeleton": {
       "name": "@contentful/f36-skeleton",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-table": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-table": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/spinner": {
       "name": "@contentful/f36-spinner",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^4.21.0"
+        "@contentful/f36-typography": "^4.21.3"
       },
       "peerDependencies": {
         "react": ">=16.8"
@@ -38344,37 +38362,39 @@
     },
     "packages/components/table": {
       "name": "@contentful/f36-table",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/tabs": {
       "name": "@contentful/f36-tabs",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "@radix-ui/react-tabs": "0.1.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/text-link": {
       "name": "@contentful/f36-text-link",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -38384,27 +38404,28 @@
     },
     "packages/components/tooltip": {
       "name": "@contentful/f36-tooltip",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-utils": "^4.21.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/components/typography": {
       "name": "@contentful/f36-typography",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -38414,7 +38435,7 @@
     },
     "packages/components/utils": {
       "name": "@contentful/f36-utils",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
         "emotion": "^10.0.17"
@@ -38438,12 +38459,13 @@
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/core": {
       "name": "@contentful/f36-core",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.1",
@@ -38453,7 +38475,8 @@
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/core/node_modules/@emotion/is-prop-valid": {
@@ -38480,7 +38503,8 @@
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "packages/forma-36-codemod": {
@@ -38729,42 +38753,42 @@
     },
     "packages/forma-36-react-components": {
       "name": "@contentful/f36-components",
-      "version": "4.21.0",
+      "version": "4.21.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.21.0",
-        "@contentful/f36-asset": "^4.21.0",
-        "@contentful/f36-autocomplete": "^4.21.0",
-        "@contentful/f36-badge": "^4.21.0",
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-card": "^4.21.0",
-        "@contentful/f36-collapse": "^4.21.0",
-        "@contentful/f36-copybutton": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-datepicker": "^4.21.0",
-        "@contentful/f36-datetime": "^4.21.0",
-        "@contentful/f36-drag-handle": "^4.21.0",
-        "@contentful/f36-entity-list": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-list": "^4.21.0",
-        "@contentful/f36-menu": "^4.21.0",
-        "@contentful/f36-modal": "^4.21.0",
-        "@contentful/f36-note": "^4.21.0",
-        "@contentful/f36-notification": "^4.21.0",
-        "@contentful/f36-pagination": "^4.21.0",
-        "@contentful/f36-pill": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
-        "@contentful/f36-spinner": "^4.21.0",
-        "@contentful/f36-table": "^4.21.0",
-        "@contentful/f36-tabs": "^4.21.0",
-        "@contentful/f36-text-link": "^4.21.0",
+        "@contentful/f36-accordion": "^4.21.3",
+        "@contentful/f36-asset": "^4.21.3",
+        "@contentful/f36-autocomplete": "^4.21.3",
+        "@contentful/f36-badge": "^4.21.3",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-card": "^4.21.3",
+        "@contentful/f36-collapse": "^4.21.3",
+        "@contentful/f36-copybutton": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-datepicker": "^4.21.3",
+        "@contentful/f36-datetime": "^4.21.3",
+        "@contentful/f36-drag-handle": "^4.21.3",
+        "@contentful/f36-entity-list": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-list": "^4.21.3",
+        "@contentful/f36-menu": "^4.21.3",
+        "@contentful/f36-modal": "^4.21.3",
+        "@contentful/f36-note": "^4.21.3",
+        "@contentful/f36-notification": "^4.21.3",
+        "@contentful/f36-pagination": "^4.21.3",
+        "@contentful/f36-pill": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
+        "@contentful/f36-spinner": "^4.21.3",
+        "@contentful/f36-table": "^4.21.3",
+        "@contentful/f36-tabs": "^4.21.3",
+        "@contentful/f36-text-link": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
-        "@contentful/f36-typography": "^4.21.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
+        "@contentful/f36-typography": "^4.21.3",
+        "@contentful/f36-utils": "^4.21.3",
         "@types/react": "16.14.22",
         "@types/react-dom": "16.9.14"
       },
@@ -42073,12 +42097,12 @@
       "version": "1.0.0",
       "dependencies": {
         "@codesandbox/sandpack-react": "0.18.1",
-        "@contentful/f36-components": "^4.21.0",
+        "@contentful/f36-components": "^4.21.3",
         "@contentful/f36-docs-utils": "^4.0.1",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-utils": "^4.21.3",
         "@contentful/rich-text-react-renderer": "^15.11.1",
         "@emotion/core": "^10.0.17",
         "@mdx-js/loader": "^1.6.22",
@@ -44908,37 +44932,37 @@
     "@contentful/f36-accordion": {
       "version": "file:packages/components/accordion",
       "requires": {
-        "@contentful/f36-collapse": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-collapse": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
       "version": "file:packages/components/asset",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
       "version": "file:packages/components/autocomplete",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
+        "@contentful/f36-utils": "^4.21.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
@@ -44946,19 +44970,19 @@
     "@contentful/f36-badge": {
       "version": "file:packages/components/badge",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
       "version": "file:packages/components/button",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-spinner": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-spinner": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -44966,18 +44990,18 @@
     "@contentful/f36-card": {
       "version": "file:packages/components/card",
       "requires": {
-        "@contentful/f36-asset": "^4.21.0",
-        "@contentful/f36-badge": "^4.21.0",
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-drag-handle": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-menu": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
+        "@contentful/f36-asset": "^4.21.3",
+        "@contentful/f36-badge": "^4.21.3",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-drag-handle": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-menu": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
@@ -45134,7 +45158,7 @@
     "@contentful/f36-collapse": {
       "version": "file:packages/components/collapse",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -45142,39 +45166,39 @@
     "@contentful/f36-components": {
       "version": "file:packages/forma-36-react-components",
       "requires": {
-        "@contentful/f36-accordion": "^4.21.0",
-        "@contentful/f36-asset": "^4.21.0",
-        "@contentful/f36-autocomplete": "^4.21.0",
-        "@contentful/f36-badge": "^4.21.0",
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-card": "^4.21.0",
-        "@contentful/f36-collapse": "^4.21.0",
-        "@contentful/f36-copybutton": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-datepicker": "^4.21.0",
-        "@contentful/f36-datetime": "^4.21.0",
-        "@contentful/f36-drag-handle": "^4.21.0",
-        "@contentful/f36-entity-list": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-list": "^4.21.0",
-        "@contentful/f36-menu": "^4.21.0",
-        "@contentful/f36-modal": "^4.21.0",
-        "@contentful/f36-note": "^4.21.0",
-        "@contentful/f36-notification": "^4.21.0",
-        "@contentful/f36-pagination": "^4.21.0",
-        "@contentful/f36-pill": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
-        "@contentful/f36-spinner": "^4.21.0",
-        "@contentful/f36-table": "^4.21.0",
-        "@contentful/f36-tabs": "^4.21.0",
-        "@contentful/f36-text-link": "^4.21.0",
+        "@contentful/f36-accordion": "^4.21.3",
+        "@contentful/f36-asset": "^4.21.3",
+        "@contentful/f36-autocomplete": "^4.21.3",
+        "@contentful/f36-badge": "^4.21.3",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-card": "^4.21.3",
+        "@contentful/f36-collapse": "^4.21.3",
+        "@contentful/f36-copybutton": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-datepicker": "^4.21.3",
+        "@contentful/f36-datetime": "^4.21.3",
+        "@contentful/f36-drag-handle": "^4.21.3",
+        "@contentful/f36-entity-list": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-list": "^4.21.3",
+        "@contentful/f36-menu": "^4.21.3",
+        "@contentful/f36-modal": "^4.21.3",
+        "@contentful/f36-note": "^4.21.3",
+        "@contentful/f36-notification": "^4.21.3",
+        "@contentful/f36-pagination": "^4.21.3",
+        "@contentful/f36-pill": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
+        "@contentful/f36-spinner": "^4.21.3",
+        "@contentful/f36-table": "^4.21.3",
+        "@contentful/f36-tabs": "^4.21.3",
+        "@contentful/f36-text-link": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
-        "@contentful/f36-typography": "^4.21.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
+        "@contentful/f36-typography": "^4.21.3",
+        "@contentful/f36-utils": "^4.21.3",
         "@types/react": "16.14.22",
         "@types/react-dom": "16.9.14",
         "microbundle": "^0.15.1",
@@ -47479,10 +47503,10 @@
     "@contentful/f36-copybutton": {
       "version": "file:packages/components/copybutton",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
         "emotion": "^10.0.17",
         "react-copy-to-clipboard": "^5.1.0"
       }
@@ -47515,13 +47539,13 @@
     "@contentful/f36-datepicker": {
       "version": "file:packages/components/datepicker",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.3.5",
@@ -47539,7 +47563,7 @@
     "@contentful/f36-datetime": {
       "version": "file:packages/components/datetime",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -47557,8 +47581,8 @@
     "@contentful/f36-drag-handle": {
       "version": "file:packages/components/drag-handle",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47566,26 +47590,26 @@
     "@contentful/f36-entity-list": {
       "version": "file:packages/components/entity-list",
       "requires": {
-        "@contentful/f36-badge": "^4.21.0",
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-drag-handle": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-menu": "^4.21.0",
-        "@contentful/f36-skeleton": "^4.21.0",
+        "@contentful/f36-badge": "^4.21.3",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-drag-handle": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-menu": "^4.21.3",
+        "@contentful/f36-skeleton": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
       "version": "file:packages/components/forms",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17",
         "formik": "^2.2.9",
         "react-hook-form": "^7.15.0"
@@ -47594,7 +47618,7 @@
     "@contentful/f36-icon": {
       "version": "file:packages/components/icon",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17",
         "react-icons": "^4.4.0"
@@ -47603,8 +47627,8 @@
     "@contentful/f36-icons": {
       "version": "file:packages/components/icons",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47612,7 +47636,7 @@
     "@contentful/f36-list": {
       "version": "file:packages/components/list",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47620,23 +47644,23 @@
     "@contentful/f36-menu": {
       "version": "file:packages/components/menu",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-popover": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-popover": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
+        "@contentful/f36-utils": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
       "version": "file:packages/components/modal",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "@types/react-modal": "^3.12.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.14.3"
@@ -47663,12 +47687,12 @@
     "@contentful/f36-note": {
       "version": "file:packages/components/note",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "@emotion/serialize": "^0.11.15",
         "emotion": "^10.0.17"
       }
@@ -47676,12 +47700,12 @@
     "@contentful/f36-notification": {
       "version": "file:packages/components/notification",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
-        "@contentful/f36-text-link": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
+        "@contentful/f36-text-link": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "@swc/helpers": "^0.4.2",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -47690,32 +47714,32 @@
     "@contentful/f36-pagination": {
       "version": "file:packages/components/pagination",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-forms": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-forms": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
       "version": "file:packages/components/pill",
       "requires": {
-        "@contentful/f36-button": "^4.21.0",
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-button": "^4.21.3",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.21.0",
+        "@contentful/f36-tooltip": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
       "version": "file:packages/components/popover",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-utils": "^4.21.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
@@ -47724,8 +47748,8 @@
     "@contentful/f36-skeleton": {
       "version": "file:packages/components/skeleton",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
-        "@contentful/f36-table": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
+        "@contentful/f36-table": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47733,16 +47757,16 @@
     "@contentful/f36-spinner": {
       "version": "file:packages/components/spinner",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.21.0",
+        "@contentful/f36-typography": "^4.21.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
       "version": "file:packages/components/table",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47750,7 +47774,7 @@
     "@contentful/f36-tabs": {
       "version": "file:packages/components/tabs",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "@radix-ui/react-tabs": "0.1.1",
         "emotion": "^10.0.17"
@@ -47759,7 +47783,7 @@
     "@contentful/f36-text-link": {
       "version": "file:packages/components/text-link",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47803,9 +47827,9 @@
     "@contentful/f36-tooltip": {
       "version": "file:packages/components/tooltip",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-utils": "^4.21.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
@@ -47815,7 +47839,7 @@
     "@contentful/f36-typography": {
       "version": "file:packages/components/typography",
       "requires": {
-        "@contentful/f36-core": "^4.21.0",
+        "@contentful/f36-core": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
@@ -47830,12 +47854,12 @@
       "version": "file:packages/website",
       "requires": {
         "@codesandbox/sandpack-react": "0.18.1",
-        "@contentful/f36-components": "^4.21.0",
+        "@contentful/f36-components": "^4.21.3",
         "@contentful/f36-docs-utils": "^4.0.1",
-        "@contentful/f36-icon": "^4.21.0",
-        "@contentful/f36-icons": "^4.21.0",
+        "@contentful/f36-icon": "^4.21.3",
+        "@contentful/f36-icons": "^4.21.3",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-utils": "^4.21.0",
+        "@contentful/f36-utils": "^4.21.3",
         "@contentful/rich-text-react-renderer": "^15.11.1",
         "@contentful/rich-text-types": "^15.11.1",
         "@emotion/babel-preset-css-prop": "^10.2.1",

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -28,7 +28,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/asset/package.json
+++ b/packages/components/asset/package.json
@@ -14,7 +14,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/autocomplete/package.json
+++ b/packages/components/autocomplete/package.json
@@ -19,7 +19,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/badge/package.json
+++ b/packages/components/badge/package.json
@@ -28,7 +28,8 @@
     "@contentful/f36-typography": "^4.21.3"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -16,7 +16,8 @@
     "@contentful/f36-icons": "^4.21.3"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -22,7 +22,8 @@
     "truncate": "^3.0.0"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/collapse/package.json
+++ b/packages/components/collapse/package.json
@@ -25,7 +25,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/copybutton/package.json
+++ b/packages/components/copybutton/package.json
@@ -14,7 +14,8 @@
     "react-copy-to-clipboard": "^5.1.0"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/datepicker/package.json
+++ b/packages/components/datepicker/package.json
@@ -19,7 +19,8 @@
     "react-focus-lock": "^2.9.1"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/datetime/package.json
+++ b/packages/components/datetime/package.json
@@ -12,7 +12,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/drag-handle/package.json
+++ b/packages/components/drag-handle/package.json
@@ -12,7 +12,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/entity-list/package.json
+++ b/packages/components/entity-list/package.json
@@ -19,7 +19,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/forms/package.json
+++ b/packages/components/forms/package.json
@@ -13,7 +13,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/icons/package.json
+++ b/packages/components/icons/package.json
@@ -13,7 +13,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "files": [
     "dist"

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -15,7 +15,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/note/package.json
+++ b/packages/components/note/package.json
@@ -18,7 +18,8 @@
     "@emotion/serialize": "^0.11.15"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/pill/package.json
+++ b/packages/components/pill/package.json
@@ -14,7 +14,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/skeleton/package.json
+++ b/packages/components/skeleton/package.json
@@ -12,7 +12,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/table/package.json
+++ b/packages/components/table/package.json
@@ -11,7 +11,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -12,7 +12,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -15,7 +15,8 @@
     "react-popper": "^2.3.0"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/workbench/package.json
+++ b/packages/components/workbench/package.json
@@ -15,7 +15,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/f36-docs-utils/package.json
+++ b/packages/f36-docs-utils/package.json
@@ -25,7 +25,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/plop-templates/package/package.json.hbs
+++ b/scripts/plop-templates/package/package.json.hbs
@@ -11,7 +11,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [


### PR DESCRIPTION
# Purpose of PR

Adds `"react-dom": ">=16.8"` as a peer dependency to our packages. We need this to be able to properly resolve peer dependencies of some libraries we use without conflicts emerging.