### PR TITLE
Revert "chore: bump downshift from 6.1.12 to 7.6.0 (#2527)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15905,9 +15905,8 @@
       "license": "MIT"
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz",
-      "integrity": "sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g=="
+      "version": "1.0.17",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -17844,12 +17843,11 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/downshift": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-7.6.0.tgz",
-      "integrity": "sha512-VSoTVynTAsabou/hbZ6HJHUVhtBiVOjQoBsCPcQq5eAROIGP+9XKMp9asAKQ3cEcUP4oe0fFdD2pziUjhFY33Q==",
+      "version": "6.1.12",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.14.8",
-        "compute-scroll-into-view": "^2.0.4",
+        "compute-scroll-into-view": "^1.0.17",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2",
         "tslib": "^2.3.0"
@@ -38099,7 +38097,7 @@
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-typography": "^4.45.0",
         "@contentful/f36-utils": "^4.23.2",
-        "downshift": "^7.6.0",
+        "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -45420,7 +45418,7 @@
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-typography": "^4.45.0",
         "@contentful/f36-utils": "^4.23.2",
-        "downshift": "^7.6.0",
+        "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
     },
@@ -57093,9 +57091,7 @@
       }
     },
     "compute-scroll-into-view": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz",
-      "integrity": "sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g=="
+      "version": "1.0.17"
     },
     "concat-map": {
       "version": "0.0.1"
@@ -58399,12 +58395,10 @@
       "dev": true
     },
     "downshift": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-7.6.0.tgz",
-      "integrity": "sha512-VSoTVynTAsabou/hbZ6HJHUVhtBiVOjQoBsCPcQq5eAROIGP+9XKMp9asAKQ3cEcUP4oe0fFdD2pziUjhFY33Q==",
+      "version": "6.1.12",
       "requires": {
         "@babel/runtime": "^7.14.8",
-        "compute-scroll-into-view": "^2.0.4",
+        "compute-scroll-into-view": "^1.0.17",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2",
         "tslib": "^2.3.0"

--- a/packages/components/autocomplete/package.json
+++ b/packages/components/autocomplete/package.json
@@ -15,7 +15,7 @@
     "@contentful/f36-tokens": "^4.0.2",
     "@contentful/f36-typography": "^4.47.1",
     "@contentful/f36-utils": "^4.23.2",
-    "downshift": "^7.6.0",
+    "downshift": "^6.1.12",
     "emotion": "^10.0.17"
   },
   "peerDependencies": {

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -224,6 +224,7 @@ function _Autocomplete<ItemType>(
     : items.length === 0;
 
   const {
+    getComboboxProps,
     getInputProps,
     getItemProps,
     getMenuProps,
@@ -266,6 +267,7 @@ function _Autocomplete<ItemType>(
     id: _inputId,
     ...inputProps
   } = getInputProps();
+  const comboboxProps = getComboboxProps();
   const toggleProps = getToggleButtonProps();
   const menuProps = getMenuProps();
   let elementStartIndex = 0;
@@ -288,7 +290,7 @@ function _Autocomplete<ItemType>(
         id={menuProps.id}
       >
         <Popover.Trigger>
-          <div className={styles.combobox}>
+          <div {...comboboxProps} className={styles.combobox}>
             <TextInput
               className={styles.inputField}
               {...inputProps}


### PR DESCRIPTION
Reverts contentful/forma-36#2527

The downshift bump is causing the EnvironmentSelect.spec.tsx test (which relies on the Autocomplete component) to fail on the user_interface. The `f36-components` version in the `user_interface` is `v4.45.0` so it remained unnoticed so far, until [I bumped](https://github.com/contentful/user_interface/pull/16391) it to `v4.47.0` to benefit from my work on the Note component.

See https://app.circleci.com/pipelines/github/contentful/user_interface/72280/workflows/fd1014a8-6653-49a2-8282-986fd32f8519/jobs/546005.

The `Uncaught [TypeError: compute__default.default is not a function]` error leads to one of the Downshift’s dependencies, `compute-scroll-into-view`, see https://unpkg.com/downshift@7.6.1/dist/downshift.cjs.js.

A similar issue had been opened some time ago, see https://github.com/downshift-js/downshift/issues/1449.

The bump was done to keep the packages up to date, there isn't any critical need for it, reverting is the best option for now.