### PR TITLE
fix: entry card wrapping [TOL-1721]

### DIFF
--- a/.changeset/rotten-eggs-compare.md
+++ b/.changeset/rotten-eggs-compare.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-card': minor
+---
+
+fix styling for entry cards on smaller widths

--- a/packages/components/card/src/BaseCard/CardActions.styles.ts
+++ b/packages/components/card/src/BaseCard/CardActions.styles.ts
@@ -6,7 +6,6 @@ export const getCardActionsStyles = () => {
     root: css({
       minHeight: 'auto',
       padding: tokens.spacing2Xs,
-      marginLeft: tokens.spacingXs,
     }),
   };
 };

--- a/packages/components/card/src/BaseCard/DefaultCardHeader.tsx
+++ b/packages/components/card/src/BaseCard/DefaultCardHeader.tsx
@@ -11,6 +11,7 @@ import { BaseCardInternalProps } from './BaseCard.types';
 const getHeaderStyles = () => {
   return {
     header: css({
+      rowGap: tokens.spacing2Xs,
       alignItems: 'center',
       borderBottomColor: tokens.gray200,
       borderBottomStyle: 'solid',
@@ -31,9 +32,9 @@ const getHeaderStyles = () => {
       minHeight: '37px',
     }),
     headerWithActions: css({
-      paddingBottom: 0,
+      paddingBottom: tokens.spacing2Xs,
       paddingRight: tokens.spacingXs,
-      paddingTop: 0,
+      paddingTop: tokens.spacing2Xs,
     }),
   };
 };
@@ -52,8 +53,11 @@ export const DefaultCardHeader = (
   const { icon, type, actions, actionsButtonProps, badge } = props;
   const styles = getHeaderStyles();
   return (
-    <Flex className={cx(styles.header, actions && styles.headerWithActions)}>
-      <Flex flexGrow={1}>
+    <Flex
+      flexWrap="wrap"
+      className={cx(styles.header, actions && styles.headerWithActions)}
+    >
+      <Flex flexGrow={1} marginRight="spacingXs">
         {type && (
           <Text fontColor="gray600" isWordBreak>
             {type}
@@ -61,15 +65,11 @@ export const DefaultCardHeader = (
         )}
       </Flex>
       {icon && (
-        <Flex alignItems="center" marginLeft="spacingXs">
+        <Flex marginRight="spacingXs" alignItems="center">
           {icon}
         </Flex>
       )}
-      {badge && (
-        <Flex alignItems="center" marginLeft="spacingXs">
-          {badge}
-        </Flex>
-      )}
+      {badge && <Flex alignItems="center">{badge}</Flex>}
       {actions && actions.length > 0 && (
         <Flex
           // don't propagate click event, so onClick handler on the card is not triggered

--- a/packages/components/card/src/BaseCard/DefaultCardHeader.tsx
+++ b/packages/components/card/src/BaseCard/DefaultCardHeader.tsx
@@ -11,6 +11,7 @@ import { BaseCardInternalProps } from './BaseCard.types';
 const getHeaderStyles = () => {
   return {
     header: css({
+      columnGap: tokens.spacingXs,
       rowGap: tokens.spacing2Xs,
       alignItems: 'center',
       borderBottomColor: tokens.gray200,
@@ -57,18 +58,14 @@ export const DefaultCardHeader = (
       flexWrap="wrap"
       className={cx(styles.header, actions && styles.headerWithActions)}
     >
-      <Flex flexGrow={1} marginRight="spacingXs">
+      <Flex flexGrow={1}>
         {type && (
           <Text fontColor="gray600" isWordBreak>
             {type}
           </Text>
         )}
       </Flex>
-      {icon && (
-        <Flex marginRight="spacingXs" alignItems="center">
-          {icon}
-        </Flex>
-      )}
+      {icon && <Flex alignItems="center">{icon}</Flex>}
       {badge && <Flex alignItems="center">{badge}</Flex>}
       {actions && actions.length > 0 && (
         <Flex


### PR DESCRIPTION
# Purpose of PR

Fix entry card wrapping style for smaller sizes (like in Live Preview)

##Before
<img width="353" alt="Screenshot 2024-01-02 at 15 44 16" src="https://github.com/contentful/forma-36/assets/22968325/6da464e0-30ec-47c8-91a5-6f4ebe240070">

##After
<img width="519" alt="Screenshot 2024-01-02 at 15 42 37" src="https://github.com/contentful/forma-36/assets/22968325/c35dc575-170a-4aa2-9de6-fd832111d262">
