### PR TITLE
feat(Skeleton): add and expose raduis properties

### DIFF
--- a/.changeset/afraid-singers-notice.md
+++ b/.changeset/afraid-singers-notice.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-skeleton": patch
+---
+
+feat(Skeleton): add and expose raduis properties

--- a/packages/components/skeleton/src/SkeletonImage/SkeletonImage.tsx
+++ b/packages/components/skeleton/src/SkeletonImage/SkeletonImage.tsx
@@ -1,3 +1,4 @@
+import tokens from '@contentful/f36-tokens';
 import React from 'react';
 
 type stringOrNumber = string | number;
@@ -18,8 +19,8 @@ export const SkeletonImage = ({
   offsetTop,
   width = 70,
   height = 70,
-  radiusX = 0,
-  radiusY = 0,
+  radiusX = tokens.borderRadiusSmall,
+  radiusY = tokens.borderRadiusSmall,
   ...otherProps
 }: SkeletonImageProps): React.ReactElement => {
   return (

--- a/packages/components/skeleton/src/SkeletonText/SkeletonText.tsx
+++ b/packages/components/skeleton/src/SkeletonText/SkeletonText.tsx
@@ -1,3 +1,4 @@
+import tokens from '@contentful/f36-tokens';
 import React, { useCallback } from 'react';
 
 type stringOrNumber = string | number;
@@ -24,6 +25,14 @@ export interface SkeletonTextProps {
    */
   marginBottom?: stringOrNumber;
   /**
+   * X-axis border radius (in number)
+   */
+  radiusX?: stringOrNumber;
+  /**
+   * Y-axis border radius (in number)
+   */
+  radiusY?: stringOrNumber;
+  /**
    * A width of a line
    */
   width?: stringOrNumber;
@@ -35,6 +44,8 @@ export const SkeletonText = ({
   offsetTop = 0,
   lineHeight = 21,
   marginBottom = 20,
+  radiusX = tokens.borderRadiusSmall,
+  radiusY = tokens.borderRadiusSmall,
   width,
 }: SkeletonTextProps) => {
   const getLineWidth = useCallback(
@@ -57,8 +68,8 @@ export const SkeletonText = ({
           y={
             index * (+lineHeight! + +marginBottom!) + +offsetTop! // eslint-disable-line @typescript-eslint/no-non-null-assertion
           }
-          rx="0"
-          ry="0"
+          rx={radiusX}
+          ry={radiusY}
           width={getLineWidth(
             numberOfLines! > 1 && numberOfLines! - index === 1, // eslint-disable-line @typescript-eslint/no-non-null-assertion
           )}


### PR DESCRIPTION
# Purpose of PR

* Adds default border radius of `4px` to Skeleton components
* Exposes `radiusX` and `radiusY` property to Skeleton components

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
