### PR TITLE
chore: fix secret name on changelog job []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
       - vault/get-secrets:
           template-preset: semantic-release
       - run: |
-          echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_READ_TOKEN}" > ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_WRITE_TOKEN}" > ~/.npmrc
           echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
       - attach_workspace:
           at: ~/circleci-f36-build


### PR DESCRIPTION
# Purpose of PR

The `semantic-release` template of the vault doesn't have the `READ` secret, only the `WRITE`