### PR TITLE
fix: close modal when clicking outside closely

### DIFF
--- a/.changeset/cold-baboons-jog.md
+++ b/.changeset/cold-baboons-jog.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-modal": patch
+---
+
+fix: close modal when clicking outside closely

--- a/packages/components/modal/src/Modal.styles.ts
+++ b/packages/components/modal/src/Modal.styles.ts
@@ -12,7 +12,6 @@ export function getModalStyles(props: {
 }) {
   const modal = cx(
     css({
-      margin: tokens.spacing2Xl,
       backgroundColor: tokens.colorWhite,
       borderRadius: props.size === 'zen' ? 0 : tokens.borderRadiusMedium,
       boxShadow: tokens.boxShadowHeavy,

--- a/packages/components/modal/src/Modal.styles.ts
+++ b/packages/components/modal/src/Modal.styles.ts
@@ -87,6 +87,7 @@ export function getModalStyles(props: {
           overflowY: 'auto',
           backgroundColor: 'rgba(12, 20, 28, 0.74902)',
           textAlign: 'center',
+          padding: tokens.spacing2Xl,
         }),
         props.position === 'center'
           ? css({


### PR DESCRIPTION
## Purpose of PR

### Expected behaviour
When clicking outside the modal content, the modal should close.

### Actual behaviour
When clicking close to the modal content edges, the modal doesn't close


https://user-images.githubusercontent.com/6163988/234340673-77ce3163-dfac-4f07-93aa-22177ce563bc.mov



## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
