### PR TITLE
feat: enable Badge option on EntryCard

### DIFF
--- a/.changeset/beige-olives-report.md
+++ b/.changeset/beige-olives-report.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-card': minor
+---
+
+The <EntryCard> component will now accepts a new option Badge. This will enable users to add custom badges on the card for entities that do not share the same statuses as a contentful Entry.

--- a/package-lock.json
+++ b/package-lock.json
@@ -267,7 +267,7 @@
     },
     "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-explode-assignable-expression": "^7.16.0",
@@ -345,7 +345,7 @@
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
@@ -360,7 +360,7 @@
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.13.0",
@@ -378,7 +378,7 @@
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
       "version": "6.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -394,7 +394,7 @@
     },
     "node_modules/@babel/helper-explode-assignable-expression": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.16.0"
@@ -487,7 +487,7 @@
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
@@ -573,7 +573,7 @@
     },
     "node_modules/@babel/helper-wrap-function": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-function-name": "^7.16.0",
@@ -680,7 +680,7 @@
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.16.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -694,7 +694,7 @@
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -710,7 +710,7 @@
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -726,7 +726,7 @@
     },
     "node_modules/@babel/plugin-proposal-class-properties": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.16.0",
@@ -741,7 +741,7 @@
     },
     "node_modules/@babel/plugin-proposal-class-static-block": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.16.0",
@@ -775,7 +775,7 @@
     },
     "node_modules/@babel/plugin-proposal-dynamic-import": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -805,7 +805,7 @@
     },
     "node_modules/@babel/plugin-proposal-export-namespace-from": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -820,7 +820,7 @@
     },
     "node_modules/@babel/plugin-proposal-json-strings": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -835,7 +835,7 @@
     },
     "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -850,7 +850,7 @@
     },
     "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -865,7 +865,7 @@
     },
     "node_modules/@babel/plugin-proposal-numeric-separator": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -880,7 +880,7 @@
     },
     "node_modules/@babel/plugin-proposal-object-rest-spread": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.16.0",
@@ -898,7 +898,7 @@
     },
     "node_modules/@babel/plugin-proposal-optional-catch-binding": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -913,7 +913,7 @@
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -929,7 +929,7 @@
     },
     "node_modules/@babel/plugin-proposal-private-methods": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.16.0",
@@ -944,7 +944,7 @@
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.18.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -961,7 +961,7 @@
     },
     "node_modules/@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.16.0",
@@ -976,7 +976,7 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -998,7 +998,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -1009,7 +1009,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1037,7 +1037,7 @@
     },
     "node_modules/@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1062,7 +1062,7 @@
     },
     "node_modules/@babel/plugin-syntax-export-namespace-from": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -1098,7 +1098,7 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1123,7 +1123,7 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1144,7 +1144,7 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -1165,7 +1165,7 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -1186,7 +1186,7 @@
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1200,7 +1200,7 @@
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1228,7 +1228,7 @@
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1242,7 +1242,7 @@
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.0",
@@ -1258,7 +1258,7 @@
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1272,7 +1272,7 @@
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1301,7 +1301,7 @@
     },
     "node_modules/@babel/plugin-transform-classes": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
@@ -1321,7 +1321,7 @@
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1335,7 +1335,7 @@
     },
     "node_modules/@babel/plugin-transform-destructuring": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1349,7 +1349,7 @@
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.16.0",
@@ -1364,7 +1364,7 @@
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1378,7 +1378,7 @@
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.16.0",
@@ -1408,7 +1408,7 @@
     },
     "node_modules/@babel/plugin-transform-for-of": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1422,7 +1422,7 @@
     },
     "node_modules/@babel/plugin-transform-function-name": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-function-name": "^7.16.0",
@@ -1437,7 +1437,7 @@
     },
     "node_modules/@babel/plugin-transform-literals": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1451,7 +1451,7 @@
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1465,7 +1465,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.16.0",
@@ -1497,7 +1497,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-hoist-variables": "^7.16.0",
@@ -1515,7 +1515,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.16.0",
@@ -1530,7 +1530,7 @@
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.16.0"
@@ -1544,7 +1544,7 @@
     },
     "node_modules/@babel/plugin-transform-new-target": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1573,7 +1573,7 @@
     },
     "node_modules/@babel/plugin-transform-object-super": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -1632,7 +1632,7 @@
     },
     "node_modules/@babel/plugin-transform-property-literals": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1707,7 +1707,7 @@
     },
     "node_modules/@babel/plugin-transform-regenerator": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-transform": "^0.14.2"
@@ -1721,7 +1721,7 @@
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1735,7 +1735,7 @@
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1749,7 +1749,7 @@
     },
     "node_modules/@babel/plugin-transform-spread": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -1764,7 +1764,7 @@
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1778,7 +1778,7 @@
     },
     "node_modules/@babel/plugin-transform-template-literals": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1792,7 +1792,7 @@
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1823,7 +1823,7 @@
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1837,7 +1837,7 @@
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.16.0",
@@ -1852,7 +1852,7 @@
     },
     "node_modules/@babel/preset-env": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.16.0",
@@ -1939,7 +1939,7 @@
     },
     "node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.2.4",
@@ -1951,7 +1951,7 @@
     },
     "node_modules/@babel/preset-env/node_modules/semver": {
       "version": "6.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1975,7 +1975,7 @@
     },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -5316,7 +5316,6 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
@@ -12436,7 +12435,6 @@
     },
     "node_modules/@types/eslint": {
       "version": "8.4.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
@@ -12445,7 +12443,6 @@
     },
     "node_modules/@types/eslint-scope": {
       "version": "3.7.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/eslint": "*",
@@ -12756,7 +12753,6 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -12821,7 +12817,6 @@
     },
     "node_modules/@types/node": {
       "version": "17.0.21",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node-fetch": {
@@ -13394,7 +13389,6 @@
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.11.1",
@@ -13403,22 +13397,18 @@
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.11.1",
@@ -13428,12 +13418,10 @@
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
@@ -13444,7 +13432,6 @@
     },
     "node_modules/@webassemblyjs/ieee754": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
@@ -13452,7 +13439,6 @@
     },
     "node_modules/@webassemblyjs/leb128": {
       "version": "1.11.1",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
@@ -13460,12 +13446,10 @@
     },
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
@@ -13480,7 +13464,6 @@
     },
     "node_modules/@webassemblyjs/wasm-edit/node_modules/@webassemblyjs/wast-printer": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
@@ -13489,7 +13472,6 @@
     },
     "node_modules/@webassemblyjs/wasm-gen": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
@@ -13501,7 +13483,6 @@
     },
     "node_modules/@webassemblyjs/wasm-opt": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
@@ -13512,7 +13493,6 @@
     },
     "node_modules/@webassemblyjs/wasm-parser": {
       "version": "1.11.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
@@ -13525,12 +13505,10 @@
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/abab": {
@@ -13587,7 +13565,6 @@
     },
     "node_modules/acorn-import-assertions": {
       "version": "1.8.0",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
@@ -13686,7 +13663,6 @@
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "ajv": "^6.9.1"
@@ -14545,7 +14521,7 @@
     },
     "node_modules/babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "object.assign": "^4.1.0"
@@ -14649,7 +14625,7 @@
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.13.11",
@@ -14662,7 +14638,7 @@
     },
     "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
       "version": "6.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -14708,7 +14684,7 @@
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
       "version": "0.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.2.4"
