### PR TITLE
chore: upgrade turbo to 1.7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - node/install-packages
       - run:
           name: Build packages
-          command: npm run-script build
+          command: npm run-script build -- --force
       - persist_to_workspace:
           root: .
           paths:

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "simple-git-hooks": "^2.8.1",
         "size-limit": "^8.1.0",
         "tsup": "^6.2.3",
-        "turbo": "^1.7.0",
+        "turbo": "^1.7.4",
         "typescript": "4.7.3",
         "webpack": "5"
       },
@@ -35573,27 +35573,27 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.7.0.tgz",
-      "integrity": "sha512-cwympNwQNnQZ/TffBd8yT0i0O10Cf/hlxccCYgUcwhcGEb9rDjE5thDbHoHw1hlJQUF/5ua7ERJe7Zr0lNE/ww==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.7.4.tgz",
+      "integrity": "sha512-8RLedDoUL0kkVKWEZ/RMM70BvKLyDFen06QuKKhYC2XNOfNKqFDqzIdcY/vGick869bNIWalChoy4O07k0HLsA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.7.0",
-        "turbo-darwin-arm64": "1.7.0",
-        "turbo-linux-64": "1.7.0",
-        "turbo-linux-arm64": "1.7.0",
-        "turbo-windows-64": "1.7.0",
-        "turbo-windows-arm64": "1.7.0"
+        "turbo-darwin-64": "1.7.4",
+        "turbo-darwin-arm64": "1.7.4",
+        "turbo-linux-64": "1.7.4",
+        "turbo-linux-arm64": "1.7.4",
+        "turbo-windows-64": "1.7.4",
+        "turbo-windows-arm64": "1.7.4"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.7.0.tgz",
-      "integrity": "sha512-hSGAueSf5Ko8J67mpqjpt9FsP6ePn1nMcl7IVPoJq5dHsgX3anCP/BPlexJ502bNK+87DDyhQhJ/LPSJXKrSYQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.7.4.tgz",
+      "integrity": "sha512-ZyYrQlUl8K/mYN1e6R7bEhPPYjMakz0DYMaexkyD7TAijQtWmTSd4a+I7VknOYNEssnUZ/v41GU3gPV1JAzxxQ==",
       "cpu": [
         "x64"
       ],
@@ -35604,9 +35604,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.7.0.tgz",
-      "integrity": "sha512-BLLOW5W6VZxk5+0ZOj5AO1qjM0P5isIgjbEuyAl8lHZ4s9antUbY4CtFrspT32XxPTYoDl4UjviPMcSsbcl3WQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.7.4.tgz",
+      "integrity": "sha512-CKIXg9uqp1a+Yeq/c4U0alPOqvwLUq5SBZf1PGYhGqJsfG0fRBtJfkUjHuBsuJIOGXg8rCmcGSWGIsIF6fqYuw==",
       "cpu": [
         "arm64"
       ],
@@ -35617,9 +35617,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.7.0.tgz",
-      "integrity": "sha512-aw2qxmfZa+kT87SB3GNUoFimqEPzTlzlRqhPgHuAAT6Uf0JHnmebPt4K+ZPtDNl5yfVmtB05bhHPqw+5QV97Yg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.7.4.tgz",
+      "integrity": "sha512-RIUl4RUFFyzD2T024vL7509Ygwcw+SEa8NOwPfaN6TtJHK7RZV/SBP3fLNVOptG9WRLnOWX3OvsLMbiOqDLLyA==",
       "cpu": [
         "x64"
       ],
@@ -35630,9 +35630,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.7.0.tgz",
-      "integrity": "sha512-AJEx2jX+zO5fQtJpO3r6uhTabj4oSA5ZhB7zTs/rwu/XqoydsvStA4X8NDW4poTbOjF7DcSHizqwi04tSMzpJw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.7.4.tgz",
+      "integrity": "sha512-Bg65F0AjYYYxqE6RPf2H5TIGuA/EyWMeGOATHVSZOWAbYcnG3Ly03GZii8AHnUi7ntWBdjwvXf/QbOS1ayNB6A==",
       "cpu": [
         "arm64"
       ],
@@ -35643,9 +35643,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.7.0.tgz",
-      "integrity": "sha512-ewj7PPv2uxqv0r31hgnBa3E5qwUu7eyVRP5M1gB/TJXfSHduU79gbxpKCyxIZv2fL/N2/3U7EPOQPSZxBAoljA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.7.4.tgz",
+      "integrity": "sha512-rTaV50XZ2BRxRHOHqt1UsWfeDmYLbn8UKE6g2D2ED+uW+kmnTvR9s01nmlGWd2sAuWcRYQyQ2V+O09VfKPKcQw==",
       "cpu": [
         "x64"
       ],
@@ -35656,9 +35656,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.7.0.tgz",
-      "integrity": "sha512-LzjOUzveWkvTD0jP8DBMYiAnYemmydsvqxdSmsUapHHJkl6wKZIOQNSO7pxsy+9XM/1/+0f9Y9F9ZNl5lePTEA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.7.4.tgz",
+      "integrity": "sha512-h8sxdKPvHTnWUPtwnYszFMmSO0P/iUUwmYY9n7iYThA71zSao28UeZ0H0Gw75cY3MPjvkjn2C4EBAUGPjuZJLw==",
       "cpu": [
         "arm64"
       ],
@@ -68896,58 +68896,58 @@
       }
     },
     "turbo": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.7.0.tgz",
