### PR TITLE
chore: replace npm registry with GitHub packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,9 @@ jobs:
       - checkout
       - vault/get-secrets:
           template-preset: semantic-release
-      - run: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
+      - run: |
+        echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_READ_TOKEN}" > ~/.npmrc
+        echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
       - attach_workspace:
           at: ~/circleci-f36-build
       - add_ssh_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,8 +113,8 @@ jobs:
       - vault/get-secrets:
           template-preset: semantic-release
       - run: |
-        echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_READ_TOKEN}" > ~/.npmrc
-        echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_READ_TOKEN}" > ~/.npmrc
+          echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
       - attach_workspace:
           at: ~/circleci-f36-build
       - add_ssh_keys:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,9 @@
 version: 2
+registries:
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.NPM_REGISTRY_REGISTRY_GH_ORG_TOKEN}}
 
 updates:
   - package-ecosystem: npm
@@ -12,3 +17,5 @@ updates:
     commit-message:
       prefix: chore
     versioning-strategy: widen
+    registries:
+      - npm-github

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -32,6 +32,7 @@
     "react-dom": ">=16.8"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/asset/package.json
+++ b/packages/components/asset/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/autocomplete/package.json
+++ b/packages/components/autocomplete/package.json
@@ -37,6 +37,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/badge/package.json
+++ b/packages/components/badge/package.json
@@ -33,6 +33,7 @@
     "react-dom": ">=16.8"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -35,6 +35,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -40,6 +40,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/collapse/package.json
+++ b/packages/components/collapse/package.json
@@ -29,6 +29,7 @@
     "react-dom": ">=16.8"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/copybutton/package.json
+++ b/packages/components/copybutton/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/datepicker/package.json
+++ b/packages/components/datepicker/package.json
@@ -37,6 +37,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/datetime/package.json
+++ b/packages/components/datetime/package.json
@@ -30,6 +30,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/density-container/package.json
+++ b/packages/components/density-container/package.json
@@ -30,6 +30,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/drag-handle/package.json
+++ b/packages/components/drag-handle/package.json
@@ -31,6 +31,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/empty-state/package.json
+++ b/packages/components/empty-state/package.json
@@ -29,6 +29,7 @@
     "react-dom": ">=16.8"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/entity-list/package.json
+++ b/packages/components/entity-list/package.json
@@ -37,6 +37,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/forms/package.json
+++ b/packages/components/forms/package.json
@@ -31,7 +31,8 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   },
   "devDependencies": {
     "formik": "^2.4.2",

--- a/packages/components/header/package.json
+++ b/packages/components/header/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/icons/package.json
+++ b/packages/components/icons/package.json
@@ -30,6 +30,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/image/package.json
+++ b/packages/components/image/package.json
@@ -30,6 +30,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/layout/package.json
+++ b/packages/components/layout/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/list/package.json
+++ b/packages/components/list/package.json
@@ -29,6 +29,7 @@
     "react-dom": ">=16.8"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/multiselect/package.json
+++ b/packages/components/multiselect/package.json
@@ -38,7 +38,8 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   },
   "devDependencies": {
     "formik": "^2.4.2",

--- a/packages/components/navbar/package.json
+++ b/packages/components/navbar/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/navlist/package.json
+++ b/packages/components/navlist/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/note/package.json
+++ b/packages/components/note/package.json
@@ -36,6 +36,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/notification/package.json
+++ b/packages/components/notification/package.json
@@ -35,6 +35,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/pill/package.json
+++ b/packages/components/pill/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/skeleton/package.json
+++ b/packages/components/skeleton/package.json
@@ -30,6 +30,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/table/package.json
+++ b/packages/components/table/package.json
@@ -31,6 +31,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -30,6 +30,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/text-link/package.json
+++ b/packages/components/text-link/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/typography/package.json
+++ b/packages/components/typography/package.json
@@ -29,6 +29,7 @@
     "react-dom": ">=16.8"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/utils/package.json
+++ b/packages/components/utils/package.json
@@ -27,6 +27,7 @@
     "react-dom": ">=16.8"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/components/workbench/package.json
+++ b/packages/components/workbench/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
     "react-dom": ">=16.8"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/f36-docs-utils/package.json
+++ b/packages/f36-docs-utils/package.json
@@ -29,6 +29,7 @@
     "react-dom": ">=16.8"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/packages/forma-36-codemod/package.json
+++ b/packages/forma-36-codemod/package.json
@@ -23,7 +23,8 @@
     "jest": "^29.3.1"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   },
   "dependencies": {
     "chalk": "^4.1.1",

--- a/packages/forma-36-react-components/package.json
+++ b/packages/forma-36-react-components/package.json
@@ -84,7 +84,8 @@
     "js-yaml": "3.13.1"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   },
   "gitHead": "e7d604672b4c32b089c41fee14f9c878929d7b20"
 }

--- a/packages/forma-36-tokens/package.json
+++ b/packages/forma-36-tokens/package.json
@@ -20,6 +20,7 @@
     "build:types": "tsc src/**/*.js --declaration --emitDeclarationOnly --declarationDir dist --jsx preserve"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }

--- a/scripts/plop-templates/package/package.json.hbs
+++ b/scripts/plop-templates/package/package.json.hbs
@@ -29,6 +29,7 @@
     "url": "https://github.com/contentful/forma-36"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
   }
 }


### PR DESCRIPTION
# Purpose of PR

We will use GitHub packages for all `@contentful` scoped packages currently in npmjs.

- Updates the registry in the `config.yml`
- Adds the registry in the `dependabot.yml`
- Adds the registry to the `package.json` files
- Updates the Plop script to ensure it’s added in the future

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
