### PR TITLE
feat: deprecate Icon Trimmed Variants

### DIFF
--- a/.changeset/fifty-starfishes-refuse.md
+++ b/.changeset/fifty-starfishes-refuse.md
@@ -1,0 +1,7 @@
+---
+'@contentful/f36-icons': minor
+'@contentful/f36-codemod': minor
+'@contentful/f36-icon': minor
+---
+
+Deprecate trimmed icon variations

--- a/package-lock.json
+++ b/package-lock.json
@@ -20016,12 +20016,18 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.53",
-      "license": "ISC",
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
       "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/es5-shim": {
@@ -20816,6 +20822,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esniff/node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+    },
     "node_modules/espree": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
@@ -21015,6 +21040,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "node_modules/eventemitter3": {
@@ -31250,8 +31284,9 @@
       }
     },
     "node_modules/next-tick": {
-      "version": "1.0.0",
-      "license": "MIT"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.14",
@@ -61947,11 +61982,14 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.53",
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
       }
     },
     "es5-shim": {
@@ -62492,6 +62530,24 @@
         }
       }
     },
+    "esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+        }
+      }
+    },
     "espree": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
@@ -62616,6 +62672,15 @@
     "etag": {
       "version": "1.8.1",
       "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -69567,7 +69632,9 @@
       }
     },
     "next-tick": {
-      "version": "1.0.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40155,14 +40155,14 @@
     },
     "packages/components/accordion": {
       "name": "@contentful/f36-accordion",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-collapse": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -40172,14 +40172,14 @@
     },
     "packages/components/asset": {
       "name": "@contentful/f36-asset",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -40189,17 +40189,17 @@
     },
     "packages/components/autocomplete": {
       "name": "@contentful/f36-autocomplete",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-forms": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-forms": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.61.0",
-        "@contentful/f36-skeleton": "^4.61.0",
+        "@contentful/f36-popover": "^4.62.0",
+        "@contentful/f36-skeleton": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -40214,11 +40214,11 @@
       "version": "4.0.0-alpha.11",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-image": "^4.0.0-alpha.0",
-        "@contentful/f36-menu": "^4.61.0",
+        "@contentful/f36-menu": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.61.0",
+        "@contentful/f36-tooltip": "^4.62.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -40228,16 +40228,16 @@
     },
     "packages/components/badge": {
       "name": "@contentful/f36-badge",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^4.61.0"
+        "@contentful/f36-typography": "^4.62.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -40246,17 +40246,17 @@
     },
     "packages/components/button": {
       "name": "@contentful/f36-button",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-spinner": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-spinner": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0"
       },
       "peerDependencies": {
@@ -40266,21 +40266,21 @@
     },
     "packages/components/card": {
       "name": "@contentful/f36-card",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-asset": "^4.61.0",
-        "@contentful/f36-badge": "^4.61.0",
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-drag-handle": "^4.61.0",
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-asset": "^4.62.0",
+        "@contentful/f36-badge": "^4.62.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-drag-handle": "^4.62.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.61.0",
-        "@contentful/f36-skeleton": "^4.61.0",
+        "@contentful/f36-menu": "^4.62.0",
+        "@contentful/f36-skeleton": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.61.0",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-tooltip": "^4.62.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -40291,10 +40291,10 @@
     },
     "packages/components/collapse": {
       "name": "@contentful/f36-collapse",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -40305,14 +40305,14 @@
     },
     "packages/components/copybutton": {
       "name": "@contentful/f36-copybutton",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.61.0",
+        "@contentful/f36-tooltip": "^4.62.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -40322,16 +40322,16 @@
     },
     "packages/components/datepicker": {
       "name": "@contentful/f36-datepicker",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-forms": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-forms": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.61.0",
+        "@contentful/f36-popover": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -40344,10 +40344,10 @@
     },
     "packages/components/datetime": {
       "name": "@contentful/f36-datetime",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -40359,10 +40359,10 @@
     },
     "packages/components/drag-handle": {
       "name": "@contentful/f36-drag-handle",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -40375,11 +40375,11 @@
     },
     "packages/components/empty-state": {
       "name": "@contentful/f36-empty-state",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -40389,19 +40389,19 @@
     },
     "packages/components/entity-list": {
       "name": "@contentful/f36-entity-list",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-badge": "^4.61.0",
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-drag-handle": "^4.61.0",
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-badge": "^4.62.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-drag-handle": "^4.62.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.61.0",
-        "@contentful/f36-skeleton": "^4.61.0",
+        "@contentful/f36-menu": "^4.62.0",
+        "@contentful/f36-skeleton": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -40411,13 +40411,13 @@
     },
     "packages/components/forms": {
       "name": "@contentful/f36-forms",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -40435,11 +40435,11 @@
       "version": "4.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -40449,10 +40449,10 @@
     },
     "packages/components/icon": {
       "name": "@contentful/f36-icon",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -40484,8 +40484,8 @@
       "version": "4.0.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-skeleton": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-skeleton": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       },
@@ -40499,7 +40499,7 @@
       "version": "4.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       },
@@ -40510,10 +40510,10 @@
     },
     "packages/components/list": {
       "name": "@contentful/f36-list",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -40524,14 +40524,14 @@
     },
     "packages/components/menu": {
       "name": "@contentful/f36-menu",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.61.0",
+        "@contentful/f36-popover": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -40542,14 +40542,14 @@
     },
     "packages/components/modal": {
       "name": "@contentful/f36-modal",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -40678,7 +40678,7 @@
       "version": "4.1.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       },
@@ -40689,15 +40689,15 @@
     },
     "packages/components/note": {
       "name": "@contentful/f36-note",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
@@ -40742,15 +40742,15 @@
     },
     "packages/components/notification": {
       "name": "@contentful/f36-notification",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-text-link": "^4.61.0",
+        "@contentful/f36-text-link": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -40770,15 +40770,15 @@
     },
     "packages/components/pagination": {
       "name": "@contentful/f36-pagination",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-forms": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-forms": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -40788,15 +40788,15 @@
     },
     "packages/components/pill": {
       "name": "@contentful/f36-pill",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-drag-handle": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-drag-handle": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.61.0",
+        "@contentful/f36-tooltip": "^4.62.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -40806,10 +40806,10 @@
     },
     "packages/components/popover": {
       "name": "@contentful/f36-popover",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -40823,11 +40823,11 @@
     },
     "packages/components/skeleton": {
       "name": "@contentful/f36-skeleton",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-table": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-table": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -40838,15 +40838,15 @@
     },
     "packages/components/spinner": {
       "name": "@contentful/f36-spinner",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^4.61.0"
+        "@contentful/f36-typography": "^4.62.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -40855,13 +40855,13 @@
     },
     "packages/components/table": {
       "name": "@contentful/f36-table",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -40871,10 +40871,10 @@
     },
     "packages/components/tabs": {
       "name": "@contentful/f36-tabs",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -41022,10 +41022,10 @@
     },
     "packages/components/text-link": {
       "name": "@contentful/f36-text-link",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -41036,10 +41036,10 @@
     },
     "packages/components/tooltip": {
       "name": "@contentful/f36-tooltip",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -41054,10 +41054,10 @@
     },
     "packages/components/typography": {
       "name": "@contentful/f36-typography",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -41099,7 +41099,7 @@
     },
     "packages/core": {
       "name": "@contentful/f36-core",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
@@ -41385,43 +41385,43 @@
     },
     "packages/forma-36-react-components": {
       "name": "@contentful/f36-components",
-      "version": "4.61.0",
+      "version": "4.62.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.61.0",
-        "@contentful/f36-asset": "^4.61.0",
-        "@contentful/f36-autocomplete": "^4.61.0",
-        "@contentful/f36-badge": "^4.61.0",
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-card": "^4.61.0",
-        "@contentful/f36-collapse": "^4.61.0",
-        "@contentful/f36-copybutton": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-datepicker": "^4.61.0",
-        "@contentful/f36-datetime": "^4.61.0",
-        "@contentful/f36-drag-handle": "^4.61.0",
-        "@contentful/f36-empty-state": "^4.61.0",
-        "@contentful/f36-entity-list": "^4.61.0",
-        "@contentful/f36-forms": "^4.61.0",
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-accordion": "^4.62.0",
+        "@contentful/f36-asset": "^4.62.0",
+        "@contentful/f36-autocomplete": "^4.62.0",
+        "@contentful/f36-badge": "^4.62.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-card": "^4.62.0",
+        "@contentful/f36-collapse": "^4.62.0",
+        "@contentful/f36-copybutton": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-datepicker": "^4.62.0",
+        "@contentful/f36-datetime": "^4.62.0",
+        "@contentful/f36-drag-handle": "^4.62.0",
+        "@contentful/f36-empty-state": "^4.62.0",
+        "@contentful/f36-entity-list": "^4.62.0",
+        "@contentful/f36-forms": "^4.62.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-list": "^4.61.0",
-        "@contentful/f36-menu": "^4.61.0",
-        "@contentful/f36-modal": "^4.61.0",
+        "@contentful/f36-list": "^4.62.0",
+        "@contentful/f36-menu": "^4.62.0",
+        "@contentful/f36-modal": "^4.62.0",
         "@contentful/f36-navbar": "^4.1.1",
-        "@contentful/f36-note": "^4.61.0",
-        "@contentful/f36-notification": "^4.61.0",
-        "@contentful/f36-pagination": "^4.61.0",
-        "@contentful/f36-pill": "^4.61.0",
-        "@contentful/f36-popover": "^4.61.0",
-        "@contentful/f36-skeleton": "^4.61.0",
-        "@contentful/f36-spinner": "^4.61.0",
-        "@contentful/f36-table": "^4.61.0",
-        "@contentful/f36-tabs": "^4.61.0",
-        "@contentful/f36-text-link": "^4.61.0",
+        "@contentful/f36-note": "^4.62.0",
+        "@contentful/f36-notification": "^4.62.0",
+        "@contentful/f36-pagination": "^4.62.0",
+        "@contentful/f36-pill": "^4.62.0",
+        "@contentful/f36-popover": "^4.62.0",
+        "@contentful/f36-skeleton": "^4.62.0",
+        "@contentful/f36-spinner": "^4.62.0",
+        "@contentful/f36-table": "^4.62.0",
+        "@contentful/f36-tabs": "^4.62.0",
+        "@contentful/f36-text-link": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.61.0",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-tooltip": "^4.62.0",
+        "@contentful/f36-typography": "^4.62.0",
         "@contentful/f36-utils": "^4.24.3"
       },
       "devDependencies": {
@@ -44613,11 +44613,11 @@
       "dependencies": {
         "@codesandbox/sandpack-react": "^1.17.0",
         "@contentful/f36-avatar": "^4.0.0-alpha.0",
-        "@contentful/f36-components": "^4.61.0",
+        "@contentful/f36-components": "^4.62.0",
         "@contentful/f36-docs-utils": "^4.0.2",
-        "@contentful/f36-empty-state": "^4.61.0",
+        "@contentful/f36-empty-state": "^4.62.0",
         "@contentful/f36-header": "^4.0.0-alpha.0",
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-image": "^4.0.0-alpha.0",
         "@contentful/f36-layout": "^4.0.0-alpha.0",
@@ -48298,36 +48298,36 @@
     "@contentful/f36-accordion": {
       "version": "file:packages/components/accordion",
       "requires": {
-        "@contentful/f36-collapse": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-collapse": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
       "version": "file:packages/components/asset",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
       "version": "file:packages/components/autocomplete",
       "requires": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-forms": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-forms": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.61.0",
-        "@contentful/f36-skeleton": "^4.61.0",
+        "@contentful/f36-popover": "^4.62.0",
+        "@contentful/f36-skeleton": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -48336,31 +48336,31 @@
     "@contentful/f36-avatar": {
       "version": "file:packages/components/avatar",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-image": "^4.0.0-alpha.0",
-        "@contentful/f36-menu": "^4.61.0",
+        "@contentful/f36-menu": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.61.0",
+        "@contentful/f36-tooltip": "^4.62.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
       "version": "file:packages/components/badge",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
       "version": "file:packages/components/button",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-spinner": "^4.61.0",
+        "@contentful/f36-spinner": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -48369,18 +48369,18 @@
     "@contentful/f36-card": {
       "version": "file:packages/components/card",
       "requires": {
-        "@contentful/f36-asset": "^4.61.0",
-        "@contentful/f36-badge": "^4.61.0",
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-drag-handle": "^4.61.0",
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-asset": "^4.62.0",
+        "@contentful/f36-badge": "^4.62.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-drag-handle": "^4.62.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.61.0",
-        "@contentful/f36-skeleton": "^4.61.0",
+        "@contentful/f36-menu": "^4.62.0",
+        "@contentful/f36-skeleton": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.61.0",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-tooltip": "^4.62.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
@@ -48537,7 +48537,7 @@
     "@contentful/f36-collapse": {
       "version": "file:packages/components/collapse",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -48545,40 +48545,40 @@
     "@contentful/f36-components": {
       "version": "file:packages/forma-36-react-components",
       "requires": {
-        "@contentful/f36-accordion": "^4.61.0",
-        "@contentful/f36-asset": "^4.61.0",
-        "@contentful/f36-autocomplete": "^4.61.0",
-        "@contentful/f36-badge": "^4.61.0",
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-card": "^4.61.0",
-        "@contentful/f36-collapse": "^4.61.0",
-        "@contentful/f36-copybutton": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-datepicker": "^4.61.0",
-        "@contentful/f36-datetime": "^4.61.0",
-        "@contentful/f36-drag-handle": "^4.61.0",
-        "@contentful/f36-empty-state": "^4.61.0",
-        "@contentful/f36-entity-list": "^4.61.0",
-        "@contentful/f36-forms": "^4.61.0",
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-accordion": "^4.62.0",
+        "@contentful/f36-asset": "^4.62.0",
+        "@contentful/f36-autocomplete": "^4.62.0",
+        "@contentful/f36-badge": "^4.62.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-card": "^4.62.0",
+        "@contentful/f36-collapse": "^4.62.0",
+        "@contentful/f36-copybutton": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-datepicker": "^4.62.0",
+        "@contentful/f36-datetime": "^4.62.0",
+        "@contentful/f36-drag-handle": "^4.62.0",
+        "@contentful/f36-empty-state": "^4.62.0",
+        "@contentful/f36-entity-list": "^4.62.0",
+        "@contentful/f36-forms": "^4.62.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-list": "^4.61.0",
-        "@contentful/f36-menu": "^4.61.0",
-        "@contentful/f36-modal": "^4.61.0",
+        "@contentful/f36-list": "^4.62.0",
+        "@contentful/f36-menu": "^4.62.0",
+        "@contentful/f36-modal": "^4.62.0",
         "@contentful/f36-navbar": "^4.1.1",
-        "@contentful/f36-note": "^4.61.0",
-        "@contentful/f36-notification": "^4.61.0",
-        "@contentful/f36-pagination": "^4.61.0",
-        "@contentful/f36-pill": "^4.61.0",
-        "@contentful/f36-popover": "^4.61.0",
-        "@contentful/f36-skeleton": "^4.61.0",
-        "@contentful/f36-spinner": "^4.61.0",
-        "@contentful/f36-table": "^4.61.0",
-        "@contentful/f36-tabs": "^4.61.0",
-        "@contentful/f36-text-link": "^4.61.0",
+        "@contentful/f36-note": "^4.62.0",
+        "@contentful/f36-notification": "^4.62.0",
+        "@contentful/f36-pagination": "^4.62.0",
+        "@contentful/f36-pill": "^4.62.0",
+        "@contentful/f36-popover": "^4.62.0",
+        "@contentful/f36-skeleton": "^4.62.0",
+        "@contentful/f36-spinner": "^4.62.0",
+        "@contentful/f36-table": "^4.62.0",
+        "@contentful/f36-tabs": "^4.62.0",
+        "@contentful/f36-text-link": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.61.0",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-tooltip": "^4.62.0",
+        "@contentful/f36-typography": "^4.62.0",
         "@contentful/f36-utils": "^4.24.3",
         "microbundle": "^0.15.1",
         "react": "16.14.0",
@@ -50727,11 +50727,11 @@
     "@contentful/f36-copybutton": {
       "version": "file:packages/components/copybutton",
       "requires": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.61.0",
+        "@contentful/f36-tooltip": "^4.62.0",
         "emotion": "^10.0.17"
       }
     },
@@ -50759,13 +50759,13 @@
     "@contentful/f36-datepicker": {
       "version": "file:packages/components/datepicker",
       "requires": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-forms": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-forms": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.61.0",
+        "@contentful/f36-popover": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -50775,7 +50775,7 @@
     "@contentful/f36-datetime": {
       "version": "file:packages/components/datetime",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -50793,7 +50793,7 @@
     "@contentful/f36-drag-handle": {
       "version": "file:packages/components/drag-handle",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -50804,33 +50804,33 @@
       "version": "file:packages/components/empty-state",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
       "version": "file:packages/components/entity-list",
       "requires": {
-        "@contentful/f36-badge": "^4.61.0",
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-drag-handle": "^4.61.0",
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-badge": "^4.62.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-drag-handle": "^4.62.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.61.0",
-        "@contentful/f36-skeleton": "^4.61.0",
+        "@contentful/f36-menu": "^4.62.0",
+        "@contentful/f36-skeleton": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
       "version": "file:packages/components/forms",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17",
         "formik": "^2.4.2",
@@ -50840,18 +50840,18 @@
     "@contentful/f36-header": {
       "version": "file:packages/components/header",
       "requires": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
       "version": "file:packages/components/icon",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17",
         "react-icons": "^4.4.0"
@@ -50869,8 +50869,8 @@
     "@contentful/f36-image": {
       "version": "file:packages/components/image",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-skeleton": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-skeleton": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       }
@@ -50878,7 +50878,7 @@
     "@contentful/f36-layout": {
       "version": "file:packages/components/layout",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       }
@@ -50886,7 +50886,7 @@
     "@contentful/f36-list": {
       "version": "file:packages/components/list",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -50894,11 +50894,11 @@
     "@contentful/f36-menu": {
       "version": "file:packages/components/menu",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.61.0",
+        "@contentful/f36-popover": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
@@ -50906,11 +50906,11 @@
     "@contentful/f36-modal": {
       "version": "file:packages/components/modal",
       "requires": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -50999,7 +50999,7 @@
     "@contentful/f36-navlist": {
       "version": "file:packages/components/navlist",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       }
@@ -51007,12 +51007,12 @@
     "@contentful/f36-note": {
       "version": "file:packages/components/note",
       "requires": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "@emotion/serialize": "^1.1.1",
         "emotion": "^10.0.17"
       },
@@ -51049,12 +51049,12 @@
     "@contentful/f36-notification": {
       "version": "file:packages/components/notification",
       "requires": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-text-link": "^4.61.0",
+        "@contentful/f36-text-link": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -51073,31 +51073,31 @@
     "@contentful/f36-pagination": {
       "version": "file:packages/components/pagination",
       "requires": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-forms": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-forms": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
       "version": "file:packages/components/pill",
       "requires": {
-        "@contentful/f36-button": "^4.61.0",
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-drag-handle": "^4.61.0",
+        "@contentful/f36-button": "^4.62.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-drag-handle": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.61.0",
+        "@contentful/f36-tooltip": "^4.62.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
       "version": "file:packages/components/popover",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -51108,8 +51108,8 @@
     "@contentful/f36-skeleton": {
       "version": "file:packages/components/skeleton",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
-        "@contentful/f36-table": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
+        "@contentful/f36-table": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -51117,26 +51117,26 @@
     "@contentful/f36-spinner": {
       "version": "file:packages/components/spinner",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
       "version": "file:packages/components/table",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.61.0",
+        "@contentful/f36-typography": "^4.62.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
       "version": "file:packages/components/tabs",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -51238,7 +51238,7 @@
     "@contentful/f36-text-link": {
       "version": "file:packages/components/text-link",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -51282,7 +51282,7 @@
     "@contentful/f36-tooltip": {
       "version": "file:packages/components/tooltip",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -51294,7 +51294,7 @@
     "@contentful/f36-typography": {
       "version": "file:packages/components/typography",
       "requires": {
-        "@contentful/f36-core": "^4.61.0",
+        "@contentful/f36-core": "^4.62.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -51311,11 +51311,11 @@
       "requires": {
         "@codesandbox/sandpack-react": "^1.17.0",
         "@contentful/f36-avatar": "^4.0.0-alpha.0",
-        "@contentful/f36-components": "^4.61.0",
+        "@contentful/f36-components": "^4.62.0",
         "@contentful/f36-docs-utils": "^4.0.2",
-        "@contentful/f36-empty-state": "^4.61.0",
+        "@contentful/f36-empty-state": "^4.62.0",
         "@contentful/f36-header": "^4.0.0-alpha.0",
-        "@contentful/f36-icon": "^4.61.0",
+        "@contentful/f36-icon": "^4.62.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-image": "^4.0.0-alpha.0",
         "@contentful/f36-layout": "^4.0.0-alpha.0",

--- a/packages/components/icon/examples/AllIconsExample.tsx
+++ b/packages/components/icon/examples/AllIconsExample.tsx
@@ -11,8 +11,6 @@ import {
 } from '@contentful/f36-components';
 
 export default function AllIconsExample() {
-  console.log(f36icons);
-
   const [deprecatedIcons, availableIcons] = Object.entries(f36icons).reduce(
     (result, [name, icon]) => {
       result[name.includes('Trimmed') ? 0 : 1].push([name, icon]);

--- a/packages/components/icon/examples/AllIconsExample.tsx
+++ b/packages/components/icon/examples/AllIconsExample.tsx
@@ -1,29 +1,72 @@
 import * as React from 'react';
 import * as f36icons from '@contentful/f36-icons';
-import { Grid, Flex, Text } from '@contentful/f36-components';
+import {
+  Grid,
+  Flex,
+  Text,
+  Heading,
+  Badge,
+  Subheading,
+  Box,
+} from '@contentful/f36-components';
 
 export default function AllIconsExample() {
-  return (
-    <Grid columns="repeat(2, 1fr)">
-      {Object.entries(f36icons).map(([name, icon]) => {
-        const Component = icon;
+  console.log(f36icons);
 
-        return (
-          <Flex
-            key={name}
-            padding="spacingS"
-            marginRight="spacingM"
-            alignItems="center"
-            justifyContent="flex-start"
-            flexGrow={0}
-          >
-            <Flex marginRight="spacingS">
-              <Component key={name} size="medium" />
+  const [deprecatedIcons, availableIcons] = Object.entries(f36icons).reduce(
+    (result, [name, icon]) => {
+      result[name.includes('Trimmed') ? 0 : 1].push([name, icon]);
+      return result;
+    },
+    [[], []],
+  );
+
+  return (
+    <Box>
+      <Grid columns="repeat(2, 1fr)">
+        {availableIcons.map(([name, icon]) => {
+          const Component = icon;
+          return (
+            <Flex
+              key={name}
+              padding="spacingS"
+              marginRight="spacingM"
+              flexDirection="column"
+              alignItems="flex-start"
+            >
+              <Flex marginRight="spacingS" gap="spacingXs">
+                <Component key={name} size="medium" />
+                <Text>{name}</Text>
+              </Flex>
             </Flex>
-            <Text>{name}</Text>
-          </Flex>
-        );
-      })}
-    </Grid>
+          );
+        })}
+      </Grid>
+      <Heading as="h3" marginTop="spacingM" marginBottom="spacingS">
+        Trimmed Variants <Badge variant="negative">deprecated</Badge>
+      </Heading>
+      <Subheading>
+        Trimmed Icons will no longer be available in the next Iteration
+      </Subheading>
+      <Grid columns="repeat(2, 1fr)">
+        {deprecatedIcons.map(([name, icon]) => {
+          const Component = icon;
+          return (
+            <Flex
+              key={name}
+              padding="spacingS"
+              marginRight="spacingM"
+              flexDirection="column"
+              alignItems="flex-start"
+            >
+              <Flex marginRight="spacingS" gap="spacingXs">
+                <Component key={name} size="medium" />
+                <Text>{name}</Text>
+              </Flex>
+            </Flex>
+          );
+        })}
+      </Grid>
+    </Box>
   );
 }

--- a/packages/components/icon/src/Icon.tsx
+++ b/packages/components/icon/src/Icon.tsx
@@ -74,7 +74,7 @@ export type IconInternalProps = CommonProps & {
   size?: IconSize;
   /**
    * Whether or not to trim the icon width, i.e. set `width` to `auto`
-   * @deprecated IconsV5 will no longer support the trimmed option.
+   * @deprecated Trimmed icons will be removed in a future major release
    */
   trimmed?: boolean;
   /**

--- a/packages/components/icon/src/Icon.tsx
+++ b/packages/components/icon/src/Icon.tsx
@@ -74,7 +74,7 @@ export type IconInternalProps = CommonProps & {
   size?: IconSize;
   /**
    * Whether or not to trim the icon width, i.e. set `width` to `auto`
-   * @deprecated Trimmed icons will be removed in a future major release
+   * @deprecated Trimmed icons will be removed in a future major release. Please try to adapt to the untrimmed icon variant.
    */
   trimmed?: boolean;
   /**
@@ -127,16 +127,6 @@ export function _Icon<E extends React.ElementType = IconComponent>(
   }: IconProps<E>,
   forwardedRef: React.Ref<any>,
 ) {
-  React.useEffect(() => {
-    if (trimmed) {
-      // eslint-disable-next-line no-console -- allow this warning until we refactor
-      console.warn(
-        'Forma 36: Trimmed Icon variants are deprecated and will be removed in the next Icon iteration.',
-      );
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   const shared = {
     className: cx(
       css({

--- a/packages/components/icon/src/Icon.tsx
+++ b/packages/components/icon/src/Icon.tsx
@@ -74,6 +74,7 @@ export type IconInternalProps = CommonProps & {
   size?: IconSize;
   /**
    * Whether or not to trim the icon width, i.e. set `width` to `auto`
+   * @deprecated IconsV5 will no longer support the trimmed option.
    */
   trimmed?: boolean;
   /**
@@ -126,6 +127,16 @@ export function _Icon<E extends React.ElementType = IconComponent>(
   }: IconProps<E>,
   forwardedRef: React.Ref<any>,
 ) {
+  React.useEffect(() => {
+    if (trimmed) {
+      // eslint-disable-next-line no-console -- allow this warning until we refactor
+      console.warn(
+        'Forma 36: Trimmed Icon variants are deprecated and will be removed in the next Icon iteration.',
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const shared = {
     className: cx(
       css({

--- a/packages/components/icon/src/generateIcon.tsx
+++ b/packages/components/icon/src/generateIcon.tsx
@@ -22,7 +22,7 @@ type GenerateIconParameters = {
   props?: GeneratedIconProps;
   /**
    * Whether or not to trim the icon width, i.e. set `width` to `auto`
-   * @deprecated IconsV5 will no longer support the trimmed option.
+   * @deprecated Trimmed icons will be removed in a future major release. Please try to adapt to the untrimmed icon variant.
    */
   trimmed?: IconProps['trimmed'];
   /**

--- a/packages/components/icon/src/generateIcon.tsx
+++ b/packages/components/icon/src/generateIcon.tsx
@@ -22,6 +22,7 @@ type GenerateIconParameters = {
   props?: GeneratedIconProps;
   /**
    * Whether or not to trim the icon width, i.e. set `width` to `auto`
+   * @deprecated IconsV5 will no longer support the trimmed option.
    */
   trimmed?: IconProps['trimmed'];
   /**

--- a/packages/components/icons/src/ArrowDownTrimmed.tsx
+++ b/packages/components/icons/src/ArrowDownTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ArrowDown.
+ */
 export const ArrowDownTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ArrowDownTrimmed',
   path: (

--- a/packages/components/icons/src/ArrowForwardTrimmed.tsx
+++ b/packages/components/icons/src/ArrowForwardTrimmed.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ArrowForward.
+ */
 export const ArrowForwardTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ArrowForwardTrimmed',
   viewBox: '0 0 24 24',

--- a/packages/components/icons/src/ArrowUpTrimmed.tsx
+++ b/packages/components/icons/src/ArrowUpTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ArrowUp.
+ */
 export const ArrowUpTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ArrowUpTrimmed',
   path: (

--- a/packages/components/icons/src/AssetTrimmed.tsx
+++ b/packages/components/icons/src/AssetTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Asset.
+ */
 export const AssetTrimmed = /*#__PURE__*/ generateIcon({
   name: 'AssetTrimmed',
   path: (

--- a/packages/components/icons/src/ChatBubbleTrimmed.tsx
+++ b/packages/components/icons/src/ChatBubbleTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ChatBubble.
+ */
 export const ChatBubbleTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ChatBubbleTrimmed',
   path: (

--- a/packages/components/icons/src/CheckCircleTrimmed.tsx
+++ b/packages/components/icons/src/CheckCircleTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant CheckCircle.
+ */
 export const CheckCircleTrimmed = /*#__PURE__*/ generateIcon({
   name: 'CheckCircleTrimmed',
   path: (

--- a/packages/components/icons/src/ChevronDownTrimmed.tsx
+++ b/packages/components/icons/src/ChevronDownTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ChevronDown.
+ */
 export const ChevronDownTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ChevronDownTrimmed',
   path: (

--- a/packages/components/icons/src/ChevronLeftTrimmed.tsx
+++ b/packages/components/icons/src/ChevronLeftTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ChevronLeft.
+ */
 export const ChevronLeftTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ChevronLeftTrimmed',
   path: (

--- a/packages/components/icons/src/ChevronRightTrimmed.tsx
+++ b/packages/components/icons/src/ChevronRightTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ChevronRight.
+ */
 export const ChevronRightTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ChevronRightTrimmed',
   path: (

--- a/packages/components/icons/src/ChevronUpTrimmed.tsx
+++ b/packages/components/icons/src/ChevronUpTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ChevronUp.
+ */
 export const ChevronUpTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ChevronUpTrimmed',
   path: (

--- a/packages/components/icons/src/ClockTrimmed.tsx
+++ b/packages/components/icons/src/ClockTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Clock.
+ */
 export const ClockTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ClockTrimmed',
   path: (

--- a/packages/components/icons/src/CloseTrimmed.tsx
+++ b/packages/components/icons/src/CloseTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Close.
+ */
 export const CloseTrimmed = /*#__PURE__*/ generateIcon({
   name: 'CloseTrimmed',
   path: (

--- a/packages/components/icons/src/CodeTrimmed.tsx
+++ b/packages/components/icons/src/CodeTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Code.
+ */
 export const CodeTrimmed = /*#__PURE__*/ generateIcon({
   name: 'CodeTrimmed',
   path: (

--- a/packages/components/icons/src/CopyTrimmed.tsx
+++ b/packages/components/icons/src/CopyTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Copy.
+ */
 export const CopyTrimmed = /*#__PURE__*/ generateIcon({
   name: 'CopyTrimmed',
   path: (

--- a/packages/components/icons/src/CycleTrimmed.tsx
+++ b/packages/components/icons/src/CycleTrimmed.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Cycle.
+ */
 export const CycleTrimmed = /*#__PURE__*/ generateIcon({
   name: 'CycleTrimmed',
   path: (

--- a/packages/components/icons/src/DeleteTrimmed.tsx
+++ b/packages/components/icons/src/DeleteTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Delete.
+ */
 export const DeleteTrimmed = /*#__PURE__*/ generateIcon({
   name: 'DeleteTrimmed',
   path: (

--- a/packages/components/icons/src/DownloadTrimmed.tsx
+++ b/packages/components/icons/src/DownloadTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Download.
+ */
 export const DownloadTrimmed = /*#__PURE__*/ generateIcon({
   name: 'DownloadTrimmed',
   path: (

--- a/packages/components/icons/src/DragTrimmed.tsx
+++ b/packages/components/icons/src/DragTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Drag.
+ */
 export const DragTrimmed = /*#__PURE__*/ generateIcon({
   name: 'DragTrimmed',
   path: (

--- a/packages/components/icons/src/EditTrimmed.tsx
+++ b/packages/components/icons/src/EditTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Edit.
+ */
 export const EditTrimmed = /*#__PURE__*/ generateIcon({
   name: 'EditTrimmed',
   path: (

--- a/packages/components/icons/src/EmbeddedEntryBlockTrimmed.tsx
+++ b/packages/components/icons/src/EmbeddedEntryBlockTrimmed.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant EmbeddedEntryBlock.
+ */
 export const EmbeddedEntryBlockTrimmed = /*#__PURE__*/ generateIcon({
   name: 'EmbeddedEntryBlockTrimmed',
   path: (

--- a/packages/components/icons/src/EmbeddedEntryInlineTrimmed.tsx
+++ b/packages/components/icons/src/EmbeddedEntryInlineTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant EmbeddedEntryInline.
+ */
 export const EmbeddedEntryInlineTrimmed = /*#__PURE__*/ generateIcon({
   name: 'EmbeddedEntryInlineTrimmed',
   path: (

--- a/packages/components/icons/src/EntryTrimmed.tsx
+++ b/packages/components/icons/src/EntryTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Entry.
+ */
 export const EntryTrimmed = /*#__PURE__*/ generateIcon({
   name: 'EntryTrimmed',
   path: (

--- a/packages/components/icons/src/ErrorCircleTrimmed.tsx
+++ b/packages/components/icons/src/ErrorCircleTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ErrorCircle.
+ */
 export const ErrorCircleTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ErrorCircleTrimmed',
   path: (

--- a/packages/components/icons/src/ExternalLinkTrimmed.tsx
+++ b/packages/components/icons/src/ExternalLinkTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ExternalLink.
+ */
 export const ExternalLinkTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ExternalLinkTrimmed',
   path: (

--- a/packages/components/icons/src/FaceHappyTrimmed.tsx
+++ b/packages/components/icons/src/FaceHappyTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant FaceHappy.
+ */
 export const FaceHappyTrimmed = /*#__PURE__*/ generateIcon({
   name: 'FaceHappyTrimmed',
   path: (

--- a/packages/components/icons/src/FilterTrimmed.tsx
+++ b/packages/components/icons/src/FilterTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Filter.
+ */
 export const FilterTrimmed = /*#__PURE__*/ generateIcon({
   name: 'FilterTrimmed',
   path: (

--- a/packages/components/icons/src/FolderCreateTrimmed.tsx
+++ b/packages/components/icons/src/FolderCreateTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant FolderCreate.
+ */
 export const FolderCreateTrimmed = /*#__PURE__*/ generateIcon({
   name: 'FolderCreateTrimmed',
   path: (

--- a/packages/components/icons/src/FolderOpenTrimmed.tsx
+++ b/packages/components/icons/src/FolderOpenTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant FolderOpen.
+ */
 export const FolderOpenTrimmed = /*#__PURE__*/ generateIcon({
   name: 'FolderOpenTrimmed',
   path: (

--- a/packages/components/icons/src/FolderTrimmed.tsx
+++ b/packages/components/icons/src/FolderTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Folder.
+ */
 export const FolderTrimmed = /*#__PURE__*/ generateIcon({
   name: 'FolderTrimmed',
   path: (

--- a/packages/components/icons/src/FormatBoldTrimmed.tsx
+++ b/packages/components/icons/src/FormatBoldTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant FormatBold.
+ */
 export const FormatBoldTrimmed = /*#__PURE__*/ generateIcon({
   name: 'FormatBoldTrimmed',
   path: (

--- a/packages/components/icons/src/FormatItalicTrimmed.tsx
+++ b/packages/components/icons/src/FormatItalicTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant FormatItalic.
+ */
 export const FormatItalicTrimmed = /*#__PURE__*/ generateIcon({
   name: 'FormatItalicTrimmed',
   path: (

--- a/packages/components/icons/src/FormatUnderlinedTrimmed.tsx
+++ b/packages/components/icons/src/FormatUnderlinedTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant FormatUnderlined.
+ */
 export const FormatUnderlinedTrimmed = /*#__PURE__*/ generateIcon({
   name: 'FormatUnderlinedTrimmed',
   path: (

--- a/packages/components/icons/src/HeadingOneTrimmed.tsx
+++ b/packages/components/icons/src/HeadingOneTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant HeadingOne.
+ */
 export const HeadingOneTrimmed = /*#__PURE__*/ generateIcon({
   name: 'HeadingOneTrimmed',
   path: (

--- a/packages/components/icons/src/HeadingTrimmed.tsx
+++ b/packages/components/icons/src/HeadingTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Heading.
+ */
 export const HeadingTrimmed = /*#__PURE__*/ generateIcon({
   name: 'HeadingTrimmed',
   path: (

--- a/packages/components/icons/src/HeadingTwoTrimmed.tsx
+++ b/packages/components/icons/src/HeadingTwoTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant HeadingTwo.
+ */
 export const HeadingTwoTrimmed = /*#__PURE__*/ generateIcon({
   name: 'HeadingTwoTrimmed',
   path: (

--- a/packages/components/icons/src/HelpCircleTrimmed.tsx
+++ b/packages/components/icons/src/HelpCircleTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant HelpCircle.
+ */
 export const HelpCircleTrimmed = /*#__PURE__*/ generateIcon({
   name: 'HelpCircleTrimmed',
   path: (

--- a/packages/components/icons/src/HorizontalRuleTrimmed.tsx
+++ b/packages/components/icons/src/HorizontalRuleTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant HorizontalRule.
+ */
 export const HorizontalRuleTrimmed = /*#__PURE__*/ generateIcon({
   name: 'HorizontalRuleTrimmed',
   path: (

--- a/packages/components/icons/src/InfoCircleTrimmed.tsx
+++ b/packages/components/icons/src/InfoCircleTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant InfoCircle.
+ */
 export const InfoCircleTrimmed = /*#__PURE__*/ generateIcon({
   name: 'InfoCircleTrimmed',
   path: (

--- a/packages/components/icons/src/LinkTrimmed.tsx
+++ b/packages/components/icons/src/LinkTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Link.
+ */
 export const LinkTrimmed = /*#__PURE__*/ generateIcon({
   name: 'LinkTrimmed',
   path: (

--- a/packages/components/icons/src/ListBulletedTrimmed.tsx
+++ b/packages/components/icons/src/ListBulletedTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ListBulleted.
+ */
 export const ListBulletedTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ListBulletedTrimmed',
   path: (

--- a/packages/components/icons/src/ListNumberedTrimmed.tsx
+++ b/packages/components/icons/src/ListNumberedTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ListNumbered.
+ */
 export const ListNumberedTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ListNumberedTrimmed',
   path: (

--- a/packages/components/icons/src/LockTrimmed.tsx
+++ b/packages/components/icons/src/LockTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Lock.
+ */
 export const LockTrimmed = /*#__PURE__*/ generateIcon({
   name: 'LockTrimmed',
   path: (

--- a/packages/components/icons/src/LooksOneTrimmed.tsx
+++ b/packages/components/icons/src/LooksOneTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant LooksOne.
+ */
 export const LooksOneTrimmed = /*#__PURE__*/ generateIcon({
   name: 'LooksOneTrimmed',
   path: (

--- a/packages/components/icons/src/LooksTwoTrimmed.tsx
+++ b/packages/components/icons/src/LooksTwoTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant LooksTwo.
+ */
 export const LooksTwoTrimmed = /*#__PURE__*/ generateIcon({
   name: 'LooksTwoTrimmed',
   path: (

--- a/packages/components/icons/src/MenuTrimmed.tsx
+++ b/packages/components/icons/src/MenuTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Menu.
+ */
 export const MenuTrimmed = /*#__PURE__*/ generateIcon({
   name: 'MenuTrimmed',
   path: (

--- a/packages/components/icons/src/MoreHorizontalTrimmed.tsx
+++ b/packages/components/icons/src/MoreHorizontalTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant MoreHorizontal.
+ */
 export const MoreHorizontalTrimmed = /*#__PURE__*/ generateIcon({
   name: 'MoreHorizontalTrimmed',
   path: (

--- a/packages/components/icons/src/MoreVerticalTrimmed.tsx
+++ b/packages/components/icons/src/MoreVerticalTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant MoreVertical.
+ */
 export const MoreVerticalTrimmed = /*#__PURE__*/ generateIcon({
   name: 'MoreVerticalTrimmed',
   path: (

--- a/packages/components/icons/src/PageTrimmed.tsx
+++ b/packages/components/icons/src/PageTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Page.
+ */
 export const PageTrimmed = /*#__PURE__*/ generateIcon({
   name: 'PageTrimmed',
   path: (

--- a/packages/components/icons/src/PlusCircleTrimmed.tsx
+++ b/packages/components/icons/src/PlusCircleTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant PlusCircle.
+ */
 export const PlusCircleTrimmed = /*#__PURE__*/ generateIcon({
   name: 'PlusCircleTrimmed',
   path: (

--- a/packages/components/icons/src/PlusTrimmed.tsx
+++ b/packages/components/icons/src/PlusTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Plus.
+ */
 export const PlusTrimmed = /*#__PURE__*/ generateIcon({
   name: 'PlusTrimmed',
   path: (

--- a/packages/components/icons/src/QuoteTrimmed.tsx
+++ b/packages/components/icons/src/QuoteTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Quote.
+ */
 export const QuoteTrimmed = /*#__PURE__*/ generateIcon({
   name: 'QuoteTrimmed',
   path: (

--- a/packages/components/icons/src/ReceiptTrimmed.tsx
+++ b/packages/components/icons/src/ReceiptTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Receipt.
+ */
 export const ReceiptTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ReceiptTrimmed',
   path: (

--- a/packages/components/icons/src/ReleaseTrimmed.tsx
+++ b/packages/components/icons/src/ReleaseTrimmed.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Release.
+ */
 export const ReleaseTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ReleaseTrimmed',
   path: (

--- a/packages/components/icons/src/SearchTrimmed.tsx
+++ b/packages/components/icons/src/SearchTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Search.
+ */
 export const SearchTrimmed = /*#__PURE__*/ generateIcon({
   name: 'SearchTrimmed',
   path: (

--- a/packages/components/icons/src/SettingsTrimmed.tsx
+++ b/packages/components/icons/src/SettingsTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Settings.
+ */
 export const SettingsTrimmed = /*#__PURE__*/ generateIcon({
   name: 'SettingsTrimmed',
   path: (

--- a/packages/components/icons/src/ShoppingCartTrimmed.tsx
+++ b/packages/components/icons/src/ShoppingCartTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ShoppingCart.
+ */
 export const ShoppingCartTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ShoppingCartTrimmed',
   path: (

--- a/packages/components/icons/src/StarTrimmed.tsx
+++ b/packages/components/icons/src/StarTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Star.
+ */
 export const StarTrimmed = /*#__PURE__*/ generateIcon({
   name: 'StarTrimmed',
   path: (

--- a/packages/components/icons/src/SubscriptTrimmed.tsx
+++ b/packages/components/icons/src/SubscriptTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Subscript.
+ */
 export const SubscriptTrimmed = /*#__PURE__*/ generateIcon({
   name: 'SubscriptTrimmed',
   path: (

--- a/packages/components/icons/src/SuperscriptTrimmed.tsx
+++ b/packages/components/icons/src/SuperscriptTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Superscript.
+ */
 export const SuperscriptTrimmed = /*#__PURE__*/ generateIcon({
   name: 'SuperscriptTrimmed',
   path: (

--- a/packages/components/icons/src/TextTrimmed.tsx
+++ b/packages/components/icons/src/TextTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Text.
+ */
 export const TextTrimmed = /*#__PURE__*/ generateIcon({
   name: 'TextTrimmed',
   path: (

--- a/packages/components/icons/src/ThumbDownTrimmed.tsx
+++ b/packages/components/icons/src/ThumbDownTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ThumbDown.
+ */
 export const ThumbDownTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ThumbDownTrimmed',
   path: (

--- a/packages/components/icons/src/ThumbUpTrimmed.tsx
+++ b/packages/components/icons/src/ThumbUpTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant ThumbUp.
+ */
 export const ThumbUpTrimmed = /*#__PURE__*/ generateIcon({
   name: 'ThumbUpTrimmed',
   path: (

--- a/packages/components/icons/src/UsersTrimmed.tsx
+++ b/packages/components/icons/src/UsersTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Users.
+ */
 export const UsersTrimmed = /*#__PURE__*/ generateIcon({
   name: 'UsersTrimmed',
   path: (

--- a/packages/components/icons/src/WarningTrimmed.tsx
+++ b/packages/components/icons/src/WarningTrimmed.tsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from 'react';
 import { generateIcon } from '@contentful/f36-icon';
 
+/**
+ * @deprecated Trimmed icons will be removed in a future major release.
+ * Please try to adapt to the untrimmed icon variant Warning.
+ */
 export const WarningTrimmed = /*#__PURE__*/ generateIcon({
   name: 'WarningTrimmed',
   path: (


### PR DESCRIPTION
# Purpose of PR

Deprecate the trimmed Icon variant, they will be removed with the next Iteration over Icons.

<img width="385" alt="image" src="https://github.com/contentful/forma-36/assets/1789174/0ab58a28-4e23-481b-894d-5cf15595dc89">
