### PR TITLE
feat: account for when there is no entity card description

### DIFF
--- a/packages/components/entity-list/src/EntityListItem/EntityListItem.styles.ts
+++ b/packages/components/entity-list/src/EntityListItem/EntityListItem.styles.ts
@@ -59,18 +59,16 @@ export const getEntityListItemStyles = () => ({
   }),
   entityType: css({
     textTransform: 'capitalize',
-
-    '&::after': {
-      content: '" "',
-      position: 'absolute',
-      borderRight: `1px solid ${tokens.gray400}`,
-      height: '25%',
-      marginTop: tokens.spacing2Xs,
-      width: tokens.spacingXs,
-    },
   }),
   description: css({
-    marginLeft: tokens.spacingM,
+    '&::before': {
+      content: '"|"',
+      color: tokens.gray400,
+      height: '25%',
+      marginTop: tokens.spacing2Xs,
+      marginLeft: tokens.spacing2Xs,
+      marginRight: tokens.spacing2Xs,
+    },
   }),
   meta: css({
     marginLeft: 'auto',


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR
Related to https://github.com/contentful/forma-36/pull/2331, account for when there's no `description`
<img width="614" alt="Screenshot 2022-11-18 at 16 56 48" src="https://user-images.githubusercontent.com/30434146/202747028-32851854-60de-4358-ad55-8a332042d7d4.png">
<img width="866" alt="Screenshot 2022-11-18 at 16 57 11" src="https://user-images.githubusercontent.com/30434146/202747118-1eef3e00-2429-47c4-ab5d-494bb5a9a4df.png">

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
