### PR TITLE
Revert "chore: bump react-live from 2.4.1 to 3.1.1 (#2353)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10726,6 +10726,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/buble": {
+      "version": "0.20.1",
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.25.0"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.7",
       "license": "MIT",
@@ -11956,6 +11963,7 @@
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
@@ -13419,6 +13427,71 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/buble": {
+      "version": "0.19.6",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "magic-string": "^0.25.1",
+        "minimist": "^1.2.0",
+        "os-homedir": "^1.0.1",
+        "regexpu-core": "^4.2.0",
+        "vlq": "^1.0.0"
+      },
+      "bin": {
+        "buble": "bin/buble"
+      }
+    },
+    "node_modules/buble/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/buble/node_modules/chalk": {
+      "version": "2.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/buble/node_modules/color-convert": {
+      "version": "1.9.3",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/buble/node_modules/color-name": {
+      "version": "1.1.3",
+      "license": "MIT"
+    },
+    "node_modules/buble/node_modules/has-flag": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/buble/node_modules/supports-color": {
+      "version": "5.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "funding": [
@@ -14494,6 +14567,13 @@
       "version": "1.3.0",
       "license": "MIT"
     },
+    "node_modules/component-props": {
+      "version": "1.1.1"
+    },
+    "node_modules/component-xor": {
+      "version": "0.0.4",
+      "license": "MIT"
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "dev": true,
@@ -14751,7 +14831,6 @@
     },
     "node_modules/core-js": {
       "version": "3.23.5",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -16360,6 +16439,14 @@
       "license": "MIT",
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-iterator": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "component-props": "1.1.1",
+        "component-xor": "0.0.4"
       }
     },
     "node_modules/dom-serializer": {
@@ -26260,7 +26347,6 @@
     },
     "node_modules/magic-string": {
       "version": "0.25.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sourcemap-codec": "^1.4.4"
@@ -27991,6 +28077,7 @@
     },
     "node_modules/mz": {
       "version": "2.7.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -28954,9 +29041,7 @@
     },
     "node_modules/os-homedir": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -31152,6 +31237,24 @@
       "version": "3.0.4",
       "license": "MIT"
     },
