### PR TITLE
feat(badge): add prop to skip CSS text transforms

### DIFF
--- a/.changeset/chatty-singers-cry.md
+++ b/.changeset/chatty-singers-cry.md
@@ -1,5 +1,0 @@
----
-"@contentful/f36-badge": patch
----
-
-feat(badge): add prop to customize CSS text transforms

--- a/.changeset/chatty-singers-cry.md
+++ b/.changeset/chatty-singers-cry.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-badge": patch
+---
+
+feat(badge): add prop to customize CSS text transforms

--- a/.changeset/chilly-kiwis-exercise.md
+++ b/.changeset/chilly-kiwis-exercise.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-badge': minor
+---
+
+add prop to customize CSS text transforms

--- a/packages/components/badge/src/Badge/Badge.styles.ts
+++ b/packages/components/badge/src/Badge/Badge.styles.ts
@@ -64,7 +64,7 @@ const sizeToStyles = ({ size }: { size: BadgeSize }): CSSObject => {
 };
 
 export const getBadgeStyles = (
-  textTransform: CSSProperties['textTransform'],
+  textTransform: CSSProperties['textTransform'] = 'capitalize',
 ) => ({
   badge: ({ variant, size }: BadgeStylesProps) =>
     css({

--- a/packages/components/badge/src/Badge/Badge.styles.ts
+++ b/packages/components/badge/src/Badge/Badge.styles.ts
@@ -2,6 +2,7 @@ import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
 import type { BadgeVariant, BadgeSize, BadgeStylesProps } from '../types';
 import type { CSSObject } from '@emotion/serialize';
+import { CSSProperties } from 'react';
 
 const variantToStyles = ({ variant }: { variant: BadgeVariant }): CSSObject => {
   switch (variant) {
@@ -62,7 +63,9 @@ const sizeToStyles = ({ size }: { size: BadgeSize }): CSSObject => {
   }
 };
 
-export const getBadgeStyles = (noTextTransforms?: boolean) => ({
+export const getBadgeStyles = (
+  textTransform: CSSProperties['textTransform'],
+) => ({
   badge: ({ variant, size }: BadgeStylesProps) =>
     css({
       columnGap: tokens.spacing2Xs,
@@ -83,9 +86,6 @@ export const getBadgeStyles = (noTextTransforms?: boolean) => ({
   badgeText: css({
     color: 'currentcolor',
     lineHeight: 'inherit',
-    textTransform: noTextTransforms ? 'none' : 'lowercase',
-    '::first-letter': {
-      textTransform: noTextTransforms ? 'none' : 'uppercase',
-    },
+    textTransform,
   }),
 });

--- a/packages/components/badge/src/Badge/Badge.styles.ts
+++ b/packages/components/badge/src/Badge/Badge.styles.ts
@@ -62,7 +62,7 @@ const sizeToStyles = ({ size }: { size: BadgeSize }): CSSObject => {
   }
 };
 
-export const getBadgeStyles = () => ({
+export const getBadgeStyles = (noTextTransforms?: boolean) => ({
   badge: ({ variant, size }: BadgeStylesProps) =>
     css({
       columnGap: tokens.spacing2Xs,
@@ -83,9 +83,9 @@ export const getBadgeStyles = () => ({
   badgeText: css({
     color: 'currentcolor',
     lineHeight: 'inherit',
-    textTransform: 'lowercase',
+    textTransform: noTextTransforms ? 'none' : 'lowercase',
     '::first-letter': {
-      textTransform: 'uppercase',
+      textTransform: noTextTransforms ? 'none' : 'uppercase',
     },
   }),
 });

--- a/packages/components/badge/src/Badge/Badge.tsx
+++ b/packages/components/badge/src/Badge/Badge.tsx
@@ -31,13 +31,17 @@ export type BadgeInternalProps = CommonProps & {
    * Expects any of the icon components. Renders the icon aligned to the end
    */
   endIcon?: React.ReactNode;
+  /**
+   * Disables CSS text transforms
+   */
+  noTextTransform?: boolean;
 };
 
 export type BadgeProps = PropsWithHTMLElement<BadgeInternalProps, 'div'>;
 
 export const Badge = React.forwardRef<HTMLDivElement, ExpandProps<BadgeProps>>(
   (props, ref) => {
-    const styles = getBadgeStyles();
+    const styles = getBadgeStyles(props.noTextTransforms);
     const {
       children,
       variant = 'primary',

--- a/packages/components/badge/src/Badge/Badge.tsx
+++ b/packages/components/badge/src/Badge/Badge.tsx
@@ -32,7 +32,7 @@ export type BadgeInternalProps = CommonProps & {
    */
   endIcon?: React.ReactNode;
   /**
-   * Expects any valid CSS text-transform value. If not provided, will default to 'capitalized'
+   * Expects any valid CSS text-transform value. If not provided, will default to 'capitalize'
    */
   textTransform?: CSSProperties['textTransform'];
 };
@@ -41,7 +41,7 @@ export type BadgeProps = PropsWithHTMLElement<BadgeInternalProps, 'div'>;
 
 export const Badge = React.forwardRef<HTMLDivElement, ExpandProps<BadgeProps>>(
   (props, ref) => {
-    const styles = getBadgeStyles(props.textTransform ?? 'capitalized');
+    const styles = getBadgeStyles(props.textTransform ?? 'capitalize');
     const {
       children,
       variant = 'primary',

--- a/packages/components/badge/src/Badge/Badge.tsx
+++ b/packages/components/badge/src/Badge/Badge.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import { cx } from 'emotion';
 import {
   Box,
@@ -32,16 +32,16 @@ export type BadgeInternalProps = CommonProps & {
    */
   endIcon?: React.ReactNode;
   /**
-   * Disables CSS text transforms
+   * Expects any valid CSS text-transform value. If not provided, will default to 'capitalized'
    */
-  noTextTransforms?: boolean;
+  textTransform?: CSSProperties['textTransform'];
 };
 
 export type BadgeProps = PropsWithHTMLElement<BadgeInternalProps, 'div'>;
 
 export const Badge = React.forwardRef<HTMLDivElement, ExpandProps<BadgeProps>>(
   (props, ref) => {
-    const styles = getBadgeStyles(props.noTextTransforms);
+    const styles = getBadgeStyles(props.textTransform ?? 'capitalized');
     const {
       children,
       variant = 'primary',

--- a/packages/components/badge/src/Badge/Badge.tsx
+++ b/packages/components/badge/src/Badge/Badge.tsx
@@ -34,7 +34,7 @@ export type BadgeInternalProps = CommonProps & {
   /**
    * Disables CSS text transforms
    */
-  noTextTransform?: boolean;
+  noTextTransforms?: boolean;
 };
 
 export type BadgeProps = PropsWithHTMLElement<BadgeInternalProps, 'div'>;

--- a/packages/components/badge/src/Badge/Badge.tsx
+++ b/packages/components/badge/src/Badge/Badge.tsx
@@ -41,7 +41,7 @@ export type BadgeProps = PropsWithHTMLElement<BadgeInternalProps, 'div'>;
 
 export const Badge = React.forwardRef<HTMLDivElement, ExpandProps<BadgeProps>>(
   (props, ref) => {
-    const styles = getBadgeStyles(props.textTransform ?? 'capitalize');
+    const styles = getBadgeStyles(props.textTransform);
     const {
       children,
       variant = 'primary',


### PR DESCRIPTION
# Purpose of PR

This adds a prop to the Badge component so as to not have to overwrite styles when using it with text that should remain consistently capitalized and not adhere to the Badge capitalization restrictions

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/**not required**
- [x] Tests are passing
- [x] Storybook stories are added/updated/**not required**
- [x] Usage notes are added/updated/**not required**
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
