### PR TITLE
feat: Introduce new properties for the Avatar component [HOMER-2119]

### DIFF
--- a/packages/components/avatar/README.mdx
+++ b/packages/components/avatar/README.mdx
@@ -44,7 +44,7 @@ The Avatar can be rendered in different sizes:
 
 ### Show Color Borders
 
-The Avatar can be rendered with outline colors, the color is determined by the position of the Avatar
+The Avatar can be rendered with outline colors, the color is determined by the position of the Avatar. There are 6 different colors: green, red, yellow, orange, purple and gray
 
 ```jsx file=./examples/AvatarColorBorderExamples.tsx
 
@@ -60,7 +60,7 @@ The Avatar can be rendered with a special color border reserved for the current 
 
 ### IsActive
 
-This property modifies the opacity of the Avatar component when is not active
+This property modifies the opacity of the Avatar component when it is not active
 
 ```jsx file=./examples/AvatarIsActiveExamples.tsx
 

--- a/packages/components/avatar/README.mdx
+++ b/packages/components/avatar/README.mdx
@@ -33,7 +33,7 @@ The Avatar can be rendered in different variants:
 
 The Avatar can be rendered in different sizes:
 
-- **tiny** - 20px
+- **Tiny** - 20px
 - **Small** - 24px
 - **Medium** - 32px, default size
 - **Large** - 48px

--- a/packages/components/avatar/README.mdx
+++ b/packages/components/avatar/README.mdx
@@ -50,6 +50,30 @@ The Avatar can be rendered with outline colors, the color is determined by the p
 
 ```
 
+### IsPrimary
+
+The Avatar can be rendered with a special color border reserved for the current user
+
+```jsx file=./examples/AvatarIsPrimaryExamples.tsx
+
+```
+
+### IsActive
+
+This property modifies the opacity of the Avatar component when is not active
+
+```jsx file=./examples/AvatarIsActiveExamples.tsx
+
+```
+
+### Icons
+
+An Avatar can display an icon on top of the image
+
+```jsx file=./examples/AvatarIconExamples.tsx
+
+```
+
 ### Fallback
 
 In some cases a user or an app will have no avatar to display. Instead, a fallback can be rendered when the `src` property is undefined (or an empty string `""`) and the loading state is not `true`.

--- a/packages/components/avatar/README.mdx
+++ b/packages/components/avatar/README.mdx
@@ -22,8 +22,8 @@ import { Avatar, Size, Variant } from '@contentful/f36-avatar';
 
 The Avatar can be rendered in different variants:
 
-- **User** - default variant
-- **App** - default variant
+- **user** - default variant
+- **app** - default variant
 
 ```jsx file=./examples/AvatarVariantExample.tsx
 
@@ -33,12 +33,20 @@ The Avatar can be rendered in different variants:
 
 The Avatar can be rendered in different sizes:
 
-- **Tiny** - 20px
-- **Small** - 24px
-- **Medium** - 32px, default size
-- **Large** - 48px
+- **tiny** - 20px
+- **small** - 24px
+- **medium** - 32px, default size
+- **large** - 48px
 
 ```jsx file=./examples/AvatarSizeExample.tsx
+
+```
+
+### Show Color Borders
+
+The Avatar can be rendered with outline colors, the color is determined by the position of the Avatar
+
+```jsx file=./examples/AvatarColorBorderExamples.tsx
 
 ```
 

--- a/packages/components/avatar/README.mdx
+++ b/packages/components/avatar/README.mdx
@@ -22,8 +22,8 @@ import { Avatar, Size, Variant } from '@contentful/f36-avatar';
 
 The Avatar can be rendered in different variants:
 
