### PR TITLE
fix(copy-button): copy in environments without clipboard API permission

### DIFF
--- a/.changeset/bright-bugs-drum.md
+++ b/.changeset/bright-bugs-drum.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-copybutton": patch
+---
+
+fix(copy-button): copy in environments without clipboard API permission

--- a/packages/components/copybutton/src/CopyButton.tsx
+++ b/packages/components/copybutton/src/CopyButton.tsx
@@ -89,7 +89,23 @@ function _CopyButton(
     try {
       await window.navigator.clipboard.writeText(value);
     } catch (error) {
-      console.error(error);
+      // Chrome requires specific permissions on iframes using the async clipboard
+      // API. We can't control that so we fall back to this
+      const input = document.createElement('input');
+      input.style.display = 'none';
+      document.body.appendChild(input);
+      input.value = value;
+      input.focus();
+      input.select();
+      const result = document.execCommand('copy');
+
+      // @ts-expect-error -- The return type of `execCommand` can also be string
+      if (result === 'unsuccessful') {
+        // eslint-disable-next-line no-console
+        console.error('Failed to copy text.');
+      }
+      input.remove();
+
       return;
     }
 

--- a/packages/components/copybutton/src/CopyButton.tsx
+++ b/packages/components/copybutton/src/CopyButton.tsx
@@ -101,8 +101,7 @@ function _CopyButton(
 
       // @ts-expect-error -- The return type of `execCommand` can also be string
       if (result === 'unsuccessful') {
-        // eslint-disable-next-line no-console
-        console.error('Failed to copy text.');
+        throw new Error('Unable to copy value', { cause: result });
       }
       input.remove();
 


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Adds a fallback copy method for the async clipboard API to fix an issue where Chrome would not let the `CopyButton` copy in iframes without the `allow="clipboard-write"` attribute. We currently have a lot of these iframes since they render apps. 