### PR TITLE
refactor(Modal): adjust header border-color to `gray/200`

### DIFF
--- a/.changeset/eighty-candles-change.md
+++ b/.changeset/eighty-candles-change.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-modal": patch
+---
+
+refactor: adjust modal header border-color to `gray/200`

--- a/packages/components/modal/src/ModalHeader/ModalHeader.styles.ts
+++ b/packages/components/modal/src/ModalHeader/ModalHeader.styles.ts
@@ -7,7 +7,7 @@ export function getModalHeaderStyles() {
       position: 'relative',
       padding: `${tokens.spacingM} ${tokens.spacingM} ${tokens.spacingM} ${tokens.spacingL}`,
       borderRadius: `${tokens.borderRadiusMedium} ${tokens.borderRadiusMedium} 0 0`,
-      borderBottom: `1px solid ${tokens.gray300}`,
+      borderBottom: `1px solid ${tokens.gray200}`,
     }),
     buttonContainer: css({
       position: 'relative',


### PR DESCRIPTION
# Purpose of PR

Ensure design <-> code is aligned.

Our modal header border color is set to `gray/300` in the code vs `gray/200` in the design.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
