### PR TITLE
feat(ModalLauncher): wait for Modals to be closed

### DIFF
--- a/.changeset/famous-doors-kiss.md
+++ b/.changeset/famous-doors-kiss.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-modal': minor
+---
+
+`closeAll()` awaits for all modals to be closed

--- a/packages/components/modal/src/ModalLauncher/ModalLauncher.test.tsx
+++ b/packages/components/modal/src/ModalLauncher/ModalLauncher.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+import { ModalLauncher } from './ModalLauncher';
+
+it('closeAll', async () => {
+  ModalLauncher.open(() => <div>Test Modal</div>);
+  expect(screen.queryByText('Test Modal')).toBeDefined();
+
+  await ModalLauncher.closeAll();
+  expect(screen.queryByText('Test Modal')).toBeNull();
+});

--- a/packages/components/modal/src/ModalLauncher/ModalLauncher.tsx
+++ b/packages/components/modal/src/ModalLauncher/ModalLauncher.tsx
@@ -41,14 +41,18 @@ const getRoot = (rootElId: string): HTMLElement => {
 };
 
 const openModalsIds: Map<string, CloseModalData> = new Map();
-function closeAll() {
-  openModalsIds.forEach(async ({ render, currentConfig, delay }, rootElId) => {
-    const config = { ...currentConfig, isShown: false };
-    render(config);
-    await new Promise((resolveDelay) => setTimeout(resolveDelay, delay));
-    ReactDOM.unmountComponentAtNode(getRoot(rootElId));
-    openModalsIds.delete(rootElId);
-  });
+async function closeAll(): Promise<void> {
+  await Promise.all(
+    Array.from(openModalsIds.entries()).map(
+      async ([rootElId, { render, currentConfig, delay }]) => {
+        const config = { ...currentConfig, isShown: false };
+        render(config);
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, delay));
+        ReactDOM.unmountComponentAtNode(getRoot(rootElId));
+        openModalsIds.delete(rootElId);
+      },
+    ),
+  );
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/components/modal/stories/ModalLauncher.stories.tsx
+++ b/packages/components/modal/stories/ModalLauncher.stories.tsx
@@ -86,7 +86,7 @@ export const CloseAllStory = () => {
 
   useEffect(() => {
     openModal(`Modal one`);
-    return ModalLauncher.closeAll;
+    return () => ModalLauncher.closeAll();
   }, [openModal]);
 
   return (

--- a/packages/components/modal/stories/ModalLauncher.stories.tsx
+++ b/packages/components/modal/stories/ModalLauncher.stories.tsx
@@ -86,7 +86,9 @@ export const CloseAllStory = () => {
 
   useEffect(() => {
     openModal(`Modal one`);
-    return () => ModalLauncher.closeAll();
+    return () => {
+      ModalLauncher.closeAll();
+    };
   }, [openModal]);
 
   return (


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

It's currently not possible to know when all Modal have been closed after `ModalLauncher.closeAll()`. Due to close delays and the async implementation, Modals may still be open after `ModalLauncher.closeAll()` is called.

This PR makes the function async and resolve when all Modals are closed. This changes the return type and could therefore cause typescript issues in projects using F36.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
