### PR TITLE
docs(TextLink): update link

### DIFF
--- a/packages/components/text-link/README.mdx
+++ b/packages/components/text-link/README.mdx
@@ -24,7 +24,7 @@ import { TextLink } from '@contentful/f36-text-link';
 
 By default, `TextLink` renders `<a>` HTML tag and should be used as an usual link attribute.
 
-Note that if you use `TextLink` for linking to third party content and use `target="_blank"` property, [it is recommended](https://web.dev/external-anchors-use-rel-noopener/) to set `rel="noreferrer noopener"`.
+Note that if you use `TextLink` for linking to third party content and use `target="_blank"` property, [it is recommended](https://developer.chrome.com/docs/lighthouse/best-practices/external-anchors-use-rel-noopener/) to set `rel="noreferrer noopener"`.
 
 ```jsx file=examples/TextLinkBasicExample.tsx
 
@@ -64,4 +64,4 @@ There are a number of variations of `TextLink` styles, here is a guide for when 
 ## Accessibility
 
 - Avoid using extra styling that that make link looks just like regular text.
-- If you use `TextLink` for linking to third party content and use `target="_blank"` property, it is recommended to set `rel="noreferrer noopener"`. [More details about external links security](https://web.dev/external-anchors-use-rel-noopener/)
+- If you use `TextLink` for linking to third party content and use `target="_blank"` property, it is recommended to set `rel="noreferrer noopener"`. [More details about external links security](https://developer.chrome.com/docs/lighthouse/best-practices/external-anchors-use-rel-noopener/)


### PR DESCRIPTION
# Purpose of PR

Fixing the broken link from the [CircleCI link check](https://app.circleci.com/pipelines/github/contentful/forma-36/10968/workflows/11fe9971-5313-43d2-adeb-22db7cb7ccc1/jobs/30405/parallel-runs/0/steps/0-113?invite=true#step-113-183689_50).

The previous link seems to redirect to a new domain, maybe this redirect was failing on the CLI 🤷 

<img width="2254" alt="Screenshot 2023-10-23 at 14 46 00" src="https://github.com/contentful/forma-36/assets/103024358/430e31a3-fa92-4b49-ab35-024b71571b5e">

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
