### PR TITLE
chore(dependabot): widen versions when possible

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,4 @@ updates:
       - dependencies
     commit-message:
       prefix: chore
+    versioning-strategy: widen


### PR DESCRIPTION
# Purpose of PR

Set [dependabot versioning strategy](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy) to `widen`. This seems like the right move for libraries.