### PR TITLE
feat: add subtitle prop to Modal

### DIFF
--- a/.changeset/large-mangos-do.md
+++ b/.changeset/large-mangos-do.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-modal": minor
+---
+
+feat: add subtitle prop to Modal

--- a/packages/components/modal/examples/ModalBasicExample.tsx
+++ b/packages/components/modal/examples/ModalBasicExample.tsx
@@ -10,7 +10,11 @@ export default function ModalBasicExample() {
       <Modal onClose={() => setShown(false)} isShown={isShown}>
         {() => (
           <>
-            <Modal.Header title="Modal title" onClose={() => setShown(false)} />
+            <Modal.Header
+              title="Modal title"
+              subtitle="subtitle"
+              onClose={() => setShown(false)}
+            />
             <Modal.Content>
               <Heading>
                 First entry published! It can now be fetched via the APIs

--- a/packages/components/modal/src/Modal.tsx
+++ b/packages/components/modal/src/Modal.tsx
@@ -63,6 +63,10 @@ export interface ModalProps extends CommonProps {
    */
   title?: string;
   /**
+   * Modal subtitle that is used in header
+   */
+  subtitle?: string;
+  /**
    * Size of the modal window
    * @default medium
    */
@@ -177,6 +181,7 @@ export const Modal = ({
         {otherProps.title && (
           <ModalHeader
             title={otherProps.title}
+            subtitle={otherProps.subtitle}
             onClose={props.onClose}
             {...otherProps.modalHeaderProps}
           />

--- a/packages/components/modal/src/ModalHeader/ModalHeader.tsx
+++ b/packages/components/modal/src/ModalHeader/ModalHeader.tsx
@@ -43,7 +43,7 @@ export const ModalHeader = ({
       <Subheading as="h2" isTruncated marginBottom="none">
         {title}
         {subtitle && (
-          <Text marginLeft="spacingXs" color="gray700">
+          <Text marginLeft="spacingXs" fontColor="gray700">
             {subtitle}
           </Text>
         )}

--- a/packages/components/modal/src/ModalHeader/ModalHeader.tsx
+++ b/packages/components/modal/src/ModalHeader/ModalHeader.tsx
@@ -7,12 +7,13 @@ import {
   type CommonProps,
 } from '@contentful/f36-core';
 import { Button } from '@contentful/f36-button';
-import { Subheading } from '@contentful/f36-typography';
+import { Text, Subheading } from '@contentful/f36-typography';
 
 import { getModalHeaderStyles } from './ModalHeader.styles';
 
 interface ModalHeaderInternalProps extends CommonProps {
   title: string;
+  subtitle?: string;
   onClose?: Function;
 }
 
@@ -24,6 +25,7 @@ export type ModalHeaderProps = PropsWithHTMLElement<
 export const ModalHeader = ({
   onClose,
   title,
+  subtitle,
   testId = 'cf-ui-modal-header',
   className,
   ...otherProps
@@ -40,6 +42,11 @@ export const ModalHeader = ({
     >
       <Subheading as="h2" isTruncated marginBottom="none">
         {title}
+        {subtitle && (
+          <Text marginLeft="spacingXs" color="grey700">
+            {subtitle}
+          </Text>
+        )}
       </Subheading>
       {onClose && (
         <Flex alignItems="center" className={styles.buttonContainer}>

--- a/packages/components/modal/src/ModalHeader/ModalHeader.tsx
+++ b/packages/components/modal/src/ModalHeader/ModalHeader.tsx
@@ -43,7 +43,7 @@ export const ModalHeader = ({
       <Subheading as="h2" isTruncated marginBottom="none">
         {title}
         {subtitle && (
-          <Text marginLeft="spacingXs" color="grey700">
+          <Text marginLeft="spacingXs" color="gray700">
             {subtitle}
           </Text>
         )}

--- a/packages/components/modal/stories/Modal.stories.tsx
+++ b/packages/components/modal/stories/Modal.stories.tsx
@@ -73,6 +73,7 @@ export const Basic: Story<ModalProps> = (props) => {
 
 Basic.args = {
   title: 'Default modal',
+  subtitle: 'Subtitle',
 };
 
 export const LongModal: Story<ModalProps> = (props) => {


### PR DESCRIPTION
# Purpose of PR

Add subtitle prop to Modal


<img width="568" alt="Screenshot 2023-05-10 at 17 42 26" src="https://github.com/contentful/forma-36/assets/6163988/febaed4c-65bc-4247-a08a-6a3ea399d866">

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
