### PR TITLE
fix: badge letter casing

### DIFF
--- a/packages/components/badge/src/Badge/Badge.styles.ts
+++ b/packages/components/badge/src/Badge/Badge.styles.ts
@@ -79,5 +79,9 @@ export const getBadgeStyles = () => ({
   badgeText: css({
     color: 'currentcolor',
     lineHeight: 'inherit',
+    textTransform: 'lowercase',
+    '::first-letter': {
+      textTransform: 'uppercase',
+    },
   }),
 });

--- a/packages/components/badge/src/EntityStatusBadge/EntityStatusBadge.tsx
+++ b/packages/components/badge/src/EntityStatusBadge/EntityStatusBadge.tsx
@@ -19,26 +19,15 @@ export interface EntityStatusBadgeProps
   entityStatus: EntityStatus;
 }
 
-const getStyle = () => ({
-  capitalizeStatus: css({ textTransform: 'capitalize' }),
-});
-
 function EntityStatusBadge(
   props: EntityStatusBadgeProps,
   ref: React.Ref<HTMLDivElement>,
 ) {
   const { entityStatus, size = 'default', ...otherProps } = props;
-  const styles = getStyle();
 
   const variant = statusMap[entityStatus];
   return (
-    <Badge
-      {...otherProps}
-      size={size}
-      variant={variant}
-      ref={ref}
-      className={styles.capitalizeStatus}
-    >
+    <Badge {...otherProps} size={size} variant={variant} ref={ref}>
       {entityStatus}
     </Badge>
   );

--- a/packages/components/badge/src/EntityStatusBadge/EntityStatusBadge.tsx
+++ b/packages/components/badge/src/EntityStatusBadge/EntityStatusBadge.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { css } from 'emotion';
 import type { EntityStatus, ExpandProps } from '@contentful/f36-core';
 
 import { Badge, type BadgeProps } from '../Badge/Badge';


### PR DESCRIPTION
# Purpose of PR

> I noticed that we (recently I believe) removed the uppercase conversion on the Badge element that we were previously doing, I assume intentionally.
One small unintended side effect is that it exposes inconsistent casing in the underlying text which never used to matter since it wasn't visibile. Case in point on the Forma 36 website itself:
Main section shows Title case, sidebar is lower case.

Sentence case is what we want to enforce

![image](https://user-images.githubusercontent.com/6163988/225056832-2af6b674-dce0-4d90-a5ec-5b550c6c5727.png)


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
