### PR TITLE
fix(button): retain transparent button focus background

### DIFF
--- a/.changeset/stupid-readers-heal.md
+++ b/.changeset/stupid-readers-heal.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-button": patch
+---
+
+fix(button): keep transparent button focus background

--- a/packages/components/button/src/Button/Button.styles.ts
+++ b/packages/components/button/src/Button/Button.styles.ts
@@ -117,18 +117,15 @@ const variantToStyles = (variant: ButtonVariant): CSSObject => {
       };
     case 'transparent':
       return {
-        color: tokens.gray800,
+        color: tokens.gray900,
         background: 'none',
         borderColor: 'transparent',
         boxShadow: 'none',
         '&:hover': {
           backgroundColor: hexToRGBA(tokens.gray900, 0.05),
-          color: tokens.gray900,
         },
         '&:active': variantActiveStyles(variant),
         '&:focus': {
-          backgroundColor: hexToRGBA(tokens.gray900, 0.05),
-          color: tokens.gray900,
           boxShadow: tokens.glowPrimary,
         },
         '&:focus:not(:focus-visible)': {


### PR DESCRIPTION
# Purpose of PR

The transparent button should keep the background as `none` when focused, only difference should be the outline. Have a look at https://forma-36-git-fix-transparent-button-hover.colorfuldemo.com/components/button#variants

![image](https://github.com/contentful/forma-36/assets/219017/fac536e4-7e7f-47a4-a345-2de0422df602)
