### PR TITLE
docs(calendar): align naming of Indicator vs Custom Day content examples

### DIFF
--- a/packages/components/datepicker/examples/Calendar/CustomDayContent.tsx
+++ b/packages/components/datepicker/examples/Calendar/CustomDayContent.tsx
@@ -3,7 +3,7 @@ import { Calendar, DayContent } from '@contentful/f36-components';
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 
-export default function IndicatorExample() {
+export default function CustomDayContentExample() {
   const today = new Date();
   const tomorrow = new Date();
   tomorrow.setDate(tomorrow.getDate() + 1);

--- a/packages/components/datepicker/src/Calendar/README.mdx
+++ b/packages/components/datepicker/src/Calendar/README.mdx
@@ -45,7 +45,7 @@ Use `from...` and `to...` props to control time frames
 
 ### Indicators
 
-Use modifiers to modify certain days, for example showing incators for scheduled actions
+Use modifiers to modify certain days, for example showing indicators for scheduled actions
 
 Read more about modifiers: https://react-day-picker.js.org/basics/modifiers
 


### PR DESCRIPTION
Adjusted the naming of Custom Day content example code to not reflect Indicator. Also Adjusted a typo.

<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

The purpose of this PR is to align on the Calendar component naming - specifically the use of Indicator vs Custom Day content. We noticed that within the Custom Day content code example within the docs, it references an 'IndicatorExample', so we have adjusted this to be `CustomDayContentExample`. There also existed a small typo in the docs (Incators vs Indicators) so we have adjusted this. 

Note the main change here: 

## Before
<img width="757" alt="Screenshot 2023-11-09 at 3 56 10 PM" src="https://github.com/contentful/forma-36/assets/58186851/11c2fd72-76e3-4de3-962e-43943c0f5f7d">

## After
<img width="773" alt="Screenshot 2023-11-09 at 3 55 57 PM" src="https://github.com/contentful/forma-36/assets/58186851/7c6e87db-2738-4c8c-8b0b-6a78cfb9eecc">

We believed this to be the extent of the name alignment task, but also considered in the beginning that perhaps the Indicator and CustomDayContent examples are duplicative. We determined that each code example is reflecting differing implementation methods, even though the end result examples are the same, so they are not entirely duplicative and are separate for this reason. Please let me know if this is not the case and I am happy to make adjustments where necessary :). 



## PR Checklist

- [X] I have read the relevant `readme.md` file(s)
- [X] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [X] Tests are added/updated/not required
- [X] Tests are passing
- [X] Storybook stories are added/updated/not required
- [X] Usage notes are added/updated/not required
- [X] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [X] Doesn't contain any sensitive information