-      "integrity": "sha512-cwympNwQNnQZ/TffBd8yT0i0O10Cf/hlxccCYgUcwhcGEb9rDjE5thDbHoHw1hlJQUF/5ua7ERJe7Zr0lNE/ww==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.7.4.tgz",
+      "integrity": "sha512-8RLedDoUL0kkVKWEZ/RMM70BvKLyDFen06QuKKhYC2XNOfNKqFDqzIdcY/vGick869bNIWalChoy4O07k0HLsA==",
       "dev": true,
       "requires": {
-        "turbo-darwin-64": "1.7.0",
-        "turbo-darwin-arm64": "1.7.0",
-        "turbo-linux-64": "1.7.0",
-        "turbo-linux-arm64": "1.7.0",
-        "turbo-windows-64": "1.7.0",
-        "turbo-windows-arm64": "1.7.0"
+        "turbo-darwin-64": "1.7.4",
+        "turbo-darwin-arm64": "1.7.4",
+        "turbo-linux-64": "1.7.4",
+        "turbo-linux-arm64": "1.7.4",
+        "turbo-windows-64": "1.7.4",
+        "turbo-windows-arm64": "1.7.4"
       }
     },
     "turbo-darwin-64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.7.0.tgz",
-      "integrity": "sha512-hSGAueSf5Ko8J67mpqjpt9FsP6ePn1nMcl7IVPoJq5dHsgX3anCP/BPlexJ502bNK+87DDyhQhJ/LPSJXKrSYQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.7.4.tgz",
+      "integrity": "sha512-ZyYrQlUl8K/mYN1e6R7bEhPPYjMakz0DYMaexkyD7TAijQtWmTSd4a+I7VknOYNEssnUZ/v41GU3gPV1JAzxxQ==",
       "dev": true,
       "optional": true
     },
     "turbo-darwin-arm64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.7.0.tgz",
-      "integrity": "sha512-BLLOW5W6VZxk5+0ZOj5AO1qjM0P5isIgjbEuyAl8lHZ4s9antUbY4CtFrspT32XxPTYoDl4UjviPMcSsbcl3WQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.7.4.tgz",
+      "integrity": "sha512-CKIXg9uqp1a+Yeq/c4U0alPOqvwLUq5SBZf1PGYhGqJsfG0fRBtJfkUjHuBsuJIOGXg8rCmcGSWGIsIF6fqYuw==",
       "dev": true,
       "optional": true
     },
     "turbo-linux-64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.7.0.tgz",
-      "integrity": "sha512-aw2qxmfZa+kT87SB3GNUoFimqEPzTlzlRqhPgHuAAT6Uf0JHnmebPt4K+ZPtDNl5yfVmtB05bhHPqw+5QV97Yg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.7.4.tgz",
+      "integrity": "sha512-RIUl4RUFFyzD2T024vL7509Ygwcw+SEa8NOwPfaN6TtJHK7RZV/SBP3fLNVOptG9WRLnOWX3OvsLMbiOqDLLyA==",
       "dev": true,
       "optional": true
     },
     "turbo-linux-arm64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.7.0.tgz",
-      "integrity": "sha512-AJEx2jX+zO5fQtJpO3r6uhTabj4oSA5ZhB7zTs/rwu/XqoydsvStA4X8NDW4poTbOjF7DcSHizqwi04tSMzpJw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.7.4.tgz",
+      "integrity": "sha512-Bg65F0AjYYYxqE6RPf2H5TIGuA/EyWMeGOATHVSZOWAbYcnG3Ly03GZii8AHnUi7ntWBdjwvXf/QbOS1ayNB6A==",
       "dev": true,
       "optional": true
     },
     "turbo-windows-64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.7.0.tgz",
-      "integrity": "sha512-ewj7PPv2uxqv0r31hgnBa3E5qwUu7eyVRP5M1gB/TJXfSHduU79gbxpKCyxIZv2fL/N2/3U7EPOQPSZxBAoljA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.7.4.tgz",
+      "integrity": "sha512-rTaV50XZ2BRxRHOHqt1UsWfeDmYLbn8UKE6g2D2ED+uW+kmnTvR9s01nmlGWd2sAuWcRYQyQ2V+O09VfKPKcQw==",
       "dev": true,
       "optional": true
     },
     "turbo-windows-arm64": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.7.0.tgz",
-      "integrity": "sha512-LzjOUzveWkvTD0jP8DBMYiAnYemmydsvqxdSmsUapHHJkl6wKZIOQNSO7pxsy+9XM/1/+0f9Y9F9ZNl5lePTEA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.7.4.tgz",
+      "integrity": "sha512-h8sxdKPvHTnWUPtwnYszFMmSO0P/iUUwmYY9n7iYThA71zSao28UeZ0H0Gw75cY3MPjvkjn2C4EBAUGPjuZJLw==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/components/*"
   ],
   "scripts": {
-    "build": "turbo run build --force",
+    "build": "turbo run build",
     "commit": "git-cz",
     "commitmsg": "validate-commit-msg",
     "generate": "plop --plopfile scripts/plopfile.js",
@@ -116,7 +116,7 @@
     "simple-git-hooks": "^2.8.1",
     "size-limit": "^8.1.0",
     "tsup": "^6.2.3",
-    "turbo": "^1.7.0",
+    "turbo": "^1.7.4",
     "typescript": "4.7.3",
     "webpack": "5"
   },


### PR DESCRIPTION
# Purpose of PR

Bump turbo to `1.7.4`
Move `--force` to circleci config to enable running commands per package using `--filter`

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
