### PR TITLE
fix(TextLink): vertical alignment when used within flexbox container

### DIFF
--- a/.changeset/heavy-geese-lick.md
+++ b/.changeset/heavy-geese-lick.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-text-link': patch
+---
+
+fix(TextLink): vertical alignment when used within flexbox container

--- a/packages/components/text-link/src/TextLink.styles.ts
+++ b/packages/components/text-link/src/TextLink.styles.ts
@@ -66,7 +66,7 @@ const textLink = ({
   css({
     display: 'inline-flex',
     justifyContent: 'center',
-    alignItems: 'baseline',
+    alignItems: 'center',
     boxSizing: 'border-box',
     border: 0,
     padding: 0,
@@ -121,8 +121,16 @@ const textLinkText = ({ alignIcon }: Pick<TextLinkProps, 'alignIcon'>) => {
   }
 };
 
+const textLinkContent = () => {
+  return css({
+    display: 'flex',
+    alignItems: 'baseline',
+  });
+};
+
 export const styles = {
   textLink,
   textLinkIcon,
   textLinkText,
+  textLinkContent,
 };

--- a/packages/components/text-link/src/TextLink.tsx
+++ b/packages/components/text-link/src/TextLink.tsx
@@ -85,7 +85,7 @@ function _TextLink<E extends React.ElementType = typeof TEXT_LINK_DEFAULT_TAG>(
   ) : null;
 
   const commonContent = (
-    <>
+    <span className={styles.textLinkContent()}>
       {icon && alignIcon === 'start' && iconContent}
       {children && (
         <span
@@ -97,7 +97,7 @@ function _TextLink<E extends React.ElementType = typeof TEXT_LINK_DEFAULT_TAG>(
         </span>
       )}
       {icon && alignIcon === 'end' && iconContent}
-    </>
+    </span>
   );
 
   if (as === 'button') {

--- a/packages/components/text-link/stories/TextLink.stories.tsx
+++ b/packages/components/text-link/stories/TextLink.stories.tsx
@@ -132,6 +132,74 @@ export const UsedWithList = () => {
   );
 };
 
+export const UsedWithinFlexbox = () => {
+  const Box = ({ children }) => (
+    <Flex
+      style={{
+        width: 200,
+        height: 100,
+        background: 'black',
+        color: 'white',
+      }}
+    >
+      {children}
+    </Flex>
+  );
+
+  return (
+    <Flex flexDirection="column" gap="spacingL">
+      <Flex gap="spacingM">
+        <Box>icon: end</Box>
+        <TextLink
+          href="https://contentful.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          icon={<Icon as={icons.ExternalLinkIcon} />}
+          alignIcon="end"
+        >
+          Contentful Website
+        </TextLink>
+      </Flex>
+      <Flex gap="spacingM">
+        <Box>icon: start</Box>
+        <TextLink
+          href="https://contentful.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          icon={<Icon as={icons.ExternalLinkIcon} />}
+          alignIcon="start"
+        >
+          Contentful Website
+        </TextLink>
+      </Flex>
+      <Flex gap="spacingM" alignItems="flex-start">
+        <Box>align-items: flex-start</Box>
+        <TextLink
+          href="https://contentful.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          icon={<Icon as={icons.ExternalLinkIcon} />}
+          alignIcon="start"
+        >
+          Contentful Website
+        </TextLink>
+      </Flex>
+      <Flex gap="spacingM" alignItems="flex-end">
+        <Box>align-items: flex-end</Box>
+        <TextLink
+          href="https://contentful.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          icon={<Icon as={icons.ExternalLinkIcon} />}
+          alignIcon="end"
+        >
+          Contentful Website
+        </TextLink>
+      </Flex>
+    </Flex>
+  );
+};
+
 const textLinkVariants = [
   'primary',
   'positive',


### PR DESCRIPTION
# Purpose of PR

Fix TextLink vertical alignment when used within flexbox container.

## Problem

When used within a flexbox container TextLink stretches to full height. It used to have `style="align-items: center"` so when it's stretched it still would look aligned. But with recent changes in  https://github.com/contentful/forma-36/pull/2574 it was changed to `style="align-items: baseline"` to align it when used within inline text elements.

With this PR I'd like to return previous behaviour back (when TextLink is stretched to full height, and its elements are centrally aligned), but at the same time keep text and icon aligned to baseline when used within other text.

🚨 But to make it work I had to add an extra DOM element.

<img width="522" alt="image" src="https://github.com/contentful/forma-36/assets/22265863/d4059523-b771-4a72-b5bb-0103fe7e8d35">




<details>
  <summary>Bug screenshots</summary>

 
  ![image](https://github.com/contentful/forma-36/assets/22265863/e593b632-401e-4aa6-a1cb-9d92e504d180)
 
  ![image](https://github.com/contentful/forma-36/assets/22265863/de9935c2-52aa-46e9-9289-e2163f42b3da)
 
  ![image](https://github.com/contentful/forma-36/assets/22265863/23b68eef-ec26-467d-8a3a-1cf4756e9fc9)
  
</details>
