### PR TITLE
fix: make `@types/react` & `@types/react-dom` peer dependencies

### DIFF
--- a/.changeset/khaki-books-change.md
+++ b/.changeset/khaki-books-change.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-components': patch
+---
+
+Make `@types/react` & `@types/react-dom` peer dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -39987,9 +39987,7 @@
         "@contentful/f36-tokens": "^4.0.2",
         "@contentful/f36-tooltip": "^4.54.1",
         "@contentful/f36-typography": "^4.54.1",
-        "@contentful/f36-utils": "^4.23.2",
-        "@types/react": "16.14.22",
-        "@types/react-dom": "16.9.14"
+        "@contentful/f36-utils": "^4.23.2"
       },
       "devDependencies": {
         "microbundle": "^0.15.1",
@@ -39998,8 +39996,18 @@
         "semantic-release": "^19.0.5"
       },
       "peerDependencies": {
+        "@types/react": ">=16.8",
+        "@types/react-dom": ">=16.8",
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "packages/forma-36-react-components/node_modules/@octokit/core": {
@@ -40200,6 +40208,8 @@
     "packages/forma-36-react-components/node_modules/@types/react-dom": {
       "version": "16.9.14",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/react": "^16"
       }
@@ -46269,8 +46279,6 @@
         "@contentful/f36-tooltip": "^4.54.1",
         "@contentful/f36-typography": "^4.54.1",
         "@contentful/f36-utils": "^4.23.2",
-        "@types/react": "16.14.22",
-        "@types/react-dom": "16.9.14",
         "microbundle": "^0.15.1",
         "react": "16.14.0",
         "react-dom": "16.14.0",
@@ -46411,6 +46419,8 @@
         },
         "@types/react-dom": {
           "version": "16.9.14",
+          "optional": true,
+          "peer": true,
           "requires": {
             "@types/react": "^16"
           }

--- a/packages/forma-36-react-components/package.json
+++ b/packages/forma-36-react-components/package.json
@@ -16,8 +16,18 @@
     "semantic-release": "semantic-release"
   },
   "peerDependencies": {
+    "@types/react": ">=16.8",
+    "@types/react-dom": ">=16.8",
     "react": ">=16.8",
     "react-dom": ">=16.8"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@contentful/f36-accordion": "^4.54.1",
@@ -54,9 +64,7 @@
     "@contentful/f36-tokens": "^4.0.2",
     "@contentful/f36-tooltip": "^4.54.1",
     "@contentful/f36-typography": "^4.54.1",
-    "@contentful/f36-utils": "^4.23.2",
-    "@types/react": "16.14.22",
-    "@types/react-dom": "16.9.14"
+    "@contentful/f36-utils": "^4.23.2"
   },
   "devDependencies": {
     "microbundle": "^0.15.1",


### PR DESCRIPTION
F36 currently has a pinned dependency on `@types/react` and `@types/react-dom`. When the consuming project of F36  installs a different version of the type packages, they might run into type issues/conflicts.

This PR moves `@types/react` and `@types/react-dom` to peer dependencies, marks them as optional and unpins them. That way the packages can be deduped which prevents type issues.

This matches how [@mui/material](https://github.com/mui/material-ui/blob/b7fea89bc232622546b6bc9675a818bfa95a8376/packages/mui-material/package.json#L90-L107) and [react-bootstrap](https://github.com/react-bootstrap/react-bootstrap/blob/a58a0cd6e548c653cda23ed529f3cff69ec123cc/package.json#L147-L156) handle these dependencies.