### PR TITLE
fix(components): fix rendering glitch on Safari 17.x

### DIFF
--- a/.changeset/eighty-lobsters-cheat.md
+++ b/.changeset/eighty-lobsters-cheat.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-workbench': patch
+---
+
+- fix rendering glitch on Safari 17.x

--- a/packages/components/workbench/src/WorkbenchContent/WorkbenchContent.styles.ts
+++ b/packages/components/workbench/src/WorkbenchContent/WorkbenchContent.styles.ts
@@ -20,6 +20,7 @@ export const getWorkbenchContentStyles = (
 
   return {
     workbenchContent: css({
+      position: 'relative',
       padding: tokens.spacingL,
       overflowY: 'auto',
       overflowX: 'hidden',

--- a/packages/components/workbench/src/WorkbenchSidebar/WorkbenchSidebar.styles.ts
+++ b/packages/components/workbench/src/WorkbenchSidebar/WorkbenchSidebar.styles.ts
@@ -7,6 +7,7 @@ export const getWorkbenchSidebarStyles = (position = 'left') => {
 
   return {
     workbenchSidebar: css({
+      position: 'relative',
       backgroundColor: tokens.gray100,
       [borderStyleKey]: `1px solid ${tokens.gray200}`,
       width,


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

Fix a glitch on Safari 17.x where the view gets corrupted on scroll.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
