### PR TITLE
Header: Remove unwanted margin from title, release as stable component

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,6 @@
     }
   ],
   "ignore": [
-    "@contentful/f36-header",
     "@contentful/f36-layout",
     "@contentful/f36-navlist",
     "@contentful/f36-website"
@@ -31,6 +30,7 @@
       "@contentful/f36-empty-state",
       "@contentful/f36-forms",
       "@contentful/f36-icon",
+      "@contentful/f36-header",
       "@contentful/f36-list",
       "@contentful/f36-menu",
       "@contentful/f36-modal",

--- a/.changeset/happy-beds-glow.md
+++ b/.changeset/happy-beds-glow.md
@@ -1,0 +1,6 @@
+---
+'@contentful/f36-components': patch
+'@contentful/f36-header': patch
+---
+
+Move Header from alpha package to automatic release.

--- a/packages/components/header/README.mdx
+++ b/packages/components/header/README.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Header'
 type: 'layout'
-status: 'alpha'
 slug: /components/header/
 github: 'https://github.com/contentful/forma-36/tree/main/packages/components/header'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-header--default'

--- a/packages/components/header/package.json
+++ b/packages/components/header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-header",
-  "version": "4.0.0-alpha.7",
+  "version": "4.0.0",
   "description": "Forma 36: Header component",
   "scripts": {
     "build": "tsup"

--- a/packages/components/header/src/Header.styles.ts
+++ b/packages/components/header/src/Header.styles.ts
@@ -43,6 +43,8 @@ export const getHeaderStyles = () => ({
   }),
   noWrap: css({
     textWrap: 'nowrap',
-    marginLeft: tokens.spacingXs,
+    '&:not(:first-child)': {
+      marginLeft: tokens.spacingXs,
+    },
   }),
 });

--- a/packages/forma-36-react-components/package.json
+++ b/packages/forma-36-react-components/package.json
@@ -49,6 +49,7 @@
     "@contentful/f36-icon": "^4.65.8",
     "@contentful/f36-icons": "^4.28.1",
     "@contentful/f36-image": "4.65.8",
+    "@contentful/f36-header": "^4.0.0",
     "@contentful/f36-list": "^4.65.8",
     "@contentful/f36-menu": "^4.65.8",
     "@contentful/f36-modal": "^4.65.8",

--- a/packages/forma-36-react-components/src/index.ts
+++ b/packages/forma-36-react-components/src/index.ts
@@ -15,6 +15,7 @@ export * from '@contentful/f36-entity-list';
 export * from '@contentful/f36-empty-state';
 export * from '@contentful/f36-forms';
 export * from '@contentful/f36-icon';
+export * from '@contentful/f36-header';
 export * from '@contentful/f36-image';
 export * from '@contentful/f36-list';
 export * from '@contentful/f36-menu';

--- a/packages/website/components/LiveEditor/ComponentSource.tsx
+++ b/packages/website/components/LiveEditor/ComponentSource.tsx
@@ -13,7 +13,6 @@ import * as f36Components from '@contentful/f36-components';
 import { Multiselect } from '@contentful/f36-multiselect';
 import { NavList } from '@contentful/f36-navlist';
 import * as f36utils from '@contentful/f36-utils';
-import { Header } from '@contentful/f36-header';
 import { Layout } from '@contentful/f36-layout';
 import { useForm, useController } from 'react-hook-form';
 import { MdAccessAlarm } from 'react-icons/md';
@@ -39,7 +38,6 @@ const liveProviderScope = {
   ...f36Components,
   ...f36icons,
   ...f36utils,
-  Header, // Remove when added to f36-components
   Layout, // Remove when added to f36-components
   Multiselect, // Remove when added to f36-components
   NavList, // Remove when added to f36-components

--- a/packages/website/components/Playground/SandpackRenderer.tsx
+++ b/packages/website/components/Playground/SandpackRenderer.tsx
@@ -95,7 +95,6 @@ export function SandpackRenderer({
           'react-dom': '^17.0.0',
           'react-scripts': '^4.0.0',
           '@contentful/f36-components': '^4.0.0',
-          '@contentful/f36-header': '^4.0.0',
           '@contentful/f36-layout': '^4.0.0-alpha.0', // Remove when added to f36-components
           '@contentful/f36-multiselect': '^4.0.0', // Remove when added to f36-components
           '@contentful/f36-navlist': '^4.1.0-alpha.0', // Remove when added to f36-components

--- a/packages/website/components/Playground/SandpackRenderer.tsx
+++ b/packages/website/components/Playground/SandpackRenderer.tsx
@@ -95,7 +95,7 @@ export function SandpackRenderer({
           'react-dom': '^17.0.0',
           'react-scripts': '^4.0.0',
           '@contentful/f36-components': '^4.0.0',
-          '@contentful/f36-header': '^4.0.0-alpha.0', // Remove when added to f36-components
+          '@contentful/f36-header': '^4.0.0',
           '@contentful/f36-layout': '^4.0.0-alpha.0', // Remove when added to f36-components
           '@contentful/f36-multiselect': '^4.0.0', // Remove when added to f36-components
           '@contentful/f36-navlist': '^4.1.0-alpha.0', // Remove when added to f36-components

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -14,7 +14,7 @@
     "@contentful/f36-components": "^4.65.8",
     "@contentful/f36-docs-utils": "^4.0.2",
     "@contentful/f36-empty-state": "^4.65.8",
-    "@contentful/f36-header": "^4.0.0-alpha.0",
+    "@contentful/f36-header": "^4.0.0",
     "@contentful/f36-icon": "^4.65.8",
     "@contentful/f36-icons": "^4.28.2",
     "@contentful/f36-image": "4.65.8",


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR
Left margin on Header’s title prop is no longer rendered when there’s no element to the left of the title

![Screenshot 2024-06-03 at 12 31 06](https://github.com/contentful/forma-36/assets/32452823/7bef2c7b-b378-4fab-af06-8fd80cc0a2fc)

![Screenshot 2024-06-03 at 12 31 23](https://github.com/contentful/forma-36/assets/32452823/df7d909d-9ae8-4240-aade-ea4d14664ce4)

I updated the `noWrap` class styling so that the margin is only applied if the element is not first-child. This follows the existing approach we use for the `title` class

I had done something similar when working on the Updated Layout component, in [this commit](https://github.com/contentful/forma-36/pull/2747/commits/6576cdf2392465023ad282ecd9182ac07330d9fb).

Tickets: 
https://contentful.atlassian.net/browse/CFISO-1571

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
