### PR TITLE
fix(tooltip): normalise letter spacing and text transform on tooltip

### DIFF
--- a/packages/components/tooltip/src/Tooltip.styles.ts
+++ b/packages/components/tooltip/src/Tooltip.styles.ts
@@ -23,6 +23,8 @@ export function getStyles() {
       padding: `${tokens.spacingXs} calc(1rem * (10 / ${tokens.fontBaseDefault}))`,
       borderRadius: tokens.borderRadiusMedium,
       whiteSpace: 'normal',
+      textTransform: 'initial',
+      letterSpacing: 'initial',
     }),
     tooltipHidden: css({
       visibility: 'hidden',


### PR DESCRIPTION
# Purpose of PR

Set textTransform and letterSpacing to initial value on the Tooltip, to avoid it inheriting the style from parent.

**Before**
<img width="322" alt="image" src="https://user-images.githubusercontent.com/1071799/211604745-6fba5f7b-003e-44b3-8ed3-22d9106c6f08.png">

**After**
<img width="226" alt="image" src="https://user-images.githubusercontent.com/1071799/211605101-502f8c9f-c466-4306-a35d-5e465fbb18fb.png">
