### PR TITLE
chore: add changelog to alpha packages

### DIFF
--- a/packages/components/avatar/CHANGELOG.md
+++ b/packages/components/avatar/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/packages/components/density-container/CHANGELOG.md
+++ b/packages/components/density-container/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/packages/components/header/CHANGELOG.md
+++ b/packages/components/header/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/packages/components/image/CHANGELOG.md
+++ b/packages/components/image/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/packages/components/layout/CHANGELOG.md
+++ b/packages/components/layout/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/packages/components/navlist/CHANGELOG.md
+++ b/packages/components/navlist/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log


### PR DESCRIPTION
# Purpose of PR

Follow-up #2629.

The prerelease script tries to access the CHANGELOG.md of each package but the `alpha` packages do not have such (because they aren't released).

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
