### PR TITLE
feat(header): only apply margin left if noWrap is not first child

### DIFF
--- a/packages/components/header/src/Header.styles.ts
+++ b/packages/components/header/src/Header.styles.ts
@@ -43,6 +43,8 @@ export const getHeaderStyles = () => ({
   }),
   noWrap: css({
     textWrap: 'nowrap',
-    marginLeft: tokens.spacingXs,
+    '&:not(:first-child)': {
+      marginLeft: tokens.spacingXs,
+    },
   }),
 });


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR
Left margin on Header’s title prop is no longer rendered when there’s no element to the left of the title

Tickets: 
https://contentful.atlassian.net/browse/CFISO-1571

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
