### PR TITLE
feat: add downward icon [SDK-2498]

### DIFF
--- a/.changeset/happy-chicken-notice.md
+++ b/.changeset/happy-chicken-notice.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-icons': minor
+---
+
+add ArrowDownward Icon

--- a/packages/components/icons/src/ArrowDownward.tsx
+++ b/packages/components/icons/src/ArrowDownward.tsx
@@ -1,0 +1,12 @@
+import React, { Fragment } from 'react';
+import { generateIcon } from '@contentful/f36-icon';
+
+export const ArrowDownward = /*#__PURE__*/ generateIcon({
+  name: 'ArrowDownward',
+  path: (
+    <Fragment>
+      <path d="M13.3333 8.00008L12.3933 7.06008L8.66667 10.7801V2.66675H7.33333L7.33333 10.7801L3.60667 7.06008L2.66667 8.00008L8 13.3334L13.3333 8.00008Z" />
+    </Fragment>
+  ),
+  viewBox: '0 0 16 16',
+});

--- a/packages/components/icons/src/index.ts
+++ b/packages/components/icons/src/index.ts
@@ -17,6 +17,7 @@ export { ArrowForwardTrimmed as ArrowForwardTrimmedIcon } from './ArrowForwardTr
 export { ArrowUp as ArrowUpIcon } from './ArrowUp';
 export { ArrowUpTrimmed as ArrowUpTrimmedIcon } from './ArrowUpTrimmed';
 export { ArrowUpward as ArrowUpwardIcon } from './ArrowUpward';
+export { ArrowDownward as ArrowDownwardIcon } from './ArrowDownward';
 export { Asset as AssetIcon } from './Asset';
 export { AssetTrimmed as AssetTrimmedIcon } from './AssetTrimmed';
 export { Audio as AudioIcon } from './Audio';


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Add the long-missing icon "ArrowDownward" ![Icon=ArrowDownward, Size=Tiny, Color=Secondary](https://user-images.githubusercontent.com/156505/215063240-fcc9e4e1-db34-4302-ae4e-5fdb1234f0a7.svg) to the set of icons. 


<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
