### PR TITLE
docs: update react day picker links

### DIFF
--- a/packages/components/datepicker/src/Calendar/README.mdx
+++ b/packages/components/datepicker/src/Calendar/README.mdx
@@ -57,7 +57,7 @@ Use `from...` and `to...` props to control time frames
 
 Use modifiers to modify certain days, for example showing indicators for scheduled actions.
 
-Read more about modifiers: https://react-day-picker.js.org/advanced-guides/custom-modifiers
+Read more about modifiers: https://daypicker.dev/advanced-guides/custom-modifiers
 
 ```jsx file=../../examples/Calendar/Indicator.tsx
 
@@ -67,7 +67,7 @@ Read more about modifiers: https://react-day-picker.js.org/advanced-guides/custo
 
 Use components to modify certain parts of the calendar, for example modifying day content.
 
-Read more about custom components: https://react-day-picker.js.org/advanced-guides/custom-components
+Read more about custom components: https://daypicker.dev/advanced-guides/custom-components
 
 ```jsx file=../../examples/Calendar/CustomDayContent.tsx
 


### PR DESCRIPTION

# Purpose of PR

React Day Picker changed its website to https://daypicker.dev/ – this PR updates our doc links.