@@ -15943,7 +15919,6 @@
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^1.9.0"
@@ -15954,7 +15929,6 @@
     },
     "node_modules/chrome-trace-event/node_modules/tslib": {
       "version": "1.14.1",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/ci-info": {
@@ -16236,7 +16210,6 @@
     },
     "node_modules/commander": {
       "version": "2.20.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commitizen": {
@@ -16725,7 +16698,7 @@
     },
     "node_modules/core-js-compat": {
       "version": "3.19.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.17.6",
@@ -16738,7 +16711,7 @@
     },
     "node_modules/core-js-compat/node_modules/semver": {
       "version": "7.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -18617,7 +18590,6 @@
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
       "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -18628,7 +18600,6 @@
     },
     "node_modules/enhanced-resolve/node_modules/tapable": {
       "version": "2.2.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18860,7 +18831,6 @@
     },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-shim-unscopables": {
@@ -19564,7 +19534,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -19576,7 +19545,6 @@
     },
     "node_modules/eslint-scope/node_modules/estraverse": {
       "version": "4.3.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -19757,7 +19725,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -19794,7 +19761,6 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -19892,7 +19858,7 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -19913,7 +19879,6 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -26309,7 +26274,6 @@
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -26322,7 +26286,6 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -27794,7 +27757,6 @@
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
@@ -27852,7 +27814,7 @@
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.escaperegexp": {
@@ -32797,7 +32759,6 @@
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
@@ -33498,7 +33459,7 @@
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.4"
@@ -34942,7 +34903,6 @@
     },
     "node_modules/schema-utils": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
@@ -36533,7 +36493,6 @@
     },
     "node_modules/terser": {
       "version": "5.15.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -36550,7 +36509,6 @@
     },
     "node_modules/terser-webpack-plugin": {
       "version": "5.3.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.14",
@@ -36583,7 +36541,6 @@
     },
     "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
       "version": "6.0.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
