### PR TITLE
fix: changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The Changelog gives an overview of the changes we've made to Forma 36
 
 **F36 Card** `v4.60.0`
 
-- The <EntryCard> component will now accepts a new option Badge. This will enable users to add custom badges on the card for entities that do not share the same statuses as a contentful Entry.
+- The EntryCard component will now accept a new option Badge. This will enable users to add custom badges on the card for entities that do not share the same statuses as a contentful Entry.
 
 ## 08-02-2024
 

--- a/packages/components/card/CHANGELOG.md
+++ b/packages/components/card/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Minor Changes
 
-- [#2671](https://github.com/contentful/forma-36/pull/2671) [`40ba00bc7`](https://github.com/contentful/forma-36/commit/40ba00bc7541534de5b443f199ce6412d4e07e66) Thanks [@Cyberxon](https://github.com/Cyberxon)! - The <EntryCard> component will now accepts a new option Badge. This will enable users to add custom badges on the card for entities that do not share the same statuses as a contentful Entry.
+- [#2671](https://github.com/contentful/forma-36/pull/2671) [`40ba00bc7`](https://github.com/contentful/forma-36/commit/40ba00bc7541534de5b443f199ce6412d4e07e66) Thanks [@Cyberxon](https://github.com/Cyberxon)! - The EntryCard component will now accept a new option Badge. This will enable users to add custom badges on the card for entities that do not share the same statuses as a contentful Entry.
 
 ### Patch Changes
 

--- a/packages/website/content/changelog.mdx
+++ b/packages/website/content/changelog.mdx
@@ -23,7 +23,7 @@ The Changelog gives an overview of the changes we've made to Forma 36
 
 **F36 Card** `v4.60.0`
 
-- The <EntryCard> component will now accepts a new option Badge. This will enable users to add custom badges on the card for entities that do not share the same statuses as a contentful Entry.
+- The EntryCard component will now accept a new option Badge. This will enable users to add custom badges on the card for entities that do not share the same statuses as a contentful Entry.
 
 ## 08-02-2024
 


### PR DESCRIPTION
# Purpose of PR

Previously fixed changelog messages reappeared and are failing on the CI, this time updated missed files which reintroduced the issue.

Avoid using component tags in the changelog messages because if the closing tag is missing the CI will break.