### PR TITLE
fix: simplify ButtonGroup child type

### DIFF
--- a/.changeset/chilly-baboons-sip.md
+++ b/.changeset/chilly-baboons-sip.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-button': minor
+---
+
+Simplify children type of ButtonGroup component

--- a/.changeset/chilly-baboons-sip.md
+++ b/.changeset/chilly-baboons-sip.md
@@ -1,5 +1,0 @@
----
-'@contentful/f36-button': minor
----
-
-Simplify children type of ButtonGroup component

--- a/.changeset/olive-starfishes-chew.md
+++ b/.changeset/olive-starfishes-chew.md
@@ -1,0 +1,6 @@
+---
+'@contentful/f36-button': minor
+'@contentful/f36-card': minor
+---
+
+simplify BaseCard badge and ButtonGroup child props type

--- a/packages/components/button/src/ButtonGroup/types.ts
+++ b/packages/components/button/src/ButtonGroup/types.ts
@@ -1,6 +1,6 @@
 import type { CommonProps } from '@contentful/f36-core';
 import type { SpacingTokens } from '@contentful/f36-tokens';
-import type { ReactElement } from 'react';
+import type { ReactNode } from 'react';
 
 export type ButtonGroupVariants = 'spaced' | 'merged' | 'collapsed';
 
@@ -23,12 +23,7 @@ interface BaseButtonGroupProps extends CommonProps {
    * @default spacingS
    */
   spacing?: ButtonGroupSpacing;
-  children:
-    | ReactElement
-    | boolean
-    | null
-    | undefined
-    | (ReactElement | boolean | null | undefined)[];
+  children: ReactNode;
 }
 
 interface SpacedButtonGroupProps extends BaseButtonGroupProps {

--- a/packages/components/card/src/BaseCard/BaseCard.types.ts
+++ b/packages/components/card/src/BaseCard/BaseCard.types.ts
@@ -40,12 +40,7 @@ export type BaseCardInternalProps = CommonProps &
     /**
      * Badge component to show in Card header
      */
-    badge?:
-      | ReactElement
-      | boolean
-      | null
-      | undefined
-      | (ReactElement | boolean | null | undefined)[];
+    badge?: ReactNode;
     /**
      * Passing href into the Card. You need to also add property as="a" to make it rendered as <a />
      */


### PR DESCRIPTION
# Purpose of PR

- simplify `ButtonGroup` child prop type and `BaseCard` badge prop type
