### PR TITLE
fix: Add "@contentful/f36-navbar" to umbrella package as a fixed dependency

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -36,6 +36,7 @@
       "@contentful/f36-list",
       "@contentful/f36-menu",
       "@contentful/f36-modal",
+      "@contentful/f36-navbar",
       "@contentful/f36-note",
       "@contentful/f36-notification",
       "@contentful/f36-pagination",

--- a/.changeset/selfish-monkeys-beam.md
+++ b/.changeset/selfish-monkeys-beam.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-navbar': patch
+---
+
+Add "@contentful/f36-navbar" to umbrella package as a fixed dependency


### PR DESCRIPTION
# Purpose of PR

Add "@contentful/f36-navbar" to umbrella package as a fixed dependency