### PR TITLE
fix: improve Menu & Popover onBlur handler

### DIFF
--- a/.changeset/fast-colts-joke.md
+++ b/.changeset/fast-colts-joke.md
@@ -1,0 +1,6 @@
+---
+'@contentful/f36-menu': minor
+'@contentful/f36-popover': minor
+---
+
+Improve Popover and Menu components onBlur logic. So when a user clicks outside of the document or uses some browser features, like search (with cmd/ctrl+F combination) the dropdown is not collapsing. It's also handy for developers if they want to debug dropdown content.

--- a/packages/components/menu/src/Menu.tsx
+++ b/packages/components/menu/src/Menu.tsx
@@ -200,7 +200,8 @@ export function Menu(props: MenuProps) {
             return;
           }
 
-          const relatedTarget = event.relatedTarget as Node;
+          const activeElement = document.activeElement;
+          const relatedTarget = event.relatedTarget || activeElement;
 
           const targetIsMenu =
             menuListRef.current === relatedTarget ||

--- a/packages/components/popover/src/Popover.tsx
+++ b/packages/components/popover/src/Popover.tsx
@@ -232,7 +232,8 @@ export function Popover(props: ExpandProps<PopoverProps>) {
             return;
           }
 
-          const relatedTarget = event.relatedTarget as Node;
+          const activeElement = document.activeElement;
+          const relatedTarget = event.relatedTarget || activeElement;
 
           const targetIsPopover =
             popoverElement === relatedTarget ||


### PR DESCRIPTION
# Purpose of PR

- Improve `Popover` and `Menu` components `onBlur` logic.  So when a user clicks outside of the document or uses some browser features, like search (with `cmd/ctrl+F` combination) the dropdown is not collapsing. It's also handy for developers if they want to debug dropdown content.

I've tested it in Safari, Firefox & Chrome. And encourage you to do the same 🙂

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support).
- [x] Doesn't contain any sensitive information
