### PR TITLE
feat(entity-list-item): add support for Experience type entity

### DIFF
--- a/.changeset/great-masks-bake.md
+++ b/.changeset/great-masks-bake.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-entity-list': patch
+---
+
+feat(entity-list-item): add support for Experience type entity

--- a/package-lock.json
+++ b/package-lock.json
@@ -3728,9 +3728,48 @@
       "resolved": "packages/components/icon",
       "link": true
     },
+    "node_modules/@contentful/f36-icon-alpha": {
+      "name": "@contentful/f36-icon",
+      "version": "5.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
+      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@phosphor-icons/react": "^2.1.5",
+        "emotion": "^10.0.17"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/@contentful/f36-icons": {
       "resolved": "packages/components/icons",
       "link": true
+    },
+    "node_modules/@contentful/f36-icons-alpha": {
+      "name": "@contentful/f36-icons",
+      "version": "5.0.0-alpha.26",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.26.tgz",
+      "integrity": "sha512-iiU9fX4nRdpsVfYcWcfYVLnvMY4p3S3dFVw08IWokTrmL7k5j1t8k3yxRT3kvfE+uMktRRrrSKbrXpfpntQurQ==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.63.0",
+        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@alpha",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@phosphor-icons/react": "^2.1.4",
+        "emotion": "^10.0.17"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/@contentful/f36-image": {
       "resolved": "packages/components/image",
@@ -6503,6 +6542,18 @@
       "integrity": "sha512-dhPeilub1NuIG0X5Kvhh9lH4iW3ZsHlnzwgwbOlgwQ2wG1IqFzsgHqmKPk3WzsdWAeaxKJxgM0+W433RmN45GA==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
+      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -40013,6 +40064,7 @@
         "@contentful/f36-drag-handle": "^4.67.1",
         "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
         "@contentful/f36-menu": "^4.67.1",
         "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
@@ -40200,7 +40252,7 @@
     },
     "packages/components/multiselect": {
       "name": "@contentful/f36-multiselect",
-      "version": "4.23.1",
+      "version": "4.24.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
@@ -44264,7 +44316,7 @@
         "@contentful/f36-icons": "^4.28.2",
         "@contentful/f36-image": "4.67.1",
         "@contentful/f36-layout": "^4.0.0-alpha.0",
-        "@contentful/f36-multiselect": "^4.23.1",
+        "@contentful/f36-multiselect": "^4.24.0",
         "@contentful/f36-navlist": "4.1.0-alpha.1",
         "@contentful/f36-progress-stepper": "4.0.0-alpha.0",
         "@contentful/f36-tokens": "^4.0.5",
@@ -49698,6 +49750,7 @@
         "@contentful/f36-drag-handle": "^4.67.1",
         "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
         "@contentful/f36-menu": "^4.67.1",
         "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
@@ -49738,12 +49791,35 @@
         "react-icons": "^4.4.0"
       }
     },
+    "@contentful/f36-icon-alpha": {
+      "version": "npm:@contentful/f36-icon@5.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
+      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
+      "requires": {
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@phosphor-icons/react": "^2.1.5",
+        "emotion": "^10.0.17"
+      }
+    },
     "@contentful/f36-icons": {
       "version": "file:packages/components/icons",
       "requires": {
         "@contentful/f36-core": "^4.65.0",
         "@contentful/f36-icon": "^4.65.0",
         "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      }
+    },
+    "@contentful/f36-icons-alpha": {
+      "version": "npm:@contentful/f36-icons@5.0.0-alpha.26",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.26.tgz",
+      "integrity": "sha512-iiU9fX4nRdpsVfYcWcfYVLnvMY4p3S3dFVw08IWokTrmL7k5j1t8k3yxRT3kvfE+uMktRRrrSKbrXpfpntQurQ==",
+      "requires": {
+        "@contentful/f36-core": "^4.63.0",
+        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@alpha",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@phosphor-icons/react": "^2.1.4",
         "emotion": "^10.0.17"
       }
     },
@@ -50212,7 +50288,7 @@
         "@contentful/f36-icons": "^4.28.2",
         "@contentful/f36-image": "4.67.1",
         "@contentful/f36-layout": "^4.0.0-alpha.0",
-        "@contentful/f36-multiselect": "^4.23.1",
+        "@contentful/f36-multiselect": "^4.24.0",
         "@contentful/f36-navlist": "4.1.0-alpha.1",
         "@contentful/f36-progress-stepper": "4.0.0-alpha.0",
         "@contentful/f36-tokens": "^4.0.5",
@@ -52292,6 +52368,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.1.1.tgz",
       "integrity": "sha512-dhPeilub1NuIG0X5Kvhh9lH4iW3ZsHlnzwgwbOlgwQ2wG1IqFzsgHqmKPk3WzsdWAeaxKJxgM0+W433RmN45GA=="
+    },
+    "@phosphor-icons/react": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
+      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
+      "requires": {}
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.8",

