### PR TITLE
chore: remove previous changeset

### DIFF
--- a/.changeset/breezy-geese-hug.md
+++ b/.changeset/breezy-geese-hug.md
@@ -1,6 +1,0 @@
----
-'@contentful/f36-avatar': minor
-'@contentful/f36-tooltip': minor
----
-
-Tooltips can now render ReactElement as their Content


### PR DESCRIPTION
The previous changeset was causing the pipeline to break since it has a mixed of:
```
Found ignored packages: @contentful/f36-avatar
Found not ignored packages: @contentful/f36-tooltip
```