### PR TITLE
refactor: pass color prop to icon from Button [CFISO-1471]

### DIFF
--- a/.changeset/small-ways-kneel.md
+++ b/.changeset/small-ways-kneel.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-button': patch
+---
+
+Pass color prop to icon from button

--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -76,7 +76,10 @@ function _Button<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
             // We need to pass the color to the icons to enable the usaged of the V5 icons
             // it may change in the future
             color:
-              (variant === 'transparent' && icon.props.variant === undefined && icon.props.color) || 'currentColor',
+              (variant === 'transparent' &&
+                icon.props.variant === undefined &&
+                icon.props.color) ||
+              'currentColor',
             // we want to allow variants for icons for transparent buttons
             variant:
               (variant === 'transparent' && icon.props.variant) ||

--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -7,6 +7,7 @@ import {
   type PolymorphicComponent,
   type ExpandProps,
 } from '@contentful/f36-core';
+import tokens from '@contentful/f36-tokens';
 import { useDensity } from '@contentful/f36-utils';
 import { Spinner } from '@contentful/f36-spinner';
 
@@ -73,6 +74,8 @@ function _Button<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
         >
           {React.cloneElement(icon, {
             size: icon.props.size ?? `${size === 'large' ? 'medium' : 'small'}`,
+            color:
+              (variant === 'transparent' && icon.props.color) || 'currentColor',
             // we want to allow variants for icons for transparent buttons
             variant:
               (variant === 'transparent' && icon.props.variant) ||

--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -76,7 +76,7 @@ function _Button<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
             // We need to pass the color to the icons to enable the usaged of the V5 icons
             // it may change in the future
             color:
-              (variant === 'transparent' && icon.props.color) || 'currentColor',
+              (variant === 'transparent' && icon.props.variant === undefined && icon.props.color) || 'currentColor',
             // we want to allow variants for icons for transparent buttons
             variant:
               (variant === 'transparent' && icon.props.variant) ||

--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -74,6 +74,8 @@ function _Button<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
         >
           {React.cloneElement(icon, {
             size: icon.props.size ?? `${size === 'large' ? 'medium' : 'small'}`,
+            // We need to pass the color to the icons to enable the usaged of the V5 icons
+            // it may change in the future
             color:
               (variant === 'transparent' && icon.props.color) || 'currentColor',
             // we want to allow variants for icons for transparent buttons

--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -7,7 +7,6 @@ import {
   type PolymorphicComponent,
   type ExpandProps,
 } from '@contentful/f36-core';
-import tokens from '@contentful/f36-tokens';
 import { useDensity } from '@contentful/f36-utils';
 import { Spinner } from '@contentful/f36-spinner';
 


### PR DESCRIPTION
# Purpose of PR

To enable usage of the Icons V5 alpha we need to pass the color prop from the Button to the Icons