### PR TITLE
chore: adjust `npm-package-publisher` action

### DIFF
--- a/.github/workflows/npm-package-publisher.yml
+++ b/.github/workflows/npm-package-publisher.yml
@@ -13,7 +13,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: contentful/npm-package-publisher@v1
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          repository: contentful/npm-package-publisher
+          ref: v1.0
+          token: ${{ secrets.GITHUB_TOKEN  }}
+          path: ./action
+      - name: Run my action
+        uses: ./action
         with:
           VAULT_URL: ${{ secrets.VAULT_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Purpose of PR

Follow-up of #2631 

The GitHub action is not able to access the action from the private package (even tho it is located in the same organization).

Checking out the repository and running the action locally should resolve it ([documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-an-action-inside-a-different-private-repository-than-the-workflow)).

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