-- **user** - default variant
-- **app** - default variant
+- **User** - default variant
+- **App** - default variant
 
 ```jsx file=./examples/AvatarVariantExample.tsx
 
@@ -34,15 +34,15 @@ The Avatar can be rendered in different variants:
 The Avatar can be rendered in different sizes:
 
 - **tiny** - 20px
-- **small** - 24px
-- **medium** - 32px, default size
-- **large** - 48px
+- **Small** - 24px
+- **Medium** - 32px, default size
+- **Large** - 48px
 
 ```jsx file=./examples/AvatarSizeExample.tsx
 
 ```
 
-### Show Color Borders
+### Show Color Border
 
 The Avatar can be rendered with outline colors, the color is determined by the position of the Avatar. There are 6 different colors: green, red, yellow, orange, purple and gray
 

--- a/packages/components/avatar/examples/AvatarColorBorderExamples.tsx
+++ b/packages/components/avatar/examples/AvatarColorBorderExamples.tsx
@@ -7,12 +7,26 @@ export default function AvatarVariantsExample() {
     <Stack>
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
-        variant="user"
+        size="medium"
+        showColorBorders
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
-        variant="app"
+        size="medium"
+        showColorBorders
+      />
+
+      <Avatar
+        src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
+        size="medium"
+        showColorBorders
+      />
+
+      <Avatar
+        src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
+        size="medium"
+        showColorBorders
       />
     </Stack>
   );

--- a/packages/components/avatar/examples/AvatarColorBorderExamples.tsx
+++ b/packages/components/avatar/examples/AvatarColorBorderExamples.tsx
@@ -2,9 +2,21 @@ import React from 'react';
 import { Avatar } from '@contentful/f36-avatar';
 import { Stack } from '@contentful/f36-core';
 
-export default function AvatarVariantsExample() {
+export default function AvatarColorBordersExample() {
   return (
     <Stack>
+      <Avatar
+        src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
+        size="medium"
+        showColorBorders
+      />
+
+      <Avatar
+        src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
+        size="medium"
+        showColorBorders
+      />
+
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
         size="medium"

--- a/packages/components/avatar/examples/AvatarColorBorderExamples.tsx
+++ b/packages/components/avatar/examples/AvatarColorBorderExamples.tsx
@@ -8,37 +8,37 @@ export default function AvatarColorBordersExample() {
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
         size="medium"
-        showColorBorders
+        showColorBorder
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
         size="medium"
-        showColorBorders
+        showColorBorder
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
         size="medium"
-        showColorBorders
+        showColorBorder
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
         size="medium"
-        showColorBorders
+        showColorBorder
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
         size="medium"
-        showColorBorders
+        showColorBorder
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
         size="medium"
-        showColorBorders
+        showColorBorder
       />
     </Stack>
   );

--- a/packages/components/avatar/examples/AvatarIconExamples.tsx
+++ b/packages/components/avatar/examples/AvatarIconExamples.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Avatar } from '@contentful/f36-avatar';
+import { Stack } from '@contentful/f36-core';
+import { CheckCircleIcon } from '@contentful/f36-icons';
+
+export default function AvatarIconExamples() {
+  return (
+    <Stack>
+      <Avatar
+        src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
+        size="medium"
+      />
+
+      <Avatar
+        src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
+        size="medium"
+        icon={<CheckCircleIcon variant="positive" />}
+      />
+    </Stack>
+  );
+}

--- a/packages/components/avatar/examples/AvatarIsActiveExamples.tsx
+++ b/packages/components/avatar/examples/AvatarIsActiveExamples.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Avatar } from '@contentful/f36-avatar';
+import { Stack } from '@contentful/f36-core';
+
+export default function AvatarActiveExample() {
+  return (
+    <Stack>
+      <Avatar
+        src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
+        size="medium"
+      />
+
+      <Avatar
+        src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
+        size="medium"
+        isActive
+      />
+    </Stack>
+  );
+}

--- a/packages/components/avatar/examples/AvatarIsActiveExamples.tsx
+++ b/packages/components/avatar/examples/AvatarIsActiveExamples.tsx
@@ -13,7 +13,7 @@ export default function AvatarActiveExample() {
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
         size="medium"
-        isActive
+        isActive={false}
       />
     </Stack>
   );

--- a/packages/components/avatar/examples/AvatarIsPrimaryExamples.tsx
+++ b/packages/components/avatar/examples/AvatarIsPrimaryExamples.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Avatar } from '@contentful/f36-avatar';
+import { Stack } from '@contentful/f36-core';
+
+export default function AvatarPrimaryExample() {
+  return (
+    <Stack>
+      <Avatar
+        src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
+        size="medium"
+      />
+
+      <Avatar
+        src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
+        size="medium"
+        isPrimary
+      />
+    </Stack>
+  );
+}

--- a/packages/components/avatar/examples/AvatarSizeExample.tsx
+++ b/packages/components/avatar/examples/AvatarSizeExample.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Avatar, Size } from '@contentful/f36-avatar';
+import { Avatar } from '@contentful/f36-avatar';
 import { Stack } from '@contentful/f36-core';
 
 export default function AvatarVariantsExample() {
@@ -7,22 +7,22 @@ export default function AvatarVariantsExample() {
     <Stack>
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
-        size={Size.Tiny}
+        size="tiny"
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
-        size={Size.Small}
+        size="small"
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
-        size={Size.Medium}
+        size="medium"
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
-        size={Size.Large}
+        size="large"
       />
     </Stack>
   );

--- a/packages/components/avatar/src/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar.styles.ts
@@ -1,6 +1,6 @@
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
-import { type AvatarProps, Variant } from './Avatar';
+import { type AvatarProps } from './Avatar';
 
 export const getAvatarStyles = ({
   isFallback,
@@ -12,7 +12,14 @@ export const getAvatarStyles = ({
   variant: AvatarProps['variant'];
 }) => {
   const borderRadius =
-    variant === Variant.App ? tokens.borderRadiusSmall : '99999999em';
+    variant === 'app' ? tokens.borderRadiusSmall : '99999999em';
+
+  const sizePixels = {
+    tiny: '20px',
+    small: '24px',
+    medium: '32px',
+    large: '48px',
+  }[size];
 
   return {
     fallback: css({
@@ -27,10 +34,10 @@ export const getAvatarStyles = ({
     root: css([
       {
         borderRadius,
-        height: size,
+        height: sizePixels,
         overflow: 'hidden',
         position: 'relative',
-        width: size,
+        width: sizePixels,
       },
       !isFallback && {
         '&::after': {
@@ -46,5 +53,30 @@ export const getAvatarStyles = ({
         },
       },
     ]),
+    rootColorBorder: css({
+      ':nth-child(6n+1)::after': {
+        boxShadow: `0px 0px 0px 2px ${tokens.green400} inset`,
+      },
+      ':nth-child(6n+2)::after': {
+        boxShadow: `0px 0px 0px 2px ${tokens.red400} inset`,
+      },
+      ':nth-child(6n+3)::after': {
+        boxShadow: `0px 0px 0px 2px ${tokens.orange400} inset`,
+      },
+      ':nth-child(6n+4)::after': {
+        boxShadow: `0px 0px 0px 2px ${tokens.yellow400} inset`,
+      },
+      ':nth-child(6n+5)::after': {
+        boxShadow: `0px 0px 0px 2px ${tokens.purple400} inset`,
+      },
+      ':nth-child(6n+6)::after': {
+        boxShadow: `0px 0px 0px 2px ${tokens.gray400} inset`,
+      },
+    }),
+    isPrimaryAvatar: css({
+      '&::after': {
+        boxShadow: `0px 0px 0px 2px ${tokens.blue400} inset !important`,
+      },
+    }),
   };
 };

--- a/packages/components/avatar/src/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar.styles.ts
@@ -78,5 +78,21 @@ export const getAvatarStyles = ({
         boxShadow: `0px 0px 0px 2px ${tokens.blue400} inset !important`,
       },
     }),
+    imageContainer: css({
+      overflow: 'visible',
+      zIndex: 1,
+    }),
+    overlayIcon: css({
+      svg: {
+        backgroundColor: tokens.colorWhite,
+        borderRadius: '99999999em',
+        position: 'absolute',
+        bottom: 0,
+        right: '-10%',
+        width: '40%',
+        height: '40%',
+        zIndex: 1,
+      },
+    }),
   };
 };

--- a/packages/components/avatar/src/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar.styles.ts
@@ -94,5 +94,8 @@ export const getAvatarStyles = ({
         zIndex: 1,
       },
     }),
+    isInactive: css({
+      opacity: 0.5,
+    }),
   };
 };

--- a/packages/components/avatar/src/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar.styles.ts
@@ -2,6 +2,14 @@ import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 import { type AvatarProps } from './Avatar';
 
+export const convertSizeToPixels = (size: AvatarProps['size']) =>
+  ({
+    tiny: '20px',
+    small: '24px',
+    medium: '32px',
+    large: '48px',
+  }[size]);
+
 export const getAvatarStyles = ({
   isFallback,
   size,
@@ -14,12 +22,7 @@ export const getAvatarStyles = ({
   const borderRadius =
     variant === 'app' ? tokens.borderRadiusSmall : '99999999em';
 
-  const sizePixels = {
-    tiny: '20px',
-    small: '24px',
-    medium: '32px',
-    large: '48px',
-  }[size];
+  const sizePixels = convertSizeToPixels(size);
 
   return {
     fallback: css({

--- a/packages/components/avatar/src/Avatar.test.tsx
+++ b/packages/components/avatar/src/Avatar.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Avatar } from './Avatar';
+import { CheckCircleIcon } from '@contentful/f36-icons';
 
 jest.mock('@contentful/f36-image', () => ({
   // eslint-disable-next-line jsx-a11y/alt-text
@@ -19,5 +20,10 @@ describe('Avatar', () => {
     render(<Avatar src={src} />);
 
     expect(screen.getByRole('img')).toHaveAttribute('src', src);
+  });
+
+  it('renders an icon when it is provided', () => {
+    const src = 'https://example.com/image.jpg';
+    render(<Avatar src={src} icon={<CheckCircleIcon variant="positive" />} />);
   });
 });

--- a/packages/components/avatar/src/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar.tsx
@@ -4,17 +4,9 @@ import { type CommonProps } from '@contentful/f36-core';
 import { Image, type ImageProps } from '@contentful/f36-image';
 import { getAvatarStyles } from './Avatar.styles';
 
-export enum Size {
-  Tiny = '20px',
-  Small = '24px',
-  Medium = '32px',
-  Large = '48px',
-}
+export type Size = 'tiny' | 'small' | 'medium' | 'large';
 
-export enum Variant {
-  App = 'app',
-  User = 'user',
-}
+export type Variant = 'app' | 'user';
 
 export interface AvatarProps extends CommonProps {
   alt?: ImageProps['alt'];
@@ -22,6 +14,8 @@ export interface AvatarProps extends CommonProps {
   size?: Size;
   src?: ImageProps['src'];
   variant?: Variant;
+  showColorBorders?: boolean;
+  isPrimary?: boolean;
 }
 
 function _Avatar(
@@ -29,10 +23,12 @@ function _Avatar(
     alt = '',
     className,
     isLoading = false,
-    size = Size.Medium,
+    size = 'medium',
     src,
     testId = 'cf-ui-avatar',
-    variant = Variant.User,
+    variant = 'user',
+    showColorBorders = false,
+    isPrimary = false,
   }: AvatarProps,
   forwardedRef: React.Ref<HTMLDivElement>,
 ) {
@@ -42,7 +38,10 @@ function _Avatar(
 
   return (
     <div
-      className={cx(styles.root, className)}
+      className={cx(styles.root, className, {
+        [styles.rootColorBorder]: showColorBorders,
+        [styles.isPrimaryAvatar]: isPrimary,
+      })}
       data-test-id={testId}
       ref={forwardedRef}
     >

--- a/packages/components/avatar/src/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar.tsx
@@ -16,6 +16,7 @@ export interface AvatarProps extends CommonProps {
   variant?: Variant;
   showColorBorders?: boolean;
   isPrimary?: boolean;
+  icon?: React.ReactElement;
 }
 
 function _Avatar(
@@ -29,6 +30,7 @@ function _Avatar(
     variant = 'user',
     showColorBorders = false,
     isPrimary = false,
+    icon = null,
   }: AvatarProps,
   forwardedRef: React.Ref<HTMLDivElement>,
 ) {
@@ -41,11 +43,14 @@ function _Avatar(
       className={cx(styles.root, className, {
         [styles.rootColorBorder]: showColorBorders,
         [styles.isPrimaryAvatar]: isPrimary,
+        [styles.imageContainer]: icon !== null,
       })}
       data-test-id={testId}
       ref={forwardedRef}
     >
-      {!isFallback ? (
+      {isFallback ? (
+        <div className={styles.fallback} data-test-id={`${testId}-fallback`} />
+      ) : (
         <Image
           alt={alt}
           className={styles.image}
@@ -53,9 +58,8 @@ function _Avatar(
           src={src}
           width={size}
         />
-      ) : (
-        <div className={styles.fallback} data-test-id={`${testId}-fallback`} />
       )}
+      {icon !== null && <span className={styles.overlayIcon}>{icon}</span>}
     </div>
   );
 }

--- a/packages/components/avatar/src/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar.tsx
@@ -44,10 +44,10 @@ function _Avatar(
   return (
     <div
       className={cx(styles.root, className, {
-        [styles.rootColorBorder]: showColorBorder && !isLoading,
-        [styles.isPrimaryAvatar]: isPrimary && !isLoading,
-        [styles.imageContainer]: icon !== null && !isLoading,
-        [styles.isInactive]: !isActive && !isLoading,
+        [styles.rootColorBorder]: showColorBorder,
+        [styles.isPrimaryAvatar]: isPrimary,
+        [styles.imageContainer]: icon !== null,
+        [styles.isInactive]: !isActive,
       })}
       data-test-id={testId}
       ref={forwardedRef}

--- a/packages/components/avatar/src/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react';
 import { cx } from 'emotion';
 import { type CommonProps } from '@contentful/f36-core';
 import { Image, type ImageProps } from '@contentful/f36-image';
-import { getAvatarStyles } from './Avatar.styles';
+import { convertSizeToPixels, getAvatarStyles } from './Avatar.styles';
 
 export type Size = 'tiny' | 'small' | 'medium' | 'large';
 
@@ -14,7 +14,7 @@ export interface AvatarProps extends CommonProps {
   size?: Size;
   src?: ImageProps['src'];
   variant?: Variant;
-  showColorBorders?: boolean;
+  showColorBorder?: boolean;
   isPrimary?: boolean;
   isActive?: boolean;
   icon?: React.ReactElement;
@@ -29,7 +29,7 @@ function _Avatar(
     src,
     testId = 'cf-ui-avatar',
     variant = 'user',
-    showColorBorders = false,
+    showColorBorder = false,
     isPrimary = false,
     isActive = true,
     icon = null,
@@ -39,14 +39,15 @@ function _Avatar(
   // Only render the fallback when `src` is undefined or an empty string
   const isFallback = Boolean(!isLoading && !src);
   const styles = getAvatarStyles({ isFallback, size, variant });
+  const sizePixels = convertSizeToPixels(size);
 
   return (
     <div
       className={cx(styles.root, className, {
-        [styles.rootColorBorder]: showColorBorders,
-        [styles.isPrimaryAvatar]: isPrimary,
-        [styles.imageContainer]: icon !== null,
-        [styles.isInactive]: !isActive,
+        [styles.rootColorBorder]: showColorBorder && !isLoading,
+        [styles.isPrimaryAvatar]: isPrimary && !isLoading,
+        [styles.imageContainer]: icon !== null && !isLoading,
+        [styles.isInactive]: !isActive && !isLoading,
       })}
       data-test-id={testId}
       ref={forwardedRef}
@@ -57,9 +58,9 @@ function _Avatar(
         <Image
           alt={alt}
           className={styles.image}
-          height={size}
+          height={sizePixels}
           src={src}
-          width={size}
+          width={sizePixels}
         />
       )}
       {icon !== null && <span className={styles.overlayIcon}>{icon}</span>}

--- a/packages/components/avatar/src/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar.tsx
@@ -16,6 +16,7 @@ export interface AvatarProps extends CommonProps {
   variant?: Variant;
   showColorBorders?: boolean;
   isPrimary?: boolean;
+  isActive?: boolean;
   icon?: React.ReactElement;
 }
 
@@ -30,6 +31,7 @@ function _Avatar(
     variant = 'user',
     showColorBorders = false,
     isPrimary = false,
+    isActive = true,
     icon = null,
   }: AvatarProps,
   forwardedRef: React.Ref<HTMLDivElement>,
@@ -44,6 +46,7 @@ function _Avatar(
         [styles.rootColorBorder]: showColorBorders,
         [styles.isPrimaryAvatar]: isPrimary,
         [styles.imageContainer]: icon !== null,
+        [styles.isInactive]: !isActive,
       })}
       data-test-id={testId}
       ref={forwardedRef}

--- a/packages/components/avatar/src/index.ts
+++ b/packages/components/avatar/src/index.ts
@@ -1,2 +1,2 @@
-export { Avatar, Size, Variant } from './Avatar';
+export { Avatar } from './Avatar';
 export type { AvatarProps } from './Avatar';

--- a/packages/components/avatar/stories/Avatar.stories.tsx
+++ b/packages/components/avatar/stories/Avatar.stories.tsx
@@ -4,6 +4,7 @@ import { Flex } from '@contentful/f36-core';
 import { SectionHeading } from '@contentful/f36-typography';
 
 import { Avatar, type AvatarProps } from '../src/Avatar';
+import { CheckCircleIcon } from '@contentful/f36-icons/src';
 
 export default {
   component: Avatar,
@@ -62,8 +63,20 @@ export const Overview: Story<AvatarProps> = (args) => {
         <Avatar {...args} size="large" showColorBorders isPrimary />
         <Avatar {...args} size="large" variant="app" showColorBorders />
         <Avatar {...args} size="medium" variant="app" showColorBorders />
+        <Avatar
+          {...args}
+          size="medium"
+          showColorBorders
+          icon={<CheckCircleIcon variant="positive" />}
+        />
         <Avatar {...args} size="small" variant="app" showColorBorders />
-        <Avatar {...args} size="tiny" variant="app" showColorBorders />
+        <Avatar
+          {...args}
+          size="tiny"
+          variant="app"
+          showColorBorders
+          icon={<CheckCircleIcon variant="positive" />}
+        />
       </Flex>
     </>
   );

--- a/packages/components/avatar/stories/Avatar.stories.tsx
+++ b/packages/components/avatar/stories/Avatar.stories.tsx
@@ -27,7 +27,7 @@ export const Overview: Story<AvatarProps> = (args) => {
         <Avatar size="tiny" variant="user" />
         <Avatar size="small" variant="user" />
         <Avatar size="medium" variant="user" />
-        <Avatar size="large" variant="user" />
+        <Avatar isLoading size="large" variant="user" />
         <Avatar size="large" variant="app" />
         <Avatar size="large" variant="user" />
         <Avatar size="medium" variant="app" />
@@ -57,31 +57,31 @@ export const Overview: Story<AvatarProps> = (args) => {
         gap="spacingS"
         marginBottom="spacingM"
       >
-        <Avatar {...args} size="tiny" showColorBorders />
-        <Avatar {...args} size="small" showColorBorders />
-        <Avatar {...args} size="medium" showColorBorders />
-        <Avatar {...args} size="large" showColorBorders isPrimary />
-        <Avatar {...args} size="large" variant="app" showColorBorders />
+        <Avatar {...args} size="tiny" showColorBorder />
+        <Avatar {...args} size="small" showColorBorder />
+        <Avatar {...args} size="medium" showColorBorder />
+        <Avatar {...args} size="large" showColorBorder isPrimary />
+        <Avatar {...args} size="large" variant="app" showColorBorder />
         <Avatar
           {...args}
           size="large"
           variant="app"
-          showColorBorders
+          showColorBorder
           isActive={false}
         />
-        <Avatar {...args} size="medium" variant="app" showColorBorders />
+        <Avatar {...args} size="medium" variant="app" showColorBorder />
         <Avatar
           {...args}
           size="medium"
-          showColorBorders
+          showColorBorder
           icon={<CheckCircleIcon variant="positive" />}
         />
-        <Avatar {...args} size="small" variant="app" showColorBorders />
+        <Avatar {...args} size="small" variant="app" showColorBorder />
         <Avatar
           {...args}
           size="tiny"
           variant="app"
-          showColorBorders
+          showColorBorder
           icon={<CheckCircleIcon variant="positive" />}
         />
       </Flex>

--- a/packages/components/avatar/stories/Avatar.stories.tsx
+++ b/packages/components/avatar/stories/Avatar.stories.tsx
@@ -62,6 +62,13 @@ export const Overview: Story<AvatarProps> = (args) => {
         <Avatar {...args} size="medium" showColorBorders />
         <Avatar {...args} size="large" showColorBorders isPrimary />
         <Avatar {...args} size="large" variant="app" showColorBorders />
+        <Avatar
+          {...args}
+          size="large"
+          variant="app"
+          showColorBorders
+          isActive={false}
+        />
         <Avatar {...args} size="medium" variant="app" showColorBorders />
         <Avatar
           {...args}

--- a/packages/components/avatar/stories/Avatar.stories.tsx
+++ b/packages/components/avatar/stories/Avatar.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Flex } from '@contentful/f36-core';
 import { SectionHeading } from '@contentful/f36-typography';
 
-import { Avatar, Variant, type AvatarProps, Size } from '../src/Avatar';
+import { Avatar, type AvatarProps } from '../src/Avatar';
 
 export default {
   component: Avatar,
@@ -23,14 +23,15 @@ export const Overview: Story<AvatarProps> = (args) => {
         gap="spacingS"
         marginBottom="spacingM"
       >
-        <Avatar size={Size.Tiny} variant={Variant.User} />
-        <Avatar size={Size.Small} variant={Variant.User} />
-        <Avatar size={Size.Medium} variant={Variant.User} />
-        <Avatar size={Size.Large} variant={Variant.User} />
-        <Avatar size={Size.Large} variant={Variant.App} />
-        <Avatar size={Size.Medium} variant={Variant.App} />
-        <Avatar size={Size.Small} variant={Variant.App} />
-        <Avatar size={Size.Tiny} variant={Variant.App} />
+        <Avatar size="tiny" variant="user" />
+        <Avatar size="small" variant="user" />
+        <Avatar size="medium" variant="user" />
+        <Avatar size="large" variant="user" />
+        <Avatar size="large" variant="app" />
+        <Avatar size="large" variant="user" />
+        <Avatar size="medium" variant="app" />
+        <Avatar size="small" variant="app" />
+        <Avatar size="tiny" variant="app" />
       </Flex>
 
       <Flex
@@ -39,14 +40,30 @@ export const Overview: Story<AvatarProps> = (args) => {
         gap="spacingS"
         marginBottom="spacingM"
       >
-        <Avatar {...args} size={Size.Tiny} />
-        <Avatar {...args} size={Size.Small} />
-        <Avatar {...args} size={Size.Medium} />
-        <Avatar {...args} size={Size.Large} />
-        <Avatar {...args} size={Size.Large} variant={Variant.App} />
-        <Avatar {...args} size={Size.Medium} variant={Variant.App} />
-        <Avatar {...args} size={Size.Small} variant={Variant.App} />
-        <Avatar {...args} size={Size.Tiny} variant={Variant.App} />
+        <Avatar {...args} size="tiny" />
+        <Avatar {...args} size="small" />
+        <Avatar {...args} size="medium" />
+        <Avatar {...args} size="large" />
+        <Avatar {...args} size="large" variant="app" />
+        <Avatar {...args} size="medium" variant="app" />
+        <Avatar {...args} size="small" variant="app" />
+        <Avatar {...args} size="tiny" variant="app" />
+      </Flex>
+
+      <Flex
+        alignItems="center"
+        flexDirection="row"
+        gap="spacingS"
+        marginBottom="spacingM"
+      >
+        <Avatar {...args} size="tiny" showColorBorders />
+        <Avatar {...args} size="small" showColorBorders />
+        <Avatar {...args} size="medium" showColorBorders />
+        <Avatar {...args} size="large" showColorBorders isPrimary />
+        <Avatar {...args} size="large" variant="app" showColorBorders />
+        <Avatar {...args} size="medium" variant="app" showColorBorders />
+        <Avatar {...args} size="small" variant="app" showColorBorders />
+        <Avatar {...args} size="tiny" variant="app" showColorBorders />
       </Flex>
     </>
   );

--- a/packages/website/components/LiveEditor/ComponentSource.tsx
+++ b/packages/website/components/LiveEditor/ComponentSource.tsx
@@ -13,7 +13,7 @@ import * as f36Components from '@contentful/f36-components';
 import { Multiselect } from '@contentful/f36-multiselect';
 import { NavList } from '@contentful/f36-navlist';
 import * as f36utils from '@contentful/f36-utils';
-import { Avatar, Variant, Size } from '@contentful/f36-avatar';
+import { Avatar } from '@contentful/f36-avatar';
 import { Image } from '@contentful/f36-image';
 import { useForm, useController } from 'react-hook-form';
 import { MdAccessAlarm } from 'react-icons/md';
@@ -40,8 +40,6 @@ const liveProviderScope = {
   ...f36icons,
   ...f36utils,
   Avatar, // Remove when avatar is added to f36-components
-  Variant, // Remove when avatar is added to f36-components
-  Size, // Remove when avatar is added to f36-components
   Image, // Remove when added to f36-components
   Multiselect, // Remove when added to f36-components
   NavList, // Remove when added to f36-components


### PR DESCRIPTION
# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

This PR adds the following new properties to the `Avatar` component:
- showColorBorders
- isPrimary
- isActive
- icon

And replace enums for sizes and variants with simple string types

<img width="1180" alt="image" src="https://github.com/contentful/forma-36/assets/5839623/83f52084-00f8-4f8b-b1e9-8f5c0f721c3d">


## PR Checklist

- [X] I have read the relevant `readme.md` file(s)
- [X] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [X] Tests are added/updated/not required
- [X] Tests are passing
- [X] Storybook stories are added/updated/not required
- [X] Usage notes are added/updated/not required
- [X] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [X] Doesn't contain any sensitive information
