### PR TITLE
feat(icons): add `BookOpenIcon`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41199,7 +41199,7 @@
     },
     "packages/components/icons": {
       "name": "@contentful/f36-icons",
-      "version": "5.0.0-alpha.30",
+      "version": "5.0.0-alpha.31",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-core": "^4.67.3",

--- a/packages/components/icons/package.json
+++ b/packages/components/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-icons",
-  "version": "5.0.0-alpha.30",
+  "version": "5.0.0-alpha.31",
   "description": "Forma 36: Icon components",
   "license": "MIT",
   "exports": {

--- a/packages/components/icons/src/index.ts
+++ b/packages/components/icons/src/index.ts
@@ -31,6 +31,7 @@ export * from './vendor/phosphor/ArrowRightIcon.js';
 export * from './vendor/phosphor/ArrowSquareOutIcon.js';
 export * from './vendor/phosphor/ArrowUpIcon.js';
 export * from './vendor/phosphor/ArrowsLeftRightIcon.js';
+export * from './vendor/phosphor/BookOpenIcon.js';
 export * from './vendor/phosphor/BookmarkSimpleIcon.js';
 export * from './vendor/phosphor/BracketsCurlyIcon.js';
 export * from './vendor/phosphor/CalendarBlankIcon.js';

--- a/packages/components/icons/src/vendor/phosphor/BookOpenIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/BookOpenIcon.tsx
@@ -1,0 +1,4 @@
+import { generateForma36Icon } from '@contentful/f36-icon-alpha';
+import { BookOpen } from '@phosphor-icons/react';
+
+export const BookOpenIcon = generateForma36Icon(BookOpen);


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

Adding a new icon: `BookOpen`

Storybook screenshot:

<img width="374" alt="image" src="https://github.com/user-attachments/assets/8b983e14-e3f1-4c3c-96c7-288aac76361b">


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
