### PR TITLE
feat(font-stack): add system-ui

### DIFF
--- a/packages/forma-36-tokens/src/tokens/typography/font-stack.js
+++ b/packages/forma-36-tokens/src/tokens/typography/font-stack.js
@@ -1,8 +1,8 @@
 const fontStack = {
   'font-stack-primary':
-    '-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol',
+    'system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol',
   'font-stack-monospace':
-    'SFMono-Regular, Consolas, Liberation Mono, Menlo,monospace',
+    'SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace',
 };
 
 module.exports = fontStack;

--- a/packages/forma-36-tokens/src/tokens/typography/font-stack.js
+++ b/packages/forma-36-tokens/src/tokens/typography/font-stack.js
@@ -1,6 +1,6 @@
 const fontStack = {
   'font-stack-primary':
-    'system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol',
+    'system-ui, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol',
   'font-stack-monospace':
     'SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace',
 };


### PR DESCRIPTION
# Purpose of PR

Chrome on Linux doesn't seem to render our medium font weight properly. This seems to be caused by issues with the browser on that plaform: 
- https://bugs.launchpad.net/ubuntu/+source/fonts-ubuntu/+bug/1512111
- https://stackoverflow.com/questions/53027044/why-is-chrome-on-linux-displaying-the-wrong-font-weight
- https://stackoverflow.com/questions/22001035/font-weight-ignored-in-chrome

This is the same bug as #1322

This PR adds `system-ui` to our font stack to see if that helps.