### PR TITLE
fix: drop transform to UTC when creting machine readable datetime [SPA-1849]

### DIFF
--- a/packages/components/datetime/src/utils/formatDateTimeUtils.test.ts
+++ b/packages/components/datetime/src/utils/formatDateTimeUtils.test.ts
@@ -1,6 +1,8 @@
 import dayjs, { extend } from 'dayjs';
 import utcPlugin from 'dayjs/plugin/utc.js';
+import timezonePlugin from 'dayjs/plugin/timezone.js';
 extend(utcPlugin);
+extend(timezonePlugin);
 
 import { formatDateAndTime, formatMachineReadableDateTime } from '.';
 
@@ -65,26 +67,36 @@ describe('formatMachineReadableDateTime', () => {
   it('returns a string with "YYYY-MM-DDTHH:mm:ss.SSS[Z]" format', () => {
     const expected = formatMachineReadableDateTime(today);
 
-    expect(expected).toBe(
-      dayjs(today).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'),
-    );
+    expect(expected).toBe(dayjs(today).format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   });
 
   it('returns a string with "YYYY-MM-DD" format when "day" is passed', () => {
     const expected = formatMachineReadableDateTime(today, 'day');
 
-    expect(expected).toBe(dayjs(today).utc().format('YYYY-MM-DD'));
+    expect(expected).toBe(dayjs(today).format('YYYY-MM-DD'));
   });
 
   it('returns a string with "MM-DD" format when "weekday" is passed', () => {
     const expected = formatMachineReadableDateTime(today, 'weekday');
 
-    expect(expected).toBe(dayjs(today).utc().format('MM-DD'));
+    expect(expected).toBe(dayjs(today).format('MM-DD'));
   });
 
   it('returns a string with "HH:mm:ss.SSS" format when "time" is passed', () => {
     const expected = formatMachineReadableDateTime(today, 'time');
 
-    expect(expected).toBe(dayjs(today).utc().format('HH:mm:ss.SSS'));
+    expect(expected).toBe(dayjs(today).format('HH:mm:ss.SSS'));
+  });
+
+  describe('when using a non-UTC timezone', () => {
+    it('returns the day for the current timezone', () => {
+      const time = '2024-02-19T01:30:00.000+01:00';
+      // We test with the LA timezone (-7h/-8h) which means that for the current
+      // client this appears to have happened on the previous day.
+      // In UTC time and in the original used timezone, it would appear as the 19th.
+      const expected = '2024-02-18';
+      const actual = formatMachineReadableDateTime(time, 'day');
+      expect(actual).toBe(expected);
+    });
   });
 });

--- a/packages/components/datetime/src/utils/formatDateTimeUtils.ts
+++ b/packages/components/datetime/src/utils/formatDateTimeUtils.ts
@@ -79,7 +79,7 @@ export function formatMachineReadableDateTime(
       template = 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'; // 2019-08-24T15:44:07.000Z
   }
 
-  return dayjs(date).utc().format(template);
+  return dayjs(date).format(template);
 }
 
 /**


### PR DESCRIPTION
# Purpose of PR

In the UI, we sometimes see mismatching times being rendered if you're not in the UTC timezone. That is because some datetime utils transform the time to the UTC timezone (`formatMachineReadableDateTime`) while others don't (`formatDateAndTime`). When we use both in the UI (e.g. for rendering scheduled actions), we get mismatching times from two different timezones (current vs. UTC).

I started this PR by first re-creating our use case to proof that this function is the root cause. Afterward, I adjusted the function and confirmed that the tests were successful.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
