### PR TITLE
fix(datepicker): prevent auto scrolling to open popover

### DIFF
--- a/packages/components/datepicker/src/Datepicker.tsx
+++ b/packages/components/datepicker/src/Datepicker.tsx
@@ -173,7 +173,7 @@ export function Datepicker(props: DatepickerProps) {
         </DatepickerTrigger>
       </Popover.Trigger>
       <Popover.Content>
-        <FocusLock returnFocus={true}>
+        <FocusLock focusOptions={{ preventScroll: true }} returnFocus={true}>
           <Calendar
             {...otherProps}
             className={styles.calendar}


### PR DESCRIPTION
# Purpose of PR

Fixes an issue where the datepicker popover in some browsers causes a scroll due to the focus lock. See https://github.com/theKashey/react-focus-lock/issues/162 for context on what's going on.