### PR TITLE
feat(entry card): entry card supports custom action button

### DIFF
--- a/.changeset/thirty-comics-repair.md
+++ b/.changeset/thirty-comics-repair.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-card': minor
+---
+
+Entry Card supports custom action button

--- a/packages/components/card/examples/EntryCard/EntryCardCustomActionButtonExample.tsx
+++ b/packages/components/card/examples/EntryCard/EntryCardCustomActionButtonExample.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { EntryCard, IconButton } from '@contentful/f36-components';
+import { CloseIcon } from '@contentful/f36-icons';
+
+export default function EntryCardCustomActionButtonExample() {
+  function CustomActionButton() {
+    return (
+      <IconButton
+        aria-label="Actions"
+        icon={<CloseIcon variant="muted" />}
+        size="small"
+        variant="transparent"
+        onClick={() => {}}
+      />
+    );
+  }
+
+  return (
+    <EntryCard
+      contentType="Author"
+      title="John Doe"
+      description="Research and recommendations for modern stack websites."
+      customActionButton={<CustomActionButton />}
+    />
+  );
+}

--- a/packages/components/card/src/BaseCard/BaseCard.tsx
+++ b/packages/components/card/src/BaseCard/BaseCard.tsx
@@ -36,6 +36,7 @@ function _BaseCard<E extends React.ElementType = typeof BASE_CARD_DEFAULT_TAG>(
     children,
     className,
     contentBodyProps,
+    customActionButton,
     header,
     href,
     icon,
@@ -65,12 +66,13 @@ function _BaseCard<E extends React.ElementType = typeof BASE_CARD_DEFAULT_TAG>(
   const isInteractive = Boolean(onClick || href || withDragHandle);
   const hasHeader = Boolean(header);
   const defaultHeader =
-    type || icon || badge || actions ? (
+    type || icon || badge || actions || customActionButton ? (
       <DefaultCardHeader
         type={type}
         icon={icon}
         badge={badge}
         actions={actions}
+        customActionButton={customActionButton}
         actionsButtonProps={actionsButtonProps}
       />
     ) : null;

--- a/packages/components/card/src/BaseCard/BaseCard.types.ts
+++ b/packages/components/card/src/BaseCard/BaseCard.types.ts
@@ -42,6 +42,10 @@ export type BaseCardInternalProps = CommonProps &
      */
     badge?: ReactNode;
     /**
+     * An element to render as the action button
+     */
+    customActionButton?: ReactNode;
+    /**
      * Passing href into the Card. You need to also add property as="a" to make it rendered as <a />
      */
     href?: string;

--- a/packages/components/card/src/BaseCard/DefaultCardHeader.tsx
+++ b/packages/components/card/src/BaseCard/DefaultCardHeader.tsx
@@ -48,15 +48,52 @@ export const stopEvents = (e: React.MouseEvent<HTMLElement>) => {
 export const DefaultCardHeader = (
   props: Pick<
     BaseCardInternalProps,
-    'type' | 'icon' | 'badge' | 'actions' | 'actionsButtonProps'
+    | 'type'
+    | 'icon'
+    | 'badge'
+    | 'actions'
+    | 'actionsButtonProps'
+    | 'customActionButton'
   >,
 ) => {
-  const { icon, type, actions, actionsButtonProps, badge } = props;
+  const { icon, type, actions, actionsButtonProps, badge, customActionButton } =
+    props;
   const styles = getHeaderStyles();
+
+  const renderActionButton = () => {
+    if (customActionButton) {
+      return (
+        <Flex
+          // don't propagate click event, so onClick handler on the card is not triggered
+          onClick={stopEvents}
+          alignItems="center"
+        >
+          {customActionButton}
+        </Flex>
+      );
+    }
+    if (actions && actions.length > 0) {
+      return (
+        <Flex
+          // don't propagate click event, so onClick handler on the card is not triggered
+          onClick={stopEvents}
+          alignItems="center"
+        >
+          <CardActions buttonProps={actionsButtonProps}>{actions}</CardActions>
+        </Flex>
+      );
+    }
+
+    return null;
+  };
+
   return (
     <Flex
       flexWrap="wrap"
-      className={cx(styles.header, actions && styles.headerWithActions)}
+      className={cx(
+        styles.header,
+        (actions || customActionButton) && styles.headerWithActions,
+      )}
     >
       <Flex flexGrow={1}>
         {type && (
@@ -67,15 +104,7 @@ export const DefaultCardHeader = (
       </Flex>
       {icon && <Flex alignItems="center">{icon}</Flex>}
       {badge && <Flex alignItems="center">{badge}</Flex>}
-      {actions && actions.length > 0 && (
-        <Flex
-          // don't propagate click event, so onClick handler on the card is not triggered
-          onClick={stopEvents}
-          alignItems="center"
-        >
-          <CardActions buttonProps={actionsButtonProps}>{actions}</CardActions>
-        </Flex>
-      )}
+      {renderActionButton()}
     </Flex>
   );
 };

--- a/packages/components/card/src/EntryCard/EntryCard.tsx
+++ b/packages/components/card/src/EntryCard/EntryCard.tsx
@@ -81,6 +81,7 @@ function _EntryCard<
     actions,
     children,
     className,
+    customActionButton,
     src,
     status,
     thumbnailElement,
@@ -108,6 +109,7 @@ function _EntryCard<
       actions={actions}
       badge={badge ? badge : entryStatusBadge}
       className={cx(styles.root, className)}
+      customActionButton={customActionButton}
       withDragHandle={withDragHandle}
       ref={forwardedRef}
       type={contentType}

--- a/packages/components/card/src/EntryCard/README.mdx
+++ b/packages/components/card/src/EntryCard/README.mdx
@@ -80,6 +80,14 @@ Like the `Card` component, it’s possible to pass a custom badge using the `bad
 
 ```
 
+### With a custom action button
+
+It is also possible to pass a custom component to be rendered in place of `...` action button. In that case, the `actions` prop will be ignored.
+
+```jsx file=../../examples/EntryCard/EntryCardCustomActionButtonExample.tsx
+
+```
+
 ## Props (API reference)
 
 <PropsTable of="EntryCard" />

--- a/packages/components/card/stories/EntryCard.stories.tsx
+++ b/packages/components/card/stories/EntryCard.stories.tsx
@@ -3,8 +3,9 @@ import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Flex } from '@contentful/f36-core';
 import { SectionHeading } from '@contentful/f36-typography';
 import { MenuItem } from '@contentful/f36-menu';
-import { ClockIcon } from '@contentful/f36-icons';
+import { ClockIcon, CloseIcon } from '@contentful/f36-icons';
 import { Badge } from '@contentful/f36-badge';
+import { IconButton } from '@contentful/f36-button';
 
 import { EntryCard, type EntryCardProps } from '../src';
 
@@ -50,6 +51,32 @@ export const WithLoadingState: Story<EntryCardProps> = (args) => {
 
 WithLoadingState.args = {
   isLoading: true,
+};
+
+export const WithCustomActionButton: Story<EntryCardProps> = (args) => {
+  return <EntryCard {...args} />;
+};
+
+const CustomActionButton = () => (
+  <IconButton
+    aria-label="Actions"
+    icon={<CloseIcon variant="muted" />}
+    size="small"
+    variant="transparent"
+    testId="cf-ui-card-actions"
+    onClick={() => {}}
+  />
+);
+
+WithCustomActionButton.args = {
+  status: 'published',
+  contentType: 'Content type',
+  title: 'Closer',
+  customActionButton: <CustomActionButton />,
+  actions: [
+    <MenuItem key="copy">Copy</MenuItem>,
+    <MenuItem key="delete">Delete</MenuItem>,
+  ],
 };
 
 const thumbnail = (
@@ -157,6 +184,25 @@ export const Overview: Story<EntryCardProps> = () => {
                 contentType="External design system"
                 size={size}
                 badge={<Badge variant={'positive'}>active</Badge>}
+              />
+            ))}
+          </Flex>
+        </Flex>
+
+        <Flex flexDirection="column" gap="spacingL">
+          <Flex flexDirection="column" gap="spacingM">
+            <SectionHeading as="h3" marginBottom="none">
+              Entities with custom action button
+            </SectionHeading>
+
+            {sizes.map((size) => (
+              <EntryCard
+                key={size}
+                thumbnailElement={thumbnail}
+                title="Forma 36"
+                contentType="Design system"
+                size={size}
+                customActionButton={<CustomActionButton />}
               />
             ))}
           </Flex>


### PR DESCRIPTION
# Purpose of PR

This PR enables consumers of Forma36 to provide their own React component as a replacement for the default `...` action menu.
If the custom component is provided, it takes precedence over default action menu. Otherwise the card renders as before with support for actions provided as Entry Card props.

**Default action menu:**
![entry-card-action-menu](https://github.com/contentful/forma-36/assets/8281495/3f4e61b7-1485-467b-9020-6c5cf066807a)

**Custom component:**
![entry-card-custom-button](https://github.com/contentful/forma-36/assets/8281495/499ec0e8-fee4-4d35-bfe9-fa34c234fd22)

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
