### PR TITLE
docs(Typography): remove duplicate line in docs

### DIFF
--- a/packages/website/content/tokens/typography.mdx
+++ b/packages/website/content/tokens/typography.mdx
@@ -49,8 +49,6 @@ _Paragraph_ is a component that renders _Text_ as `p` and applies the default ma
 
 Font size: **14px**=**0.875rem** - Line Height: **20px**=**1.25rem** - Weight: **500**
 
-Font size: **14px**=**0.875rem** - Line Height: **20px**=**1.25rem** - Weight: **500**
-
 <Subheading>Subheading</Subheading>
 
 _Subheadings_ are intended to be used as headings for copy nested within a section. EX: a subheading under Contact may be Address or Phone number.


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

The same line exists twice in the docs: 
![image](https://github.com/contentful/forma-36/assets/4947671/e66977da-2127-419a-b286-452918dc933c)

https://f36.contentful.com/tokens/typography

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
