### PR TITLE
fix(avatar-group): position of stacked avatars when using tooltip

### DIFF
--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-avatar",
-  "version": "4.0.0-alpha.6",
+  "version": "4.0.0-alpha.7",
   "description": "Forma 36: Avatar component",
   "scripts": {
     "build": "tsup"

--- a/packages/components/avatar/src/AvatarGroup/AvatarGroup.styles.ts
+++ b/packages/components/avatar/src/AvatarGroup/AvatarGroup.styles.ts
@@ -10,13 +10,13 @@ export const getAvatarGroupStyles = (size: AvatarProps['size']) => {
     }),
     groupStacked: css({
       gap: 0,
+      '> :not(:first-child)': {
+        marginLeft: `-${tokens.spacing2Xs}`,
+      },
     }),
     avatarStacked: css({
       position: 'relative',
       boxShadow: `0px 0px 0px 2px ${tokens.colorWhite}`,
-      '&:not(:first-child)': {
-        marginLeft: `-${tokens.spacing2Xs}`,
-      },
     }),
     moreAvatarsBtn: css({
       cursor: 'pointer',

--- a/packages/components/avatar/stories/AvatarGroup.stories.tsx
+++ b/packages/components/avatar/stories/AvatarGroup.stories.tsx
@@ -88,9 +88,13 @@ export const Overview: Story<AvatarProps> = (args) => {
         <Avatar {...args} alt="Lisa Simpson" variant="user" />
         <Avatar
           {...args}
-          alt="Apu Nahasapeemapetilon"
+          alt="Apu N."
           variant="user"
           colorVariant="muted"
+          tooltipProps={{
+            content: 'Apu Nahasapeemapetilon',
+            placement: 'bottom',
+          }}
         />
         <Avatar {...args} alt="Arnie Pye" variant="user" colorVariant="muted" />
         <Avatar


### PR DESCRIPTION
# Purpose of PR

When providing a tooltip for avatars, the style assignment with negative margins is lost, therefore attaching it to the wrapping container.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
