### PR TITLE
fix(breadcrumb): remove max-width

### DIFF
--- a/packages/components/header/package.json
+++ b/packages/components/header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-header",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "description": "Forma 36: Header component",
   "scripts": {
     "build": "tsup"

--- a/packages/components/header/src/Breadcrumb.styles.ts
+++ b/packages/components/header/src/Breadcrumb.styles.ts
@@ -6,6 +6,7 @@ export const getBreadcrumbStyles = () => ({
     color: tokens.gray500,
     fontSize: tokens.fontSizeL,
     fontWeight: tokens.fontWeightNormal,
+    maxWidth: 'none',
     paddingLeft: tokens.spacingXs,
     paddingRight: tokens.spacingXs,
   }),


### PR DESCRIPTION
# Purpose of PR

Removes `max-width` from breadcrumb buttons.