### PR TITLE
chore: add CHANGELOG.md file to ProgressStepper alpha component

### DIFF
--- a/packages/components/progress-stepper/CHANGELOG.md
+++ b/packages/components/progress-stepper/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log


### PR DESCRIPTION
# Purpose of PR

Similar to [this](https://github.com/contentful/forma-36/pull/2630) PR, since `ProgressStepper` is an `alpha` package, it does not have a `CHANGELOG.md`, yet the prelease script tries to access it, so I have added it here. 

This should resolve the build failure in the most recent commit to main. 

## PR Checklist

- [X] I have read the relevant `readme.md` file(s)
- [X] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [X] Tests are added/updated/not required
- [X] Tests are passing
- [X] Storybook stories are added/updated/not required
- [X] Usage notes are added/updated/not required
- [X] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [X] Doesn't contain any sensitive information
