### PR TITLE
feat: add hexToRGBA utility function

### DIFF
--- a/.changeset/happy-beers-sip.md
+++ b/.changeset/happy-beers-sip.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-utils": minor
+---
+
+feat: add hexToRGBA utility function

--- a/packages/components/utils/src/hexToRGBA/hexToRGBA.mdx
+++ b/packages/components/utils/src/hexToRGBA/hexToRGBA.mdx
@@ -1,0 +1,31 @@
+---
+title: 'hexToRGBA'
+type: 'component'
+slug: /utils/hexToRGBA/
+section: 'utils'
+typescript: ./hexToRGBA.ts
+---
+
+`hexToRGBA` is a utility function that converts a hex color to an RGBA color.
+
+## Import
+
+```jsx static=true
+import { hexToRGBA } from '@contentful/f36-utils';
+```
+
+## Example
+
+### Basic usage
+
+```ts
+import tokens from '@contentful/f36-tokens';
+
+const color = hexToRGBA(tokens.colorBlack);
+console.log(color);
+// rgba(0, 0, 0, 1)
+
+const colorWithOpacity = hexToRGBA(tokens.colorBlack, 0.5);
+console.log(colorWithOpacity);
+// rgba(0, 0, 0, 0.5)
+```

--- a/packages/components/utils/src/hexToRGBA/hexToRGBA.test.ts
+++ b/packages/components/utils/src/hexToRGBA/hexToRGBA.test.ts
@@ -8,7 +8,7 @@ describe('hexToRGBA', () => {
   });
 
   it('should return rgba color from tokens', () => {
-    expect(hexToRGBA(tokens.colorBlack)).toBe('rgba(0, 0, 0, 1)');
-    expect(hexToRGBA(tokens.colorBlack, 0.5)).toBe('rgba(0, 0, 0, 0.5)');
+    expect(hexToRGBA(tokens.colorBlack)).toBe('rgba(12, 20, 28, 1)');
+    expect(hexToRGBA(tokens.colorBlack, 0.5)).toBe('rgba(12, 20, 28, 0.5)');
   });
 });

--- a/packages/components/utils/src/hexToRGBA/hexToRGBA.test.ts
+++ b/packages/components/utils/src/hexToRGBA/hexToRGBA.test.ts
@@ -1,0 +1,14 @@
+import { hexToRGBA } from './hexToRGBA';
+import tokens from '@contentful/f36-tokens';
+
+describe('hexToRGBA', () => {
+  it('should return rgba color', () => {
+    expect(hexToRGBA('#000000')).toBe('rgba(0, 0, 0, 1)');
+    expect(hexToRGBA('#000000', 0.5)).toBe('rgba(0, 0, 0, 0.5)');
+  });
+
+  it('should return rgba color from tokens', () => {
+    expect(hexToRGBA(tokens.colorBlack)).toBe('rgba(0, 0, 0, 1)');
+    expect(hexToRGBA(tokens.colorBlack, 0.5)).toBe('rgba(0, 0, 0, 0.5)');
+  });
+});

--- a/packages/components/utils/src/hexToRGBA/hexToRGBA.ts
+++ b/packages/components/utils/src/hexToRGBA/hexToRGBA.ts
@@ -1,0 +1,15 @@
+/**
+ * Converts a hex color to rgba
+ * @param hex - Hex color
+ * @param alpha - Alpha value @default 1
+ * @returns rgba color
+ * @example
+ * hexToRGBA('#000000', 0.5)
+ */
+export function hexToRGBA(hex: string, alpha = 1) {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}

--- a/packages/components/utils/src/index.ts
+++ b/packages/components/utils/src/index.ts
@@ -3,3 +3,4 @@ export type { PortalProps } from './Portal/Portal';
 export { useKeyboard } from './useKeyboard/useKeyboard';
 export type { UseKeyboardProps } from './useKeyboard/useKeyboard';
 export { getStringMatch } from './getStringMatch/getStringMatch';
+export { hexToRGBA } from './hexToRGBA/hexToRGBA';


### PR DESCRIPTION
# Purpose of PR

Add `hexToRGBA` utility function to manipulate tokens opacity

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [ ] ~~Storybook stories are added/updated/not required~~
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
