### PR TITLE
feat: add a 'role' prop for icon elements

### DIFF
--- a/packages/components/icon/src/Icon.tsx
+++ b/packages/components/icon/src/Icon.tsx
@@ -115,6 +115,7 @@ export function _Icon<E extends React.ElementType = IconComponent>(
     children,
     className,
     variant = 'primary',
+    role = 'img',
     size = 'small',
     testId = 'cf-ui-icon',
     trimmed,
@@ -134,6 +135,7 @@ export function _Icon<E extends React.ElementType = IconComponent>(
     ),
     ref: forwardedRef,
     testId,
+    role,
   };
 
   const ariaHiddenProps = useAriaHidden(otherProps);


### PR DESCRIPTION
# Purpose of PR

Adding a `role` prop for image components adds a `aria-role` attribute, which not only increases the accessibility, but also allows us to use `findByRole` queries in tests to find image elements.