### PR TITLE
fix(copy-button): omit native HTML onCopy prop

### DIFF
--- a/.changeset/metal-suns-dream.md
+++ b/.changeset/metal-suns-dream.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-copybutton": patch
+---
+
+fix(copy-button): omit native HTML onCopy prop

--- a/packages/components/copybutton/src/CopyButton.tsx
+++ b/packages/components/copybutton/src/CopyButton.tsx
@@ -13,7 +13,7 @@ import { cx } from 'emotion';
 
 export type CopyButtonProps = Omit<
   ButtonProps,
-  'children' | 'endIcon' | 'startIcon' | 'isDisabed' | 'size'
+  'children' | 'endIcon' | 'onCopy' | 'startIcon' | 'isDisabed' | 'size'
 > & {
   /**
    * Function that gets called when the button is clicked


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Omit native `onCopy` prop from CopyButton