### PR TITLE
docs(calendar): move calendar stories and rename Basic story

### DIFF
--- a/packages/components/datepicker/stories/Calendar.stories.tsx
+++ b/packages/components/datepicker/stories/Calendar.stories.tsx
@@ -14,10 +14,10 @@ const testDate = new Date('2022-04-15');
 
 export default {
   component: Calendar,
-  title: 'Components/Datepicker/Calendar',
+  title: 'Components/Calendar',
 } as Meta;
 
-export const Default: Story<CalendarProps> = (args) => {
+export const Basic: Story<CalendarProps> = (args) => {
   const [selectedDay, setSelectedDay] = useState<Date>(testDate);
 
   return (


### PR DESCRIPTION
Move Calendar component stories out of Datepicker in the Storybook navigation. Rename Default story to Basic.

<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

This PR moves the Calendar component stories out from under the Date Picker in the Storybook navigation. It also renames the `Default` story to `Basic`.

![Screenshot 2023-11-09 at 8 36 35 AM](https://github.com/contentful/forma-36/assets/62958907/38270392-0939-4634-bb74-5bc21f9864e9)

## PR Checklist

- [X] I have read the relevant `readme.md` file(s)
- [X] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [X] Tests are added/updated/not required
- [X] Tests are passing
- [X] Storybook stories are added/updated/not required
- [X] Usage notes are added/updated/not required
- [X] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [X] Doesn't contain any sensitive information
