### PR TITLE
fix: remove underline from badge when hovered on sidebar

### DIFF
--- a/packages/website/components/SidebarLink.tsx
+++ b/packages/website/components/SidebarLink.tsx
@@ -19,7 +19,7 @@ const styles = {
     fontSize: tokens.fontSizeM,
     lineHeight: tokens.lineHeightM,
     textDecoration: 'none',
-    '&:hover span:first-child': {
+    '&:hover > span:first-child': {
       textDecoration: 'underline',
     },
   }),


### PR DESCRIPTION
# Purpose of PR

Fix badge also having underline when link is hovered on the sidebar