### PR TITLE
feat(Tooltip): support ReactElement as content

### DIFF
--- a/.changeset/breezy-geese-hug.md
+++ b/.changeset/breezy-geese-hug.md
@@ -1,0 +1,6 @@
+---
+'@contentful/f36-avatar': minor
+'@contentful/f36-tooltip': minor
+---
+
+Tooltips can now render ReactElement as their Content

--- a/packages/components/avatar/src/Avatar/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar/Avatar.tsx
@@ -3,7 +3,12 @@ import { cx } from 'emotion';
 
 import { type CommonProps } from '@contentful/f36-core';
 import { Image, type ImageProps } from '@contentful/f36-image';
-import { Tooltip, type TooltipProps } from '@contentful/f36-tooltip';
+import {
+  Tooltip,
+  type TooltipProps,
+  type TooltipInternalProps,
+  type WithEnhancedContent,
+} from '@contentful/f36-tooltip';
 
 import { convertSizeToPixels, getAvatarStyles } from './Avatar.styles';
 import type { ColorVariant } from './utils';
@@ -20,7 +25,9 @@ export interface AvatarProps extends CommonProps {
   /**
    * A tooltipProps attribute used to conditionally render the tooltip around root element
    */
-  tooltipProps?: Omit<TooltipProps, 'children'>;
+  tooltipProps?: CommonProps &
+    WithEnhancedContent &
+    Omit<TooltipInternalProps, 'children'>;
   variant?: Variant;
   colorVariant?: ColorVariant;
   icon?: React.ReactElement;

--- a/packages/components/avatar/src/Avatar/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar/Avatar.tsx
@@ -5,7 +5,6 @@ import { type CommonProps } from '@contentful/f36-core';
 import { Image, type ImageProps } from '@contentful/f36-image';
 import {
   Tooltip,
-  type TooltipProps,
   type TooltipInternalProps,
   type WithEnhancedContent,
 } from '@contentful/f36-tooltip';

--- a/packages/components/avatar/src/Avatar/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar/Avatar.tsx
@@ -20,7 +20,7 @@ export interface AvatarProps extends CommonProps {
   /**
    * A tooltipProps attribute used to conditionally render the tooltip around root element
    */
-  tooltipProps?: TooltipProps;
+  tooltipProps?: Omit<TooltipProps, 'children'>;
   variant?: Variant;
   colorVariant?: ColorVariant;
   icon?: React.ReactElement;

--- a/packages/components/avatar/src/Avatar/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar/Avatar.tsx
@@ -20,7 +20,7 @@ export interface AvatarProps extends CommonProps {
   /**
    * A tooltipProps attribute used to conditionally render the tooltip around root element
    */
-  tooltipProps?: Omit<TooltipProps, 'children'>;
+  tooltipProps?: TooltipProps;
   variant?: Variant;
   colorVariant?: ColorVariant;
   icon?: React.ReactElement;

--- a/packages/components/tooltip/README.mdx
+++ b/packages/components/tooltip/README.mdx
@@ -50,3 +50,5 @@ import { Tooltip } from '@contentful/f36-tooltip';
   <TextLink>Hover me</TextLink>
 </Tooltip>
 ```
+
+- When using `ReactElement` as the content, it's recommended to use the `ScreenReaderOnly` component when displaying critical information.

--- a/packages/components/tooltip/README.mdx
+++ b/packages/components/tooltip/README.mdx
@@ -39,6 +39,8 @@ import { Tooltip } from '@contentful/f36-tooltip';
 ## Content guidelines
 
 - Use short and clear messages as the `Tooltip`’s content
+- The Tooltip component allows you to pass React elements as content. However, this should be used with care. ReactElement as content is best suited for text formatting purposes. It should not be used for interactive elements like links, buttons, or form elements. Additionally, extensive images should be avoided, except for text-decorator icons that give semantic meaning to the text shown in the tooltip (e.g., warning signs or other relevant icons).
+  - When using `ReactElement` as the content, it's recommended to use the `ScreenReaderOnly` component when displaying critical information.
 
 ## Accessibility
 
@@ -50,5 +52,3 @@ import { Tooltip } from '@contentful/f36-tooltip';
   <TextLink>Hover me</TextLink>
 </Tooltip>
 ```
-
-- When using `ReactElement` as the content, it's recommended to use the `ScreenReaderOnly` component when displaying critical information.

--- a/packages/components/tooltip/src/Tooltip.test.tsx
+++ b/packages/components/tooltip/src/Tooltip.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { axe } from '@/scripts/test/axeHelper';
 
 import { Tooltip } from './Tooltip';
+import { Paragraph } from '@contentful/f36-typography';
 
 jest.mock('@contentful/f36-core', () => {
   const actual = jest.requireActual('@contentful/f36-core');
@@ -125,5 +126,27 @@ describe('Tooltip', () => {
     const results = await axe(container);
 
     expect(results).toHaveNoViolations();
+  });
+
+  it('render a React Element as children', async () => {
+    const user = userEvent.setup();
+
+    const { container } = render(
+      <Tooltip
+        label="With React Element"
+        id="Tooltip"
+        content={<Paragraph>Ich bin ein Paragraph</Paragraph>}
+      >
+        <span>Hover me</span>
+      </Tooltip>,
+    );
+    await user.hover(screen.getByText('Hover me'));
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+    expect(screen.getByRole('tooltip').textContent).toBe(
+      'Ich bin ein Paragraph',
+    );
   });
 });

--- a/packages/components/tooltip/src/Tooltip.tsx
+++ b/packages/components/tooltip/src/Tooltip.tsx
@@ -18,6 +18,28 @@ import { getStyles } from './Tooltip.styles';
 
 export type TooltipPlacement = Placement;
 
+type TextContentTooltip = {
+  /**
+   * Content of the tooltip
+   */
+  content?: string;
+  /**
+   * Accesible label property, only required when using ReactElement as content
+   */
+  label?: string;
+};
+
+type RichContentTooltip = {
+  /**
+   * Content of the tooltip
+   */
+  content?: React.ReactElement;
+  /**
+   * Accesible label property, only required when using ReactElement as content
+   */
+  label: string;
+};
+
 export interface TooltipProps extends CommonProps {
   /**
    * Child nodes to be rendered in the component and that will show the tooltip when they are hovered
@@ -27,10 +49,6 @@ export interface TooltipProps extends CommonProps {
    * HTML element used to wrap the target of the tooltip
    */
   as?: React.ElementType;
-  /**
-   * Content of the tooltip
-   */
-  content?: string;
   /**
    * A unique id of the tooltip
    */
@@ -101,6 +119,7 @@ export const Tooltip = ({
   className,
   as: HtmlTag = 'span',
   content,
+  label,
   id,
   isVisible = false,
   hideDelay = 0,
@@ -117,7 +136,7 @@ export const Tooltip = ({
   usePortal = false,
   isDisabled = false,
   ...otherProps
-}: TooltipProps) => {
+}: TooltipProps & (TextContentTooltip | RichContentTooltip)) => {
   const styles = getStyles();
   const [show, setShow] = useState(isVisible);
   const tooltipId = useId(id, 'tooltip');
@@ -210,7 +229,7 @@ export const Tooltip = ({
       }}
       {...attributes.popper}
     >
-      <span>{content}</span>
+      <span aria-label={label}>{content}</span>
       <span
         className={styles.tooltipArrow}
         data-placement={

--- a/packages/components/tooltip/src/Tooltip.tsx
+++ b/packages/components/tooltip/src/Tooltip.tsx
@@ -5,6 +5,7 @@ import React, {
   type MouseEvent,
   type FocusEvent,
   type CSSProperties,
+  ReactElement,
 } from 'react';
 import { usePopper } from 'react-popper';
 import type { Placement } from '@popperjs/core';
@@ -18,27 +19,27 @@ import { getStyles } from './Tooltip.styles';
 
 export type TooltipPlacement = Placement;
 
-type TextContentTooltip = {
-  /**
-   * Content of the tooltip
-   */
-  content?: string;
-  /**
-   * Accesible label property, only required when using ReactElement as content
-   */
-  label?: string;
-};
-
-type RichContentTooltip = {
-  /**
-   * Content of the tooltip
-   */
-  content?: React.ReactElement;
-  /**
-   * Accesible label property, only required when using ReactElement as content
-   */
-  label: string;
-};
+type WithEnhancedContent =
+  | {
+      /**
+       * Content of the tooltip
+       */
+      content: ReactElement;
+      /**
+       * Accesible label property, only required when using ReactElement as content
+       */
+      label: string;
+    }
+  | {
+      /**
+       * Content of the tooltip
+       */
+      content: string;
+      /**
+       * Accesible label property, only required when using ReactElement as content
+       */
+      label?: string;
+    };
 
 export type TooltipProps = CommonProps & {
   /**
@@ -112,7 +113,7 @@ export type TooltipProps = CommonProps & {
    * @default false
    */
   isDisabled?: boolean;
-} & (TextContentTooltip | RichContentTooltip);
+} & WithEnhancedContent;
 
 export const Tooltip = ({
   children,

--- a/packages/components/tooltip/src/Tooltip.tsx
+++ b/packages/components/tooltip/src/Tooltip.tsx
@@ -40,7 +40,7 @@ type RichContentTooltip = {
   label: string;
 };
 
-export interface TooltipProps extends CommonProps {
+export type TooltipProps = CommonProps & {
   /**
    * Child nodes to be rendered in the component and that will show the tooltip when they are hovered
    */
@@ -112,7 +112,7 @@ export interface TooltipProps extends CommonProps {
    * @default false
    */
   isDisabled?: boolean;
-}
+} & (TextContentTooltip | RichContentTooltip);
 
 export const Tooltip = ({
   children,
@@ -136,7 +136,7 @@ export const Tooltip = ({
   usePortal = false,
   isDisabled = false,
   ...otherProps
-}: TooltipProps & (TextContentTooltip | RichContentTooltip)) => {
+}: TooltipProps) => {
   const styles = getStyles();
   const [show, setShow] = useState(isVisible);
   const tooltipId = useId(id, 'tooltip');

--- a/packages/components/tooltip/src/Tooltip.tsx
+++ b/packages/components/tooltip/src/Tooltip.tsx
@@ -19,7 +19,7 @@ import { getStyles } from './Tooltip.styles';
 
 export type TooltipPlacement = Placement;
 
-type WithEnhancedContent =
+export type WithEnhancedContent =
   | {
       /**
        * Content of the tooltip
@@ -41,7 +41,7 @@ type WithEnhancedContent =
       label?: string;
     };
 
-export type TooltipProps = CommonProps & {
+export type TooltipInternalProps = {
   /**
    * Child nodes to be rendered in the component and that will show the tooltip when they are hovered
    */
@@ -113,7 +113,11 @@ export type TooltipProps = CommonProps & {
    * @default false
    */
   isDisabled?: boolean;
-} & WithEnhancedContent;
+};
+
+export type TooltipProps = CommonProps &
+  TooltipInternalProps &
+  WithEnhancedContent;
 
 export const Tooltip = ({
   children,

--- a/packages/components/tooltip/src/index.ts
+++ b/packages/components/tooltip/src/index.ts
@@ -1,2 +1,6 @@
 export { Tooltip } from './Tooltip';
-export type { TooltipProps } from './Tooltip';
+export type {
+  TooltipInternalProps,
+  TooltipProps,
+  WithEnhancedContent,
+} from './Tooltip';

--- a/packages/components/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/components/tooltip/stories/Tooltip.stories.tsx
@@ -228,7 +228,7 @@ export const WithReactElement = () => {
           label="Render a paragrah with a React Element"
           content={
             <Flex>
-              <p className={css({ marginBottom: 0 })}>I'm a React Element</p>
+              <p className={css({ marginBottom: 0 })}>I am a React Element</p>
             </Flex>
           }
         >

--- a/packages/components/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/components/tooltip/stories/Tooltip.stories.tsx
@@ -3,6 +3,7 @@ import { SectionHeading } from '@contentful/f36-typography';
 import { Tooltip } from '../src/Tooltip';
 import { TextLink } from '@contentful/f36-text-link';
 import { Flex } from '@contentful/f36-core';
+import { css } from 'emotion';
 
 export default {
   title: 'Components/Tooltip',
@@ -206,6 +207,31 @@ export const WithDelays = () => {
       </Flex>
       <Flex marginBottom="spacingS">
         <Tooltip content="I am a Tooltip 🙌" maxWidth={360} hideDelay={400}>
+          <TextLink href="/">Hover me</TextLink>
+        </Tooltip>
+      </Flex>
+    </>
+  );
+};
+
+export const WithReactElement = () => {
+  return (
+    <>
+      <SectionHeading as="h3" marginBottom="spacingS">
+        With React Elements as children
+      </SectionHeading>
+
+      <Flex marginBottom="spacingS">
+        <Tooltip
+          isVisible
+          hideDelay={60000}
+          label="Render a paragrah with a React Element"
+          content={
+            <Flex>
+              <p className={css({ marginBottom: 0 })}>I'm a React Element</p>
+            </Flex>
+          }
+        >
           <TextLink href="/">Hover me</TextLink>
         </Tooltip>
       </Flex>

--- a/packages/components/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/components/tooltip/stories/Tooltip.stories.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { Heading, Paragraph, SectionHeading } from '@contentful/f36-typography';
 import { Tooltip } from '../src/Tooltip';
 import { TextLink } from '@contentful/f36-text-link';
-import { Flex, Stack } from '@contentful/f36-core';
-import { css } from 'emotion';
+import { Flex } from '@contentful/f36-core';
 import tokens from '@contentful/f36-tokens';
 
 export default {

--- a/packages/components/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/components/tooltip/stories/Tooltip.stories.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { SectionHeading } from '@contentful/f36-typography';
+import { Heading, Paragraph, SectionHeading } from '@contentful/f36-typography';
 import { Tooltip } from '../src/Tooltip';
 import { TextLink } from '@contentful/f36-text-link';
-import { Flex } from '@contentful/f36-core';
+import { Flex, Stack } from '@contentful/f36-core';
 import { css } from 'emotion';
+import tokens from '@contentful/f36-tokens';
 
 export default {
   title: 'Components/Tooltip',
@@ -223,12 +224,15 @@ export const WithReactElement = () => {
 
       <Flex marginBottom="spacingS">
         <Tooltip
-          isVisible
-          hideDelay={60000}
           label="Render a paragrah with a React Element"
           content={
-            <Flex>
-              <p className={css({ marginBottom: 0 })}>I am a React Element</p>
+            <Flex flexDirection="column">
+              <Heading style={{ color: tokens.colorWhite }}>
+                I am a Heading
+              </Heading>
+              <Paragraph style={{ color: tokens.colorWhite }}>
+                I am a paragraph
+              </Paragraph>
             </Flex>
           }
         >

--- a/packages/forma-36-codemod/transforms/v4-tooltip.js
+++ b/packages/forma-36-codemod/transforms/v4-tooltip.js
@@ -1,19 +1,7 @@
 const { modifyPropsCodemod } = require('./common/modify-props-codemod');
-const { hasProperty, getProperty } = require('../utils');
 
 module.exports = modifyPropsCodemod({
   componentName: 'Tooltip',
-  beforeRename: (attributes) => {
-    if (
-      hasProperty(attributes, { propertyName: 'content' }) &&
-      typeof getProperty(attributes, { propertyName: 'content' } !== 'string')
-    ) {
-      console.error(
-        'Value of property "content" on Tooltip component should be a string.',
-      );
-    }
-    return attributes;
-  },
   renameMap: {
     place: 'placement',
     containerElement: 'as',


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Support `ReactElement` as Content for `Tooltips`

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [X] I have read the relevant `readme.md` file(s)
- [X] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [X] Tests are added/updated/not required
- [X] Tests are passing
- [X] Storybook stories are added/updated/not required
- [X] Usage notes are added/updated/not required
- [X] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [X] Doesn't contain any sensitive information
