### PR TITLE
refactor: pass pointerEvents none to children of button

### DIFF
--- a/.changeset/modern-lions-poke.md
+++ b/.changeset/modern-lions-poke.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-button': patch
+---
+
+fix issue with event having wrong target

--- a/packages/components/button/src/Button/Button.styles.ts
+++ b/packages/components/button/src/Button/Button.styles.ts
@@ -206,6 +206,9 @@ export const getStyles = () => ({
             '&, &:focus': variantActiveStyles(variant),
           }
         : {}),
+      '& *': {
+        pointerEvents: 'none',
+      },
     }),
   buttonIcon: getButtonIconStyle,
   buttonContent: css({

--- a/packages/components/button/stories/ButtonComponent.stories.tsx
+++ b/packages/components/button/stories/ButtonComponent.stories.tsx
@@ -7,6 +7,7 @@ import { SectionHeading } from '@contentful/f36-typography';
 import * as icons from '@contentful/f36-icons';
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
+import { action } from '@storybook/addon-actions';
 
 export default {
   title: 'Components/Button components',
@@ -46,6 +47,7 @@ _Button.args = {
   size: 'medium',
   variant: 'primary',
   children: 'Button CTA',
+  onClick: action('click'),
 };
 
 export const Overview = ({ startIcon, endIcon }) => {

--- a/packages/components/button/stories/IconButton.stories.tsx
+++ b/packages/components/button/stories/IconButton.stories.tsx
@@ -7,6 +7,7 @@ import { Icon } from '@contentful/f36-icon';
 import * as icons from '@contentful/f36-icons';
 
 import { IconButton } from '../src/IconButton';
+import { action } from '@storybook/addon-actions';
 
 export default {
   title: 'Components/Button components/IconButton',
@@ -44,6 +45,7 @@ basic.args = {
     size: 'medium',
   },
   variant: 'transparent',
+  onClick: action('click'),
 };
 
 export const ColoredIconInTransparentIconButton = () => {


### PR DESCRIPTION
# Purpose of PR

In some cases when using SVGs and other elements inside a button the event handler would consider them as being the target of the event, and not the button.
By adding the `pointer-events: none` to the children, we make it so it consistently consider event target being the button.

Also adding an onClick action on the storybook of button to be easier to check.

**Before**

https://github.com/contentful/forma-36/assets/1071799/d66e1e7c-bdf9-44fa-9009-88d3f8158915

**After**

https://github.com/contentful/forma-36/assets/1071799/416652cd-4bc1-4a1b-8de7-db6207c30bff

