### PR TITLE
fix: replace placeImg with static image on Asset examples

### DIFF
--- a/packages/components/asset/examples/ArchivedAssetExample.tsx
+++ b/packages/components/asset/examples/ArchivedAssetExample.tsx
@@ -4,7 +4,7 @@ import { Asset } from '@contentful/f36-components';
 export default function ArchivedAssetExample() {
   return (
     <Asset
-      src="https://placeimg.com/200/300/animals"
+      src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=200&h=300"
       status="archived"
       title="An archived image asset"
       type="image"

--- a/packages/components/asset/examples/AssetExample.tsx
+++ b/packages/components/asset/examples/AssetExample.tsx
@@ -4,7 +4,7 @@ import { Asset } from '@contentful/f36-components';
 export default function AssetExample() {
   return (
     <Asset
-      src="https://placeimg.com/200/300/animals"
+      src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=200&h=300"
       title="A PDF asset"
       type="pdf"
     />

--- a/packages/components/asset/examples/ImageAssetExample.tsx
+++ b/packages/components/asset/examples/ImageAssetExample.tsx
@@ -4,7 +4,7 @@ import { Asset } from '@contentful/f36-components';
 export default function ImageAssetExample() {
   return (
     <Asset
-      src="https://placeimg.com/200/300/animals"
+      src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=200&h=300"
       title="An image asset"
       type="image"
     />


### PR DESCRIPTION
# Purpose of PR

Replace usage of placeimg with asset from Contentful's image service on Asset examples