### PR TITLE
chore(forms): update accessibility guidelines for inputs

### DIFF
--- a/.changeset/plenty-steaks-pretend.md
+++ b/.changeset/plenty-steaks-pretend.md
@@ -1,5 +1,0 @@
----
-'@contentful/f36-forms': patch
----
-
-Updates accessibility guidelines for form inputs.

--- a/.changeset/plenty-steaks-pretend.md
+++ b/.changeset/plenty-steaks-pretend.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-forms': patch
+---
+
+Updates accessibility guidelines for form inputs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38508,7 +38508,7 @@
     },
     "packages/components/avatar": {
       "name": "@contentful/f36-avatar",
-      "version": "4.0.0-alpha.7",
+      "version": "4.0.0-alpha.8",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-core": "^4.48.0",

--- a/packages/components/forms/src/Checkbox/README.mdx
+++ b/packages/components/forms/src/Checkbox/README.mdx
@@ -92,8 +92,20 @@ The Checkbox can be rendered as disabled with the `isDisabled` property.
 
 ## Accessibility
 
-- To ensure `Checkbox` meets accessibility standards, provide `name` and `id`;
-- When using `Checkbox.Group` it should be wrapped in a `<FormControl as="fieldset">` and have a `<FormControl.Label as="legend">`.
+- Each checkbox is independently controlled, where you can enable multiple identifiable options.
+- To ensure the `Checkbox` meets accessibility keyboard standards, set the `name` and `id` properties.
+
+### Checkbox Group
+
+- Set the `name` prop to give each indivual value the same name
+- The Checkbox.Group should be wrapped in a `<FormControl as="fieldset">`
+- In order to easier identify the indivual Checkboxes as a group and set a label via `<FormControl.Label as="legend">`.
+- For more information about validation and controlling form fields, please refer to [FormControl](./form-control).
+
+### Keyboard Usage
+
+- To switch between options, use the “tab + space” command on the keyboard.
+- To check and uncheck the checkboxes, hit “space” on the keyboard.
 
 ## Props (API reference)
 

--- a/packages/components/forms/src/Radio/README.mdx
+++ b/packages/components/forms/src/Radio/README.mdx
@@ -69,6 +69,27 @@ We also provide the `Radio.Group` component that helps when using multiple radio
 
 ```
 
+## Content guidelines
+
+- Use direct, succinct copy that helps a user to successfully complete a form
+- Do not use punctuation for labels
+- Use sentence style caps (in which only the first word of a sentence or term is capitalized)
+
+## Accessibility
+
+- To ensure `Radio` meets accessibility keyboard standards, set the `name` and `id` properties.
+
+### Radio Group
+
+- Set the `name` prop to give each indivual value the same name
+- The Radio.Group should be wrapped in a `<FormControl as="fieldset">`
+- In order to easier identify the indivual Radio options as a group and set a label via `<FormControl.Label as="legend">`. For example, “Dinner Menu (select 1 of 3 options): (x) Menu 1, () Menu 2, () Menu 3.”
+- For more information about validation and controlling form fields, please refer to [FormControl](./form-control).
+
+### Keyboard Usage
+
+- To switch between options with the keyboard, use the “tab + space” and the arrow keys (“←”, ”↑”, “→”, and “↓”).
+
 ## Props (API reference)
 
 ### Radio
@@ -78,14 +99,3 @@ We also provide the `Radio.Group` component that helps when using multiple radio
 ### Radio.Group
 
 <PropsTable of="RadioGroup" />
-
-## Content guidelines
-
-- Use direct, succinct copy that helps a user to successfully complete a form
-- Do not use punctuation for labels
-- Use sentence style caps (in which only the first word of a sentence or term is capitalized)
-
-## Accessibility
-
-- To ensure `Radio` meets accessibility standards, provide `name` and `id`
-- When using `Radio.Group` it should be wrapped in a `<FormControl as="fieldset">` and have a `<FormControl.Label as="legend">`

--- a/packages/components/forms/src/Radio/README.mdx
+++ b/packages/components/forms/src/Radio/README.mdx
@@ -71,9 +71,9 @@ We also provide the `Radio.Group` component that helps when using multiple radio
 
 ## Content guidelines
 
-- Use direct, succinct copy that helps a user to successfully complete a form
-- Do not use punctuation for labels
-- Use sentence style caps (in which only the first word of a sentence or term is capitalized)
+- Use direct, succinct copy that helps a user to successfully complete a form for example “Dinner menu (select 1 of 3 options)“
+- Do not use punctuation for labels for example “Vegetarian“ instead of “Vegetarian.“
+- Use sentence style caps in which only the first word of a sentence or term is capitalized for example “Dairy free“ instead of “Dairy Free“
 
 ## Accessibility
 
@@ -83,7 +83,7 @@ We also provide the `Radio.Group` component that helps when using multiple radio
 
 - Set the `name` prop to give each indivual value the same name
 - The Radio.Group should be wrapped in a `<FormControl as="fieldset">`
-- In order to easier identify the indivual Radio options as a group and set a label via `<FormControl.Label as="legend">`. For example, “Dinner Menu (select 1 of 3 options): (x) Menu 1, () Menu 2, () Menu 3.”
+- In order to easier identify the indivual Radio options as a group and set a label via `<FormControl.Label as="legend">`. For example, “Dinner menu (select 1 of 3 options): (x) Menu 1, () Menu 2, () Menu 3.”
 - For more information about validation and controlling form fields, please refer to [FormControl](./form-control).
 
 ### Keyboard Usage

--- a/packages/components/forms/src/Radio/README.mdx
+++ b/packages/components/forms/src/Radio/README.mdx
@@ -71,9 +71,9 @@ We also provide the `Radio.Group` component that helps when using multiple radio
 
 ## Content guidelines
 
-- Use direct, succinct copy that helps a user to successfully complete a form for example “Dinner menu (select 1 of 3 options)“
-- Do not use punctuation for labels for example “Vegetarian“ instead of “Vegetarian.“
-- Use sentence style caps in which only the first word of a sentence or term is capitalized for example “Dairy free“ instead of “Dairy Free“
+- Use direct, succinct copy that helps a user to successfully complete a form, for example, “Dinner menu (select 1 of 3 options)“
+- Do not use punctuation for labels, for example, “Vegetarian“ instead of “Vegetarian.“
+- Use sentence style caps in which only the first word of a sentence or term is capitalized, for example, “Dairy free“ instead of “Dairy Free“
 
 ## Accessibility
 

--- a/packages/components/forms/src/Select/README.mdx
+++ b/packages/components/forms/src/Select/README.mdx
@@ -101,7 +101,7 @@ There might be cases where you would need to include the help text or validation
 ## Accessibility
 
 - To ensure `Select` meets accessibility keyboard standards, set the `name` and `id` properties.
-- The component should be wrapped in a `<FormControl as="fieldset">` and set a label via `<FormControl.Label as="legend">`.
+- The component should be wrapped in a `<FormControl>` and set a label via `<FormControl.Label`.
 - Make use of `<FormControl.HelpText>` and `<FormControl.ValidationMessage>` to provide further context
 - For more information about validation and controlling form fields, please refer to [FormControl](./form-control).
 

--- a/packages/components/forms/src/Select/README.mdx
+++ b/packages/components/forms/src/Select/README.mdx
@@ -83,16 +83,6 @@ There might be cases where you would need to include the help text or validation
 
 ```
 
-## Props (API reference)
-
-### Select
-
-<PropsTable of="Select" />
-
-### Select Option
-
-<PropsTable of="Option" />
-
 ## Content guidelines
 
 - Use `Select` to present many different options in one component
@@ -110,5 +100,22 @@ There might be cases where you would need to include the help text or validation
 
 ## Accessibility
 
-- Select should contain a label, if needed help message and validation message if needed.
-- Select should always a `name` property.
+- To ensure `Select` meets accessibility keyboard standards, set the `name` and `id` properties.
+- The component should be wrapped in a `<FormControl as="fieldset">` and set a label via `<FormControl.Label as="legend">`.
+- Make use of `<FormControl.HelpText>` and `<FormControl.ValidationMessage>` to provide further context
+- For more information about validation and controlling form fields, please refer to [FormControl](./form-control).
+
+### Keyboard Usage
+
+- Use the “arrow keys (“←”, ”↑”. “→”, and “↓”) + enter” to send the form.
+- To switch between options with the keyboard, use the “tab + space” and the arrow keys.
+
+## Props (API reference)
+
+### Select
+
+<PropsTable of="Select" />
+
+### Select Option
+
+<PropsTable of="Option" />

--- a/packages/components/forms/src/Textarea/README.mdx
+++ b/packages/components/forms/src/Textarea/README.mdx
@@ -57,14 +57,16 @@ When `Textarea` is used outside of form (without `FormControl`) and has no `<lab
 
 ```
 
+## Accessibility
+
+- To ensure `Textarea` meets accessibility keyboard standards, set the `name` and `id` properties.
+- If you are using this component in a form, provide validation to the input and use `isInvalid` to control the error state of Textarea.
+- The `invalid` and `disabled` states do not need to be set on FormControl but can be set in Textarea.
+- In case the input is required, use `isRequired` prop.
+- To display meaningful error messages make use of `<FormControl.ValidationMessage>`. For further details refer to [FormControl](./form-control).
+
 ## Props (API reference)
 
 This component also accepts [relevant HTML attributes](https://www.w3.org/wiki/HTML/Elements/textarea) as props. These include `rows`, `autoFocus` and `autoComplete`.
 
 <PropsTable of="Textarea" />
-
-## Accessibility
-
-- To ensure accessibility, provide a `name` prop
-- In case the input is required, use `isRequired` prop
-- If you are using this component in a form, provide validation to the input and use `isInvalid` to control the error state of `Textarea`. Also show meaningful error messages with the `ValidationMessage` component.

--- a/packages/components/forms/stories/CheckboxGroup.stories.tsx
+++ b/packages/components/forms/stories/CheckboxGroup.stories.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { action } from '@storybook/addon-actions';
 import { Checkbox, CheckboxGroupProps } from '../src';
+import { FormControl } from '@contentful/f36-forms';
+import { Paragraph } from '@contentful/f36-typography';
 
 export default {
   title: 'Form Elements/Checkbox/CheckboxGroup',
@@ -61,5 +63,50 @@ export const Uncontrolled = (args: CheckboxGroupProps) => {
 };
 
 Uncontrolled.args = {
+  defaultValue: ['apples', 'kiwis'],
+};
+
+export const WithFormControl = (args: CheckboxGroupProps) => {
+  const [groupState, setGroupState] = useState(args.value || args.defaultValue);
+  const handleOnChange = (e) => {
+    e.persist();
+    const value = e.target.value;
+    setGroupState((prevState) =>
+      prevState.includes(value)
+        ? prevState.filter((v) => v !== value)
+        : [...prevState, value],
+    );
+    action('onChange')(e);
+  };
+
+  const { value } = args;
+  useEffect(() => {
+    Array.isArray(value) && setGroupState(value);
+  }, [value]);
+
+  return (
+    <FormControl>
+      <FormControl.Label as="legend" marginBottom="spacing2Xs">
+        Fruits
+      </FormControl.Label>
+      <Paragraph>Choose your favorit fruit</Paragraph>
+      <Checkbox.Group
+        {...args}
+        value={groupState}
+        name="Fruit"
+        onChange={handleOnChange}
+      >
+        <Checkbox value="apples">Apples</Checkbox>
+        <Checkbox value="pears">Pears</Checkbox>
+        <Checkbox value="peaches">Peaches</Checkbox>
+        <Checkbox value="mangos">Mangos</Checkbox>
+        <Checkbox value="kiwis">Kiwis</Checkbox>
+        <Checkbox value="bananas">Bananas</Checkbox>
+      </Checkbox.Group>
+    </FormControl>
+  );
+};
+
+WithFormControl.args = {
   defaultValue: ['apples', 'kiwis'],
 };

--- a/packages/components/forms/stories/CheckboxGroup.stories.tsx
+++ b/packages/components/forms/stories/CheckboxGroup.stories.tsx
@@ -85,7 +85,7 @@ export const WithFormControl = (args: CheckboxGroupProps) => {
   }, [value]);
 
   return (
-    <FormControl>
+    <FormControl as="fieldset">
       <FormControl.Label as="legend" marginBottom="spacing2Xs">
         Fruits
       </FormControl.Label>

--- a/packages/components/forms/stories/RadioGroup.stories.tsx
+++ b/packages/components/forms/stories/RadioGroup.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { action } from '@storybook/addon-actions';
 import { Radio, RadioGroupProps } from '../src';
+import { FormControl } from '@contentful/f36-forms';
 
 export default {
   title: 'Form Elements/Radio/RadioGroup',
@@ -70,5 +71,51 @@ Uncontrolled.argTypes = {
 
 Uncontrolled.args = {
   defaultValue: 'kiwis',
+  name: 'fruits',
+};
+
+export const WithFormControl = (args: RadioGroupProps) => {
+  const [groupState, setGroupState] = useState(args.defaultValue);
+  const handleOnChange = (e) => {
+    e.persist();
+    setGroupState(e.target.value);
+    action('onChange')(e);
+  };
+
+  const { value } = args;
+  useEffect(() => {
+    setGroupState(value);
+  }, [value]);
+
+  return (
+    <FormControl as="fieldset">
+      <FormControl.Label as="legend">Fruits</FormControl.Label>
+      <Radio.Group
+        {...args}
+        value={groupState}
+        onChange={handleOnChange}
+        name="Fruit"
+      >
+        <Radio value="apples">Apples</Radio>
+        <Radio value="pears">Pears</Radio>
+        <Radio value="peaches">Peaches</Radio>
+        <Radio value="mangos">Mangos</Radio>
+        <Radio value="kiwis">Kiwis</Radio>
+        <Radio value="bananas">Bananas</Radio>
+      </Radio.Group>
+    </FormControl>
+  );
+};
+
+Basic.argTypes = {
+  defaultValue: { control: { disable: true } },
+  value: {
+    options: ['apples', 'pears', 'peaches', 'mangos', 'kiwis', 'bananas'],
+    control: { type: 'select' },
+  },
+};
+
+Basic.args = {
+  defaultValue: 'peaches',
   name: 'fruits',
 };


### PR DESCRIPTION
# Purpose of PR

This is an update for the documentation to further improve the accessibility guidelines and how to leverage `FormContro`l for semantic validation and error states.

Updated guidelines for following components:
- Checkbox and Checkbox.Group
- Radio and Radio.Group
- Select
- Textarea