### PR TITLE
fix(TextLink): vertical alignment when used in list

### DIFF
--- a/.changeset/spotty-insects-talk.md
+++ b/.changeset/spotty-insects-talk.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-text-link': patch
+---
+
+fix(TextLink): vertical alignment when used in list

--- a/packages/components/text-link/src/TextLink.styles.ts
+++ b/packages/components/text-link/src/TextLink.styles.ts
@@ -66,7 +66,7 @@ const textLink = ({
   css({
     display: 'inline-flex',
     justifyContent: 'center',
-    alignItems: 'center',
+    alignItems: 'baseline',
     boxSizing: 'border-box',
     border: 0,
     padding: 0,
@@ -84,7 +84,6 @@ const textLink = ({
     opacity: isDisabled ? 0.5 : 1,
     ...variantToStyles(variant),
     outline: 'none',
-    verticalAlign: 'bottom',
     '&:focus, &:focus-visible, &:hover': {
       textDecoration: isDisabled ? 'none' : 'underline',
     },

--- a/packages/components/text-link/src/TextLink.tsx
+++ b/packages/components/text-link/src/TextLink.tsx
@@ -76,7 +76,7 @@ function _TextLink<E extends React.ElementType = typeof TEXT_LINK_DEFAULT_TAG>(
   };
 
   const iconContent = icon ? (
-    <Flex as="span">
+    <Flex as="span" alignSelf="center">
       {React.cloneElement(icon, {
         className: cx(icon.props.className, styles.textLinkIcon()),
         size: 'small',

--- a/packages/components/text-link/stories/TextLink.stories.tsx
+++ b/packages/components/text-link/stories/TextLink.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, Story } from '@storybook/react/types-6-0';
 import * as icons from '@contentful/f36-icons';
 import { Icon } from '@contentful/f36-icon';
 import { Paragraph, Text } from '@contentful/f36-typography';
+import { List } from '@contentful/f36-list';
 import { Flex } from '@contentful/f36-core';
 import tokens from '@contentful/f36-tokens';
 
@@ -78,6 +79,56 @@ export const UsedWithText = () => {
       third-largest metropolitan region after the Rhine-Ruhr and Rhine-Main
       regions.
     </Paragraph>
+  );
+};
+
+export const UsedWithList = () => {
+  return (
+    <List>
+      <List.Item>
+        <Text>
+          List item with a link:{' '}
+          <TextLink
+            href="https://contentful.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Contentful
+          </TextLink>{' '}
+          Website
+        </Text>
+      </List.Item>
+      <List.Item>
+        <Text>
+          List item with a link and start icon:{' '}
+          <TextLink
+            href="https://contentful.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            icon={<Icon as={icons.ExternalLinkIcon} />}
+            alignIcon="start"
+          >
+            Contentful
+          </TextLink>{' '}
+          Website
+        </Text>
+      </List.Item>
+      <List.Item>
+        <Text>
+          List item with a link and end icon:{' '}
+          <TextLink
+            href="https://contentful.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            icon={<Icon as={icons.ExternalLinkIcon} />}
+            alignIcon="end"
+          >
+            Contentful
+          </TextLink>{' '}
+          Website
+        </Text>
+      </List.Item>
+    </List>
   );
 };
 


### PR DESCRIPTION
# Purpose of PR

TextLink text should be align to baseline, but Icon inside should be center aligned.

Before: 

<img width="519" alt="image" src="https://github.com/contentful/forma-36/assets/22265863/6ed56ed5-18e3-4352-8c90-c1e3046a7bf0">


After:

<img width="457" alt="image" src="https://github.com/contentful/forma-36/assets/22265863/36680f09-6319-4c6c-ba9f-012739c80d7f">


Related to https://github.com/contentful/forma-36/pull/2295
