### PR TITLE
fix(entity-status-badge): use secondary variant for Archived

### DIFF
--- a/.changeset/beige-experts-hug.md
+++ b/.changeset/beige-experts-hug.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-badge": patch
+---
+
+fix(entity-status-badge): use secondary Badge variant for Archived

--- a/packages/components/badge/src/EntityStatusBadge/EntityStatusBadge.tsx
+++ b/packages/components/badge/src/EntityStatusBadge/EntityStatusBadge.tsx
@@ -7,7 +7,7 @@ import type { BadgeVariant } from '../types';
 const statusMap: { [key in EntityStatus]: BadgeVariant } = {
   published: 'positive',
   draft: 'warning',
-  archived: 'negative',
+  archived: 'secondary',
   changed: 'primary',
   deleted: 'negative',
   new: 'primary-filled',


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Changes Archived status from `negative` variant to `secondary`.