### PR TITLE
fix: focus lock multi select

### DIFF
--- a/packages/components/multiselect/src/Multiselect.tsx
+++ b/packages/components/multiselect/src/Multiselect.tsx
@@ -296,7 +296,7 @@ function _Multiselect(props: MultiselectProps, ref: React.Ref<HTMLDivElement>) {
           testId="cf-multiselect-container"
           onBlur={() => onBlur?.()}
         >
-          <FocusLock>
+          <FocusLock focusOptions={{ preventScroll: true }} returnFocus={true}>
             {hasSearch && (
               <div className={styles.searchBar}>
                 <TextInput


### PR DESCRIPTION
# Purpose of PR

This pull request addresses a scrolling issue encountered when using the Multi Select component. By adding the `preventScroll: true` option, we ensure that the user's scroll position is maintained while the focus lock is active.

- Modified the FocusLock component in Multi Select to include focusOptions with `preventScroll: true`.
- Ensured the focus is returned after the FocusLock is deactivated using `returnFocus={true}`.

## Video before:
https://github.com/contentful/forma-36/assets/22968325/a8dd9161-5ff2-4517-9601-0d297d206180

## Video after:
https://github.com/contentful/forma-36/assets/22968325/3beb8ef4-9a3b-4b68-83c1-187961acb6f4