### PR TITLE
docs: show deprecated prop badge

### DIFF
--- a/packages/f36-docs-utils/src/PropsTable/PropsTable.tsx
+++ b/packages/f36-docs-utils/src/PropsTable/PropsTable.tsx
@@ -5,6 +5,7 @@ import {
   Subheading,
   Text,
   Table,
+  Tooltip,
 } from '@contentful/f36-components';
 
 import { getPropsTableStyles } from './PropsTable.styles';
@@ -57,6 +58,13 @@ export function PropsTable({ of }: PropsTableProps) {
                   <Badge variant="featured" size="small">
                     required
                   </Badge>
+                )}{' '}
+                {item.tags && 'deprecated' in item.tags && (
+                  <Tooltip content={item.tags.deprecated}>
+                    <Badge variant="negative" size="small">
+                      Deprecated
+                    </Badge>
+                  </Tooltip>
                 )}
               </Table.Cell>
               <Table.Cell className={styles.cell}>

--- a/packages/website/utils/propsMeta.ts
+++ b/packages/website/utils/propsMeta.ts
@@ -47,6 +47,7 @@ function getTypescriptMetaInformation(sourcePath) {
         shouldExtractLiteralValuesFromEnum: true,
         shouldExtractValuesFromUnion: true,
         skipChildrenPropWithoutDoc: false,
+        shouldIncludePropTagMap: true,
       },
     );
 


### PR DESCRIPTION
# Purpose of PR

Add a clear way to mark props as deprecated in the docs.

Example: https://forma-36-git-feat-docsdeprecated.colorfuldemo.com/components/autocomplete#props-api-reference:~:text=the%20root%20element-,clearAfterSelect

Before:

<img width="752" alt="image" src="https://github.com/contentful/forma-36/assets/22265863/e06edd4a-18ef-4e6d-af39-a4708feb6397">


After:

<img width="752" alt="image" src="https://github.com/contentful/forma-36/assets/22265863/4fe3fd92-2db1-4204-ba3b-f7c1bc5b0ad8">

<img width="752" alt="image" src="https://github.com/contentful/forma-36/assets/22265863/c7541e35-ba68-411a-a499-6a9ee9794bfb">
