### PR TITLE
feat: update avatar colors [HOMER-2193]

### DIFF
--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-avatar",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0-alpha.4",
   "description": "Forma 36: Avatar component",
   "scripts": {
     "build": "tsup"

--- a/packages/components/avatar/src/Avatar/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar/Avatar.styles.ts
@@ -1,13 +1,13 @@
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 import { type AvatarProps } from './Avatar';
-import { avatarColorVariant, type ColorVariant } from './utils';
+import { avatarColorMap, type ColorVariant } from './utils';
 
 export const getColorVariantStyles = (colorVariant: ColorVariant) => {
-  const colorToken = avatarColorVariant[colorVariant];
+  const colorToken = avatarColorMap[colorVariant];
 
   return {
-    boxShadow: `0px 0px 0px 2px  ${tokens[colorToken]} inset, 0px 0px 0px 3px  ${tokens.colorWhite} inset`,
+    boxShadow: `0px 0px 0px 2px ${colorToken} inset, 0px 0px 0px 3px  ${tokens.colorWhite} inset`,
   };
 };
 

--- a/packages/components/avatar/src/Avatar/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar/Avatar.styles.ts
@@ -88,8 +88,11 @@ export const getAvatarStyles = ({
         zIndex: 1,
       },
     }),
-    isInactive: css({
-      opacity: 0.5,
+    isMuted: css({
+      backgroundColor: tokens.colorWhite,
+      img: {
+        opacity: 0.5,
+      },
     }),
   };
 };

