### PR TITLE
feat: add promotions prop for promotions section in new nav bar

### DIFF
--- a/packages/components/navbar/src/Navbar.tsx
+++ b/packages/components/navbar/src/Navbar.tsx
@@ -14,6 +14,9 @@ type NavbarOwnProps = CommonProps & {
    */
   logo?: React.ReactNode;
 
+  /** Promotions component, displayed on most left side */
+  promotions?: React.ReactNode;
+
   /** Environment Switcher component */
   switcher?: React.ReactNode;
 
@@ -50,6 +53,7 @@ export type NavbarProps = NavbarHTMLElementProps & NavbarOwnProps;
 function _Navbar(props: ExpandProps<NavbarProps>, ref: React.Ref<HTMLElement>) {
   const {
     logo,
+    promotions,
     switcher,
     mainNavigation,
     secondaryNavigation,
@@ -104,6 +108,7 @@ function _Navbar(props: ExpandProps<NavbarProps>, ref: React.Ref<HTMLElement>) {
           )}
         </Flex>
         <Flex alignItems="center" gap="spacingXs">
+          <Flex alignItems="center">{promotions}</Flex>
           <Flex alignItems="center">{switcher}</Flex>
           <Flex alignItems="center" gap="spacingXs">
             {secondaryNavigation && (

--- a/packages/components/navbar/stories/Navbar.stories.tsx
+++ b/packages/components/navbar/stories/Navbar.stories.tsx
@@ -16,7 +16,7 @@ import { SectionHeading } from '@contentful/f36-typography';
 import { Flex } from '@contentful/f36-core';
 import { NavbarAccountProps } from '../src/NavbarAccount/NavbarAccount';
 import { NavbarSwitcherProps } from '../src/NavbarSwitcher/NavbarSwitcher';
-import { Button } from '@contentful/f36-button/src';
+import { Button } from '@contentful/f36-button';
 
 export default {
   component: Navbar,

--- a/packages/components/navbar/stories/Navbar.stories.tsx
+++ b/packages/components/navbar/stories/Navbar.stories.tsx
@@ -16,6 +16,7 @@ import { SectionHeading } from '@contentful/f36-typography';
 import { Flex } from '@contentful/f36-core';
 import { NavbarAccountProps } from '../src/NavbarAccount/NavbarAccount';
 import { NavbarSwitcherProps } from '../src/NavbarSwitcher/NavbarSwitcher';
+import { Button } from '@contentful/f36-button/src';
 
 export default {
   component: Navbar,
@@ -282,6 +283,7 @@ export const Complete: Story<{ initials?: string; avatar?: string }> = (
   return (
     <Navbar
       mobileNavigation={<MobileMenu />}
+      promotions={<Button>Upgrade</Button>}
       switcher={<Switcher />}
       mainNavigation={<MainItems />}
       account={


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

For the purpose of adding the upgrade button as seen in [new design](https://www.figma.com/design/RBKfzEzcmiC974nFdtI2wK/Modern-%26-Scalable-%E2%80%93-2024-Webapp-Navigation?node-id=6351-23527&t=brDy0Gcl5MxlvqlD-0),  we want to create a new prop which would place itself in front of the switcher

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
