### PR TITLE
fix(inline-entry-card): remove size prop

### DIFF
--- a/.changeset/mean-pigs-fail.md
+++ b/.changeset/mean-pigs-fail.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-card": patch
+---
+
+fix(inline-entry-card): remove unsupported size prop

--- a/packages/components/card/src/InlineEntryCard/InlineEntryCard.tsx
+++ b/packages/components/card/src/InlineEntryCard/InlineEntryCard.tsx
@@ -12,7 +12,7 @@ import { CardActions } from '../BaseCard/CardActions';
 
 export type InlineEntryCardInternalProps = Omit<
   EntryCardInternalProps,
-  'icon' | 'ref' | 'src' | 'type' | keyof BaseCardDragHandleProps
+  'icon' | 'ref' | 'src' | 'size' | 'type' | keyof BaseCardDragHandleProps
 >;
 
 export type InlineEntryCardProps = InlineEntryCardInternalProps;


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Remove the `size` prop from InlineEntryCard. This prop was never supported or used.