### PR TITLE
fix: properly pass testId as data-test-id to components []

### DIFF
--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-icon",
-  "version": "5.0.0-alpha.9",
+  "version": "5.0.0-alpha.10",
   "description": "Forma 36: Icon component",
   "license": "MIT",
   "exports": {

--- a/packages/components/icon/src/utils/wrapPhosphorIcon.tsx
+++ b/packages/components/icon/src/utils/wrapPhosphorIcon.tsx
@@ -15,12 +15,16 @@ export function wrapPhosphorIcon(PhosphorIcon: PhosphorIcon) {
     isActive = false,
     color = isActive ? tokens.blue500 : tokens.gray900,
     size = 'medium',
+    testId,
     ...props
   }: GeneratedIconProps & { weight?: IconWeight }) => {
+    const commonProps = { ...props, 'data-test-id': testId };
     return (
       <Icon
-        {...props}
-        as={() => <PhosphorIcon {...props} color={color} size={sizes[size]} />}
+        {...commonProps}
+        as={() => (
+          <PhosphorIcon {...commonProps} color={color} size={sizes[size]} />
+        )}
       />
     );
   };

--- a/packages/components/icons/package.json
+++ b/packages/components/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-icons",
-  "version": "5.0.0-alpha.9",
+  "version": "5.0.0-alpha.10",
   "description": "Forma 36: Icon components",
   "license": "MIT",
   "exports": {


### PR DESCRIPTION
# Purpose of PR

We were passing the `testId` prop without renaming it, what would make tests that rely on the `data-test-id` to fail