### PR TITLE
feat(multi-select): forward popover onClose

### DIFF
--- a/.changeset/rotten-ways-drop.md
+++ b/.changeset/rotten-ways-drop.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-multiselect': minor
+---
+
+MultiSelect now forwards `popoverProps.onClose` providing a listener to the popover closing

--- a/packages/components/multiselect/src/Multiselect.tsx
+++ b/packages/components/multiselect/src/Multiselect.tsx
@@ -163,7 +163,7 @@ function _Multiselect(props: MultiselectProps, ref: React.Ref<HTMLDivElement>) {
     onBlur,
   } = props;
 
-  const { listMaxHeight = 180, listRef } = popoverProps;
+  const { listMaxHeight = 180, listRef, onClose } = popoverProps;
 
   const styles = getMultiselectStyles();
 
@@ -269,7 +269,12 @@ function _Multiselect(props: MultiselectProps, ref: React.Ref<HTMLDivElement>) {
         {...popoverProps}
         // popoverProps should never overwrite the internal opening logic
         isOpen={isOpen}
-        onClose={() => setIsOpen(false)}
+        onClose={() => {
+          setIsOpen(false);
+          if (onClose) {
+            onClose();
+          }
+        }}
       >
         <Popover.Trigger>
           <Button

--- a/packages/website/content/changelog.mdx
+++ b/packages/website/content/changelog.mdx
@@ -10,7 +10,7 @@ The Changelog gives an overview of the changes we've made to Forma 36
 
 **F36 Card** `v4.60.0`
 
-- The <EntryCard> component will now accepts a new option Badge. This will enable users to add custom badges on the card for entities that do not share the same statuses as a contentful Entry.
+- The EntryCard component will now accepts a new option Badge. This will enable users to add custom badges on the card for entities that do not share the same statuses as a contentful Entry.
 
 ## 08-02-2024
 


### PR DESCRIPTION
MultiSelect: Forwards the `onClose` Popover-prop inside the MultiSelect component ensuring it's called. 