### PR TITLE
docs: change status from alpha to stable of Avatar and Image []

### DIFF
--- a/packages/components/avatar/src/Avatar/README.mdx
+++ b/packages/components/avatar/src/Avatar/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Avatar'
 type: 'component'
-status: 'alpha'
+status: 'stable'
 section: 'avatarComponents'
 slug: /components/avatar/
 github: 'https://github.com/contentful/forma-36/tree/main/packages/components/avatar'

--- a/packages/components/avatar/src/AvatarGroup/README.mdx
+++ b/packages/components/avatar/src/AvatarGroup/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'AvatarGroup'
 type: 'component'
-status: 'alpha'
+status: 'stable'
 section: 'avatarComponents'
 slug: /components/avatar-group/
 github: 'https://github.com/contentful/forma-36/tree/main/packages/components/avatargroup'

--- a/packages/components/image/README.mdx
+++ b/packages/components/image/README.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Image'
 type: 'component'
-status: 'alpha'
+status: 'stable'
 slug: /components/image/
 github: 'https://github.com/contentful/forma-36/tree/main/packages/components/image'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-image--overview'


### PR DESCRIPTION
 Purpose of PR

Update website to remove `alpha` tag from Avatar, AvatarGroup and Image components.

Should we add the `new` tag?