### PR TITLE
chore: bump workbench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The Changelog gives an overview of the changes we've made to Forma 36
 
 <!-- CHANGELOG:INSERT -->
 
+## 21-11-2022
+
+**F36 Workbench** `v4.20.6`
+
+- Bump package to fix the latest release
+
 ## 19-11-2022
 
 **F36 Entity List** `v4.22.0`

--- a/packages/components/workbench/package.json
+++ b/packages/components/workbench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-workbench",
-  "version": "4.20.5",
+  "version": "4.20.6",
   "description": "Forma 36: Workbench component",
   "scripts": {
     "build": "tsup"


### PR DESCRIPTION
- bump workbench and manually publish to have the correct latest version on npm
<img width="769" alt="image" src="https://user-images.githubusercontent.com/10744462/203060345-f284b366-ab3f-423c-bb44-88a599bd4bd9.png">
