### PR TITLE
chore: [F36-889] full height button group divider

### DIFF
--- a/.changeset/grumpy-bags-complain.md
+++ b/.changeset/grumpy-bags-complain.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-button': minor
+---
+
+chore: full height button group divider; remove positive/primary button border color

--- a/packages/components/button/src/Button/Button.styles.ts
+++ b/packages/components/button/src/Button/Button.styles.ts
@@ -7,11 +7,11 @@ import { hexToRGBA } from '@contentful/f36-utils';
 const variantActiveStyles = (variant: ButtonVariant): CSSObject => {
   switch (variant) {
     case 'primary':
-      return { backgroundColor: tokens.blue700, borderColor: tokens.blue700 };
+      return { backgroundColor: tokens.blue700 };
     case 'secondary':
       return { backgroundColor: tokens.gray200 };
     case 'positive':
-      return { backgroundColor: tokens.green700, borderColor: tokens.green700 };
+      return { backgroundColor: tokens.green700 };
     case 'negative':
       return { backgroundColor: tokens.gray200 };
     case 'transparent':
@@ -27,23 +27,13 @@ const variantToStyles = (variant: ButtonVariant): CSSObject => {
       return {
         color: tokens.colorWhite,
         backgroundColor: tokens.blue500,
-        borderColor: tokens.blue500,
+        borderColor: 'transparent',
         '&:hover': {
           backgroundColor: tokens.blue600,
-          borderColor: tokens.blue600,
           color: tokens.colorWhite,
         },
         '&:active': variantActiveStyles(variant),
-        '&:focus': {
-          borderColor: tokens.blue600,
-          boxShadow: tokens.glowPrimary,
-        },
-        '&:focus:not(:focus-visible)': {
-          borderColor: tokens.blue500,
-          boxShadow: 'unset',
-        },
         '&:focus-visible': {
-          borderColor: tokens.blue600,
           boxShadow: tokens.glowPrimary,
         },
       };
@@ -71,23 +61,13 @@ const variantToStyles = (variant: ButtonVariant): CSSObject => {
       return {
         color: tokens.colorWhite,
         backgroundColor: tokens.green500,
-        borderColor: tokens.green500,
+        borderColor: 'transparent',
         '&:hover': {
           backgroundColor: tokens.green600,
-          borderColor: tokens.green600,
           color: tokens.colorWhite,
         },
         '&:active': variantActiveStyles(variant),
-        '&:focus': {
-          borderColor: tokens.green600,
-          boxShadow: tokens.glowPositive,
-        },
-        '&:focus:not(:focus-visible)': {
-          borderColor: tokens.green500,
-          boxShadow: 'unset',
-        },
         '&:focus-visible': {
-          borderColor: tokens.green600,
           boxShadow: tokens.glowPositive,
         },
       };

--- a/packages/components/button/src/ButtonGroup/ButtonGroup.styles.ts
+++ b/packages/components/button/src/ButtonGroup/ButtonGroup.styles.ts
@@ -1,61 +1,50 @@
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
-import type { GetStyleArguments } from './types';
+import { hexToRGBA } from '@contentful/f36-utils';
 import type { CSSObject } from '@emotion/serialize';
+import type { GetStyleArguments } from './types';
 
-const getGroupContentStyle = ({ withDivider }: GetStyleArguments) => {
+export default ({ withDivider }: GetStyleArguments) => {
   const dividerStyle = getDividerStyle(withDivider);
 
   return {
-    borderRadius: '0 !important',
-    marginRight: '-1px',
-    zIndex: tokens.zIndexDefault,
-    '&:first-child': {
-      borderBottomLeftRadius: `${tokens.borderRadiusMedium} !important`,
-      borderTopLeftRadius: `${tokens.borderRadiusMedium} !important`,
-    },
-    '&:last-child': {
-      borderBottomRightRadius: `${tokens.borderRadiusMedium} !important`,
-      borderTopRightRadius: `${tokens.borderRadiusMedium} !important`,
-      marginRight: 0,
-    },
-    '&:focus': {
-      zIndex: tokens.zIndexDefault + 1,
-    },
-    ...dividerStyle,
+    buttonGroup: css({
+      display: 'inline-flex',
+      position: 'relative',
+    }),
+    groupContent: css({
+      borderRadius: '0 !important',
+      marginRight: '-1px',
+      '&:first-child': {
+        borderBottomLeftRadius: `${tokens.borderRadiusMedium} !important`,
+        borderTopLeftRadius: `${tokens.borderRadiusMedium} !important`,
+      },
+      '&:last-child': {
+        borderBottomRightRadius: `${tokens.borderRadiusMedium} !important`,
+        borderTopRightRadius: `${tokens.borderRadiusMedium} !important`,
+        marginRight: 0,
+      },
+      '&:focus': {
+        zIndex: tokens.zIndexDefault,
+      },
+      ...dividerStyle,
+    }),
   };
 };
 
 const getDividerStyle = (withDivider: boolean): CSSObject => {
   if (!withDivider) return {};
+
+  const divider = `1px solid ${hexToRGBA(tokens.colorWhite, 0.2)}`;
+
   return {
-    position: 'relative',
-    '&:before': {
-      content: '""',
-      width: '1px',
-      opacity: '20%',
-      backgroundColor: tokens.colorWhite,
-      height: '60%',
-      left: '0',
-      position: 'absolute',
+    borderTop: 'none',
+    borderBottom: 'none',
+    '&:not(:first-child,:focus-visible)': {
+      borderLeft: divider,
     },
-    '&:first-child, &:focus': {
-      '&:before': {
-        display: 'none',
-      },
-    },
-    '&:hover, &:hover + &': {
-      '&:before': {
-        display: 'none',
-      },
+    '&:not(:last-child,:focus-visible)': {
+      borderRight: divider,
     },
   };
 };
-
-export default ({ withDivider }: GetStyleArguments) => ({
-  buttonGroup: css({
-    display: 'inline-flex',
-    position: 'relative',
-  }),
-  groupContent: css(getGroupContentStyle({ withDivider })),
-});


### PR DESCRIPTION
# Purpose of PR

ButtonGroup: add full height divider to Primary and Positive: 1px #FFFFFF at 20% opacity;
Button: Remove Primary/Positive button border color


https://github.com/contentful/forma-36/assets/22265863/fb1e4ddf-a8c7-46d6-8077-a7a2dd7ad3ac



<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