@@ -37496,7 +37453,6 @@
     },
     "node_modules/typescript": {
       "version": "4.7.3",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -38375,7 +38331,6 @@
     },
     "node_modules/watchpack": {
       "version": "2.4.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
@@ -38387,7 +38342,6 @@
     },
     "node_modules/watchpack/node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/wcwidth": {
@@ -38415,7 +38369,6 @@
     },
     "node_modules/webpack": {
       "version": "5.74.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -38538,12 +38491,10 @@
     },
     "node_modules/webpack/node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack/node_modules/tapable": {
       "version": "2.2.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -38551,7 +38502,6 @@
     },
     "node_modules/webpack/node_modules/webpack-sources": {
       "version": "3.2.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -38871,14 +38821,14 @@
     },
     "packages/components/accordion": {
       "name": "@contentful/f36-accordion",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-collapse": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -38888,14 +38838,14 @@
     },
     "packages/components/asset": {
       "name": "@contentful/f36-asset",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -38905,18 +38855,18 @@
     },
     "packages/components/autocomplete": {
       "name": "@contentful/f36-autocomplete",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-forms": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-forms": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.58.3",
-        "@contentful/f36-skeleton": "^4.58.3",
+        "@contentful/f36-popover": "^4.59.3",
+        "@contentful/f36-skeleton": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-typography": "^4.59.3",
+        "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       },
@@ -38930,11 +38880,11 @@
       "version": "4.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-image": "^4.0.0-alpha.0",
-        "@contentful/f36-menu": "^4.58.3",
+        "@contentful/f36-menu": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.58.3",
+        "@contentful/f36-tooltip": "^4.59.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -38944,16 +38894,16 @@
     },
     "packages/components/badge": {
       "name": "@contentful/f36-badge",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^4.58.3"
+        "@contentful/f36-typography": "^4.59.3"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -38962,17 +38912,17 @@
     },
     "packages/components/button": {
       "name": "@contentful/f36-button",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-spinner": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-spinner": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0"
       },
       "peerDependencies": {
@@ -38982,21 +38932,21 @@
     },
     "packages/components/card": {
       "name": "@contentful/f36-card",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-asset": "^4.58.3",
-        "@contentful/f36-badge": "^4.58.3",
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-drag-handle": "^4.58.3",
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-asset": "^4.59.3",
+        "@contentful/f36-badge": "^4.59.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-drag-handle": "^4.59.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.58.3",
-        "@contentful/f36-skeleton": "^4.58.3",
+        "@contentful/f36-menu": "^4.59.3",
+        "@contentful/f36-skeleton": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.58.3",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-tooltip": "^4.59.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -39007,10 +38957,10 @@
     },
     "packages/components/collapse": {
       "name": "@contentful/f36-collapse",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39021,14 +38971,14 @@
     },
     "packages/components/copybutton": {
       "name": "@contentful/f36-copybutton",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.58.3",
+        "@contentful/f36-tooltip": "^4.59.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39038,16 +38988,16 @@
     },
     "packages/components/datepicker": {
       "name": "@contentful/f36-datepicker",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-forms": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-forms": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.58.3",
+        "@contentful/f36-popover": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -39060,10 +39010,10 @@
     },
     "packages/components/datetime": {
       "name": "@contentful/f36-datetime",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -39075,13 +39025,13 @@
     },
     "packages/components/drag-handle": {
       "name": "@contentful/f36-drag-handle",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39091,11 +39041,11 @@
     },
     "packages/components/empty-state": {
       "name": "@contentful/f36-empty-state",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39105,19 +39055,19 @@
     },
     "packages/components/entity-list": {
       "name": "@contentful/f36-entity-list",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-badge": "^4.58.3",
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-drag-handle": "^4.58.3",
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-badge": "^4.59.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-drag-handle": "^4.59.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.58.3",
-        "@contentful/f36-skeleton": "^4.58.3",
+        "@contentful/f36-menu": "^4.59.3",
+        "@contentful/f36-skeleton": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39127,14 +39077,14 @@
     },
     "packages/components/forms": {
       "name": "@contentful/f36-forms",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-typography": "^4.59.3",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
@@ -39151,11 +39101,11 @@
       "version": "4.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39165,10 +39115,10 @@
     },
     "packages/components/icon": {
       "name": "@contentful/f36-icon",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39200,8 +39150,8 @@
       "version": "4.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-skeleton": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-skeleton": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39215,7 +39165,7 @@
       "version": "4.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39226,10 +39176,10 @@
     },
     "packages/components/list": {
       "name": "@contentful/f36-list",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39240,15 +39190,15 @@
     },
     "packages/components/menu": {
       "name": "@contentful/f36-menu",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.58.3",
+        "@contentful/f36-popover": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-typography": "^4.59.3",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39258,14 +39208,14 @@
     },
     "packages/components/modal": {
       "name": "@contentful/f36-modal",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -39301,7 +39251,7 @@
     },
     "packages/components/multiselect": {
       "name": "@contentful/f36-multiselect",
-      "version": "4.21.0",
+      "version": "4.22.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
@@ -39372,7 +39322,7 @@
     },
     "packages/components/navbar": {
       "name": "@contentful/f36-navbar",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-core": "^4.45.0",
@@ -39394,7 +39344,7 @@
       "version": "4.1.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39405,15 +39355,15 @@
     },
     "packages/components/note": {
       "name": "@contentful/f36-note",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
@@ -39458,15 +39408,15 @@
     },
     "packages/components/notification": {
       "name": "@contentful/f36-notification",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-text-link": "^4.58.3",
+        "@contentful/f36-text-link": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -39486,15 +39436,15 @@
     },
     "packages/components/pagination": {
       "name": "@contentful/f36-pagination",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-forms": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-forms": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39504,15 +39454,15 @@
     },
     "packages/components/pill": {
       "name": "@contentful/f36-pill",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-drag-handle": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-drag-handle": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.58.3",
+        "@contentful/f36-tooltip": "^4.59.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39522,12 +39472,12 @@
     },
     "packages/components/popover": {
       "name": "@contentful/f36-popover",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
@@ -39539,11 +39489,11 @@
     },
     "packages/components/skeleton": {
       "name": "@contentful/f36-skeleton",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-table": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-table": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39554,15 +39504,15 @@
     },
     "packages/components/spinner": {
       "name": "@contentful/f36-spinner",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^4.58.3"
+        "@contentful/f36-typography": "^4.59.3"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -39571,13 +39521,13 @@
     },
     "packages/components/table": {
       "name": "@contentful/f36-table",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39587,10 +39537,10 @@
     },
     "packages/components/tabs": {
       "name": "@contentful/f36-tabs",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -39738,10 +39688,10 @@
     },
     "packages/components/text-link": {
       "name": "@contentful/f36-text-link",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39752,12 +39702,12 @@
     },
     "packages/components/tooltip": {
       "name": "@contentful/f36-tooltip",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
@@ -39770,12 +39720,12 @@
     },
     "packages/components/typography": {
       "name": "@contentful/f36-typography",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39785,7 +39735,7 @@
     },
     "packages/components/utils": {
       "name": "@contentful/f36-utils",
-      "version": "4.24.2",
+      "version": "4.24.3",
       "license": "MIT",
       "dependencies": {
         "emotion": "^10.0.17"
@@ -39797,7 +39747,7 @@
     },
     "packages/components/workbench": {
       "name": "@contentful/f36-workbench",
-      "version": "4.21.0",
+      "version": "4.21.1",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-button": "^4.21.4",
@@ -39815,7 +39765,7 @@
     },
     "packages/core": {
       "name": "@contentful/f36-core",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
@@ -40101,44 +40051,44 @@
     },
     "packages/forma-36-react-components": {
       "name": "@contentful/f36-components",
-      "version": "4.58.3",
+      "version": "4.59.3",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.58.3",
-        "@contentful/f36-asset": "^4.58.3",
-        "@contentful/f36-autocomplete": "^4.58.3",
-        "@contentful/f36-badge": "^4.58.3",
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-card": "^4.58.3",
-        "@contentful/f36-collapse": "^4.58.3",
-        "@contentful/f36-copybutton": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-datepicker": "^4.58.3",
-        "@contentful/f36-datetime": "^4.58.3",
-        "@contentful/f36-drag-handle": "^4.58.3",
-        "@contentful/f36-empty-state": "^4.58.3",
-        "@contentful/f36-entity-list": "^4.58.3",
-        "@contentful/f36-forms": "^4.58.3",
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-accordion": "^4.59.3",
+        "@contentful/f36-asset": "^4.59.3",
+        "@contentful/f36-autocomplete": "^4.59.3",
+        "@contentful/f36-badge": "^4.59.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-card": "^4.59.3",
+        "@contentful/f36-collapse": "^4.59.3",
+        "@contentful/f36-copybutton": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-datepicker": "^4.59.3",
+        "@contentful/f36-datetime": "^4.59.3",
+        "@contentful/f36-drag-handle": "^4.59.3",
+        "@contentful/f36-empty-state": "^4.59.3",
+        "@contentful/f36-entity-list": "^4.59.3",
+        "@contentful/f36-forms": "^4.59.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-list": "^4.58.3",
-        "@contentful/f36-menu": "^4.58.3",
-        "@contentful/f36-modal": "^4.58.3",
+        "@contentful/f36-list": "^4.59.3",
+        "@contentful/f36-menu": "^4.59.3",
+        "@contentful/f36-modal": "^4.59.3",
         "@contentful/f36-navbar": "^4.1.0",
-        "@contentful/f36-note": "^4.58.3",
-        "@contentful/f36-notification": "^4.58.3",
-        "@contentful/f36-pagination": "^4.58.3",
-        "@contentful/f36-pill": "^4.58.3",
-        "@contentful/f36-popover": "^4.58.3",
-        "@contentful/f36-skeleton": "^4.58.3",
-        "@contentful/f36-spinner": "^4.58.3",
-        "@contentful/f36-table": "^4.58.3",
-        "@contentful/f36-tabs": "^4.58.3",
-        "@contentful/f36-text-link": "^4.58.3",
+        "@contentful/f36-note": "^4.59.3",
+        "@contentful/f36-notification": "^4.59.3",
+        "@contentful/f36-pagination": "^4.59.3",
+        "@contentful/f36-pill": "^4.59.3",
+        "@contentful/f36-popover": "^4.59.3",
+        "@contentful/f36-skeleton": "^4.59.3",
+        "@contentful/f36-spinner": "^4.59.3",
+        "@contentful/f36-table": "^4.59.3",
+        "@contentful/f36-tabs": "^4.59.3",
+        "@contentful/f36-text-link": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.58.3",
-        "@contentful/f36-typography": "^4.58.3",
-        "@contentful/f36-utils": "^4.24.2"
+        "@contentful/f36-tooltip": "^4.59.3",
+        "@contentful/f36-typography": "^4.59.3",
+        "@contentful/f36-utils": "^4.24.3"
       },
       "devDependencies": {
         "microbundle": "^0.15.1",
@@ -43329,18 +43279,18 @@
       "dependencies": {
         "@codesandbox/sandpack-react": "^1.17.0",
         "@contentful/f36-avatar": "^4.0.0-alpha.0",
-        "@contentful/f36-components": "^4.58.3",
+        "@contentful/f36-components": "^4.59.3",
         "@contentful/f36-docs-utils": "^4.0.2",
-        "@contentful/f36-empty-state": "^4.58.3",
+        "@contentful/f36-empty-state": "^4.59.3",
         "@contentful/f36-header": "^4.0.0-alpha.0",
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-image": "^4.0.0-alpha.0",
         "@contentful/f36-layout": "^4.0.0-alpha.0",
-        "@contentful/f36-multiselect": "^4.21.0",
+        "@contentful/f36-multiselect": "^4.22.0",
         "@contentful/f36-navlist": "4.1.0-alpha.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-utils": "^4.24.3",
         "@contentful/rich-text-react-renderer": "^15.11.1",
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/sortable": "^7.0.2",
@@ -43816,7 +43766,7 @@
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-explode-assignable-expression": "^7.16.0",
         "@babel/types": "^7.16.0"
@@ -43879,7 +43829,7 @@
     },
     "@babel/helper-create-regexp-features-plugin": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "regexpu-core": "^4.7.1"
@@ -43887,7 +43837,7 @@
     },
     "@babel/helper-define-polyfill-provider": {
       "version": "0.2.4",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-compilation-targets": "^7.13.0",
         "@babel/helper-module-imports": "^7.12.13",
@@ -43901,7 +43851,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -43912,7 +43862,7 @@
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/types": "^7.16.0"
       }
@@ -43977,7 +43927,7 @@
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-wrap-function": "^7.16.0",
@@ -44035,7 +43985,7 @@
     },
     "@babel/helper-wrap-function": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-function-name": "^7.16.0",
         "@babel/template": "^7.16.0",
