### PR TITLE
feat(AssetCard): support for providing a custom badge

### DIFF
--- a/.changeset/polite-jobs-double.md
+++ b/.changeset/polite-jobs-double.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-card": minor
+---
+
+Add support for a custom badge to the `AssetCard`

--- a/packages/components/card/examples/AssetCard/AssetCardCustomBadgeExample.tsx
+++ b/packages/components/card/examples/AssetCard/AssetCardCustomBadgeExample.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { AssetCard, Badge } from '@contentful/f36-components';
+
+export default function AssetCardCustomBadgeExample() {
+  return (
+    <AssetCard
+      status="published"
+      type="image"
+      title="Everest"
+      src="https://bit.ly/31yL3Ps"
+      badge={<Badge variant={'positive'}>custom status</Badge>}
+    />
+  );
+}

--- a/packages/components/card/src/AssetCard/AssetCard.tsx
+++ b/packages/components/card/src/AssetCard/AssetCard.tsx
@@ -11,7 +11,7 @@ import { getAssetCardStyles } from './AssetCard.styles';
 import { DefaultCardHeader } from '../BaseCard/DefaultCardHeader';
 
 export interface AssetCardInternalProps
-  extends Omit<BaseCardInternalProps, 'badge' | 'header' | 'padding' | 'ref'> {
+  extends Omit<BaseCardInternalProps, 'header' | 'padding' | 'ref'> {
   size?: 'small' | 'default';
   src?: string;
   status?: AssetStatus;
@@ -36,10 +36,15 @@ export const AssetCard = ({
   withDragHandle = false,
   isLoading,
   testId = 'cf-ui-asset-card',
+  badge: customBadge,
   ...otherProps
 }: AssetCardInternalProps) => {
   const styles = getAssetCardStyles();
-  const badge = status ? <EntityStatusBadge entityStatus={status} /> : null;
+  const badge = customBadge ? (
+    customBadge
+  ) : status ? (
+    <EntityStatusBadge entityStatus={status} />
+  ) : null;
   const header =
     icon || badge || actions ? (
       <DefaultCardHeader icon={icon} badge={badge} actions={actions} />

--- a/packages/components/card/src/AssetCard/README.mdx
+++ b/packages/components/card/src/AssetCard/README.mdx
@@ -64,6 +64,15 @@ To show a `...` button with a menu in the card, pass an array of `MenuItem` comp
 
 ```
 
+### With a custom badge
+
+Like the `Card` component, it’s possible to pass a custom badge using the `badge` prop if the entity has different statuses than
+"archived", "changed", "deleted", "draft", "new", or "published". In this case the `status` prop will be ignored.
+
+```jsx file=../../examples/EntryCard/AssetCardCustomBadgeExample.tsx
+
+```
+
 ## Props (API reference)
 
 <PropsTable of="AssetCard" />

--- a/packages/components/card/src/AssetCard/README.mdx
+++ b/packages/components/card/src/AssetCard/README.mdx
@@ -69,7 +69,7 @@ To show a `...` button with a menu in the card, pass an array of `MenuItem` comp
 Like the `Card` component, it’s possible to pass a custom badge using the `badge` prop if the entity has different statuses than
 "archived", "changed", "deleted", "draft", "new", or "published". In this case the `status` prop will be ignored.
 
-```jsx file=../../examples/EntryCard/AssetCardCustomBadgeExample.tsx
+```jsx file=../../examples/AssetCard/AssetCardCustomBadgeExample.tsx
 
 ```
 

--- a/packages/components/card/stories/AssetCard.stories.tsx
+++ b/packages/components/card/stories/AssetCard.stories.tsx
@@ -5,6 +5,7 @@ import { SectionHeading } from '@contentful/f36-typography';
 import { MenuItem } from '@contentful/f36-menu';
 import * as icons from '@contentful/f36-icons';
 import { Icon } from '@contentful/f36-icon';
+import { Badge } from '@contentful/f36-badge';
 
 import { AssetCard, type AssetCardProps } from '../src';
 
@@ -56,6 +57,17 @@ export const WithLoadingState: Story<Args> = (args) => {
 
 WithLoadingState.args = {
   isLoading: true,
+};
+
+export const WithCustomBadge: Story<Args> = () => {
+  return (
+    <AssetCard
+      src="https://images.ctfassets.net/iq4lnigp6fgt/2EEEk92Kiz6KxREsjBLPAN/810d5a21650d91abad12e95da4cd3beb/2021-06_Everyone_is_Welcome_here_1_.png?fit=fill&f=top_left&w=200&h=300"
+      title="Asset title"
+      type="image"
+      badge={<Badge variant={'positive'}>active</Badge>}
+    />
+  );
 };
 
 export const Overview: Story<Args> = () => {


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Slack (sign up here: https://www.contentful.com/slack/.
-->

# Purpose of PR

The `EntryCard` supports providing a custom badge, the `AssetCard` don't do that yet.
This PR introduces the custom badge for the AssetCard too, to have the same behaviour and experience.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
