### PR TITLE
docs(entity-status-badge): remove content guidelines

### DIFF
--- a/packages/components/badge/src/EntityStatusBadge/README.mdx
+++ b/packages/components/badge/src/EntityStatusBadge/README.mdx
@@ -66,13 +66,3 @@ Some entities have scheduled actions, for instance an entry might be scheduled t
 ## Props (API reference)
 
 <PropsTable of="EntityStatusBadge" />
-
-## Content guidelines
-
-- try to use labels with short, scannable text
-- try to use a single word to describe the status of an element
-- try to describe the status in the past tense, like changed or archived
-
-## Accessibility
-
-- text must be clear enough for color-blind users to be able to understand immediately without needing to rely only on the color.


### PR DESCRIPTION
# Purpose of PR

Removing content and accessibility guidelines from the EntityStatusBadge readme since this is all hardcoded for this component anyway.