+    "node_modules/react-live": {
+      "version": "2.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@types/buble": "^0.20.0",
+        "buble": "0.19.6",
+        "core-js": "^3.14.0",
+        "dom-iterator": "^1.0.0",
+        "prism-react-renderer": "^1.2.1",
+        "prop-types": "^15.7.2",
+        "react-simple-code-editor": "^0.11.0",
+        "unescape": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.12.0",
+        "npm": ">= 2.0.0"
+      }
+    },
     "node_modules/react-popper": {
       "version": "2.3.0",
       "license": "MIT",
@@ -31226,6 +31329,14 @@
       "version": "16.13.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-simple-code-editor": {
+      "version": "0.11.3",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
     },
     "node_modules/react-sizeme": {
       "version": "3.0.2",
@@ -33677,7 +33788,6 @@
     },
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/space-separated-tokens": {
@@ -34233,6 +34343,7 @@
     },
     "node_modules/sucrase": {
       "version": "3.25.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "^4.0.0",
@@ -34252,6 +34363,7 @@
     },
     "node_modules/sucrase/node_modules/commander": {
       "version": "4.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -34259,6 +34371,7 @@
     },
     "node_modules/sucrase/node_modules/glob": {
       "version": "7.1.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -34730,6 +34843,7 @@
     },
     "node_modules/thenify": {
       "version": "3.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -34737,6 +34851,7 @@
     },
     "node_modules/thenify-all": {
       "version": "1.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -35108,6 +35223,7 @@
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/ts-node": {
@@ -35666,6 +35782,16 @@
       "version": "0.1.2",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unescape": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -36394,6 +36520,10 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/vlq": {
+      "version": "1.0.1",
+      "license": "MIT"
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -41384,7 +41514,7 @@
         "react-focus-lock": "^2.9.1",
         "react-hook-form": "7.25.3",
         "react-icons": "4.4.0",
-        "react-live": "3.1.1",
+        "react-live": "2.4.1",
         "react-sortable-hoc": "^2.0.0",
         "rehype-slug": "^5.0.1",
         "rehype-toc": "^3.0.2",
@@ -41862,36 +41992,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "packages/website/node_modules/react-live": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/react-live/-/react-live-3.1.1.tgz",
-      "integrity": "sha512-bPjrk7jCQ7dk8W3lx+/AAcn66TFRzTNIWsVa4mWqsiwIgUjaNqzFZZIuq2kY9UlAix8x63egsEFPX6dkno92Fg==",
-      "dependencies": {
-        "prism-react-renderer": "^1.3.1",
-        "sucrase": "^3.21.0",
-        "use-editable": "^2.3.3"
-      },
-      "engines": {
-        "node": ">= 0.12.0",
-        "npm": ">= 2.0.0"
-      }
-    },
-    "packages/website/node_modules/react-live/node_modules/prism-react-renderer": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-      "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
-      "peerDependencies": {
-        "react": ">=0.14.9"
-      }
-    },
-    "packages/website/node_modules/react-live/node_modules/use-editable": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/use-editable/-/use-editable-2.3.3.tgz",
-      "integrity": "sha512-7wVD2JbfAFJ3DK0vITvXBdpd9JAz5BcKAAolsnLBuBn6UDDwBGuCIAGvR3yA2BNKm578vAMVHFCWaOcA+BhhiA==",
-      "peerDependencies": {
-        "react": ">= 16.8.0"
       }
     },
     "packages/website/node_modules/rehype-slug": {
@@ -47293,7 +47393,7 @@
         "react-focus-lock": "^2.9.1",
         "react-hook-form": "7.25.3",
         "react-icons": "4.4.0",
-        "react-live": "3.1.1",
+        "react-live": "2.4.1",
         "react-sortable-hoc": "^2.0.0",
         "rehype-slug": "^5.0.1",
         "rehype-toc": "^3.0.2",
@@ -47525,30 +47625,6 @@
             "nanoid": "^3.3.4",
             "picocolors": "^1.0.0",
             "source-map-js": "^1.0.2"
-          }
-        },
-        "react-live": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/react-live/-/react-live-3.1.1.tgz",
-          "integrity": "sha512-bPjrk7jCQ7dk8W3lx+/AAcn66TFRzTNIWsVa4mWqsiwIgUjaNqzFZZIuq2kY9UlAix8x63egsEFPX6dkno92Fg==",
-          "requires": {
-            "prism-react-renderer": "^1.3.1",
-            "sucrase": "^3.21.0",
-            "use-editable": "^2.3.3"
-          },
-          "dependencies": {
-            "prism-react-renderer": {
-              "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-              "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
-              "requires": {}
-            },
-            "use-editable": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/use-editable/-/use-editable-2.3.3.tgz",
-              "integrity": "sha512-7wVD2JbfAFJ3DK0vITvXBdpd9JAz5BcKAAolsnLBuBn6UDDwBGuCIAGvR3yA2BNKm578vAMVHFCWaOcA+BhhiA==",
-              "requires": {}
-            }
           }
         },
         "rehype-slug": {
@@ -52602,6 +52678,12 @@
       "version": "1.0.0",
       "dev": true
     },
