### PR TITLE
fix(modal): remove modal initial focus timeout

### DIFF
--- a/.changeset/twenty-ducks-confess.md
+++ b/.changeset/twenty-ducks-confess.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-modal': minor
+---
+
+Focussing child elements should not use an arbitrary timeout

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -76,6 +76,13 @@ module.exports = {
     'rulesdir/emotion-in-function': 'error',
   },
   overrides: [
+    // allow specific rules in example files so there are no eslint-disable comments in code playgrounds
+    {
+      files: ['**/examples/**/*'],
+      rules: {
+        'jsx-a11y/no-autofocus': 'off',
+      },
+    },
     {
       files: ['**/*.stories.*'],
       rules: {

--- a/packages/components/modal/examples/ModalAutoFocusExample.tsx
+++ b/packages/components/modal/examples/ModalAutoFocusExample.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import {
+  Button,
+  Modal,
+  FormControl,
+  TextInput,
+} from '@contentful/f36-components';
+
+export default function ModalAutoFocusExample() {
+  const [isShown, setShown] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setShown(true)}>Create new content type</Button>
+      <Modal onClose={() => setShown(false)} isShown={isShown}>
+        {() => (
+          <>
+            <Modal.Header
+              title="Create new content type"
+              onClose={() => setShown(false)}
+            />
+            <Modal.Content>
+              <FormControl>
+                <FormControl.Label isRequired>Name</FormControl.Label>
+                <TextInput
+                  autoFocus
+                  maxLength={20}
+                  placeholder="For example Product, Blog Post, Author"
+                />
+              </FormControl>
+            </Modal.Content>
+          </>
+        )}
+      </Modal>
+    </>
+  );
+}

--- a/packages/components/modal/examples/ModalInitialFocusRefExample.tsx
+++ b/packages/components/modal/examples/ModalInitialFocusRefExample.tsx
@@ -6,17 +6,14 @@ import {
   TextInput,
 } from '@contentful/f36-components';
 
-export default function ModalInitialFocusExample() {
+export default function ModalInitialFocusRefExample() {
   const [isShown, setShown] = useState(false);
-  const [contentTypeName, setContentTypeName] = useState('');
   const inputRef = useRef();
   return (
     <>
       <Button onClick={() => setShown(true)}>Create new content type</Button>
       <Modal
         onClose={() => setShown(false)}
-        shouldCloseOnOverlayClick
-        shouldCloseOnEscapePress
         isShown={isShown}
         initialFocusRef={inputRef}
       >
@@ -32,11 +29,7 @@ export default function ModalInitialFocusExample() {
                 <TextInput
                   ref={inputRef}
                   maxLength={20}
-                  value={contentTypeName}
                   placeholder="For example Product, Blog Post, Author"
-                  onChange={(e) => {
-                    setContentTypeName(e.target.value);
-                  }}
                 />
               </FormControl>
             </Modal.Content>

--- a/packages/components/modal/src/Modal.test.tsx
+++ b/packages/components/modal/src/Modal.test.tsx
@@ -1,17 +1,8 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { axe } from '@/scripts/test/axeHelper';
 
 import { Modal } from './Modal';
-
-jest.mock(
-  'react-modal',
-  () =>
-    // eslint-disable-next-line
-    function ReactModalMock({ children }: { children: React.ReactNode }) {
-      return <div className="react-modal">{children}</div>;
-    },
-);
 
 it('has no a11y issues', async () => {
   const { container } = render(
@@ -26,4 +17,68 @@ it('has no a11y issues', async () => {
   const results = await axe(container);
 
   expect(results).toHaveNoViolations();
+});
+
+it('should focus Close button', async () => {
+  const onAfterOpen = jest.fn();
+  render(
+    <Modal
+      title="Modal with no initial focus element"
+      isShown
+      onClose={() => {}}
+      onAfterOpen={onAfterOpen}
+    >
+      Content
+    </Modal>,
+  );
+
+  await waitFor(() => expect(onAfterOpen).toHaveBeenCalledTimes(1));
+  expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus();
+});
+
+it('should focus initialFocusRef element', async () => {
+  const onAfterOpen = jest.fn();
+
+  const Test = () => {
+    const ref = React.useRef();
+    return (
+      <Modal
+        title="Modal with initialFocusRef"
+        isShown
+        onClose={() => {}}
+        onAfterOpen={onAfterOpen}
+        initialFocusRef={ref}
+      >
+        <button type="button" ref={ref}>
+          Test button
+        </button>
+      </Modal>
+    );
+  };
+
+  render(<Test />);
+
+  await waitFor(() => expect(onAfterOpen).toHaveBeenCalledTimes(1));
+  expect(screen.getByRole('button', { name: 'Test button' })).toHaveFocus();
+});
+
+it('should focus element with native autoFocus attribute', async () => {
+  const onAfterOpen = jest.fn();
+
+  render(
+    <Modal
+      title="Modal with native autoFocus attribute"
+      isShown
+      onClose={() => {}}
+      onAfterOpen={onAfterOpen}
+    >
+      {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+      <button type="button" autoFocus>
+        Test button
+      </button>
+    </Modal>,
+  );
+
+  await waitFor(() => expect(onAfterOpen).toHaveBeenCalledTimes(1));
+  expect(screen.getByRole('button', { name: 'Test button' })).toHaveFocus();
 });

--- a/packages/components/modal/src/Modal.tsx
+++ b/packages/components/modal/src/Modal.tsx
@@ -143,19 +143,32 @@ export const Modal = ({
     overlayClassName: otherProps.overlayProps?.className,
   });
 
-  React.useEffect(() => {
-    if (props.isShown) {
-      setTimeout(() => {
-        if (props.initialFocusRef && props.initialFocusRef.current) {
-          if (props.initialFocusRef.current.focus) {
-            props.initialFocusRef.current.focus();
-          }
-        } else if (contentRef.current) {
-          focusFirstWithinNode(contentRef.current);
-        }
-      }, 100);
+  const onInitialFocus = () => {
+    const contentEl = contentRef.current;
+    if (contentEl) {
+      const activeEl = document.activeElement;
+      const isContentContainsActive =
+        contentEl !== activeEl && contentEl.contains(activeEl);
+
+      if (isContentContainsActive) {
+        return;
+      }
     }
-  }, [props.isShown, props.initialFocusRef]);
+
+    const initialFocusEl = props.initialFocusRef?.current;
+    if (initialFocusEl) {
+      initialFocusEl.focus?.();
+    } else if (contentEl) {
+      focusFirstWithinNode(contentEl);
+    }
+  };
+
+  const onAfterOpen: ModalProps['onAfterOpen'] = (...args) => {
+    if (props.onAfterOpen) {
+      props.onAfterOpen(...args);
+    }
+    onInitialFocus();
+  };
 
   const renderDefault = () => {
     return (
@@ -180,7 +193,7 @@ export const Modal = ({
       aria={aria}
       onRequestClose={props.onClose}
       isOpen={otherProps.isShown}
-      onAfterOpen={props.onAfterOpen}
+      onAfterOpen={onAfterOpen}
       shouldCloseOnEsc={shouldCloseOnEscapePress}
       shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
       shouldFocusAfterRender

--- a/packages/components/modal/src/README.mdx
+++ b/packages/components/modal/src/README.mdx
@@ -61,9 +61,17 @@ As a rule of thumb, `fullWidth` modals shouldn’t be used frequently. Use them 
 
 ### Setting initial focus
 
-When the modal opens, focus is automatically set to the close button but you have a possibility to set an initial focus to a specific element of your modal dialog.
+When the modal opens, focus is automatically set to the close button, but you have the possibility to set an initial focus to a specific element of your modal dialog.
 
-```jsx file=../examples/ModalInitialFocusExample.tsx
+Either by using the `initialFocusRef` prop:
+
+```jsx file=../examples/ModalInitialFocusRefExample.tsx
+
+```
+
+... or by setting the `autoFocus` attribute to an interactive element, such as an `input` or `button`:
+
+```jsx file=../examples/ModalAutoFocusExample.tsx
 
 ```
 


### PR DESCRIPTION
# Purpose of PR

- remove an arbitrary timeout before making initial focus
- check if the already focused element is a descendant of modal element (allows to use native `autoFocus` for initial focus)

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
