### PR TITLE
chore: [F36-893] change Button border color of active and focused states

### DIFF
--- a/packages/components/button/src/Button/Button.styles.ts
+++ b/packages/components/button/src/Button/Button.styles.ts
@@ -101,16 +101,7 @@ const variantToStyles = (variant: ButtonVariant): CSSObject => {
           color: tokens.red600,
         },
         '&:active': variantActiveStyles(variant),
-        '&:focus': {
-          borderColor: tokens.gray300,
-          boxShadow: tokens.glowNegative,
-        },
-        '&:focus:not(:focus-visible)': {
-          borderColor: tokens.red600,
-          boxShadow: 'unset',
-        },
         '&:focus-visible': {
-          borderColor: tokens.red700,
           boxShadow: tokens.glowNegative,
         },
       };


### PR DESCRIPTION
# Purpose of PR

Button: change border color of active and focused states from red to grey/300.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
