### PR TITLE
chore(f36-components): bump navbar package to latest

### DIFF
--- a/.changeset/orange-rice-drop.md
+++ b/.changeset/orange-rice-drop.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-components": patch
+---
+
+chore(f36-components): bump navbar package to latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -38822,14 +38822,14 @@
     },
     "packages/components/accordion": {
       "name": "@contentful/f36-accordion",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-collapse": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -38839,14 +38839,14 @@
     },
     "packages/components/asset": {
       "name": "@contentful/f36-asset",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -38856,17 +38856,17 @@
     },
     "packages/components/autocomplete": {
       "name": "@contentful/f36-autocomplete",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-forms": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-popover": "^4.60.2",
+        "@contentful/f36-skeleton": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -38881,11 +38881,11 @@
       "version": "4.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-image": "^4.0.0-alpha.0",
-        "@contentful/f36-menu": "^4.60.0",
+        "@contentful/f36-menu": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.2",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -38895,16 +38895,16 @@
     },
     "packages/components/badge": {
       "name": "@contentful/f36-badge",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^4.60.0"
+        "@contentful/f36-typography": "^4.60.2"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -38913,17 +38913,17 @@
     },
     "packages/components/button": {
       "name": "@contentful/f36-button",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-spinner": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-spinner": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0"
       },
       "peerDependencies": {
@@ -38933,21 +38933,21 @@
     },
     "packages/components/card": {
       "name": "@contentful/f36-card",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-asset": "^4.60.0",
-        "@contentful/f36-badge": "^4.60.0",
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-asset": "^4.60.2",
+        "@contentful/f36-badge": "^4.60.2",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-drag-handle": "^4.60.2",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-menu": "^4.60.2",
+        "@contentful/f36-skeleton": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.2",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -38958,10 +38958,10 @@
     },
     "packages/components/collapse": {
       "name": "@contentful/f36-collapse",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -38972,14 +38972,14 @@
     },
     "packages/components/copybutton": {
       "name": "@contentful/f36-copybutton",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.2",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -38989,16 +38989,16 @@
     },
     "packages/components/datepicker": {
       "name": "@contentful/f36-datepicker",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-forms": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.60.0",
+        "@contentful/f36-popover": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -39011,10 +39011,10 @@
     },
     "packages/components/datetime": {
       "name": "@contentful/f36-datetime",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -39026,10 +39026,10 @@
     },
     "packages/components/drag-handle": {
       "name": "@contentful/f36-drag-handle",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -39042,11 +39042,11 @@
     },
     "packages/components/empty-state": {
       "name": "@contentful/f36-empty-state",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39056,19 +39056,19 @@
     },
     "packages/components/entity-list": {
       "name": "@contentful/f36-entity-list",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-badge": "^4.60.0",
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-badge": "^4.60.2",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-drag-handle": "^4.60.2",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-menu": "^4.60.2",
+        "@contentful/f36-skeleton": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39078,13 +39078,13 @@
     },
     "packages/components/forms": {
       "name": "@contentful/f36-forms",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -39102,11 +39102,11 @@
       "version": "4.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39116,10 +39116,10 @@
     },
     "packages/components/icon": {
       "name": "@contentful/f36-icon",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39151,8 +39151,8 @@
       "version": "4.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-skeleton": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39166,7 +39166,7 @@
       "version": "4.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39177,10 +39177,10 @@
     },
     "packages/components/list": {
       "name": "@contentful/f36-list",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39191,14 +39191,14 @@
     },
     "packages/components/menu": {
       "name": "@contentful/f36-menu",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.60.0",
+        "@contentful/f36-popover": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -39209,14 +39209,14 @@
     },
     "packages/components/modal": {
       "name": "@contentful/f36-modal",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -39252,7 +39252,7 @@
     },
     "packages/components/multiselect": {
       "name": "@contentful/f36-multiselect",
-      "version": "4.23.0",
+      "version": "4.23.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
@@ -39345,7 +39345,7 @@
       "version": "4.1.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39356,15 +39356,15 @@
     },
     "packages/components/note": {
       "name": "@contentful/f36-note",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
@@ -39409,15 +39409,15 @@
     },
     "packages/components/notification": {
       "name": "@contentful/f36-notification",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-text-link": "^4.60.0",
+        "@contentful/f36-text-link": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -39437,15 +39437,15 @@
     },
     "packages/components/pagination": {
       "name": "@contentful/f36-pagination",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-forms": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39455,15 +39455,15 @@
     },
     "packages/components/pill": {
       "name": "@contentful/f36-pill",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-drag-handle": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.2",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39473,10 +39473,10 @@
     },
     "packages/components/popover": {
       "name": "@contentful/f36-popover",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -39490,11 +39490,11 @@
     },
     "packages/components/skeleton": {
       "name": "@contentful/f36-skeleton",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-table": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-table": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39505,15 +39505,15 @@
     },
     "packages/components/spinner": {
       "name": "@contentful/f36-spinner",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^4.60.0"
+        "@contentful/f36-typography": "^4.60.2"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -39522,13 +39522,13 @@
     },
     "packages/components/table": {
       "name": "@contentful/f36-table",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -39538,10 +39538,10 @@
     },
     "packages/components/tabs": {
       "name": "@contentful/f36-tabs",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -39689,10 +39689,10 @@
     },
     "packages/components/text-link": {
       "name": "@contentful/f36-text-link",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -39703,10 +39703,10 @@
     },
     "packages/components/tooltip": {
       "name": "@contentful/f36-tooltip",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -39721,10 +39721,10 @@
     },
     "packages/components/typography": {
       "name": "@contentful/f36-typography",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -39766,7 +39766,7 @@
     },
     "packages/core": {
       "name": "@contentful/f36-core",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
@@ -40052,43 +40052,43 @@
     },
     "packages/forma-36-react-components": {
       "name": "@contentful/f36-components",
-      "version": "4.60.0",
+      "version": "4.60.2",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.60.0",
-        "@contentful/f36-asset": "^4.60.0",
-        "@contentful/f36-autocomplete": "^4.60.0",
-        "@contentful/f36-badge": "^4.60.0",
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-card": "^4.60.0",
-        "@contentful/f36-collapse": "^4.60.0",
-        "@contentful/f36-copybutton": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-datepicker": "^4.60.0",
-        "@contentful/f36-datetime": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
-        "@contentful/f36-empty-state": "^4.60.0",
-        "@contentful/f36-entity-list": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-accordion": "^4.60.2",
+        "@contentful/f36-asset": "^4.60.2",
+        "@contentful/f36-autocomplete": "^4.60.2",
+        "@contentful/f36-badge": "^4.60.2",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-card": "^4.60.2",
+        "@contentful/f36-collapse": "^4.60.2",
+        "@contentful/f36-copybutton": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-datepicker": "^4.60.2",
+        "@contentful/f36-datetime": "^4.60.2",
+        "@contentful/f36-drag-handle": "^4.60.2",
+        "@contentful/f36-empty-state": "^4.60.2",
+        "@contentful/f36-entity-list": "^4.60.2",
+        "@contentful/f36-forms": "^4.60.2",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-list": "^4.60.0",
-        "@contentful/f36-menu": "^4.60.0",
-        "@contentful/f36-modal": "^4.60.0",
-        "@contentful/f36-navbar": "^4.1.0",
-        "@contentful/f36-note": "^4.60.0",
-        "@contentful/f36-notification": "^4.60.0",
-        "@contentful/f36-pagination": "^4.60.0",
-        "@contentful/f36-pill": "^4.60.0",
-        "@contentful/f36-popover": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
-        "@contentful/f36-spinner": "^4.60.0",
-        "@contentful/f36-table": "^4.60.0",
-        "@contentful/f36-tabs": "^4.60.0",
-        "@contentful/f36-text-link": "^4.60.0",
+        "@contentful/f36-list": "^4.60.2",
+        "@contentful/f36-menu": "^4.60.2",
+        "@contentful/f36-modal": "^4.60.2",
+        "@contentful/f36-navbar": "^4.1.1",
+        "@contentful/f36-note": "^4.60.2",
+        "@contentful/f36-notification": "^4.60.2",
+        "@contentful/f36-pagination": "^4.60.2",
+        "@contentful/f36-pill": "^4.60.2",
+        "@contentful/f36-popover": "^4.60.2",
+        "@contentful/f36-skeleton": "^4.60.2",
+        "@contentful/f36-spinner": "^4.60.2",
+        "@contentful/f36-table": "^4.60.2",
+        "@contentful/f36-tabs": "^4.60.2",
+        "@contentful/f36-text-link": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.2",
+        "@contentful/f36-typography": "^4.60.2",
         "@contentful/f36-utils": "^4.24.3"
       },
       "devDependencies": {
@@ -43280,15 +43280,15 @@
       "dependencies": {
         "@codesandbox/sandpack-react": "^1.17.0",
         "@contentful/f36-avatar": "^4.0.0-alpha.0",
-        "@contentful/f36-components": "^4.60.0",
+        "@contentful/f36-components": "^4.60.2",
         "@contentful/f36-docs-utils": "^4.0.2",
-        "@contentful/f36-empty-state": "^4.60.0",
+        "@contentful/f36-empty-state": "^4.60.2",
         "@contentful/f36-header": "^4.0.0-alpha.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-image": "^4.0.0-alpha.0",
         "@contentful/f36-layout": "^4.0.0-alpha.0",
-        "@contentful/f36-multiselect": "^4.23.0",
+        "@contentful/f36-multiselect": "^4.23.1",
         "@contentful/f36-navlist": "4.1.0-alpha.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -46176,36 +46176,36 @@
     "@contentful/f36-accordion": {
       "version": "file:packages/components/accordion",
       "requires": {
-        "@contentful/f36-collapse": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-collapse": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
       "version": "file:packages/components/asset",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
       "version": "file:packages/components/autocomplete",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-forms": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-popover": "^4.60.2",
+        "@contentful/f36-skeleton": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -46214,31 +46214,31 @@
     "@contentful/f36-avatar": {
       "version": "file:packages/components/avatar",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-image": "^4.0.0-alpha.0",
-        "@contentful/f36-menu": "^4.60.0",
+        "@contentful/f36-menu": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
       "version": "file:packages/components/badge",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
       "version": "file:packages/components/button",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-spinner": "^4.60.0",
+        "@contentful/f36-spinner": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -46247,18 +46247,18 @@
     "@contentful/f36-card": {
       "version": "file:packages/components/card",
       "requires": {
-        "@contentful/f36-asset": "^4.60.0",
-        "@contentful/f36-badge": "^4.60.0",
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-asset": "^4.60.2",
+        "@contentful/f36-badge": "^4.60.2",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-drag-handle": "^4.60.2",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-menu": "^4.60.2",
+        "@contentful/f36-skeleton": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.2",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
@@ -46415,7 +46415,7 @@
     "@contentful/f36-collapse": {
       "version": "file:packages/components/collapse",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -46423,40 +46423,40 @@
     "@contentful/f36-components": {
       "version": "file:packages/forma-36-react-components",
       "requires": {
-        "@contentful/f36-accordion": "^4.60.0",
-        "@contentful/f36-asset": "^4.60.0",
-        "@contentful/f36-autocomplete": "^4.60.0",
-        "@contentful/f36-badge": "^4.60.0",
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-card": "^4.60.0",
-        "@contentful/f36-collapse": "^4.60.0",
-        "@contentful/f36-copybutton": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-datepicker": "^4.60.0",
-        "@contentful/f36-datetime": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
-        "@contentful/f36-empty-state": "^4.60.0",
-        "@contentful/f36-entity-list": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-accordion": "^4.60.2",
+        "@contentful/f36-asset": "^4.60.2",
+        "@contentful/f36-autocomplete": "^4.60.2",
+        "@contentful/f36-badge": "^4.60.2",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-card": "^4.60.2",
+        "@contentful/f36-collapse": "^4.60.2",
+        "@contentful/f36-copybutton": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-datepicker": "^4.60.2",
+        "@contentful/f36-datetime": "^4.60.2",
+        "@contentful/f36-drag-handle": "^4.60.2",
+        "@contentful/f36-empty-state": "^4.60.2",
+        "@contentful/f36-entity-list": "^4.60.2",
+        "@contentful/f36-forms": "^4.60.2",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-list": "^4.60.0",
-        "@contentful/f36-menu": "^4.60.0",
-        "@contentful/f36-modal": "^4.60.0",
-        "@contentful/f36-navbar": "^4.1.0",
-        "@contentful/f36-note": "^4.60.0",
-        "@contentful/f36-notification": "^4.60.0",
-        "@contentful/f36-pagination": "^4.60.0",
-        "@contentful/f36-pill": "^4.60.0",
-        "@contentful/f36-popover": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
-        "@contentful/f36-spinner": "^4.60.0",
-        "@contentful/f36-table": "^4.60.0",
-        "@contentful/f36-tabs": "^4.60.0",
-        "@contentful/f36-text-link": "^4.60.0",
+        "@contentful/f36-list": "^4.60.2",
+        "@contentful/f36-menu": "^4.60.2",
+        "@contentful/f36-modal": "^4.60.2",
+        "@contentful/f36-navbar": "^4.1.1",
+        "@contentful/f36-note": "^4.60.2",
+        "@contentful/f36-notification": "^4.60.2",
+        "@contentful/f36-pagination": "^4.60.2",
+        "@contentful/f36-pill": "^4.60.2",
+        "@contentful/f36-popover": "^4.60.2",
+        "@contentful/f36-skeleton": "^4.60.2",
+        "@contentful/f36-spinner": "^4.60.2",
+        "@contentful/f36-table": "^4.60.2",
+        "@contentful/f36-tabs": "^4.60.2",
+        "@contentful/f36-text-link": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.2",
+        "@contentful/f36-typography": "^4.60.2",
         "@contentful/f36-utils": "^4.24.3",
         "microbundle": "^0.15.1",
         "react": "16.14.0",
@@ -48605,11 +48605,11 @@
     "@contentful/f36-copybutton": {
       "version": "file:packages/components/copybutton",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.2",
         "emotion": "^10.0.17"
       }
     },
@@ -48637,13 +48637,13 @@
     "@contentful/f36-datepicker": {
       "version": "file:packages/components/datepicker",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-forms": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.60.0",
+        "@contentful/f36-popover": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -48653,7 +48653,7 @@
     "@contentful/f36-datetime": {
       "version": "file:packages/components/datetime",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -48671,7 +48671,7 @@
     "@contentful/f36-drag-handle": {
       "version": "file:packages/components/drag-handle",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -48682,33 +48682,33 @@
       "version": "file:packages/components/empty-state",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
       "version": "file:packages/components/entity-list",
       "requires": {
-        "@contentful/f36-badge": "^4.60.0",
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-badge": "^4.60.2",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-drag-handle": "^4.60.2",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-menu": "^4.60.2",
+        "@contentful/f36-skeleton": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
       "version": "file:packages/components/forms",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17",
         "formik": "^2.4.2",
@@ -48718,18 +48718,18 @@
     "@contentful/f36-header": {
       "version": "file:packages/components/header",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
       "version": "file:packages/components/icon",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17",
         "react-icons": "^4.4.0"
@@ -48747,8 +48747,8 @@
     "@contentful/f36-image": {
       "version": "file:packages/components/image",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-skeleton": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -48756,7 +48756,7 @@
     "@contentful/f36-layout": {
       "version": "file:packages/components/layout",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -48764,7 +48764,7 @@
     "@contentful/f36-list": {
       "version": "file:packages/components/list",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -48772,11 +48772,11 @@
     "@contentful/f36-menu": {
       "version": "file:packages/components/menu",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.60.0",
+        "@contentful/f36-popover": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
@@ -48784,11 +48784,11 @@
     "@contentful/f36-modal": {
       "version": "file:packages/components/modal",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -48877,7 +48877,7 @@
     "@contentful/f36-navlist": {
       "version": "file:packages/components/navlist",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -48885,12 +48885,12 @@
     "@contentful/f36-note": {
       "version": "file:packages/components/note",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "@emotion/serialize": "^1.1.1",
         "emotion": "^10.0.17"
       },
@@ -48927,12 +48927,12 @@
     "@contentful/f36-notification": {
       "version": "file:packages/components/notification",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-text-link": "^4.60.0",
+        "@contentful/f36-text-link": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -48951,31 +48951,31 @@
     "@contentful/f36-pagination": {
       "version": "file:packages/components/pagination",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-forms": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
       "version": "file:packages/components/pill",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
+        "@contentful/f36-button": "^4.60.2",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-drag-handle": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
       "version": "file:packages/components/popover",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -48986,8 +48986,8 @@
     "@contentful/f36-skeleton": {
       "version": "file:packages/components/skeleton",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-table": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
+        "@contentful/f36-table": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -48995,26 +48995,26 @@
     "@contentful/f36-spinner": {
       "version": "file:packages/components/spinner",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
       "version": "file:packages/components/table",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
       "version": "file:packages/components/tabs",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -49116,7 +49116,7 @@
     "@contentful/f36-text-link": {
       "version": "file:packages/components/text-link",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -49160,7 +49160,7 @@
     "@contentful/f36-tooltip": {
       "version": "file:packages/components/tooltip",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -49172,7 +49172,7 @@
     "@contentful/f36-typography": {
       "version": "file:packages/components/typography",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.2",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -49189,15 +49189,15 @@
       "requires": {
         "@codesandbox/sandpack-react": "^1.17.0",
         "@contentful/f36-avatar": "^4.0.0-alpha.0",
-        "@contentful/f36-components": "^4.60.0",
+        "@contentful/f36-components": "^4.60.2",
         "@contentful/f36-docs-utils": "^4.0.2",
-        "@contentful/f36-empty-state": "^4.60.0",
+        "@contentful/f36-empty-state": "^4.60.2",
         "@contentful/f36-header": "^4.0.0-alpha.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-icon": "^4.60.2",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-image": "^4.0.0-alpha.0",
         "@contentful/f36-layout": "^4.0.0-alpha.0",
-        "@contentful/f36-multiselect": "^4.23.0",
+        "@contentful/f36-multiselect": "^4.23.1",
         "@contentful/f36-navlist": "4.1.0-alpha.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",

--- a/packages/forma-36-react-components/package.json
+++ b/packages/forma-36-react-components/package.json
@@ -50,7 +50,7 @@
     "@contentful/f36-list": "^4.60.2",
     "@contentful/f36-menu": "^4.60.2",
     "@contentful/f36-modal": "^4.60.2",
-    "@contentful/f36-navbar": "^4.1.0",
+    "@contentful/f36-navbar": "^4.1.1",
     "@contentful/f36-note": "^4.60.2",
     "@contentful/f36-notification": "^4.60.2",
     "@contentful/f36-pagination": "^4.60.2",


### PR DESCRIPTION
## Purpose

Currently `f36-components` still serves `@contentful/f36-navbar@4.1.0` and doesn't update to the latest version `4.1.1`
