### PR TITLE
chore: add `npm-package-publisher` GitHub action

### DIFF
--- a/.github/workflows/npm-package-publisher.yml
+++ b/.github/workflows/npm-package-publisher.yml
@@ -1,0 +1,20 @@
+name: "npm-package-publisher"
+
+on:
+  registry_package:
+    types: [published]
+
+jobs:
+  worker:
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: contentful/npm-package-publisher@v1
+        with:
+          VAULT_URL: ${{ secrets.VAULT_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE_ACCESS: "public"


### PR DESCRIPTION
# Purpose of PR

Follow-up of #2628 

This is needed to keep exposing our releases to the public after the GitHub Packages registry change.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
