### PR TITLE
feat: [CFCX-1237] design system debt border radius tokens make publicly visible

### DIFF
--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -39,13 +39,14 @@ Following this structure makes it easy to find the file that needs to be updated
 ## Environment variables
 
 To run this website locally, you need to create a `.env.local` with the following variables:
+(Please get the values from 1Password / Forma36 Website Dev Env)
 
 ```
-NEXT_PUBLIC_DOCSEARCH_APP_ID={{ You can find the value of this variable at our Algolia account}}
-NEXT_PUBLIC_DOCSEARCH_API_KEY={{ You can find the value of this variable at our Algolia account}}
-NEXT_PUBLIC_DOCSEARCH_INDEX_NAME={{ You can find the value of this variable at our Algolia account}}
+NEXT_PUBLIC_DOCSEARCH_APP_ID=
+NEXT_PUBLIC_DOCSEARCH_API_KEY=
+NEXT_PUBLIC_DOCSEARCH_INDEX_NAME=
 
-CONTENTFUL_SPACE_ID={{ You can find the value of this variable at our Contentful account}}
-CONTENTFUL_ACCESS_TOKEN={{ You can find the value of this variable at our Contentful account}}
-CONTENTFUL_PREVIEW_ACCESS_TOKEN={{ You can find the value of this variable at our Contentful account}}
+CONTENTFUL_SPACE_ID=
+CONTENTFUL_ACCESS_TOKEN=
+CONTENTFUL_PREVIEW_ACCESS_TOKEN=
 ```

--- a/packages/website/content/tokens/border-radius.mdx
+++ b/packages/website/content/tokens/border-radius.mdx
@@ -1,0 +1,28 @@
+---
+title: 'Border radius'
+slug: '/tokens/border-radius/'
+section: 'tokens'
+---
+
+In Forma 36, we have border radius tokens for the following sizes: 4px and 6px.
+
+## Tokens
+
+<BorderRadiusTable />
+
+## Tokens with inline styles
+
+```jsx static=true
+import tokens from '@contentful/f36-tokens';
+
+<div style={{ borderRadius: tokens.borderRadiusSmall }} />;
+```
+
+## Tokens with emotion
+
+```jsx static=true
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+css({ borderRadius: tokens.borderRadiusSmall });
+```

--- a/packages/website/content/tokens/border-radius.mdx
+++ b/packages/website/content/tokens/border-radius.mdx
@@ -4,8 +4,6 @@ slug: '/tokens/border-radius/'
 section: 'tokens'
 ---
 
-In Forma 36, we have border radius tokens for the following sizes: 4px and 6px.
-
 ## Tokens
 
 <BorderRadiusTable />

--- a/packages/website/mdx-components/BorderRadiusTable.tsx
+++ b/packages/website/mdx-components/BorderRadiusTable.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Box, Table } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+import borderRadius from '@contentful/f36-tokens/src/tokens/border-radius/border-radius';
+
+export function BorderRadiusTable() {
+  return (
+    <Table>
+      <Table.Head>
+        <Table.Row>
+          <Table.Cell>Token</Table.Cell>
+          <Table.Cell>Value in px</Table.Cell>
+          <Table.Cell>Example</Table.Cell>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        {Object.keys(borderRadius).map((token) => {
+          const value = borderRadius[token];
+          const tokenName = token.replace(/-\d?[a-z]{1}/, (match) =>
+            match.toUpperCase().replace('-', ''),
+          );
+
+          return (
+            <Table.Row key={token}>
+              <Table.Cell style={{ verticalAlign: 'middle' }}>
+                <strong>{tokenName}</strong>
+              </Table.Cell>
+              <Table.Cell style={{ verticalAlign: 'middle' }}>
+                <pre>{value}</pre>
+              </Table.Cell>
+              <Table.Cell style={{ verticalAlign: 'middle' }}>
+                <Box
+                  style={{
+                    width: '50px',
+                    height: '50px',
+                    backgroundColor: tokens.blue500,
+                    borderRadius: value,
+                  }}
+                />
+              </Table.Cell>
+            </Table.Row>
+          );
+        })}
+      </Table.Body>
+    </Table>
+  );
+}

--- a/packages/website/mdx-components/index.ts
+++ b/packages/website/mdx-components/index.ts
@@ -9,6 +9,7 @@ import { SpacingTokensTable } from './SpacingTokensTable';
 import { TransitionTokensTable } from './TransitionTokensTable';
 import { TypographyTokensTable } from './TypographyTokensTable';
 import { ZIndexTokensTable } from './ZIndexTokensTable';
+import { BorderRadiusTable } from './BorderRadiusTable';
 
 export const MdxComponents = {
   A11yColors,
@@ -21,4 +22,5 @@ export const MdxComponents = {
   TransitionTokensTable,
   TypographyTokensTable,
   ZIndexTokensTable,
+  BorderRadiusTable,
 };

--- a/packages/website/utils/sidebarLinks.json
+++ b/packages/website/utils/sidebarLinks.json
@@ -446,6 +446,10 @@
   ],
   "tokens": [
     {
+      "title": "Border radius",
+      "slug": "/tokens/border-radius/"
+    },
+    {
       "title": "Color system",
       "slug": "/tokens/color-system/"
     },


### PR DESCRIPTION
# Purpose of PR
To make border radius tokens publicly visible

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are not required
- [x] Tests are passing

Jira ticket: https://contentful.atlassian.net/browse/CFCX-1237

What changed:
- added the border radius section in tokens
- updated the website READE file about env variables


screenshot of the new section:
![Screenshot 2024-01-18 at 16 48 49](https://github.com/contentful/forma-36/assets/47013507/366e3ffa-14be-4de6-a076-671b7516aa99)
