### PR TITLE
docs(useDensity): add documentation + test

### DIFF
--- a/packages/components/density-container/README.mdx
+++ b/packages/components/density-container/README.mdx
@@ -9,7 +9,7 @@ storybook: 'https://f36-storybook.contentful.com/?path=/story/components-density
 typescript: ./src/DensityContainer.tsx
 ---
 
-This container can be used to change the density of the children.
+This container can be used to change the density of its children.
 
 ## Import
 
@@ -34,10 +34,4 @@ import { DensityContainer } from '@contentful/f36-density-container';
 
 ## Density support
 
-To enable density support in your component, use the `useDensity` hook from `@contentful/f36-utils`.
-
-Follow the density documentation (WIP) to ensure a consistent experience across the product.
-
-```jsx file=./examples/DensitySupport.tsx
-
-```
+To enable density support in your component, use the [`useDensity`](/hooks/use-density) hook from `@contentful/f36-utils`.

--- a/packages/components/utils/src/useDensity/useDensity.mdx
+++ b/packages/components/utils/src/useDensity/useDensity.mdx
@@ -1,0 +1,42 @@
+---
+title: 'useDensity'
+type: 'hook'
+slug: /hooks/use-density/
+section: 'hooks'
+typescript: ./useDensity.ts
+---
+
+Allows to retrieve the `DensityContext` value (`low` or `high`).  
+Adding high-density support to your component is possible using this hook.
+
+## Import
+
+```jsx static=true
+import { useDensity } from '@contentful/f36-utils';
+```
+
+## Examples
+
+### Component styling
+
+Use the `useDensity` hook to add high-density support styling to your component.  
+The component will pick up the density defined in the [DensityContainer](/components/density-container) component.
+
+```jsx
+import React from 'react';
+import { Box } from '@contentful/f36-components';
+import { useDensity } from '@contentful/f36-utils';
+import { css } from 'emotion';
+
+export default function YourComponent() {
+  const density = useDensity();
+
+  const styles = {
+    box: css({
+      color: density === 'high' ? 'red' : 'green',
+    }),
+  };
+
+  return <Box className={styles.box}>Content</Box>;
+}
+```

--- a/packages/components/utils/src/useDensity/useDensity.test.tsx
+++ b/packages/components/utils/src/useDensity/useDensity.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { DensityContainer } from '@contentful/f36-density-container';
+
+import { useDensity } from './useDensity';
+
+describe('useDensity', () => {
+  it('should return the default density value', () => {
+    const { result } = renderHook(() => useDensity());
+
+    expect(result.current).toBe('low');
+  });
+
+  it('should return the low density value', () => {
+    render(<DensityContainer density="low">Children</DensityContainer>);
+
+    const { result } = renderHook(() => useDensity());
+
+    expect(result.current).toBe('low');
+  });
+
+  it('should return the high density value', () => {
+    render(<DensityContainer density="high">Children</DensityContainer>);
+
+    const { result } = renderHook(() => useDensity());
+
+    expect(result.current).toBe('low');
+  });
+});

--- a/packages/components/utils/src/useKeyboard/useKeyboard.mdx
+++ b/packages/components/utils/src/useKeyboard/useKeyboard.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'useKeyboard'
 type: 'component'
-slug: /utils/use-keyboard/
-section: 'utils'
+slug: /hooks/use-keyboard/
+section: 'hooks'
 typescript: ./useKeyboard.ts
 ---
 
-`useKeyboard` is a simple hook that accepts a reference to a component and attaches event listener to the component. By default attaches to `document`. Adds/remove the events on mount and unmount, and emits callback functions.
+Accepts a reference to a component and attaches an event listener to it (attaches to `document` by default). Adds/removes the events on mount and unmount, and emits callback functions.
 
 ## Import
 

--- a/packages/website/pages/[...slug].tsx
+++ b/packages/website/pages/[...slug].tsx
@@ -163,11 +163,13 @@ export const getStaticProps: GetStaticProps<
     HARDCODED_WEBSITE_SECTION.COMPONENTS,
     HARDCODED_WEBSITE_SECTION.INTEGRATIONS,
     HARDCODED_WEBSITE_SECTION.UTILS,
+    HARDCODED_WEBSITE_SECTION.HOOKS,
   ];
   if (sectionsWithComponentsSidebar.includes(section)) {
     sidebarLinks = [
       ...sidebarLinks,
       ...componentSidebarLinks,
+      { title: 'Hooks', links: mdxSidebarLinks.hooks },
       { title: 'Utilities', links: mdxSidebarLinks.utils },
       { title: 'Integrations', links: mdxSidebarLinks.integrations },
     ];

--- a/packages/website/types.ts
+++ b/packages/website/types.ts
@@ -20,6 +20,7 @@ export enum HARDCODED_WEBSITE_SECTION {
   TOKENS = 'tokens',
   WHATS_NEW = 'whats-new',
   UTILS = 'utils',
+  HOOKS = 'hooks',
   INTEGRATIONS = 'integrations',
 }
 

--- a/packages/website/utils/sidebarLinks.json
+++ b/packages/website/utils/sidebarLinks.json
@@ -381,6 +381,12 @@
       "slug": "/utils/use-keyboard/"
     }
   ],
+  "hooks": [
+    {
+      "title": "useDensity",
+      "slug": "/hooks/use-density/"
+    }
+  ],
   "introduction": [
     {
       "title": "What's new",

--- a/packages/website/utils/sidebarLinks.json
+++ b/packages/website/utils/sidebarLinks.json
@@ -375,16 +375,16 @@
     {
       "title": "ScreenReaderOnly",
       "slug": "/components/screen-reader-only/"
-    },
-    {
-      "title": "useKeyboard",
-      "slug": "/utils/use-keyboard/"
     }
   ],
   "hooks": [
     {
       "title": "useDensity",
       "slug": "/hooks/use-density/"
+    },
+    {
+      "title": "useKeyboard",
+      "slug": "/hooks/use-keyboard/"
     }
   ],
   "introduction": [


### PR DESCRIPTION
# Purpose of PR

When this hook was introduced, its documentation + tests were missing.

I took the opportunity to add a new `hooks` section to the sidebar, moving the `useKeyboard` there too.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
