### PR TITLE
fix: small Select padding

### DIFF
--- a/.changeset/large-hotels-wait.md
+++ b/.changeset/large-hotels-wait.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-forms': minor
+---
+
+Fix text overlapping for small Selects

--- a/.changeset/large-hotels-wait.md
+++ b/.changeset/large-hotels-wait.md
@@ -2,4 +2,4 @@
 '@contentful/f36-forms': minor
 ---
 
-Fix text overlapping for small Selects
+- Fix text overlapping for small Selects

--- a/packages/components/forms/src/Select/Select.styles.ts
+++ b/packages/components/forms/src/Select/Select.styles.ts
@@ -5,7 +5,7 @@ export function getSelectStyles({ isInvalid, isDisabled, size }) {
   const sizeStyles =
     size === 'small'
       ? {
-          padding: `${tokens.spacing2Xs} ${tokens.spacingXs}`,
+          padding: `${tokens.spacing2Xs} ${tokens.spacingL} ${tokens.spacing2Xs} ${tokens.spacingXs}`,
           height: '32px',
         }
       : {


### PR DESCRIPTION
# Purpose of PR
Small Selects had incorrect padding, which was causing long text to overlap with the chevron
Before:
<img width="209" alt="image" src="https://github.com/contentful/forma-36/assets/101652314/5001c634-691b-48a4-9119-1094b259128a">

After:
<img width="208" alt="image" src="https://github.com/contentful/forma-36/assets/101652314/ce3dc504-344b-492c-94d1-1086f63055af">
