### PR TITLE
fix(story): fix bug in Pill story where user cannot change draggable …

### DIFF
--- a/packages/components/pill/stories/Pill.stories.tsx
+++ b/packages/components/pill/stories/Pill.stories.tsx
@@ -215,7 +215,7 @@ export const InSmallContainer: Story<PillInternalProps> = (args) => {
         <Flex flexDirection="row" marginBottom="spacingM">
           <Box marginRight="spacingXs">
             <Pill
-              draggable={args.isDraggable}
+              isDraggable={args.isDraggable}
               label={args.label}
               className={styles.pill}
               onDrag={onDrag}
@@ -224,7 +224,7 @@ export const InSmallContainer: Story<PillInternalProps> = (args) => {
           </Box>
           <Box>
             <Pill
-              draggable={args.isDraggable}
+              isDraggable={args.isDraggable}
               label={args.label}
               className={styles.pill}
               onDrag={onDrag}

--- a/packages/components/pill/stories/Pill.stories.tsx
+++ b/packages/components/pill/stories/Pill.stories.tsx
@@ -26,7 +26,7 @@ export default {
 } as Meta;
 
 export const basic: Story<PillInternalProps> = (args) => (
-  <Pill label={args.label} />
+  <Pill label={args.label} isDraggable={args.isDraggable} />
 );
 
 basic.args = { label: 'example.user@contentful.com' };
@@ -205,6 +205,7 @@ export const InSmallContainer: Story<PillInternalProps> = (args) => {
       maxWidth: 200,
     }),
   };
+  const onDrag = args.isDraggable ? args.onDrag : undefined;
   return (
     <>
       <Flex flexDirection="column" marginBottom="spacingL">
@@ -214,19 +215,19 @@ export const InSmallContainer: Story<PillInternalProps> = (args) => {
         <Flex flexDirection="row" marginBottom="spacingM">
           <Box marginRight="spacingXs">
             <Pill
-              draggable
+              draggable={args.isDraggable}
               label={args.label}
               className={styles.pill}
-              onDrag={args.onDrag}
+              onDrag={onDrag}
               onClose={args.onClose}
             />
           </Box>
           <Box>
             <Pill
-              draggable
+              draggable={args.isDraggable}
               label={args.label}
               className={styles.pill}
-              onDrag={args.onDrag}
+              onDrag={onDrag}
               onClose={args.onClose}
             />
           </Box>


### PR DESCRIPTION
# Purpose of PR

This PR fixes a bug found in the Pill `basic` and `In small container `story that prevents a user from changing the component from its draggable state to its default state and vise versa. 

Essentially the prop, `isDraggable`, was not being passed effectively to the story component. Worth noting that if the props are spread, the `onDrag` prop is always true as an `actionHandler`, so it will always render the story with drag features. 

Originally this was noticed within the `basic` story, but I also fixed the logic within the `In small container` story  as well. This might not be necessary, but I figured the user might want to view the small container example with or without the drag handler - I can certainly remove that adjustment 👍 
![chrome-capture-2023-10-15-pill-fix](https://github.com/contentful/forma-36/assets/58186851/53bfece1-0a07-4216-9eb9-8ce2c5c04fc1)



## PR Checklist

- [X] I have read the relevant `readme.md` file(s)
- [X] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [X] Tests are added/updated/not required
- [X] Tests are passing
- [X] Storybook stories are added/updated/not required
- [X] Usage notes are added/updated/not required
- [X] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [X] Doesn't contain any sensitive information
