### PR TITLE
fix: proxy 'isDisabled' prop as native 'disabled' to underlying component [NONE]

### DIFF
--- a/.changeset/bright-kiwis-hear.md
+++ b/.changeset/bright-kiwis-hear.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-menu': patch
+---
+
+Fix MenuItem component to proxy 'isDisabled' prop as native 'disabled' prop to the underlying component

--- a/packages/components/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/components/menu/src/MenuItem/MenuItem.tsx
@@ -75,6 +75,7 @@ function _MenuItem<E extends React.ElementType = typeof MENU_ITEM_DEFAULT_TAG>(
       role="menuitem"
       {...otherProps}
       {...getMenuItemProps(otherProps)}
+      disabled={isDisabled ?? props.disabled}
       className={cx(styles.root, className)}
       data-test-id={itemTestId}
       ref={mergeRefs(itemRef, ref)}

--- a/packages/components/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/components/menu/src/MenuItem/MenuItem.tsx
@@ -49,7 +49,7 @@ function _MenuItem<E extends React.ElementType = typeof MENU_ITEM_DEFAULT_TAG>(
     className,
     as,
     isActive = false,
-    isDisabled = false,
+    isDisabled,
     isInitiallyFocused,
     icon,
     ...otherProps


### PR DESCRIPTION
# Purpose of PR

- proxy 'isDisabled' prop as native 'disabled' prop to the underlying component
