### PR TITLE
fix(Button): default padding for small size

### DIFF
--- a/.changeset/red-pots-trade.md
+++ b/.changeset/red-pots-trade.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-button": patch
+---
+
+fix(Button): default padding for small size

--- a/packages/components/button/src/Button/Button.styles.ts
+++ b/packages/components/button/src/Button/Button.styles.ts
@@ -118,7 +118,9 @@ const sizeToStyles = (size: ButtonSize, density: Density): CSSObject => {
       return {
         fontSize: isHighDensity ? tokens.fontSizeS : tokens.fontSizeM,
         lineHeight: tokens.lineHeightCondensed,
-        padding: `${tokens.spacing2Xs} ${tokens.spacingXs}`,
+        padding: isHighDensity
+          ? `${tokens.spacing2Xs} ${tokens.spacingXs}`
+          : `${tokens.spacing2Xs} ${tokens.spacingS}`,
         minHeight: isHighDensity ? '16px' : '32px',
       };
     case 'medium':


### PR DESCRIPTION
# Purpose of PR

Re-establish the correct (low-density) spacing for the Button's small size. 

The wrong spacing was introduced in #2620 and wrongly accepted as the baseline in Chromatic.
 
https://github.com/contentful/forma-36/pull/2620/files#diff-981a117f17abd2f26007fc35dae060ed779500d4a4fb62f4ef09969ac3ef96f9L119

| Before | After |
|--------|--------|
| <img width="268" alt="Screenshot 2023-12-06 at 14 43 33" src="https://github.com/contentful/forma-36/assets/103024358/fd40e937-d3a1-42bc-b656-9b975a469c39"> | <img width="282" alt="Screenshot 2023-12-06 at 14 43 03" src="https://github.com/contentful/forma-36/assets/103024358/bc9cc57b-31f5-41d8-8983-3203b5014f88"> | 

 ## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