--- a/packages/components/avatar/src/Avatar/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar/Avatar.tsx
@@ -42,7 +42,7 @@ function _Avatar(
     <div
       className={cx(styles.root, className, {
         [styles.imageContainer]: icon !== null,
-        [styles.isInactive]: colorVariant === 'muted',
+        [styles.isMuted]: colorVariant === 'muted',
         [styles.colorBorder]: !!colorVariant,
       })}
       data-test-id={testId}

--- a/packages/components/avatar/src/Avatar/examples/AvatarColorBorderExamples.tsx
+++ b/packages/components/avatar/src/Avatar/examples/AvatarColorBorderExamples.tsx
@@ -7,42 +7,52 @@ export default function AvatarColorBordersExample() {
     <Stack>
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
-        size="medium"
+        size="large"
         colorVariant="gray"
       />
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
-        size="medium"
+        size="large"
         colorVariant="green"
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
-        size="medium"
+        size="large"
         colorVariant="yellow"
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
-        size="medium"
+        size="large"
         colorVariant="orange"
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
-        size="medium"
+        size="large"
         colorVariant="purple"
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
-        size="medium"
-        colorVariant="red"
+        size="large"
+        colorVariant="pink"
+      />
+      <Avatar
+        src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
+        size="large"
+        colorVariant="lavender"
+      />
+      <Avatar
+        src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
+        size="large"
+        colorVariant="emerald"
       />
 
       <Avatar
         src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100"
-        size="medium"
+        size="large"
         colorVariant="primary"
       />
     </Stack>

--- a/packages/components/avatar/src/Avatar/index.ts
+++ b/packages/components/avatar/src/Avatar/index.ts
@@ -1,2 +1,4 @@
 export { Avatar } from './Avatar';
 export type { AvatarProps } from './Avatar';
+export { avatarColorMap } from './utils';
+export type { ColorVariant } from './utils';

--- a/packages/components/avatar/src/Avatar/utils.ts
+++ b/packages/components/avatar/src/Avatar/utils.ts
@@ -1,19 +1,25 @@
+import tokens from '@contentful/f36-tokens';
+
 export type ColorVariant =
   | 'primary'
   | 'muted'
   | 'green'
-  | 'red'
   | 'orange'
   | 'yellow'
   | 'purple'
+  | 'pink'
+  | 'emerald'
+  | 'lavender'
   | 'gray';
 
-export const avatarColorVariant = {
-  primary: 'blue400',
-  green: 'green400',
-  red: 'red400',
-  orange: 'orange400',
-  yellow: 'yellow500',
-  purple: 'purple400',
-  gray: 'gray400',
+export const avatarColorMap = {
+  primary: tokens.blue500,
+  green: tokens.green400,
+  orange: tokens.orange400,
+  yellow: tokens.yellow500,
+  purple: tokens.purple400,
+  gray: tokens.gray400,
+  pink: '#FF77AE',
+  emerald: '#00B8A2',
+  lavender: '#9095FF',
 };

--- a/packages/components/avatar/src/index.ts
+++ b/packages/components/avatar/src/index.ts
@@ -1,4 +1,4 @@
-export { Avatar } from './Avatar';
-export type { AvatarProps } from './Avatar';
+export { Avatar, avatarColorMap } from './Avatar';
+export type { AvatarProps, ColorVariant } from './Avatar';
 export { AvatarGroup } from './AvatarGroup';
 export type { AvatarGroupProps } from './AvatarGroup';

--- a/packages/components/avatar/stories/Avatar.stories.tsx
+++ b/packages/components/avatar/stories/Avatar.stories.tsx
@@ -64,19 +64,19 @@ export const Overview: Story<AvatarProps> = (args) => {
         <Avatar {...args} size="large" colorVariant="green" />
         <Avatar {...args} size="large" variant="app" colorVariant="gray" />
         <Avatar {...args} size="large" variant="app" colorVariant="muted" />
-        <Avatar {...args} size="medium" variant="app" colorVariant="red" />
+        <Avatar {...args} size="medium" variant="app" colorVariant="purple" />
         <Avatar
           {...args}
           size="medium"
-          colorVariant="purple"
+          colorVariant="pink"
           icon={<CheckCircleIcon variant="positive" />}
         />
-        <Avatar {...args} size="small" variant="app" colorVariant="yellow" />
+        <Avatar {...args} size="small" variant="app" colorVariant="lavender" />
         <Avatar
           {...args}
           size="tiny"
           variant="app"
-          colorVariant="green"
+          colorVariant="emerald"
           icon={<CheckCircleIcon variant="positive" />}
         />
       </Flex>

--- a/packages/components/avatar/stories/Avatar.stories.tsx
+++ b/packages/components/avatar/stories/Avatar.stories.tsx
@@ -58,27 +58,27 @@ export const Overview: Story<AvatarProps> = (args) => {
         gap="spacingS"
         marginBottom="spacingM"
       >
-        <Avatar {...args} size="tiny" colorVariant="primary" />
-        <Avatar {...args} size="small" colorVariant="purple" />
-        <Avatar {...args} size="medium" colorVariant="yellow" />
+        <Avatar
+          {...args}
+          size="large"
+          colorVariant="primary"
+          icon={<CheckCircleIcon variant="positive" />}
+        />
+        <Avatar
+          {...args}
+          variant="app"
+          size="large"
+          colorVariant="primary"
+          icon={<CheckCircleIcon variant="positive" />}
+        />
+        <Avatar {...args} size="large" colorVariant="purple" />
+        <Avatar {...args} size="large" colorVariant="yellow" />
         <Avatar {...args} size="large" colorVariant="green" />
         <Avatar {...args} size="large" variant="app" colorVariant="gray" />
         <Avatar {...args} size="large" variant="app" colorVariant="muted" />
-        <Avatar {...args} size="medium" variant="app" colorVariant="purple" />
-        <Avatar
-          {...args}
-          size="medium"
-          colorVariant="pink"
-          icon={<CheckCircleIcon variant="positive" />}
-        />
-        <Avatar {...args} size="small" variant="app" colorVariant="lavender" />
-        <Avatar
-          {...args}
-          size="tiny"
-          variant="app"
-          colorVariant="emerald"
-          icon={<CheckCircleIcon variant="positive" />}
-        />
+        <Avatar {...args} size="large" colorVariant="pink" variant="app" />
+        <Avatar {...args} size="large" variant="app" colorVariant="lavender" />
+        <Avatar {...args} size="large" variant="app" colorVariant="emerald" />
       </Flex>
     </>
   );

--- a/packages/components/avatar/stories/AvatarGroup.stories.tsx
+++ b/packages/components/avatar/stories/AvatarGroup.stories.tsx
@@ -43,9 +43,19 @@ export const Overview: Story<AvatarProps> = (args) => {
 
       <AvatarGroup maxVisibleChildren={4} variant="stacked">
         <Avatar {...args} alt="Lisa Simpson" variant="user" />
-        <Avatar {...args} alt="Apu Nahasapeemapetilon" variant="user" />
-        <Avatar {...args} alt="Arnie Pye" variant="user" />
-        <Avatar {...args} alt="Dr. Julius Hibbert" variant="user" />
+        <Avatar
+          {...args}
+          alt="Apu Nahasapeemapetilon"
+          variant="user"
+          colorVariant="muted"
+        />
+        <Avatar {...args} alt="Arnie Pye" variant="user" colorVariant="muted" />
+        <Avatar
+          {...args}
+          alt="Dr. Julius Hibbert"
+          variant="user"
+          colorVariant="muted"
+        />
         <Avatar {...args} alt="Prof. Daniel Düsentrieb" variant="user" />
       </AvatarGroup>
 
@@ -72,5 +82,6 @@ export const Overview: Story<AvatarProps> = (args) => {
 };
 
 Overview.args = {
+  size: 'large',
   src: 'https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=100&h=100',
 };


### PR DESCRIPTION
# Purpose of PR
For the Avatar component it will 
- introduce 3 custom colors
<img width="93" alt="image" src="https://github.com/contentful/forma-36/assets/1789174/d03216d5-5b21-4817-8443-7814e9dae7eb">

-  fix muted style (transparent stacked avatars where shining trough each other)
**before**
<img width="116" alt="image" src="https://github.com/contentful/forma-36/assets/1789174/001c0c50-94e4-435c-8acd-7eb13293cd85">

**after**
<img width="95" alt="image" src="https://github.com/contentful/forma-36/assets/1789174/2fa4ab8e-0934-49ca-ba63-0cbdab865be7">