### PR TITLE
fix: tooltip position by using portal option 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38112,7 +38112,7 @@
     },
     "packages/components/avatar": {
       "name": "@contentful/f36-avatar",
-      "version": "4.0.0-alpha.6",
+      "version": "4.0.0-alpha.7",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-core": "^4.48.0",

--- a/packages/components/avatar/src/Avatar/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar/Avatar.tsx
@@ -73,7 +73,12 @@ function _Avatar(
     </div>
   );
 
-  if (tooltipProps) return <Tooltip {...tooltipProps}>{content}</Tooltip>;
+  if (tooltipProps)
+    return (
+      <Tooltip {...tooltipProps} usePortal>
+        {content}
+      </Tooltip>
+    );
 
   return content;
 }

--- a/packages/components/avatar/stories/AvatarGroup.stories.tsx
+++ b/packages/components/avatar/stories/AvatarGroup.stories.tsx
@@ -124,6 +124,40 @@ export const Overview: Story<AvatarProps> = (args) => {
         <Avatar {...args} alt="Dr. Julius Hibbert" variant="user" />
         <Avatar {...args} alt="Prof. Daniel Düsentrieb" variant="user" />
       </AvatarGroup>
+
+      <SectionHeading as="h3" marginBottom="spacingS">
+        Avatar Group stacked with tooltips
+      </SectionHeading>
+
+      <AvatarGroup size="small" variant="stacked">
+        <Avatar
+          {...args}
+          alt="Arnie Pye"
+          variant="user"
+          tooltipProps={{
+            content: 'Arnie Pye',
+            placement: 'bottom',
+          }}
+        />
+        <Avatar
+          {...args}
+          alt="Dr. Julius Hibbert"
+          variant="user"
+          tooltipProps={{
+            content: 'Dr. Julius Hibbert',
+            placement: 'bottom',
+          }}
+        />
+        <Avatar
+          {...args}
+          alt="Prof. Daniel Düsentrieb"
+          variant="user"
+          tooltipProps={{
+            content: 'Prof. Daniel Düsentrieb',
+            placement: 'bottom',
+          }}
+        />
+      </AvatarGroup>
     </>
   );
 };


### PR DESCRIPTION
# Purpose of PR
When the tooltip was shown inside a stacked avatar group, the alignment was off, due to the negative margin on the elements. By leveraging the usePortal option, the tooltips are no longer influenced by the margin settings of their parents.

**before**
<img width="74" alt="image" src="https://github.com/contentful/forma-36/assets/1789174/84cd0137-bf78-4db8-a35b-832e5ffdce7e">

**after**
<img width="90" alt="image" src="https://github.com/contentful/forma-36/assets/1789174/ed659119-dc76-4833-859c-1191848c5680">
