### PR TITLE
fix(Button): transparent variant loading icon color

### DIFF
--- a/.changeset/beige-guests-exercise.md
+++ b/.changeset/beige-guests-exercise.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-button': patch
+---
+
+fix(Button): transparent variant loading icon color

--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -97,7 +97,9 @@ function _Button<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
           <Spinner
             customSize={18}
             variant={
-              variant === 'secondary' || variant === 'negative'
+              variant === 'secondary' ||
+              variant === 'negative' ||
+              variant === 'transparent'
                 ? 'default'
                 : 'white'
             }


### PR DESCRIPTION
# Purpose of PR

Fix transparent Button loading icon color

Before:

![image](https://github.com/contentful/forma-36/assets/22265863/72e09e16-84bd-4978-836f-01299849a535)


After:

<img width="140" alt="image" src="https://github.com/contentful/forma-36/assets/22265863/e5498f4e-56a2-4661-82ab-4b473d642612">
