### PR TITLE
fix(sandpackrenderer): add icons-alpha as dependency

### DIFF
--- a/packages/website/components/Playground/SandpackRenderer.tsx
+++ b/packages/website/components/Playground/SandpackRenderer.tsx
@@ -100,6 +100,8 @@ export function SandpackRenderer({
           '@contentful/f36-navlist': '^4.1.0-alpha.0', // Remove when added to f36-components
           '@contentful/f36-tokens': '^4.0.0',
           '@contentful/f36-icons': '^4.0.0',
+          '@contentful/f36-icons-alpha':
+            'npm:@contentful/f36-icons@^5.0.0-alpha.26',
           '@contentful/f36-core': '^4.0.0',
           '@contentful/f36-utils': '^4.0.0',
           emotion: '^10.0.17',


### PR DESCRIPTION
Playground currently throws an error due to missing '@contentful/f36-icons-alpha' dependency in SandpackProvider:

![image](https://github.com/user-attachments/assets/962e1cb6-b6bc-40d6-b25e-c63cd33688b5)

This PR adds the missing dependency.