### PR TITLE
ModalConfirm - render 'x' in ModalHeader

### DIFF
--- a/.changeset/fair-impalas-beg.md
+++ b/.changeset/fair-impalas-beg.md
@@ -1,0 +1,7 @@
+---
+'@contentful/f36-modal': patch
+---
+
+The ModalConfirm should always render a x close button in the modal header.
+
+This is accomplished by passing the onClose prop from ModalConfirm to Modal.Header to ensure that the header will render a close icon to dismiss the modal.

--- a/packages/components/modal/src/ModalConfirm/ModalConfirm.test.tsx
+++ b/packages/components/modal/src/ModalConfirm/ModalConfirm.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
+import { screen } from '@testing-library/dom';
 import { axe } from '@/scripts/test/axeHelper';
 
 import { ModalConfirm } from './ModalConfirm';
@@ -22,4 +23,19 @@ it('has no a11y issues', async () => {
   const results = await axe(container);
 
   expect(results).toHaveNoViolations();
+});
+
+it('renders a `x` icon to close/dismiss the modal', async () => {
+  const closeButtonSpy = jest.fn();
+
+  render(
+    <ModalConfirm isShown onConfirm={() => {}} onCancel={closeButtonSpy}>
+      ModalConfirm
+    </ModalConfirm>,
+  );
+
+  const closeButton = screen.getByRole('button', { name: /Close/i });
+  fireEvent.click(closeButton);
+
+  expect(closeButtonSpy).toHaveBeenCalledTimes(1);
 });

--- a/packages/components/modal/src/ModalConfirm/ModalConfirm.tsx
+++ b/packages/components/modal/src/ModalConfirm/ModalConfirm.tsx
@@ -152,7 +152,11 @@ export const ModalConfirm = ({
       {() => {
         return (
           <React.Fragment>
-            <Modal.Header title={title || ''} {...modalHeaderProps} />
+            <Modal.Header
+              title={title || ''}
+              {...modalHeaderProps}
+              onClose={onCancel}
+            />
             <Modal.Content {...modalContentProps}>{children}</Modal.Content>
             <Modal.Controls {...modalControlsProps}>
               {cancelButton}

--- a/packages/components/modal/src/ModalHeader/ModalHeader.tsx
+++ b/packages/components/modal/src/ModalHeader/ModalHeader.tsx
@@ -6,7 +6,7 @@ import {
   type PropsWithHTMLElement,
   type CommonProps,
 } from '@contentful/f36-core';
-import { Button } from '@contentful/f36-button';
+import { IconButton } from '@contentful/f36-button';
 import { Text, Subheading } from '@contentful/f36-typography';
 
 import { getModalHeaderStyles } from './ModalHeader.styles';
@@ -50,14 +50,14 @@ export const ModalHeader = ({
       </Subheading>
       {onClose && (
         <Flex alignItems="center" className={styles.buttonContainer}>
-          <Button
+          <IconButton
             variant="transparent"
             aria-label="Close"
-            startIcon={<CloseIcon size="small" />}
+            size="small"
+            icon={<CloseIcon size="small" />}
             onClick={() => {
               onClose();
             }}
-            size="small"
           />
         </Flex>
       )}


### PR DESCRIPTION
# Purpose of PR
The `<ModalConfirm>` should always render a `x` close button in the modal header.

This is accomplished by passing the `onClose` prop from `<ModalConfirm>` to `<Modal.Header>` to ensure that the header will render an `x` to dismiss the modal.  [See conditional rendering of close button in ModalHeader](https://github.com/contentful/forma-36/blob/main/packages/components/modal/src/ModalHeader/ModalHeader.tsx#L51-L63)

### Before view
<img width="539" alt="old" src="https://github.com/contentful/forma-36/assets/158083968/cf4fdf29-7bcd-4244-b7b0-7173fe01d87b">

### After view
<img width="530" alt="Screenshot 2024-02-12 at 10 47 13 AM" src="https://github.com/contentful/forma-36/assets/158083968/e4a6c3c5-67de-4e81-b542-80371cf749a9">


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
