### PR TITLE
docs(format-relative-date-time): add docs and example

### DIFF
--- a/packages/components/datetime/examples/FormatRelativeDateTimeExample.tsx
+++ b/packages/components/datetime/examples/FormatRelativeDateTimeExample.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {
+  Stack,
+  Text,
+  formatRelativeDateTime,
+} from '@contentful/f36-components';
+
+export default function FormatRelativeDateTimeExample() {
+  return (
+    <Stack flexDirection="column">
+      {/* passing a JS Date */}
+      <Text>{formatRelativeDateTime('2021-08-17')}</Text>
+      {/* passing a base date to compare to */}
+      <Text>{formatRelativeDateTime('2021-08-17', '2021-08-18')}</Text>
+    </Stack>
+  );
+}

--- a/packages/components/datetime/src/utils/README.mdx
+++ b/packages/components/datetime/src/utils/README.mdx
@@ -15,11 +15,13 @@ The `@contentful/f36-datetime` package provides a couple of functions to format 
 import {
   formatDateAndTime,
   formatMachineReadableDateTime,
+  formatRelativeDateTime,
 } from '@contentful/f36-components';
 // or
 import {
   formatDateAndTime,
   formatMachineReadableDateTime,
+  formatRelativeDateTime,
 } from '@contentful/f36-datetime';
 ```
 
@@ -73,5 +75,15 @@ If no format is passed to the function, it will return a string with the `full` 
 ### Different formats
 
 ```jsx file=../../examples/DifferentFormatMachineReadableDateTimeExample.tsx
+
+```
+
+## formatRelativeDateTime
+
+This function will return a relative date string such as "in a day", "in one month", or "one month ago" when comparing the given date to "now" or to the optional base date.
+
+### Examples
+
+```jsx file=../../examples/FormatRelativeDateTimeExample.tsx
 
 ```


### PR DESCRIPTION
# Purpose of PR

Our `formatRelativeDateTime` function was undocumented, this PR adds some docs and an example file.

I noticed a problem with the table of contents when doing this, the different `### Example` headings all get the same ID in the document structure, which means that the table of contents links all end up pointing to the first example heading. I tried some different things to work around this, but they didn't work with our ToC implementation.

Things I tried:
- using a custom ID in Markdown: `### Example {#custom-id}`
  - tried it with https://github.com/Eyas/md-heading-id/
- using a JSX heading `<h3 id="custom-id">Example</h3>`
- using an anchor inside the heading with custom ID: `###<a id="custom-id"></a>Example`

The last idea is probably something we can get working if we change the implementation of our ToC generation function, so that it ignores the anchor. I did not want to spend the time on it right now 🙂 