### PR TITLE
fix: fix missing peerDependency warnings

### DIFF
--- a/.changeset/tidy-bees-fry.md
+++ b/.changeset/tidy-bees-fry.md
@@ -1,0 +1,12 @@
+---
+"@contentful/f36-icon": patch
+"@contentful/f36-list": patch
+"@contentful/f36-multiselect": patch
+"@contentful/f36-pagination": patch
+"@contentful/f36-popover": patch
+"@contentful/f36-spinner": patch
+"@contentful/f36-text-link": patch
+"@contentful/f36-typography": patch
+---
+
+fix: add react-dom peer dependency

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -15,7 +15,8 @@
     "react-icons": "^4.4.0"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "files": [
     "dist"

--- a/packages/components/list/package.json
+++ b/packages/components/list/package.json
@@ -25,7 +25,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/multiselect/package.json
+++ b/packages/components/multiselect/package.json
@@ -20,7 +20,8 @@
     "react-focus-lock": "^2.9.5"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -15,7 +15,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -14,7 +14,8 @@
     "react-popper": "^2.3.0"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -14,7 +14,8 @@
     "@contentful/f36-typography": "^4.52.1"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/text-link/package.json
+++ b/packages/components/text-link/package.json
@@ -11,7 +11,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "license": "MIT",
   "files": [

--- a/packages/components/typography/package.json
+++ b/packages/components/typography/package.json
@@ -25,7 +25,8 @@
     "emotion": "^10.0.17"
   },
   "peerDependencies": {
-    "react": ">=16.8"
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
# Purpose of PR

Because the packages in question rely on `@contentful/f36-core` (and in one case, `react-popper`), which has `react-dom` in its `peerDependencies`, these packages need to have `react-dom` in their `peerDependencies` as well.

Fixes #2586

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
