### PR TITLE
fix(header): remove margin on noWrap

### DIFF
--- a/packages/components/header/src/Header.styles.ts
+++ b/packages/components/header/src/Header.styles.ts
@@ -43,6 +43,5 @@ export const getHeaderStyles = () => ({
   }),
   noWrap: css({
     textWrap: 'nowrap',
-    marginLeft: tokens.spacingXs,
   }),
 });


### PR DESCRIPTION
# Purpose of PR

@massao the Header title has a left margin at the moment that we only want on elements that aren't the first child. Can we safely remove it from the `noWrap` class?