@@ -44116,14 +44066,14 @@
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.16.2",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
@@ -44132,7 +44082,7 @@
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-remap-async-to-generator": "^7.16.0",
@@ -44141,7 +44091,7 @@
     },
     "@babel/plugin-proposal-class-properties": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -44149,7 +44099,7 @@
     },
     "@babel/plugin-proposal-class-static-block": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -44169,7 +44119,7 @@
     },
     "@babel/plugin-proposal-dynamic-import": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3"
@@ -44185,7 +44135,7 @@
     },
     "@babel/plugin-proposal-export-namespace-from": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
@@ -44193,7 +44143,7 @@
     },
     "@babel/plugin-proposal-json-strings": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-json-strings": "^7.8.3"
@@ -44201,7 +44151,7 @@
     },
     "@babel/plugin-proposal-logical-assignment-operators": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
@@ -44209,7 +44159,7 @@
     },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
@@ -44217,7 +44167,7 @@
     },
     "@babel/plugin-proposal-numeric-separator": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
@@ -44225,7 +44175,7 @@
     },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/compat-data": "^7.16.0",
         "@babel/helper-compilation-targets": "^7.16.0",
@@ -44236,7 +44186,7 @@
     },
     "@babel/plugin-proposal-optional-catch-binding": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
@@ -44244,7 +44194,7 @@
     },
     "@babel/plugin-proposal-optional-chaining": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
@@ -44253,7 +44203,7 @@
     },
     "@babel/plugin-proposal-private-methods": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -44261,7 +44211,7 @@
     },
     "@babel/plugin-proposal-private-property-in-object": {
       "version": "7.18.6",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-create-class-features-plugin": "^7.18.6",
@@ -44271,7 +44221,7 @@
     },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -44279,7 +44229,7 @@
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
@@ -44293,14 +44243,14 @@
     },
     "@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.12.13"
       }
     },
     "@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
@@ -44314,7 +44264,7 @@
     },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
@@ -44328,7 +44278,7 @@
     },
     "@babel/plugin-syntax-export-namespace-from": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
@@ -44350,7 +44300,7 @@
     },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
@@ -44365,7 +44315,7 @@
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
@@ -44378,7 +44328,7 @@
     },
     "@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
@@ -44391,7 +44341,7 @@
     },
     "@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
       }
@@ -44404,14 +44354,14 @@
     },
     "@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
@@ -44426,14 +44376,14 @@
     },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-module-imports": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -44442,14 +44392,14 @@
     },
     "@babel/plugin-transform-block-scoped-functions": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-block-scoping": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
@@ -44465,7 +44415,7 @@
     },
     "@babel/plugin-transform-classes": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.0",
         "@babel/helper-function-name": "^7.16.0",
@@ -44478,21 +44428,21 @@
     },
     "@babel/plugin-transform-computed-properties": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-destructuring": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -44500,14 +44450,14 @@
     },
     "@babel/plugin-transform-duplicate-keys": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -44524,14 +44474,14 @@
     },
     "@babel/plugin-transform-for-of": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-function-name": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-function-name": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -44539,21 +44489,21 @@
     },
     "@babel/plugin-transform-literals": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-member-expression-literals": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-modules-amd": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -44572,7 +44522,7 @@
     },
     "@babel/plugin-transform-modules-systemjs": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-hoist-variables": "^7.16.0",
         "@babel/helper-module-transforms": "^7.16.0",
@@ -44583,7 +44533,7 @@
     },
     "@babel/plugin-transform-modules-umd": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -44591,14 +44541,14 @@
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.16.0"
       }
     },
     "@babel/plugin-transform-new-target": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
@@ -44614,7 +44564,7 @@
     },
     "@babel/plugin-transform-object-super": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-replace-supers": "^7.16.0"
@@ -44647,7 +44597,7 @@
     },
     "@babel/plugin-transform-property-literals": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
@@ -44687,28 +44637,28 @@
     },
     "@babel/plugin-transform-regenerator": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "regenerator-transform": "^0.14.2"
       }
     },
     "@babel/plugin-transform-reserved-words": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-spread": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0"
@@ -44716,21 +44666,21 @@
     },
     "@babel/plugin-transform-sticky-regex": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-template-literals": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