--- a/packages/components/entity-list/package.json
+++ b/packages/components/entity-list/package.json
@@ -12,6 +12,7 @@
     "@contentful/f36-drag-handle": "^4.67.1",
     "@contentful/f36-icon": "^4.67.1",
     "@contentful/f36-icons": "^4.28.1",
+    "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
     "@contentful/f36-menu": "^4.67.1",
     "@contentful/f36-skeleton": "^4.67.1",
     "@contentful/f36-tokens": "^4.0.4",

--- a/packages/components/entity-list/src/EntityListItem/EntityListItem.test.tsx
+++ b/packages/components/entity-list/src/EntityListItem/EntityListItem.test.tsx
@@ -162,6 +162,16 @@ describe('EntityList', function () {
     expect(screen.getByLabelText('Actions')).toBeDisabled();
   });
 
+  it('renders an "Experience" entity type', () => {
+    render(
+      <EntityListItem
+        title="Premier Studio Experience"
+        entityType="Experience"
+      />,
+    );
+    expect(screen.getByTestId('thumbnail-icon-experience')).toBeInTheDocument();
+  });
+
   it('has no a11y issues', async () => {
     const { container } = render(
       <ul>

--- a/packages/components/entity-list/src/EntityListItem/EntityListItem.tsx
+++ b/packages/components/entity-list/src/EntityListItem/EntityListItem.tsx
@@ -15,6 +15,7 @@ import {
   MoreHorizontalIcon,
   PageIcon,
 } from '@contentful/f36-icons';
+import { PaintBrushIcon } from '@contentful/f36-icons-alpha';
 import { Icon } from '@contentful/f36-icon';
 import { Text } from '@contentful/f36-typography';
 import { DragHandle, type DragHandleProps } from '@contentful/f36-drag-handle';
@@ -34,6 +35,7 @@ const ICON_MAP = {
   entry: EntryIcon,
   release: ReleaseIcon,
   page: PageIcon,
+  experience: PaintBrushIcon,
 };
 
 export interface EntityListItemProps extends CommonProps {
@@ -90,7 +92,15 @@ export interface EntityListItemProps extends CommonProps {
    *
    * Note: 'entry' and 'asset' are @deprecated but supported in v1.x for backwards compatibility
    */
-  entityType?: 'Entry' | 'Asset' | 'entry' | 'asset' | 'Release' | 'Page';
+  entityType?:
+    | 'Entry'
+    | 'Asset'
+    | 'entry'
+    | 'asset'
+    | 'Release'
+    | 'Page'
+    | 'Experience'
+    | 'experience';
   /**
    * Loading state for the component - when true will display loading feedback to the user
    */
@@ -186,7 +196,11 @@ export const EntityListItem = ({
           {withThumbnail && (
             <figure className={styles.media}>
               {asIcon ? (
-                <Icon as={ICON_MAP[entityType.toLowerCase()]} variant="muted" />
+                <Icon
+                  as={ICON_MAP[entityType.toLowerCase()]}
+                  variant="muted"
+                  data-test-id={`thumbnail-icon-${entityType.toLowerCase()}`}
+                />
               ) : (
                 <img
                   src={thumbnailUrl}

--- a/packages/components/entity-list/stories/EntityList.stories.tsx
+++ b/packages/components/entity-list/stories/EntityList.stories.tsx
@@ -34,6 +34,13 @@ export const Basic: Story<EntityListProps> = () => (
       status="archived"
       entityType="Release"
     />
+    <EntityList.Item
+      title="Entry 4"
+      description="Description"
+      contentType="Experiences content type"
+      status="changed"
+      entityType="Experience"
+    />
   </EntityList>
 );
 
@@ -58,6 +65,14 @@ export const withDragHandle = () => (
       description="Description"
       contentType="My content type"
       status="archived"
+      withDragHandle
+    />
+    <EntityList.Item
+      title="Entry 4"
+      description="Description"
+      contentType="My Studio Experiences content type"
+      status="changed"
+      entityType="Experience"
       withDragHandle
     />
   </EntityList>


### PR DESCRIPTION
# Purpose of PR
Add support for Studio Experience entity type in `<EntityListItem>`

<img width="393" alt="Screenshot 2024-07-08 at 3 10 34 PM" src="https://github.com/contentful/forma-36/assets/158083968/40224bce-8cc1-4ce9-ba1d-f00099e925e6">



## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
