### PR TITLE
feat(autocomplete): add separate test ID prop for suggestion box popover

### DIFF
--- a/.changeset/pretty-drinks-buy.md
+++ b/.changeset/pretty-drinks-buy.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-autocomplete': minor
+---
+
+add test ID prop for suggestion box popover to Aucomplete component

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -164,6 +164,11 @@ export interface AutocompleteProps<ItemType>
   usePortal?: boolean;
 
   /**
+   * A [data-test-id] attribute for the suggestions box used for testing purposes
+   */
+  popoverTestId?: string;
+
+  /**
    * Function called when the input is focused
    *
    * @param event
@@ -216,6 +221,7 @@ function _Autocomplete<ItemType>(
     isLoading = false,
     usePortal = false,
     testId = 'cf-autocomplete',
+    popoverTestId = 'cf-autocomplete-container',
   } = props;
 
   type GroupType = GenericGroupType<ItemType>;
@@ -419,7 +425,7 @@ function _Autocomplete<ItemType>(
             {...menuProps}
             ref={mergeRefs(menuProps.ref, listRef)}
             className={styles.content}
-            testId="cf-autocomplete-container"
+            testId={popoverTestId}
           >
             {isLoading &&
               [...Array(3)].map((_, index) => (


### PR DESCRIPTION
Add an additional `popoverTestId` prop to the `Autocomplete` component. When passed it replaces the default suggestion box popover test ID (`cf-autocomplete-container`).

# Purpose of PR

Make elements inside the portal used for the suggestion box identifiable for tests.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
