### PR TITLE
feat: introduce size variants for light navbar

### DIFF
--- a/packages/components/navbar/package.json
+++ b/packages/components/navbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-navbar",
-  "version": "5.0.0-alpha.2",
+  "version": "5.0.0-alpha.3",
   "description": "Forma 36: Navbar component",
   "scripts": {
     "build": "tsup"

--- a/packages/components/navbar/src/Navbar.styles.ts
+++ b/packages/components/navbar/src/Navbar.styles.ts
@@ -3,9 +3,6 @@ import tokens from '@contentful/f36-tokens';
 import { mqs } from './utils.styles';
 
 export const getNavbarStyles = (maxWidth: string, variant: string) => ({
-  maxWidth: css({
-    maxWidth: variant === 'wide' ? '1524px' : '100%',
-  }),
   containerTop: css({
     justifyContent: 'center',
     backgroundColor: tokens.gray100,
@@ -16,7 +13,7 @@ export const getNavbarStyles = (maxWidth: string, variant: string) => ({
   }),
   containerTopContent: css({
     width: '100%',
-    maxWidth: maxWidth,
+    maxWidth: variant === 'wide' ? '1524px' : maxWidth,
     padding: tokens.spacingXs,
     minHeight: tokens.spacingL,
     [mqs.medium]: {
@@ -25,7 +22,7 @@ export const getNavbarStyles = (maxWidth: string, variant: string) => ({
   }),
   containerBottomContent: css({
     width: '100%',
-    maxWidth: maxWidth,
+    maxWidth: variant === 'wide' ? '1524px' : maxWidth,
     padding: 0,
     paddingTop: tokens.spacing2Xs,
     minHeight: '2.5rem',

--- a/packages/components/navbar/src/Navbar.styles.ts
+++ b/packages/components/navbar/src/Navbar.styles.ts
@@ -2,9 +2,9 @@ import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 import { mqs } from './utils.styles';
 
-export const getNavbarStyles = (maxWidth: string) => ({
-  navbarWrapper: css({
-    maxWidth: '1524px', //hardcoded magic number
+export const getNavbarStyles = (maxWidth: string, variant: string) => ({
+  maxWidth: css({
+    maxWidth: variant === 'wide' ? '1524px' : '100%',
   }),
   containerTop: css({
     justifyContent: 'center',

--- a/packages/components/navbar/src/Navbar.styles.ts
+++ b/packages/components/navbar/src/Navbar.styles.ts
@@ -3,6 +3,9 @@ import tokens from '@contentful/f36-tokens';
 import { mqs } from './utils.styles';
 
 export const getNavbarStyles = (maxWidth: string) => ({
+  navbarWrapper: css({
+    maxWidth: '1524px', //hardcoded magic number
+  }),
   containerTop: css({
     justifyContent: 'center',
     backgroundColor: tokens.gray100,

--- a/packages/components/navbar/src/Navbar.tsx
+++ b/packages/components/navbar/src/Navbar.tsx
@@ -6,7 +6,6 @@ import {
 } from '@contentful/f36-core';
 import React from 'react';
 import { getNavbarStyles } from './Navbar.styles';
-import { cx } from 'emotion';
 type NavbarOwnProps = CommonProps & {
   children?: React.ReactNode;
   account?: React.ReactNode;
@@ -59,12 +58,7 @@ function _Navbar(props: ExpandProps<NavbarProps>, ref: React.Ref<HTMLElement>) {
   const styles = getNavbarStyles(contentMaxWidth, variant);
 
   return (
-    <Box
-      {...otherProps}
-      ref={ref}
-      testId={testId}
-      className={cx(className, styles.maxWidth)}
-    >
+    <Box {...otherProps} ref={ref} testId={testId} className={className}>
       <Flex className={styles.containerTop}>
         <Flex
           className={styles.containerTopContent}

--- a/packages/components/navbar/src/Navbar.tsx
+++ b/packages/components/navbar/src/Navbar.tsx
@@ -6,7 +6,7 @@ import {
 } from '@contentful/f36-core';
 import React from 'react';
 import { getNavbarStyles } from './Navbar.styles';
-
+import { cx } from 'emotion';
 type NavbarOwnProps = CommonProps & {
   children?: React.ReactNode;
   account?: React.ReactNode;
@@ -48,12 +48,18 @@ function _Navbar(props: ExpandProps<NavbarProps>, ref: React.Ref<HTMLElement>) {
     topRightItems,
     contentMaxWidth = '100%',
     testId = 'cf-ui-navbar',
+    className,
     ...otherProps
   } = props;
   const styles = getNavbarStyles(contentMaxWidth);
 
   return (
-    <Box {...otherProps} ref={ref} testId={testId}>
+    <Box
+      {...otherProps}
+      ref={ref}
+      testId={testId}
+      className={cx(styles.navbarWrapper, className)}
+    >
       <Flex className={styles.containerTop}>
         <Flex
           className={styles.containerTopContent}

--- a/packages/components/navbar/src/Navbar.tsx
+++ b/packages/components/navbar/src/Navbar.tsx
@@ -29,6 +29,10 @@ type NavbarOwnProps = CommonProps & {
    * @default '100%'
    */
   contentMaxWidth?: string;
+  /**
+   * Describes the size variation of the navbar
+   */
+  variant?: 'wide' | 'fullscreen';
 };
 
 // expose only the HTML props that are needed to not pollute the API
@@ -49,16 +53,17 @@ function _Navbar(props: ExpandProps<NavbarProps>, ref: React.Ref<HTMLElement>) {
     contentMaxWidth = '100%',
     testId = 'cf-ui-navbar',
     className,
+    variant = 'wide',
     ...otherProps
   } = props;
-  const styles = getNavbarStyles(contentMaxWidth);
+  const styles = getNavbarStyles(contentMaxWidth, variant);
 
   return (
     <Box
       {...otherProps}
       ref={ref}
       testId={testId}
-      className={cx(styles.navbarWrapper, className)}
+      className={cx(className, styles.maxWidth)}
     >
       <Flex className={styles.containerTop}>
         <Flex

--- a/packages/components/navbar/stories/Navbar.stories.tsx
+++ b/packages/components/navbar/stories/Navbar.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Navbar, type NavbarProps } from '../src';
 import { AssetIcon, EntryIcon, FaceHappyIcon } from '@contentful/f36-icons';
 import { SectionHeading } from '@contentful/f36-typography';
-import { Flex } from '@contentful/f36-core';
+import { Flex, Stack } from '@contentful/f36-core';
 import { NavbarSwitcherItemProps } from '../src/NavbarSwitcherItem/NavbarSwitcherItem';
 import { NavbarAccountProps } from '../src/NavbarAccount/NavbarAccount';
 
@@ -71,11 +71,31 @@ const MainItems = () => (
 
 export const Basic: Story<NavbarProps> = () => {
   return (
-    <div style={{ width: '97vw' }}>
+    <div style={{ width: '900px' }}>
       <Navbar switcher={<Switcher />} account={<Account />}>
         <MainItems />
       </Navbar>
     </div>
+  );
+};
+
+export const SizeVariants: Story<NavbarProps> = () => {
+  return (
+    <Flex gap="spacingL" style={{ width: '97vw' }} flexDirection="column">
+      <SectionHeading marginBottom="none">Fullscreen</SectionHeading>
+      <Navbar
+        switcher={<Switcher />}
+        account={<Account />}
+        variant="fullscreen"
+      >
+        <MainItems />
+      </Navbar>
+
+      <SectionHeading marginBottom="none">Wide</SectionHeading>
+      <Navbar switcher={<Switcher />} account={<Account />}>
+        <MainItems />
+      </Navbar>
+    </Flex>
   );
 };
 

--- a/packages/components/navbar/stories/Navbar.stories.tsx
+++ b/packages/components/navbar/stories/Navbar.stories.tsx
@@ -71,7 +71,7 @@ const MainItems = () => (
 
 export const Basic: Story<NavbarProps> = () => {
   return (
-    <div style={{ width: '900px' }}>
+    <div style={{ width: '97vw' }}>
       <Navbar switcher={<Switcher />} account={<Account />}>
         <MainItems />
       </Navbar>

--- a/packages/components/navbar/stories/Navbar.stories.tsx
+++ b/packages/components/navbar/stories/Navbar.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, Story } from '@storybook/react/types-6-0';
 import { Navbar, type NavbarProps } from '../src';
 import { AssetIcon, EntryIcon, FaceHappyIcon } from '@contentful/f36-icons';
 import { SectionHeading } from '@contentful/f36-typography';
-import { Flex, Stack } from '@contentful/f36-core';
+import { Flex } from '@contentful/f36-core';
 import { NavbarSwitcherItemProps } from '../src/NavbarSwitcherItem/NavbarSwitcherItem';
 import { NavbarAccountProps } from '../src/NavbarAccount/NavbarAccount';
 


### PR DESCRIPTION
This enables controlling the size of the navbar content via a dedicated prop instead the need to handover specific width sizes.

<img width="1143" alt="image" src="https://github.com/contentful/forma-36/assets/1789174/9a5932e0-7639-4541-8e35-553935c82844">
