### PR TITLE
fix: icons v5 codemod size with expression container []

### DIFF
--- a/packages/forma-36-codemod/transforms/__testfixtures__/v5/icons.input.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v5/icons.input.js
@@ -13,4 +13,7 @@ import {
 <InfoCircleIcon variant="muted" />;
 
 const largeIcon = true;
-<CloseIcon size={largeIcon ? 'large' : 'xlarge'} />
+<CloseIcon size={largeIcon ? 'large' : 'xlarge'} />;
+
+<CloseIcon size={'xlarge'} />;
+<CloseIcon variant={"muted"} />;

--- a/packages/forma-36-codemod/transforms/__testfixtures__/v5/icons.output.js
+++ b/packages/forma-36-codemod/transforms/__testfixtures__/v5/icons.output.js
@@ -7,4 +7,7 @@ import { CaretDownIcon, CaretUpIcon, XIcon, TrashSimpleIcon, InfoIcon } from "@c
 <InfoIcon />;
 
 const largeIcon = true;
-<XIcon />
+<XIcon />;
+
+<XIcon />;
+<XIcon />;

--- a/packages/forma-36-codemod/transforms/v5/icons.js
+++ b/packages/forma-36-codemod/transforms/v5/icons.js
@@ -179,23 +179,17 @@ module.exports = function (file, api) {
             });
           }
 
-          size = getProperty(modifiedAttributes, {
-            propertyName: 'size',
-          });
-
-          // If ternary has same value for true and false, simplify
-          if (size.value.value === undefined) {
-            const matches = size.value.match(/\{'(\w+?)'\}/);
-            if (matches[1]) {
-              modifiedAttributes = updatePropertyValue(modifiedAttributes, {
-                j,
-                propertyName: 'size',
-                propertyValue: () => {
-                  return j.literal(matches[1]);
-                },
-              });
-            }
+          // update JSXExpressionContainer
+          if (size.value.type === 'JSXExpressionContainer') {
+            modifiedAttributes = updatePropertyValue(modifiedAttributes, {
+              j,
+              propertyName: 'size',
+              propertyValue: () => {
+                return j.literal(size.value.expression.value);
+              },
+            });
           }
+
           size = getProperty(modifiedAttributes, {
             propertyName: 'size',
           });


### PR DESCRIPTION
# Purpose of PR
- If icons had the size property as an expression, e.g. `{'large'}`, this was causing the codemod to throw an error and not update the code