### PR TITLE
docs: update react-day-picker links

### DIFF
--- a/packages/components/datepicker/src/Calendar/README.mdx
+++ b/packages/components/datepicker/src/Calendar/README.mdx
@@ -57,7 +57,7 @@ Use `from...` and `to...` props to control time frames
 
 Use modifiers to modify certain days, for example showing indicators for scheduled actions.
 
-Read more about modifiers: https://react-day-picker.js.org/basics/modifiers
+Read more about modifiers: https://react-day-picker.js.org/advanced-guides/custom-modifiers
 
 ```jsx file=../../examples/Calendar/Indicator.tsx
 
@@ -67,7 +67,7 @@ Read more about modifiers: https://react-day-picker.js.org/basics/modifiers
 
 Use components to modify certain parts of the calendar, for example modifying day content.
 
-Read more about custom components: https://react-day-picker.js.org/guides/custom-components
+Read more about custom components: https://react-day-picker.js.org/advanced-guides/custom-components
 
 ```jsx file=../../examples/Calendar/CustomDayContent.tsx
 


### PR DESCRIPTION
Their website update (https://github.com/gpbl/react-day-picker/pull/2112)
broke two links which makes CI fail

<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
