### PR TITLE
feat(Autocomplete): add controllable isOpen, inputValue props; extend text behaviour on item select

### DIFF
--- a/.changeset/soft-queens-eat.md
+++ b/.changeset/soft-queens-eat.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-autocomplete': minor
+---
+
+`clearAfterSelect` (`boolean`) replaced with `textOnAfterSelect` (`'clear' | 'preserve' | 'replace'`)

--- a/.changeset/soft-queens-eat.md
+++ b/.changeset/soft-queens-eat.md
@@ -2,4 +2,4 @@
 '@contentful/f36-autocomplete': minor
 ---
 
-`clearAfterSelect` (`boolean`) replaced with `textOnAfterSelect` (`'clear' | 'preserve' | 'replace'`)
+Add new props: `textOnAfterSelect?: 'clear' | 'preserve' | 'replace'`, `isOpen?: boolean; onOpen?: () => void; onClose?: () => void`, `inputValue?: string`

--- a/packages/components/autocomplete/examples/AutocompleteMultiSelectionExample.tsx
+++ b/packages/components/autocomplete/examples/AutocompleteMultiSelectionExample.tsx
@@ -35,8 +35,8 @@ export default function AutocompleteMultiSelectionExample() {
         onSelectItem={handleSelectItem}
         itemToString={(item) => item.name}
         renderItem={(item) => item.name}
-        // When this prop is `true`, it will clean the TextInput after an option is selected
-        clearAfterSelect
+        // When `textOnAfterSelect` is `"clear"`, it will clean the TextInput after an option is selected
+        textOnAfterSelect="clear"
         closeAfterSelect={false}
       />
 

--- a/packages/components/autocomplete/src/Autocomplete.test.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.test.tsx
@@ -97,6 +97,29 @@ describe('Autocomplete', () => {
       expect(mockOnSelectItem).toHaveBeenCalledWith('Apple 🍎');
     });
 
+    it('clears the input after item is selected when "clearAfterSelect" is true', async () => {
+      const user = userEvent.setup();
+
+      renderComponent({ clearAfterSelect: true });
+
+      // Type one letter in the input to open the list
+      await user.type(screen.getByRole('textbox'), 'a');
+
+      // checks if the list is visible
+      expect(screen.getByRole('listbox')).toBeVisible();
+
+      // go to the list first item
+      await user.keyboard('[ArrowDown]');
+
+      // press Enter to select the item
+      await user.keyboard('[Enter]');
+
+      // checks if the list got closed and the value of the input is an empty string
+      expect(screen.getByRole('listbox', { hidden: true })).not.toBeVisible();
+      expect(screen.getByRole('textbox')).toHaveValue('');
+      expect(mockOnSelectItem).toHaveBeenCalledWith('Apple 🍎');
+    });
+
     it('clears the input after item is selected when "textOnAfterSelect" is "clear"', async () => {
       const user = userEvent.setup();
 

--- a/packages/components/autocomplete/src/Autocomplete.test.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { getStringMatch } from '@contentful/f36-utils';
 import { Autocomplete, AutocompleteProps } from './Autocomplete';
 
@@ -61,198 +62,137 @@ const mockOnSelectItem = jest.fn();
 describe('Autocomplete', () => {
   describe('items is an array of strings', () => {
     it('calls the callback on input value change and selects the first item', async () => {
+      const user = userEvent.setup();
       renderComponent({});
 
-      const input = screen.getByTestId('cf-autocomplete-input');
-      const list = screen.getByTestId('cf-autocomplete-list');
-      const listFirstItem = screen.getByTestId('cf-autocomplete-list-item-0');
+      const list = screen.queryByRole('list', { hidden: true });
 
       // list is initially closed
       expect(list).not.toBeVisible();
       expect(list.childElementCount).toBe(12);
 
       // Type one letter in the input to open the list
-      fireEvent.input(input, {
-        target: {
-          value: 'a',
-        },
-      });
+      await user.type(screen.getByRole('textbox'), 'a');
 
       // checks that onInputValueChange was called with the value we typed
       expect(mockOnInputValueChange).toHaveBeenCalledWith('a');
 
       // checks if the list is visible and it only shows the filtered options
-      await waitFor(() => {
-        expect(list).toBeVisible();
-      });
+      expect(screen.getByRole('listbox')).toBeVisible();
 
       // go to the list first item
-      fireEvent.keyDown(input, {
-        key: 'ArrowDown',
-      });
+      await user.keyboard('[ArrowDown]');
 
       // checks if the first item of the list gets selected
+      const listFirstItem = screen.getAllByRole('option')[0];
       expect(listFirstItem.getAttribute('aria-selected')).toBe('true');
       expect(listFirstItem.getAttribute('class')).toContain('highlighted');
 
       // press Enter to select the item
-      fireEvent.keyDown(input, {
-        key: 'Enter',
-      });
+      await user.keyboard('[Enter]');
 
       // checks if the list got closed and the value of the input is the one we selected
       expect(list).not.toBeVisible();
-      expect(input.getAttribute('value')).toBe('Apple 🍎');
+      expect(screen.getByRole('textbox')).toHaveValue('Apple 🍎');
       expect(mockOnSelectItem).toHaveBeenCalledWith('Apple 🍎');
     });
 
     it('clears the input after item is selected when "textOnAfterSelect" is "clear"', async () => {
+      const user = userEvent.setup();
+
       renderComponent({ textOnAfterSelect: 'clear' });
 
-      const input = screen.getByTestId('cf-autocomplete-input');
-      const container = screen.getByTestId('cf-autocomplete-container');
-
       // Type one letter in the input to open the list
-      fireEvent.input(input, {
-        target: {
-          value: 'a',
-        },
-      });
+      await user.type(screen.getByRole('textbox'), 'a');
 
       // checks if the list is visible
-      await waitFor(() => {
-        expect(container).toBeVisible();
-      });
+      expect(screen.getByRole('listbox')).toBeVisible();
 
       // go to the list first item
-      fireEvent.keyDown(input, {
-        key: 'ArrowDown',
-      });
+      await user.keyboard('[ArrowDown]');
 
       // press Enter to select the item
-      fireEvent.keyDown(input, {
-        key: 'Enter',
-      });
+      await user.keyboard('[Enter]');
 
       // checks if the list got closed and the value of the input is an empty string
-      expect(container).not.toBeVisible();
-      expect(input.getAttribute('value')).toBe('');
+      expect(screen.getByRole('listbox', { hidden: true })).not.toBeVisible();
+      expect(screen.getByRole('textbox')).toHaveValue('');
       expect(mockOnSelectItem).toHaveBeenCalledWith('Apple 🍎');
     });
 
     it('preserves the same input value after item is selected when "textOnAfterSelect" is "preserve"', async () => {
+      const user = userEvent.setup();
+
       renderComponent({ textOnAfterSelect: 'preserve' });
 
-      const input = screen.getByTestId('cf-autocomplete-input');
-      const container = screen.getByTestId('cf-autocomplete-container');
-
       // Type one letter in the input to open the list
-      fireEvent.input(input, {
-        target: {
-          value: 'a',
-        },
-      });
+      await user.type(screen.getByRole('textbox'), 'a');
 
       // checks if the list is visible
-      await waitFor(() => {
-        expect(container).toBeVisible();
-      });
+      expect(screen.getByRole('listbox')).toBeVisible();
 
       // go to the list first item
-      fireEvent.keyDown(input, {
-        key: 'ArrowDown',
-      });
+      await user.keyboard('[ArrowDown]');
 
       // press Enter to select the item
-      fireEvent.keyDown(input, {
-        key: 'Enter',
-      });
+      await user.keyboard('[Enter]');
 
       // checks if the list got closed and the value of the input is an empty string
-      expect(container).not.toBeVisible();
-      expect(input.getAttribute('value')).toBe('a');
+      expect(screen.getByRole('listbox', { hidden: true })).not.toBeVisible();
+      expect(screen.getByRole('textbox')).toHaveValue('a');
       expect(mockOnSelectItem).toHaveBeenCalledWith('Apple 🍎');
     });
 
     it('shows the value of the "noMatchesMessage" when the list has 0 items', async () => {
       const noMatchesMessage = 'There is no Broccoli in the list';
 
+      const user = userEvent.setup();
       renderComponent({ noMatchesMessage, items: [] });
 
-      const input = screen.getByTestId('cf-autocomplete-input');
-
       // type anything to open the list
-      fireEvent.input(input, {
-        target: {
-          value: 'tesst',
-        },
-      });
-
-      const list = screen.getByTestId('cf-autocomplete-container');
+      await user.type(screen.getByRole('textbox'), 'tesst');
 
       // checks if the list is visible and it only shows the "No matches" message
-      await waitFor(() => {
-        expect(list).toBeVisible();
-        expect(screen.getByText(noMatchesMessage)).toBeVisible();
-      });
+      expect(screen.getByRole('listbox')).toBeVisible();
+      expect(screen.getByText(noMatchesMessage)).toBeVisible();
     });
 
     it('should show the empty list if showEmptyList is true', async () => {
       const noMatchesMessage = 'No matches found';
 
       renderComponent({ items: [], showEmptyList: true, noMatchesMessage });
-      const input = screen.getByTestId('cf-autocomplete-input');
       // Container should exist but not visible
-      expect(screen.getByTestId('cf-autocomplete-container')).not.toBeVisible();
+      expect(screen.getByRole('listbox', { hidden: true })).not.toBeVisible();
 
       // focus on input to open the list
-      fireEvent.focus(input);
+      screen.getByRole('textbox').focus();
 
       // Should be visible after clicking on the input
-      await waitFor(() => {
-        expect(screen.getByTestId('cf-autocomplete-container')).toBeVisible();
-        expect(screen.getByText(noMatchesMessage)).toBeVisible();
-      });
+      expect(screen.getByRole('listbox')).toBeVisible();
+      expect(screen.getByText(noMatchesMessage)).toBeVisible();
     });
 
     it('is not showing the container when the list has 0 items and there is no input value', async () => {
+      const user = userEvent.setup();
       renderComponent({ items: [] });
 
-      const input = screen.getByTestId('cf-autocomplete-input');
-
-      fireEvent.click(input);
-
-      // type anything to open the list
-      fireEvent.input(input, {
-        target: {
-          value: '',
-        },
-      });
-
-      const list = screen.queryByTestId('cf-autocomplete-list');
+      await user.click(screen.getByRole('textbox'));
 
       // checks if the list is not visible
-      expect(list).toBeNull();
+      expect(screen.getByRole('textbox')).toHaveFocus();
+      expect(screen.getByRole('listbox', { hidden: true })).not.toBeVisible();
     });
 
     it('shows loading state when "isLoading" is true', async () => {
+      const user = userEvent.setup();
       renderComponent({ isLoading: true });
 
-      const input = screen.getByTestId('cf-autocomplete-input');
-      const container = screen.getByTestId('cf-autocomplete-container');
-
       // type anything to open the list
-      fireEvent.input(input, {
-        target: {
-          value: 'broccoli',
-        },
-      });
+      await user.type(screen.getByRole('textbox'), 'broccoli');
 
       // checks if the list is visible and it shows the loading state
-      await waitFor(() => {
-        expect(container).toBeVisible();
-        expect(screen.queryAllByTestId('cf-ui-skeleton-form')).toHaveLength(3);
-      });
+      expect(screen.getByRole('listbox')).toBeVisible();
+      expect(screen.getAllByLabelText('Loading component...')).toHaveLength(3);
     });
   });
 
@@ -260,49 +200,39 @@ describe('Autocomplete', () => {
     const getItemName = (item: Fruit) => item.name;
 
     it('selects the first item', async () => {
+      const user = userEvent.setup();
       renderComponent({
         items: fruits,
         itemToString: getItemName,
         renderItem: getItemName,
       });
 
-      const input = screen.getByTestId('cf-autocomplete-input');
-      const list = screen.getByTestId('cf-autocomplete-list');
-      const listFirstItem = screen.getByTestId('cf-autocomplete-list-item-0');
+      const list = screen.getByRole('list', { hidden: true });
+      const listFirstItem = screen.getAllByRole('option', { hidden: true })[0];
 
       // list is initially closed
       expect(list).not.toBeVisible();
       expect(list.childElementCount).toBe(12);
 
       // Type one letter in the input to open the list
-      fireEvent.input(input, {
-        target: {
-          value: 'a',
-        },
-      });
+      await user.type(screen.getByRole('textbox'), 'a');
 
       // checks if the list is visible
-      await waitFor(() => {
-        expect(list).toBeVisible();
-      });
+      expect(list).toBeVisible();
 
       // press the ArrowDown key
-      fireEvent.keyDown(input, {
-        key: 'ArrowDown',
-      });
+      await user.keyboard('[ArrowDown]');
 
       // checks if the first item of the list gets selected
       expect(listFirstItem.getAttribute('aria-selected')).toBe('true');
       expect(listFirstItem.getAttribute('class')).toContain('highlighted');
 
       // press Enter to select the item
-      fireEvent.keyDown(input, {
-        key: 'Enter',
-      });
+      await user.keyboard('[Enter]');
 
       // checks if the list got closed and the value of the input is the one we selected
       expect(list).not.toBeVisible();
-      expect(input.getAttribute('value')).toBe('Apple 🍎');
+      expect(screen.getByRole('textbox')).toHaveValue('Apple 🍎');
       expect(mockOnSelectItem).toHaveBeenCalledWith({
         id: 1,
         name: 'Apple 🍎',
@@ -310,6 +240,7 @@ describe('Autocomplete', () => {
     });
 
     it('when used with `getStringMatch`, it will render each item with the matched text wrapped in <b> tag', async () => {
+      const user = userEvent.setup();
       renderComponent({
         items: fruits,
         itemToString: (item: Fruit) => item.name,
@@ -329,25 +260,14 @@ describe('Autocomplete', () => {
         },
       });
 
-      const input = screen.getByTestId('cf-autocomplete-input');
-      const list = screen.getByTestId('cf-autocomplete-list');
-
       // Type a text to be matched and open the list of suggestions
-      fireEvent.input(input, {
-        target: {
-          value: 'ana',
-        },
-      });
+      await user.type(screen.getByRole('textbox'), 'ana');
 
       // checks if the list is visible and it only shows the filtered options
-      await waitFor(() => {
-        expect(list).toBeVisible();
-      });
+      expect(screen.getByRole('list')).toBeVisible();
 
       // go to the list first item
-      fireEvent.keyDown(input, {
-        key: 'ArrowDown',
-      });
+      await user.keyboard('[ArrowDown]');
 
       // checks if there are two highlighted children
       expect(screen.queryAllByText(/ana/i)).toHaveLength(2);
@@ -356,23 +276,19 @@ describe('Autocomplete', () => {
 
   describe('items is a nested object with groups', () => {
     const openDropdown = async () => {
-      const input = screen.getByTestId('cf-autocomplete-input');
-      const container = screen.getByTestId('cf-autocomplete-container');
+      const user = userEvent.setup();
+
+      const input = screen.getByRole('textbox');
+      const container = screen.getByRole('listbox', { hidden: true });
       // list is initially closed
       expect(container).not.toBeVisible();
 
       // Type one letter in the input to open the list
-      fireEvent.input(input, {
-        target: {
-          value: 'a',
-        },
-      });
+      await user.type(input, 'a');
 
       // checks if the list is visible
-      await waitFor(() => {
-        expect(container).toBeVisible();
-      });
-      return { input, container };
+      expect(container).toBeVisible();
+      return { input, container, user };
     };
 
     it('renders the group titles', async () => {
@@ -386,9 +302,7 @@ describe('Autocomplete', () => {
       const { container } = await openDropdown();
 
       expect(container.childElementCount).toBe(2);
-      expect(
-        screen.queryAllByTestId('cf-autocomplete-grouptitle'),
-      ).toHaveLength(2);
+      expect(screen.getAllByRole('heading')).toHaveLength(2);
     });
     it("doesn't render an empty group", async () => {
       renderComponent<Fruit>({
@@ -401,7 +315,7 @@ describe('Autocomplete', () => {
       await openDropdown();
 
       const renderedGroupTitles = screen
-        .getAllByTestId('cf-autocomplete-grouptitle')
+        .getAllByRole('heading')
         .map((node) => node.textContent);
 
       expect(renderedGroupTitles).toContain('Fruit');
@@ -416,26 +330,22 @@ describe('Autocomplete', () => {
         renderItem: (item: Fruit) => item.name,
       });
 
-      const firstItem = screen.getByTestId('cf-autocomplete-list-item-0');
-
-      const { container, input } = await openDropdown();
+      const { container, input, user } = await openDropdown();
 
       expect(container.childElementCount).toBe(2);
 
+      const firstItem = screen.getAllByRole('option')[0];
+
       // press the ArrowDown key
-      fireEvent.keyDown(input, {
-        key: 'ArrowDown',
-      });
+      await user.keyboard('[ArrowDown]');
       expect(firstItem.getAttribute('aria-selected')).toBe('true');
 
       // press Enter to select the item
-      fireEvent.keyDown(input, {
-        key: 'Enter',
-      });
+      await user.keyboard('[Enter]');
 
       // checks if the list got closed and the value of the input is the one we selected
       expect(container).not.toBeVisible();
-      expect(input.getAttribute('value')).toBe('Apple 🍎');
+      expect(input).toHaveValue('Apple 🍎');
       expect(mockOnSelectItem).toHaveBeenCalledWith({
         id: 1,
         name: 'Apple 🍎',
@@ -457,9 +367,7 @@ describe('Autocomplete', () => {
       await openDropdown();
 
       // checks if the list is visible and it only shows the "No matches" message
-      await waitFor(() => {
-        expect(screen.getByText(noMatchesMessage)).toBeVisible();
-      });
+      expect(screen.getByText(noMatchesMessage)).toBeVisible();
     });
   });
 });

--- a/packages/components/autocomplete/src/Autocomplete.test.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.test.tsx
@@ -106,8 +106,8 @@ describe('Autocomplete', () => {
       expect(mockOnSelectItem).toHaveBeenCalledWith('Apple 🍎');
     });
 
-    it('clears the input after item is selected when "clearAfterSelect" is true', async () => {
-      renderComponent({ clearAfterSelect: true });
+    it('clears the input after item is selected when "textOnAfterSelect" is "clear"', async () => {
+      renderComponent({ textOnAfterSelect: 'clear' });
 
       const input = screen.getByTestId('cf-autocomplete-input');
       const container = screen.getByTestId('cf-autocomplete-container');
@@ -137,6 +137,40 @@ describe('Autocomplete', () => {
       // checks if the list got closed and the value of the input is an empty string
       expect(container).not.toBeVisible();
       expect(input.getAttribute('value')).toBe('');
+      expect(mockOnSelectItem).toHaveBeenCalledWith('Apple 🍎');
+    });
+
+    it('preserves the same input value after item is selected when "textOnAfterSelect" is "preserve"', async () => {
+      renderComponent({ textOnAfterSelect: 'preserve' });
+
+      const input = screen.getByTestId('cf-autocomplete-input');
+      const container = screen.getByTestId('cf-autocomplete-container');
+
+      // Type one letter in the input to open the list
+      fireEvent.input(input, {
+        target: {
+          value: 'a',
+        },
+      });
+
+      // checks if the list is visible
+      await waitFor(() => {
+        expect(container).toBeVisible();
+      });
+
+      // go to the list first item
+      fireEvent.keyDown(input, {
+        key: 'ArrowDown',
+      });
+
+      // press Enter to select the item
+      fireEvent.keyDown(input, {
+        key: 'Enter',
+      });
+
+      // checks if the list got closed and the value of the input is an empty string
+      expect(container).not.toBeVisible();
+      expect(input.getAttribute('value')).toBe('a');
       expect(mockOnSelectItem).toHaveBeenCalledWith('Apple 🍎');
     });
 

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -276,6 +276,11 @@ function _Autocomplete<ItemType>(
     },
     stateReducer: (state, { type, changes }) => {
       switch (type) {
+        case useCombobox.stateChangeTypes.InputBlur: {
+          // don't change input value on blur
+          return { ...changes, inputValue: state.inputValue };
+        }
+
         // item is selected by click or keydown
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick: {

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -102,6 +102,12 @@ export interface AutocompleteProps<ItemType>
    */
   textOnAfterSelect?: 'clear' | 'preserve' | 'replace';
   /**
+   * If this is set to `true` the text input will be cleared after an item is selected
+   * @default false
+   * @deprecated Use textOnAfterSelect="clear" instead
+   */
+  clearAfterSelect?: boolean;
+  /**
    * If this is set to `false` the dropdown menu will stay open after selecting an item
    * @default true
    */
@@ -180,7 +186,8 @@ function _Autocomplete<ItemType>(
     onOpen,
     id,
     className,
-    textOnAfterSelect = 'replace',
+    clearAfterSelect = false,
+    textOnAfterSelect = clearAfterSelect ? 'clear' : 'replace',
     closeAfterSelect = true,
     defaultValue = '',
     selectedItem,

--- a/packages/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -284,7 +284,7 @@ export const MultipleSelection = (args: AutocompleteProps<Produce>) => {
         onBlur={(e) => action('onBlur')(e)}
         itemToString={(item) => item.name}
         renderItem={(item) => item.name}
-        clearAfterSelect
+        textOnAfterSelect="clear"
         closeAfterSelect={false}
       />
 

--- a/packages/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -159,14 +159,12 @@ export const ControlledFromOutside = (args: AutocompleteProps<Produce>) => {
     id: 9,
     name: 'Pear 🍐',
   });
-  const [filteredItems, setFilteredItems] = useState(fruits);
+  const [inputValue, setInputValue] = useState(selectedFruit.name);
+  const [isOpen, setIsOpen] = useState(false);
 
-  const handleInputValueChange = (value: string) => {
-    const newFilteredItems = fruits.filter((item) =>
-      item.name.toLowerCase().includes(value.toLowerCase()),
-    );
-    setFilteredItems(newFilteredItems);
-  };
+  const filteredItems = fruits.filter((item) =>
+    item.name.toLowerCase().includes(inputValue.toLowerCase()),
+  );
 
   const handleSelectItem = (item: Produce) => {
     setSelectedFruit(item);
@@ -181,8 +179,13 @@ export const ControlledFromOutside = (args: AutocompleteProps<Produce>) => {
     >
       <Autocomplete<Produce>
         {...args}
+        listMaxHeight={120}
+        textOnAfterSelect="preserve"
         items={filteredItems}
-        onInputValueChange={handleInputValueChange}
+        isOpen={isOpen}
+        onOpen={() => setIsOpen(true)}
+        inputValue={inputValue}
+        onInputValueChange={setInputValue}
         onSelectItem={handleSelectItem}
         itemToString={(item) => item.name}
         renderItem={(item) => item.name}
@@ -190,15 +193,17 @@ export const ControlledFromOutside = (args: AutocompleteProps<Produce>) => {
         onBlur={(e) => action('onBlur')(e)}
         selectedItem={selectedFruit}
       />
-
       <Paragraph>Selected fruit: {selectedFruit?.name}</Paragraph>
+      <Paragraph>Input value: {inputValue}</Paragraph>
       <Button onClick={() => setSelectedFruit({ id: undefined, name: '' })}>
         clear selection
       </Button>
+      <Button onClick={() => setInputValue('')}>clear input value</Button>
+      <Button onClick={() => setIsOpen(!isOpen)}>toggle menu</Button>
     </Stack>
   );
 };
-UsingObjectsAsItems.args = {
+ControlledFromOutside.args = {
   placeholder: 'Search your favorite fruit',
 };
 


### PR DESCRIPTION
# Purpose of PR

What's changed:

- ❌ `clearAfterSelect` (`boolean`) replaced with 🆕 `textOnAfterSelect` (`'clear' | 'preserve' | 'replace'`) to be able to preserve the text input value when item selected
- 🆕 `inputValue` prop added to be able to clear the text input programmatically (e.g. on menu close)
- 🆕 `isOpen` prop added (and corresponding `onOpen`, `onClose` handlers) to be able to control menu state and subscribe to its change


https://github.com/contentful/forma-36/assets/22265863/65807b83-0400-422c-9a54-33ce439be045