@@ -44748,14 +44698,14 @@
     },
     "@babel/plugin-transform-unicode-escapes": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.16.0",
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -44763,7 +44713,7 @@
     },
     "@babel/preset-env": {
       "version": "7.16.0",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/compat-data": "^7.16.0",
         "@babel/helper-compilation-targets": "^7.16.0",
@@ -44843,7 +44793,7 @@
       "dependencies": {
         "babel-plugin-polyfill-corejs3": {
           "version": "0.3.0",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "@babel/helper-define-polyfill-provider": "^0.2.4",
             "core-js-compat": "^3.18.0"
@@ -44851,7 +44801,7 @@
         },
         "semver": {
           "version": "6.3.0",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -44867,7 +44817,7 @@
     },
     "@babel/preset-modules": {
       "version": "0.1.5",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
@@ -45710,7 +45660,8 @@
       }
     },
     "@code-hike/classer": {
-      "version": "0.0.0-e48fa74"
+      "version": "0.0.0-e48fa74",
+      "requires": {}
     },
     "@codemirror/autocomplete": {
       "version": "0.19.9",
@@ -46224,37 +46175,37 @@
     "@contentful/f36-accordion": {
       "version": "file:packages/components/accordion",
       "requires": {
-        "@contentful/f36-collapse": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-collapse": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
       "version": "file:packages/components/asset",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
       "version": "file:packages/components/autocomplete",
       "requires": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-forms": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-forms": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.58.3",
-        "@contentful/f36-skeleton": "^4.58.3",
+        "@contentful/f36-popover": "^4.59.3",
+        "@contentful/f36-skeleton": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-typography": "^4.59.3",
+        "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
@@ -46262,51 +46213,51 @@
     "@contentful/f36-avatar": {
       "version": "file:packages/components/avatar",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-image": "^4.0.0-alpha.0",
-        "@contentful/f36-menu": "^4.58.3",
+        "@contentful/f36-menu": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.58.3",
+        "@contentful/f36-tooltip": "^4.59.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
       "version": "file:packages/components/badge",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
       "version": "file:packages/components/button",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-spinner": "^4.58.3",
+        "@contentful/f36-spinner": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-card": {
       "version": "file:packages/components/card",
       "requires": {
-        "@contentful/f36-asset": "^4.58.3",
-        "@contentful/f36-badge": "^4.58.3",
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-drag-handle": "^4.58.3",
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-asset": "^4.59.3",
+        "@contentful/f36-badge": "^4.59.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-drag-handle": "^4.59.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.58.3",
-        "@contentful/f36-skeleton": "^4.58.3",
+        "@contentful/f36-menu": "^4.59.3",
+        "@contentful/f36-skeleton": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.58.3",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-tooltip": "^4.59.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
@@ -46463,7 +46414,7 @@
     "@contentful/f36-collapse": {
       "version": "file:packages/components/collapse",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -46471,41 +46422,41 @@
     "@contentful/f36-components": {
       "version": "file:packages/forma-36-react-components",
       "requires": {
-        "@contentful/f36-accordion": "^4.58.3",
-        "@contentful/f36-asset": "^4.58.3",
-        "@contentful/f36-autocomplete": "^4.58.3",
-        "@contentful/f36-badge": "^4.58.3",
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-card": "^4.58.3",
-        "@contentful/f36-collapse": "^4.58.3",
-        "@contentful/f36-copybutton": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-datepicker": "^4.58.3",
-        "@contentful/f36-datetime": "^4.58.3",
-        "@contentful/f36-drag-handle": "^4.58.3",
-        "@contentful/f36-empty-state": "^4.58.3",
-        "@contentful/f36-entity-list": "^4.58.3",
-        "@contentful/f36-forms": "^4.58.3",
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-accordion": "^4.59.3",
+        "@contentful/f36-asset": "^4.59.3",
+        "@contentful/f36-autocomplete": "^4.59.3",
+        "@contentful/f36-badge": "^4.59.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-card": "^4.59.3",
+        "@contentful/f36-collapse": "^4.59.3",
+        "@contentful/f36-copybutton": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-datepicker": "^4.59.3",
+        "@contentful/f36-datetime": "^4.59.3",
+        "@contentful/f36-drag-handle": "^4.59.3",
+        "@contentful/f36-empty-state": "^4.59.3",
+        "@contentful/f36-entity-list": "^4.59.3",
+        "@contentful/f36-forms": "^4.59.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-list": "^4.58.3",
-        "@contentful/f36-menu": "^4.58.3",
-        "@contentful/f36-modal": "^4.58.3",
+        "@contentful/f36-list": "^4.59.3",
+        "@contentful/f36-menu": "^4.59.3",
+        "@contentful/f36-modal": "^4.59.3",
         "@contentful/f36-navbar": "^4.1.0",
-        "@contentful/f36-note": "^4.58.3",
-        "@contentful/f36-notification": "^4.58.3",
-        "@contentful/f36-pagination": "^4.58.3",
-        "@contentful/f36-pill": "^4.58.3",
-        "@contentful/f36-popover": "^4.58.3",
-        "@contentful/f36-skeleton": "^4.58.3",
-        "@contentful/f36-spinner": "^4.58.3",
-        "@contentful/f36-table": "^4.58.3",
-        "@contentful/f36-tabs": "^4.58.3",
-        "@contentful/f36-text-link": "^4.58.3",
+        "@contentful/f36-note": "^4.59.3",
+        "@contentful/f36-notification": "^4.59.3",
+        "@contentful/f36-pagination": "^4.59.3",
+        "@contentful/f36-pill": "^4.59.3",
+        "@contentful/f36-popover": "^4.59.3",
+        "@contentful/f36-skeleton": "^4.59.3",
+        "@contentful/f36-spinner": "^4.59.3",
+        "@contentful/f36-table": "^4.59.3",
+        "@contentful/f36-tabs": "^4.59.3",
+        "@contentful/f36-text-link": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.58.3",
-        "@contentful/f36-typography": "^4.58.3",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-tooltip": "^4.59.3",
+        "@contentful/f36-typography": "^4.59.3",
+        "@contentful/f36-utils": "^4.24.3",
         "microbundle": "^0.15.1",
         "react": "16.14.0",
         "react-dom": "16.14.0",
@@ -46538,7 +46489,8 @@
         },
         "@octokit/plugin-request-log": {
           "version": "1.0.4",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "@octokit/plugin-rest-endpoint-methods": {
           "version": "6.6.2",
@@ -48652,11 +48604,11 @@
     "@contentful/f36-copybutton": {
       "version": "file:packages/components/copybutton",
       "requires": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.58.3",
+        "@contentful/f36-tooltip": "^4.59.3",
         "emotion": "^10.0.17"
       }
     },
@@ -48684,13 +48636,13 @@
     "@contentful/f36-datepicker": {
       "version": "file:packages/components/datepicker",
       "requires": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-forms": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-forms": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.58.3",
+        "@contentful/f36-popover": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -48700,7 +48652,7 @@
     "@contentful/f36-datetime": {
       "version": "file:packages/components/datetime",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -48718,10 +48670,10 @@
     "@contentful/f36-drag-handle": {
       "version": "file:packages/components/drag-handle",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
@@ -48729,34 +48681,34 @@
       "version": "file:packages/components/empty-state",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
       "version": "file:packages/components/entity-list",
       "requires": {
-        "@contentful/f36-badge": "^4.58.3",
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-drag-handle": "^4.58.3",
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-badge": "^4.59.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-drag-handle": "^4.59.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.58.3",
-        "@contentful/f36-skeleton": "^4.58.3",
+        "@contentful/f36-menu": "^4.59.3",
+        "@contentful/f36-skeleton": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
       "version": "file:packages/components/forms",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-typography": "^4.59.3",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17",
         "formik": "^2.4.2",
         "react-hook-form": "^7.15.0"
@@ -48765,18 +48717,18 @@
     "@contentful/f36-header": {
       "version": "file:packages/components/header",
       "requires": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
       "version": "file:packages/components/icon",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17",
         "react-icons": "^4.4.0"
@@ -48794,8 +48746,8 @@
     "@contentful/f36-image": {
       "version": "file:packages/components/image",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-skeleton": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-skeleton": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -48803,7 +48755,7 @@
     "@contentful/f36-layout": {
       "version": "file:packages/components/layout",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -48811,7 +48763,7 @@
     "@contentful/f36-list": {
       "version": "file:packages/components/list",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -48819,23 +48771,23 @@
     "@contentful/f36-menu": {
       "version": "file:packages/components/menu",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.58.3",
+        "@contentful/f36-popover": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-typography": "^4.59.3",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
       "version": "file:packages/components/modal",
       "requires": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -48924,7 +48876,7 @@
     "@contentful/f36-navlist": {
       "version": "file:packages/components/navlist",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -48932,12 +48884,12 @@
     "@contentful/f36-note": {
       "version": "file:packages/components/note",
       "requires": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "@emotion/serialize": "^1.1.1",
         "emotion": "^10.0.17"
       },
@@ -48974,12 +48926,12 @@
     "@contentful/f36-notification": {
       "version": "file:packages/components/notification",
       "requires": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-text-link": "^4.58.3",
+        "@contentful/f36-text-link": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -48998,33 +48950,33 @@
     "@contentful/f36-pagination": {
       "version": "file:packages/components/pagination",
       "requires": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-forms": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-forms": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
       "version": "file:packages/components/pill",
       "requires": {
-        "@contentful/f36-button": "^4.58.3",
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-drag-handle": "^4.58.3",
+        "@contentful/f36-button": "^4.59.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-drag-handle": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.58.3",
+        "@contentful/f36-tooltip": "^4.59.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
       "version": "file:packages/components/popover",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
@@ -49033,8 +48985,8 @@
     "@contentful/f36-skeleton": {
       "version": "file:packages/components/skeleton",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
-        "@contentful/f36-table": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
+        "@contentful/f36-table": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -49042,26 +48994,26 @@
     "@contentful/f36-spinner": {
       "version": "file:packages/components/spinner",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
       "version": "file:packages/components/table",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.58.3",
+        "@contentful/f36-typography": "^4.59.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
       "version": "file:packages/components/tabs",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -49163,7 +49115,7 @@
     "@contentful/f36-text-link": {
       "version": "file:packages/components/text-link",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -49207,9 +49159,9 @@
     "@contentful/f36-tooltip": {
       "version": "file:packages/components/tooltip",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
@@ -49219,9 +49171,9 @@
     "@contentful/f36-typography": {
       "version": "file:packages/components/typography",
       "requires": {
-        "@contentful/f36-core": "^4.58.3",
+        "@contentful/f36-core": "^4.59.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
@@ -49236,18 +49188,18 @@
       "requires": {
         "@codesandbox/sandpack-react": "^1.17.0",
         "@contentful/f36-avatar": "^4.0.0-alpha.0",
-        "@contentful/f36-components": "^4.58.3",
+        "@contentful/f36-components": "^4.59.3",
         "@contentful/f36-docs-utils": "^4.0.2",
-        "@contentful/f36-empty-state": "^4.58.3",
+        "@contentful/f36-empty-state": "^4.59.3",
         "@contentful/f36-header": "^4.0.0-alpha.0",
-        "@contentful/f36-icon": "^4.58.3",
+        "@contentful/f36-icon": "^4.59.3",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-image": "^4.0.0-alpha.0",
         "@contentful/f36-layout": "^4.0.0-alpha.0",
-        "@contentful/f36-multiselect": "^4.21.0",
+        "@contentful/f36-multiselect": "^4.22.0",
         "@contentful/f36-navlist": "4.1.0-alpha.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-utils": "^4.24.2",
+        "@contentful/f36-utils": "^4.24.3",
         "@contentful/rich-text-react-renderer": "^15.11.1",
         "@contentful/rich-text-types": "^15.11.1",
         "@dnd-kit/core": "^6.0.8",
@@ -49338,7 +49290,8 @@
           }
         },
         "@next/mdx": {
-          "version": "11.1.2"
+          "version": "11.1.2",
+          "requires": {}
         },
         "acorn-walk": {
           "version": "8.2.0",
@@ -50485,7 +50438,6 @@
     },
     "@jridgewell/source-map": {
       "version": "0.3.2",
-      "dev": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -50721,7 +50673,8 @@
       }
     },
     "@mdx-js/react": {
-      "version": "1.6.22"
+      "version": "1.6.22",
+      "requires": {}
     },
     "@mdx-js/util": {
       "version": "1.6.22"
@@ -51261,7 +51214,8 @@
       }
     },
     "@react-hook/passive-layout-effect": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "requires": {}
     },
     "@remix-run/router": {
       "version": "1.7.1",
@@ -52949,7 +52903,8 @@
         },
         "icss-utils": {
           "version": "5.1.0",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "interpret": {
           "version": "2.2.0",
@@ -54410,7 +54365,8 @@
         },
         "icss-utils": {
           "version": "5.1.0",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "lower-case": {
           "version": "2.0.2",
@@ -55172,7 +55128,8 @@
     },
     "@testing-library/user-event": {
       "version": "14.4.3",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -55267,7 +55224,6 @@
     },
     "@types/eslint": {
       "version": "8.4.6",
-      "dev": true,
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -55275,7 +55231,6 @@
     },
     "@types/eslint-scope": {
       "version": "3.7.4",
-      "dev": true,
       "requires": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -55514,8 +55469,7 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.11",
-      "dev": true
+      "version": "7.0.11"
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -55571,8 +55525,7 @@
       "version": "0.7.31"
     },
     "@types/node": {
-      "version": "17.0.21",
-      "dev": true
+      "version": "17.0.21"
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -55921,27 +55874,22 @@
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
-      "dev": true,
       "requires": {
         "@webassemblyjs/helper-numbers": "1.11.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.1",
-      "dev": true
+      "version": "1.11.1"
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.11.1",
-      "dev": true
+      "version": "1.11.1"
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.11.1",
-      "dev": true
+      "version": "1.11.1"
     },
     "@webassemblyjs/helper-numbers": {
       "version": "1.11.1",
-      "dev": true,
       "requires": {
         "@webassemblyjs/floating-point-hex-parser": "1.11.1",
         "@webassemblyjs/helper-api-error": "1.11.1",
@@ -55949,12 +55897,10 @@
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.1",
-      "dev": true
+      "version": "1.11.1"
     },
     "@webassemblyjs/helper-wasm-section": {
       "version": "1.11.1",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -55964,25 +55910,21 @@
     },
     "@webassemblyjs/ieee754": {
       "version": "1.11.1",
-      "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
       "version": "1.11.1",
-      "dev": true,
       "requires": {
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.11.1",
-      "dev": true
+      "version": "1.11.1"
     },
     "@webassemblyjs/wasm-edit": {
       "version": "1.11.1",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -55996,7 +55938,6 @@
       "dependencies": {
         "@webassemblyjs/wast-printer": {
           "version": "1.11.1",
-          "dev": true,
           "requires": {
             "@webassemblyjs/ast": "1.11.1",
             "@xtuc/long": "4.2.2"
@@ -56006,7 +55947,6 @@
     },
     "@webassemblyjs/wasm-gen": {
       "version": "1.11.1",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -56017,7 +55957,6 @@
     },
     "@webassemblyjs/wasm-opt": {
       "version": "1.11.1",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-buffer": "1.11.1",
@@ -56027,7 +55966,6 @@
     },
     "@webassemblyjs/wasm-parser": {
       "version": "1.11.1",
-      "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/helper-api-error": "1.11.1",
@@ -56038,12 +55976,10 @@
       }
     },
     "@xtuc/ieee754": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.0"
     },
     "@xtuc/long": {
-      "version": "4.2.2",
-      "dev": true
+      "version": "4.2.2"
     },
     "abab": {
       "version": "2.0.5",
@@ -56081,10 +56017,11 @@
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
-      "dev": true
+      "requires": {}
     },
     "acorn-jsx": {
-      "version": "5.3.2"
+      "version": "5.3.2",
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -56146,7 +56083,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true
+      "requires": {}
     },
     "algoliasearch": {
       "version": "3.35.1",
@@ -56550,7 +56487,8 @@
     "babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "requires": {}
     },
     "babel-jest": {
       "version": "29.6.1",
@@ -56729,7 +56667,7 @@
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "object.assign": "^4.1.0"
       }
@@ -56814,7 +56752,7 @@
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.2.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/compat-data": "^7.13.11",
         "@babel/helper-define-polyfill-provider": "^0.2.4",
@@ -56823,7 +56761,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -56857,7 +56795,7 @@
     },
     "babel-plugin-polyfill-regenerator": {
       "version": "0.2.3",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.2.4"
       }
@@ -57680,14 +57618,12 @@
     },
     "chrome-trace-event": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "dev": true
+          "version": "1.14.1"
         }
       }
     },
@@ -57876,8 +57812,7 @@
       "version": "1.0.8"
     },
     "commander": {
-      "version": "2.20.3",
-      "dev": true
+      "version": "2.20.3"
     },
     "commitizen": {
       "version": "4.3.0",
@@ -58233,7 +58168,7 @@
     },
     "core-js-compat": {
       "version": "3.19.1",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "browserslist": "^4.17.6",
         "semver": "7.0.0"
@@ -58241,7 +58176,7 @@
       "dependencies": {
         "semver": {
           "version": "7.0.0",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -58265,7 +58200,8 @@
     },
     "cosmiconfig-typescript-loader": {
       "version": "4.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "cp-file": {
       "version": "7.0.0",
@@ -58691,7 +58627,8 @@
     },
     "cssnano-utils": {
       "version": "3.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -59514,15 +59451,13 @@
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
       "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
       },
       "dependencies": {
         "tapable": {
-          "version": "2.2.1",
-          "dev": true
+          "version": "2.2.1"
         }
       }
     },
@@ -59683,8 +59618,7 @@
       }
     },
     "es-module-lexer": {
-      "version": "0.9.3",
-      "dev": true
+      "version": "0.9.3"
     },
     "es-shim-unscopables": {
       "version": "1.0.0",
@@ -59925,13 +59859,15 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/eslint-config-dev/-/eslint-config-dev-3.3.1.tgz",
       "integrity": "sha512-qFf7Y8y655tpas8QJxVkJI2MgcyQ1VingfxUm/pkFq/4r9XxW3fBTlGHr9zIizEWnnkTCnSk6uJLB0pl8Z16gQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-prettier": {
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
       "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",
@@ -60143,7 +60079,8 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-rulesdir": {
       "version": "0.2.2",
@@ -60232,15 +60169,13 @@
     },
     "eslint-scope": {
       "version": "5.1.1",
-      "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       },
       "dependencies": {
         "estraverse": {
-          "version": "4.3.0",
-          "dev": true
+          "version": "4.3.0"
         }
       }
     },
@@ -60290,7 +60225,6 @@
     },
     "esrecurse": {
       "version": "4.3.0",
-      "dev": true,
       "requires": {
         "estraverse": "^5.2.0"
       }
@@ -60313,8 +60247,7 @@
       }
     },
     "estraverse": {
-      "version": "5.3.0",
-      "dev": true
+      "version": "5.3.0"
     },
     "estree-to-babel": {
       "version": "3.2.1",
@@ -60378,7 +60311,7 @@
     },
     "esutils": {
       "version": "2.0.3",
-      "dev": true
+      "devOptional": true
     },
     "etag": {
       "version": "1.8.1",
@@ -60389,8 +60322,7 @@
       "dev": true
     },
     "events": {
-      "version": "3.3.0",
-      "dev": true
+      "version": "3.3.0"
     },
     "exec-sh": {
       "version": "0.3.6",
@@ -64421,7 +64353,8 @@
         },
         "ws": {
           "version": "7.5.3",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -64720,7 +64653,8 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.4.3",
@@ -65074,7 +65008,8 @@
         },
         "ws": {
           "version": "7.5.3",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -65382,7 +65317,6 @@
     },
     "jest-worker": {
       "version": "27.5.1",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -65391,7 +65325,6 @@
       "dependencies": {
         "supports-color": {
           "version": "8.1.1",
-          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -65474,7 +65407,8 @@
     "jscodeshift-find-imports": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/jscodeshift-find-imports/-/jscodeshift-find-imports-2.0.4.tgz",
-      "integrity": "sha512-HxOzjWDOFFSCf8EKSTQGqCxXeRFqZszOywnZ0HuMB9YPDFHVpxftGRsY+QS+Qq8o2qUojlmNU3JEHts5DWYS1A=="
+      "integrity": "sha512-HxOzjWDOFFSCf8EKSTQGqCxXeRFqZszOywnZ0HuMB9YPDFHVpxftGRsY+QS+Qq8o2qUojlmNU3JEHts5DWYS1A==",
+      "requires": {}
     },
     "jsdom": {
       "version": "20.0.0",
@@ -65575,7 +65509,8 @@
         },
         "ws": {
           "version": "8.8.1",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "xml-name-validator": {
           "version": "4.0.0",
@@ -65841,8 +65776,7 @@
       }
     },
     "loader-runner": {
-      "version": "4.3.0",
-      "dev": true
+      "version": "4.3.0"
     },
     "loader-utils": {
       "version": "2.0.0",
@@ -65880,7 +65814,7 @@
     },
     "lodash.debounce": {
       "version": "4.0.8",
-      "dev": true
+      "devOptional": true
     },
     "lodash.escaperegexp": {
       "version": "4.1.2",
@@ -68270,19 +68204,23 @@
     },
     "postcss-discard-comments": {
       "version": "5.1.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-flexbugs-fixes": {
       "version": "4.2.1",
@@ -68415,7 +68353,8 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -68428,7 +68367,8 @@
       "dependencies": {
         "icss-utils": {
           "version": "5.1.0",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -68448,13 +68388,15 @@
       "dependencies": {
         "icss-utils": {
           "version": "5.1.0",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
     "postcss-normalize-charset": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -68741,7 +68683,8 @@
       }
     },
     "prism-react-renderer": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "requires": {}
     },
     "prismjs": {
       "version": "1.29.0",
@@ -68907,7 +68850,6 @@
     },
     "randombytes": {
       "version": "2.1.0",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -68979,7 +68921,8 @@
     "react-day-picker": {
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.8.0.tgz",
-      "integrity": "sha512-QIC3uOuyGGbtypbd5QEggsCSqVaPNu8kzUWquZ7JjW9fuWB9yv7WyixKmnaFelTLXFdq7h7zU6n/aBleBqe/dA=="
+      "integrity": "sha512-QIC3uOuyGGbtypbd5QEggsCSqVaPNu8kzUWquZ7JjW9fuWB9yv7WyixKmnaFelTLXFdq7h7zU6n/aBleBqe/dA==",
+      "requires": {}
     },
     "react-devtools-inline": {
       "version": "4.4.0",
@@ -69004,7 +68947,8 @@
       }
     },
     "react-docgen-typescript": {
-      "version": "2.2.2"
+      "version": "2.2.2",
+      "requires": {}
     },
     "react-dom": {
       "version": "17.0.2",
@@ -69054,10 +68998,12 @@
       }
     },
     "react-hook-form": {
-      "version": "7.25.3"
+      "version": "7.25.3",
+      "requires": {}
     },
     "react-icons": {
-      "version": "4.4.0"
+      "version": "4.4.0",
+      "requires": {}
     },
     "react-inspector": {
       "version": "5.1.1",
@@ -69123,7 +69069,8 @@
       }
     },
     "react-simple-code-editor": {
-      "version": "0.11.3"
+      "version": "0.11.3",
+      "requires": {}
     },
     "react-sizeme": {
       "version": "3.0.2",
@@ -69357,7 +69304,7 @@
     },
     "regenerator-transform": {
       "version": "0.14.5",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/runtime": "^7.8.4"
       }
@@ -70303,7 +70250,6 @@
     },
     "schema-utils": {
       "version": "3.1.1",
-      "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -71137,7 +71083,8 @@
       }
     },
     "styled-jsx": {
-      "version": "5.0.7"
+      "version": "5.0.7",
+      "requires": {}
     },
     "stylehacks": {
       "version": "5.1.0",
@@ -71404,7 +71351,6 @@
     },
     "terser": {
       "version": "5.15.1",
-      "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -71414,7 +71360,6 @@
     },
     "terser-webpack-plugin": {
       "version": "5.3.6",
-      "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.14",
         "jest-worker": "^27.4.5",
@@ -71425,7 +71370,6 @@
       "dependencies": {
         "serialize-javascript": {
           "version": "6.0.0",
-          "dev": true,
           "requires": {
             "randombytes": "^2.1.0"
           }
@@ -72026,8 +71970,7 @@
       }
     },
     "typescript": {
-      "version": "4.7.3",
-      "dev": true
+      "version": "4.7.3"
     },
     "uglify-js": {
       "version": "3.13.5",
@@ -72336,7 +72279,8 @@
       }
     },
     "use-debounce": {
-      "version": "8.0.4"
+      "version": "8.0.4",
+      "requires": {}
     },
     "use-sidecar": {
       "version": "1.1.2",
@@ -72346,7 +72290,8 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "requires": {}
     },
     "user-home": {
       "version": "1.1.1",
@@ -72579,15 +72524,13 @@
     },
     "watchpack": {
       "version": "2.4.0",
-      "dev": true,
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "dependencies": {
         "glob-to-regexp": {
-          "version": "0.4.1",
-          "dev": true
+          "version": "0.4.1"
         }
       }
     },
@@ -72606,7 +72549,6 @@
     },
     "webpack": {
       "version": "5.74.0",
-      "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -72635,16 +72577,13 @@
       },
       "dependencies": {
         "glob-to-regexp": {
-          "version": "0.4.1",
-          "dev": true
+          "version": "0.4.1"
         },
         "tapable": {
-          "version": "2.2.1",
-          "dev": true
+          "version": "2.2.1"
         },
         "webpack-sources": {
-          "version": "3.2.3",
-          "dev": true
+          "version": "3.2.3"
         }
       }
     },
@@ -72661,7 +72600,8 @@
     },
     "webpack-filter-warnings-plugin": {
       "version": "1.2.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "webpack-hot-middleware": {
       "version": "2.25.1",
@@ -72834,7 +72774,8 @@
     },
     "ws": {
       "version": "8.5.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "x-default-browser": {
       "version": "0.4.0",

--- a/packages/components/card/examples/EntryCard/EntryCardCustomBadgeExample.tsx
+++ b/packages/components/card/examples/EntryCard/EntryCardCustomBadgeExample.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { EntryCard, Badge } from '@contentful/f36-components';
+
+export default function EntryCardCustomBadgeExample() {
+  return (
+    <EntryCard
+      contentType="Author"
+      title="John Doe"
+      description="Research and recommendations for modern stack websites."
+      badge={<Badge variant={'positive'}>custom status</Badge>}
+    />
+  );
+}

--- a/packages/components/card/src/EntryCard/EntryCard.tsx
+++ b/packages/components/card/src/EntryCard/EntryCard.tsx
@@ -91,13 +91,15 @@ function _EntryCard<
     size,
     testId = 'cf-ui-entry-card',
     contentType,
-      badge,
+    badge,
     ...otherProps
   }: EntryCardProps<E>,
   forwardedRef: React.Ref<any>,
 ) {
   const styles = getEntryCardStyles();
-  const entryStatusBadge = status ? <EntityStatusBadge entityStatus={status} /> : null;
+  const entryStatusBadge = status ? (
+    <EntityStatusBadge entityStatus={status} />
+  ) : null;
 
   return (
     <BaseCard

--- a/packages/components/card/src/EntryCard/EntryCard.tsx
+++ b/packages/components/card/src/EntryCard/EntryCard.tsx
@@ -91,19 +91,20 @@ function _EntryCard<
     size,
     testId = 'cf-ui-entry-card',
     contentType,
+      badge,
     ...otherProps
   }: EntryCardProps<E>,
   forwardedRef: React.Ref<any>,
 ) {
   const styles = getEntryCardStyles();
-  const badge = status ? <EntityStatusBadge entityStatus={status} /> : null;
+  const entryStatusBadge = status ? <EntityStatusBadge entityStatus={status} /> : null;
 
   return (
     <BaseCard
       as={ENTRY_CARD_DEFAULT_TAG}
       {...otherProps}
       actions={actions}
-      badge={badge}
+      badge={badge ? badge : entryStatusBadge}
       className={cx(styles.root, className)}
       withDragHandle={withDragHandle}
       ref={forwardedRef}

--- a/packages/components/card/src/EntryCard/EntryCard.types.ts
+++ b/packages/components/card/src/EntryCard/EntryCard.types.ts
@@ -8,7 +8,7 @@ export type EntryCardSize = 'default' | 'small' | 'auto';
 
 export type EntryCardInternalProps = Omit<
   BaseCardInternalProps,
-    'header' | 'padding' | 'ref' | 'type' | 'title'
+  'header' | 'padding' | 'ref' | 'type' | 'title'
 > & {
   /**
    * The title of the entry, it will be used as the value for the tooltip
@@ -27,7 +27,7 @@ export type EntryCardInternalProps = Omit<
    */
   contentType?: string;
   /**
-   * The publish status of the entry
+   * The publishing status of the entry
    */
   status?: EntityStatus;
   /**

--- a/packages/components/card/src/EntryCard/EntryCard.types.ts
+++ b/packages/components/card/src/EntryCard/EntryCard.types.ts
@@ -8,7 +8,7 @@ export type EntryCardSize = 'default' | 'small' | 'auto';
 
 export type EntryCardInternalProps = Omit<
   BaseCardInternalProps,
-  'badge' | 'header' | 'padding' | 'ref' | 'type' | 'title'
+    'header' | 'padding' | 'ref' | 'type' | 'title'
 > & {
   /**
    * The title of the entry, it will be used as the value for the tooltip

--- a/packages/components/card/src/EntryCard/README.mdx
+++ b/packages/components/card/src/EntryCard/README.mdx
@@ -19,7 +19,7 @@ import { EntryCard } from '@contentful/f36-card';
 
 ## Examples
 
-The two main props to show the content of your entry are `title` and `desciption`.
+The two main props to show the content of your entry are `title` and `description`.
 It’s also possible to pass the Entry’s content type in the `contentType` prop.
 To show a badge with the status of the entry,
 you can pass one of "archived", "changed", "deleted", "draft", "new", or "published" to the `status` prop.
@@ -68,6 +68,15 @@ To show a `...` button with a menu in the card, pass an array of `MenuItem` comp
 ### With a thumbnail
 
 ```jsx file=../../examples/EntryCard/EntryCardThumbnailExample.tsx
+
+```
+
+### With a custom badge
+
+Like the `Card` component, it’s possible to pass a custom badge using the `badge` prop if the entity has different statuses than
+"archived", "changed", "deleted", "draft", "new", or "published". In this case the `status` prop will be ignored.
+
+```jsx file=../../examples/EntryCard/EntryCardCustomBadgeExample.tsx
 
 ```
 

--- a/packages/components/card/stories/EntryCard.stories.tsx
+++ b/packages/components/card/stories/EntryCard.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
-import { Flex } from '@contentful/f36-core';
+import { Badge, Flex } from '@contentful/f36-core';
 import { SectionHeading } from '@contentful/f36-typography';
 import { MenuItem } from '@contentful/f36-menu';
 import { ClockIcon } from '@contentful/f36-icons';
@@ -140,6 +140,25 @@ export const Overview: Story<EntryCardProps> = () => {
             contentType="Design system"
             withDragHandle
           />
+        </Flex>
+
+        <Flex flexDirection="column" gap="spacingL">
+          <Flex flexDirection="column" gap="spacingM">
+            <SectionHeading as="h3" marginBottom="none">
+              Entities with custom status badges
+            </SectionHeading>
+
+            {sizes.map((size) => (
+              <EntryCard
+                key={size}
+                thumbnailElement={thumbnail}
+                title="Forma 36"
+                contentType="External design system"
+                size={size}
+                badge={<Badge variant={'positive'}>active</Badge>}
+              />
+            ))}
+          </Flex>
         </Flex>
       </Flex>
     </>

--- a/packages/components/card/stories/EntryCard.stories.tsx
+++ b/packages/components/card/stories/EntryCard.stories.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import type { Meta, Story } from '@storybook/react/types-6-0';
-import { Badge, Flex } from '@contentful/f36-core';
+import { Flex } from '@contentful/f36-core';
 import { SectionHeading } from '@contentful/f36-typography';
 import { MenuItem } from '@contentful/f36-menu';
 import { ClockIcon } from '@contentful/f36-icons';
+import { Badge } from '@contentful/f36-badge';
 
 import { EntryCard, type EntryCardProps } from '../src';
 


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

In order to properly show the new ExternalResourceCards status badges, this PR aims to enable passing the new Badges as an option `badge` to the `EntryCard` component

![image (4)](https://github.com/contentful/forma-36/assets/26111745/bd89a31f-5a03-4319-951d-79132a8e3b5a)


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
