### PR TITLE
fix(Tooltip): Fix Tooltip type issues

### DIFF
--- a/.changeset/two-penguins-argue.md
+++ b/.changeset/two-penguins-argue.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-tooltip': minor
+---
+
+Fix: Make content optional again

--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-avatar",
-  "version": "4.0.0-alpha.9",
+  "version": "4.0.0-alpha.10",
   "description": "Forma 36: Avatar component",
   "scripts": {
     "build": "tsup"

--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-avatar",
-  "version": "4.0.0-alpha.8",
+  "version": "4.0.0-alpha.9",
   "description": "Forma 36: Avatar component",
   "scripts": {
     "build": "tsup"

--- a/packages/components/tooltip/src/Tooltip.tsx
+++ b/packages/components/tooltip/src/Tooltip.tsx
@@ -19,27 +19,16 @@ import { getStyles } from './Tooltip.styles';
 
 export type TooltipPlacement = Placement;
 
-export type WithEnhancedContent =
-  | {
-      /**
-       * Content of the tooltip
-       */
-      content: ReactElement;
-      /**
-       * Accesible label property, only required when using ReactElement as content
-       */
-      label: string;
-    }
-  | {
-      /**
-       * Content of the tooltip
-       */
-      content: string;
-      /**
-       * Accesible label property, only required when using ReactElement as content
-       */
-      label?: string;
-    };
+export type WithEnhancedContent = {
+  /**
+   * Content of the tooltip
+   */
+  content?: ReactElement | string;
+  /**
+   * Accesible label property, only required when using ReactElement as content
+   */
+  label?: string;
+};
 
 export type TooltipInternalProps = {
   /**
@@ -115,9 +104,10 @@ export type TooltipInternalProps = {
   isDisabled?: boolean;
 };
 
-export type TooltipProps = CommonProps &
-  TooltipInternalProps &
-  WithEnhancedContent;
+export interface TooltipProps
+  extends CommonProps,
+    TooltipInternalProps,
+    WithEnhancedContent {}
 
 export const Tooltip = ({
   children,


### PR DESCRIPTION
- fix: Make label optional to keep backward compatibility
  - Some customers may already be providing react elements as content and this will break their implementation
- fix: Change TooltipProps back to an interface
- chore: Create new Avatar release