### PR TITLE
fix: various quirks

### DIFF
--- a/.changeset/lovely-steaks-rush.md
+++ b/.changeset/lovely-steaks-rush.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-forms": patch
+---
+
+- fix(Radio): adjust width for large copy

--- a/packages/components/collapse/examples/CollapseExample.tsx
+++ b/packages/components/collapse/examples/CollapseExample.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, Collapse, Text, Stack } from '@contentful/f36-components';
 
-export function CollapseExample() {
+export default function CollapseExample() {
   const [isExpanded, setIsExpanded] = React.useState(true);
   return (
     <Stack flexDirection="column">

--- a/packages/components/forms/src/BaseCheckbox/BaseCheckbox.styles.ts
+++ b/packages/components/forms/src/BaseCheckbox/BaseCheckbox.styles.ts
@@ -48,6 +48,9 @@ const getStyles = ({
       position: 'absolute',
       width: tokens.spacingM,
       zIndex: tokens.zIndexDefault,
+      '+ span': {
+        minWidth: tokens.spacingM,
+      },
       '&:focus': {
         outline: 'none',
         '& + span': {


### PR DESCRIPTION
# Purpose of PR

This work fixes 2 issues:

## Playground rendering

When opening the `Collapse` playground from the documentation (https://f36.contentful.com/components/collapse), the playground crashes.

| Before | After |
|--------|--------|
| <img width="1498" alt="collapse-before" src="https://github.com/contentful/forma-36/assets/103024358/8099f154-24c4-4adc-b6fe-b8db06b9fdad"> [Link](https://f36.contentful.com/playground?code=N4Igxg9gJgpiBcICWBbADhATgFwAQCUYBDMPAM0whVwHJNjSaBuAHQDtUMddhcAhAK7ZsENgBpcAYQgAbGUTQBnGBIAqMAB7YJAZWwkA1rgC+uClVoABSG2wxbZATID0ZAMwA2ALSR0o+9iKzOzsmlzkAmykSKJSsvJKMACiGkToMjAAFACUPOy4uDaKeADaSIopaERssFASytgAkhUaVTUwUAC6uAC8BAzYAHQCynpEdpnYmAIw2axsBfTYApgLmfkFuAA8Y2BGZBkaACJI9NGiPSzgsgIobFcAfBub24LCsaKSMkh7PcA5vQeuAazUq1VqmQAhOUwe0oNljA9VBAAOYojJbZxvERsJ4LF7baRyBTKXAw1rgjp-cltWqI54ErbqLR4gkEyQjEQoGCYRS4WLYAAWMFw6jSuGwSB5hWquCqAE9cAB3JBC3BEQr0KCqmWYKC4TIAQW5mB+1QZbMq9EUigkAFkiMUeZIiHr+ZhcAA1cpEbKDXBJWw8tCm0lgTlUHl8wVEABuIqFIrAgogPxFEDIFoJCqQbBRytVgvVmo6OrArv1WAL9AlmGqijIPMGWYKmOZ2FZjOcRISyk7recuwMnbm7GM7BAxiAA) | <img width="1497" alt="collapse-after" src="https://github.com/contentful/forma-36/assets/103024358/f447ddae-47f5-4320-82ca-d7fcf0ce3165"> [Link](https://forma-36-git-fix-multiple-quircks.colorfuldemo.com/playground?code=N4Igxg9gJgpiBcICWBbADhATgFwAQCUYBDMPAM0whVwHJNjSaBuAHQDtUMddhcAhAK7ZsENgBpcAYQgAbGUTQBnGBIAqMAB7YJAZWwkA1rgC+uClVoABSG2wxbZATID0ZAMwA2ALSR0o+9iKzOzsmlx4sGRETuQCbKRIolKy8kowAKIaROgyMAAUAJQ87Li4Nop4ANpIiploRGywUBLK2ACStRr1jTBQALq4ALwEDNgAdALKekR2ediYAjAFrGyl9NgCmKt5JaW4ADzTYEZkuRoAIkj0CaKDLOCyAihs9wB8u3sHgsJJopIySGOg2AhSGr1wrQ6dQaTTyAEIatCelACsZXqoIABzTG5fbOb4iNjvVafA7SOQKZS4RFdGG9YE07pNNEfUn7dRaYmk0mSSYiFAwTCKXBJbAACxguHU2Vw2CQgrKDVw9QAnrgAO5IcW4IhlehQLWKzBQXB5ACCAswgIarO5dXoikUEgAskQKoLJERjSLMLgAGo1IgFMa4dK2QVoK1UsB8qiC4ViogAN0l4slYDFEEBkogZFtpNVSDYmI1WrFOr1vUNYC9JqwpfosswDUUZEFY3zpTxHOwXLZznJqWUfa7ziOBj7y3YxnYIGMQA) | 

## Radio rendering

When presented with a large amount of text, the radio gets squished.

| Before | After |
|--------|--------|
| <img width="1256" alt="radio-before" src="https://github.com/contentful/forma-36/assets/103024358/5ab207d2-31fc-4345-b741-2778f291b2b0"> | <img width="1257" alt="radio-after" src="https://github.com/contentful/forma-36/assets/103024358/39a78cdc-d45d-45b2-84a8-80143f5bbf1f"> | 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
