### PR TITLE
fix(playground): add `f36-progress-stepper` dependency

### DIFF
--- a/packages/website/components/Playground/SandpackRenderer.tsx
+++ b/packages/website/components/Playground/SandpackRenderer.tsx
@@ -98,6 +98,7 @@ export function SandpackRenderer({
           '@contentful/f36-layout': '^4.0.0-alpha.0', // Remove when added to f36-components
           '@contentful/f36-multiselect': '^4.0.0', // Remove when added to f36-components
           '@contentful/f36-navlist': '^4.1.0-alpha.0', // Remove when added to f36-components
+          '@contentful/f36-progress-stepper': '^4.0.0-alpha.0', // Remove when added to f36-components
           '@contentful/f36-tokens': '^4.0.0',
           '@contentful/f36-icons': '^4.0.0',
           '@contentful/f36-core': '^4.0.0',


### PR DESCRIPTION
# Purpose of PR

## Playground

The new package was missing in the Sandpack Renderer (playground) dependency list resulting in an error.

<img width="1376" alt="forma-36-progress-stepper" src="https://github.com/user-attachments/assets/003d885c-5d1d-47eb-9775-2bcfcf296cad">

Fixed playground URL: https://forma-36-git-fix-progress-stepper-playground-and-search.colorfuldemo.com/playground?code=N4Igxg9gJgpiBcICWBbADhATgFwAQCUYBDMPAM0whVwHJNjSaBuAHQDtUMddhcAFSgHN6AZxEBlbDDRoYmXAF9cFKrQACkNlK1kArgBsA9GQDMANgC0aIaJEWRUmXObt2MAB5c8sMkQPldNlIkCDZ+GxgxSWlZTAAJLCQAL1DsIn0AUXcidH0YAAoASh52XFx6bF1MMPzSstwAHgEIYUiJR1jcEmwkADcYaLQAXmAAJiUiTCQiABkiACMYfSGWEASplK103GsW21wHGLlVgD46+sbm1qiOuQA6QYO0qRXwKjQ8qVXcQzOwi8uERuR0wD0cTyIL1WkFyMC+IB+fwBgL2bUGsTB0ghUJA3T6MG+v3O9SaQPaIMxaERxLKpNRwKcoMeRP+tMMV1s6LkSNwhVYbAU7BACiAA

## Search indexing

The Progress Stepper component was missing from the website search.

After some investigation, the Algolia crawler used for our website search has been blocked since September 2023 because of too many extraction records on the `/whats-new` page (changelog), hitting over the 750 records limit.

I reduced the number of records following their [documentation](https://support.algolia.com/hc/en-us/articles/8642227358737-Getting-an-Error-while-extracting-records-using-DocSearch), by changing the `recordVersion` to `v3`.

The Progress Stepper is now indexed, and components/pages still are, but we should paginate this page to prevent and fix it in the long run.