### PR TITLE
fix(docs): remove flex styles from live preview wrapper

### DIFF
--- a/packages/website/components/LiveEditor/ComponentSource.tsx
+++ b/packages/website/components/LiveEditor/ComponentSource.tsx
@@ -75,12 +75,6 @@ const styles = {
     font-family: ${tokens.fontStackPrimary};
     border-radius: ${tokens.borderRadiusMedium} ${tokens.borderRadiusMedium} 0 0 !important;
   `,
-  previewWrapper: css({
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-  }),
   floatingPanel: css`
     position: absolute;
     bottom: ${tokens.spacingS};
@@ -161,7 +155,7 @@ export function ComponentSource({
         scope={liveProviderScope}
       >
         <Card className={styles.card}>
-          <LivePreview className={styles.previewWrapper} />
+          <LivePreview />
         </Card>
         <div style={{ position: 'relative' }}>
           <LiveError className={styles.error} />


### PR DESCRIPTION
# Purpose of PR

Reason: [Skeleton](https://f36.contentful.com/components/skeleton#__next) isn't working on Safari

Currently we're using display flex on live preview wrapper to center all examples in the middle. This however sometimes breaks the default behaviour of components e.g. Skeletons works well when displayed in `div: block` but when within flex component the svg needs a fixed height.

IMO, we should display examples as it would be rendered in a normal div as a wrapper.

The cost here is that live examples won't be aligned to the center, which I believe is fine and even looks better to my eyes 


## PR Checklist


- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Doesn't contain any sensitive information
