### PR TITLE
fix: add 'f36-core' to playground dependencies

### DIFF
--- a/packages/website/components/Playground/SandpackRenderer.tsx
+++ b/packages/website/components/Playground/SandpackRenderer.tsx
@@ -103,6 +103,7 @@ export function SandpackRenderer({
           '@contentful/f36-navlist': '^4.1.0-alpha.0', // Remove when added to f36-components
           '@contentful/f36-tokens': '^4.0.0',
           '@contentful/f36-icons': '^4.0.0',
+          '@contentful/f36-core': '^4.0.0',
           emotion: '^10.0.17',
           lodash: '^4.17.21',
           'react-hook-form': '7.22.5',


### PR DESCRIPTION
# Purpose of PR

The https://npmjs.com/package/@contentful/f36-core was missing from the playground dependencies.

| Before |
|--------|
| <img alt="before" src="https://github.com/contentful/forma-36/assets/103024358/2c1c53b6-b487-4564-b8f0-f63fa5422fa8"> |

| After |
|--------|
| <img alt="after" src="https://github.com/contentful/forma-36/assets/103024358/777c0821-25f4-410c-8e15-76bef681bf36"> |

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
