### PR TITLE
chore: add GitHub Actions dependabot policy

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -4,3 +4,6 @@ services:
     policies:
       - semantic-release
       - packages-read
+  github-actions:
+    policies:
+      - dependabot


### PR DESCRIPTION
# Purpose of PR

Follow-up of #2628 

To retrieve the tokens used in the [NPM Package Publisher](https://github.com/contentful/forma-36/blob/main/.github/workflows/npm-package-publisher.yml) GitHub Action, we need to add the policy to the vault.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
