### PR TITLE
build: remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "commit": "git-cz",
     "commitmsg": "validate-commit-msg",
     "generate": "plop --plopfile scripts/plopfile.js",
-    "postinstall": "turbo run build --scope=@contentful/f36-tokens --no-deps",
     "lint": "npm run-script lint:js && npm run-script lint:packages",
     "lint:js": "eslint packages --ext .js,.jsx,.ts,.tsx",
     "lint:packages": "node scripts/lint-packages.js",


### PR DESCRIPTION
# Purpose of PR

Removes the `postinstall` script, one can use the generic build command when needed.

This unblocks Netlify's dry-run build which tries to access `turbo` when it isn't installed yet.

**Alternative:** move Storybook's production build & deployment to Vercel.