### PR TITLE
fix(asset): set full width

### DIFF
--- a/.changeset/khaki-suits-perform.md
+++ b/.changeset/khaki-suits-perform.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-asset": patch
+---
+
+fix(asset): set full width on Asset root

--- a/packages/components/asset/src/Asset.styles.ts
+++ b/packages/components/asset/src/Asset.styles.ts
@@ -3,8 +3,9 @@ import { css } from 'emotion';
 
 export function getAssetStyles() {
   return {
-    relative: css({
+    root: css({
       position: 'relative',
+      width: '100%',
     }),
     height100: css({
       height: '100%',

--- a/packages/components/asset/src/Asset.tsx
+++ b/packages/components/asset/src/Asset.tsx
@@ -57,7 +57,7 @@ function _Asset(
 
   return (
     <Box
-      className={cx(styles.relative, className)}
+      className={cx(styles.root, className)}
       testId={testId}
       ref={ref}
       {...otherProps}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Sets `width: 100%` on Asset root. This is a bug we somehow never got fixed in F36 itself, I think no one ever made a ticket.

Tested in the web app.