### PR TITLE
fix: IconButton size type

### DIFF
--- a/.changeset/khaki-cows-divide.md
+++ b/.changeset/khaki-cows-divide.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-button': patch
+---
+
+Fix IconButton size prop type.

--- a/packages/components/button/src/IconButton/IconButton.tsx
+++ b/packages/components/button/src/IconButton/IconButton.tsx
@@ -28,7 +28,7 @@ interface IconButtonInternalProps
   children?: ButtonInternalProps['children'];
   /**
    * Determines size variation of IconButton component
-   * Note: 'large' is @deprecated
+   * Note: 'large' is deprecated
    * */
   size?: ButtonInternalProps['size'];
 }


### PR DESCRIPTION
- Fix `IconButton` size prop marked as deprecated. Leave it only as comment for size `large`.

![CleanShot 2023-11-08 at 15 51 40@2x](https://github.com/contentful/forma-36/assets/10744462/add9169c-f409-4e76-9eac-ac5d3d075e09)


Related PR: 
https://github.com/contentful/forma-36/pull/2576