+    "@types/buble": {
+      "version": "0.20.1",
+      "requires": {
+        "magic-string": "^0.25.0"
+      }
+    },
     "@types/debug": {
       "version": "4.1.7",
       "requires": {
@@ -53480,7 +53562,8 @@
       "dev": true
     },
     "any-promise": {
-      "version": "1.3.0"
+      "version": "1.3.0",
+      "dev": true
     },
     "anymatch": {
       "version": "3.1.2",
@@ -54490,6 +54573,51 @@
       "version": "1.0.0",
       "dev": true
     },
+    "buble": {
+      "version": "0.19.6",
+      "requires": {
+        "chalk": "^2.4.1",
+        "magic-string": "^0.25.1",
+        "minimist": "^1.2.0",
+        "os-homedir": "^1.0.1",
+        "regexpu-core": "^4.2.0",
+        "vlq": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3"
+        },
+        "has-flag": {
+          "version": "3.0.0"
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "buffer": {
       "version": "5.7.1",
       "requires": {
@@ -55185,6 +55313,12 @@
     "component-emitter": {
       "version": "1.3.0"
     },
+    "component-props": {
+      "version": "1.1.1"
+    },
+    "component-xor": {
+      "version": "0.0.4"
+    },
     "compressible": {
       "version": "2.0.18",
       "dev": true,
@@ -55376,8 +55510,7 @@
       }
     },
     "core-js": {
-      "version": "3.23.5",
-      "dev": true
+      "version": "3.23.5"
     },
     "core-js-compat": {
       "version": "3.19.1",
@@ -56449,6 +56582,13 @@
       "dev": true,
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-iterator": {
+      "version": "1.0.0",
+      "requires": {
+        "component-props": "1.1.1",
+        "component-xor": "0.0.4"
       }
     },
     "dom-serializer": {
@@ -63167,7 +63307,6 @@
     },
     "magic-string": {
       "version": "0.25.7",
-      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -64239,6 +64378,7 @@
     },
     "mz": {
       "version": "2.7.0",
+      "dev": true,
       "requires": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -64879,9 +65019,7 @@
       }
     },
     "os-homedir": {
-      "version": "1.0.2",
-      "dev": true,
-      "optional": true
+      "version": "1.0.2"
     },
     "os-name": {
       "version": "1.0.3",
@@ -66189,6 +66327,19 @@
     "react-lifecycles-compat": {
       "version": "3.0.4"
     },
+    "react-live": {
+      "version": "2.4.1",
+      "requires": {
+        "@types/buble": "^0.20.0",
+        "buble": "0.19.6",
+        "core-js": "^3.14.0",
+        "dom-iterator": "^1.0.0",
+        "prism-react-renderer": "^1.2.1",
+        "prop-types": "^15.7.2",
+        "react-simple-code-editor": "^0.11.0",
+        "unescape": "^1.0.1"
+      }
+    },
     "react-popper": {
       "version": "2.3.0",
       "requires": {
@@ -66246,6 +66397,10 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }
+    },
+    "react-simple-code-editor": {
+      "version": "0.11.3",
+      "requires": {}
     },
     "react-sizeme": {
       "version": "3.0.2",
@@ -67891,8 +68046,7 @@
       "version": "0.4.0"
     },
     "sourcemap-codec": {
-      "version": "1.4.8",
-      "dev": true
+      "version": "1.4.8"
     },
     "space-separated-tokens": {
       "version": "1.1.5"
@@ -68275,6 +68429,7 @@
     },
     "sucrase": {
       "version": "3.25.0",
+      "dev": true,
       "requires": {
         "commander": "^4.0.0",
         "glob": "7.1.6",
@@ -68285,10 +68440,12 @@
       },
       "dependencies": {
         "commander": {
-          "version": "4.1.1"
+          "version": "4.1.1",
+          "dev": true
         },
         "glob": {
           "version": "7.1.6",
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -68595,12 +68752,14 @@
     },
     "thenify": {
       "version": "3.3.1",
+      "dev": true,
       "requires": {
         "any-promise": "^1.0.0"
       }
     },
     "thenify-all": {
       "version": "1.6.0",
+      "dev": true,
       "requires": {
         "thenify": ">= 3.1.0 < 4"
       }
@@ -68859,7 +69018,8 @@
       "dev": true
     },
     "ts-interface-checker": {
-      "version": "0.1.13"
+      "version": "0.1.13",
+      "dev": true
     },
     "ts-node": {
       "version": "10.8.2",
@@ -69207,6 +69367,12 @@
     "unc-path-regex": {
       "version": "0.1.2",
       "dev": true
+    },
+    "unescape": {
+      "version": "1.0.1",
+      "requires": {
+        "extend-shallow": "^2.0.1"
+      }
     },
     "unfetch": {
       "version": "4.2.0",
@@ -69656,6 +69822,9 @@
           }
         }
       }
+    },
+    "vlq": {
+      "version": "1.0.1"
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -43,7 +43,7 @@
     "react-focus-lock": "^2.9.1",
     "react-hook-form": "7.25.3",
     "react-icons": "4.4.0",
-    "react-live": "3.1.1",
+    "react-live": "2.4.1",
     "react-sortable-hoc": "^2.0.0",
     "rehype-slug": "^5.0.1",
     "rehype-toc": "^3.0.2",


### PR DESCRIPTION
This reverts commit e855da1457cfdee1456b9ae623ae9c39c24e5337.

Upgrade seems to have broken the styling of live previews for examples.