### PR TITLE
feat(navbar): various navbar spacing tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41237,7 +41237,7 @@
     },
     "packages/components/layout": {
       "name": "@contentful/f36-layout",
-      "version": "5.0.0-alpha.9",
+      "version": "5.0.0-alpha.15",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-core": "^4.68.1",
@@ -41530,7 +41530,7 @@
     },
     "packages/components/navbar": {
       "name": "@contentful/f36-navbar",
-      "version": "5.0.0-alpha.29",
+      "version": "5.0.0-alpha.30",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-avatar": "4.68.1",

--- a/packages/components/navbar/package.json
+++ b/packages/components/navbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-navbar",
-  "version": "5.0.0-alpha.29",
+  "version": "5.0.0-alpha.30",
   "description": "Forma 36: Navbar component",
   "scripts": {
     "build": "tsup"

--- a/packages/components/navbar/src/Navbar.styles.ts
+++ b/packages/components/navbar/src/Navbar.styles.ts
@@ -40,7 +40,9 @@ export const getNavbarStyles = ({
 
   mobileNavigationButton: css({
     display: 'flex',
+    minHeight: 'initial', // unset default 40px height
     height: '36px',
+    padding: '0 12px',
     borderRadius: '10px',
     [mqs.small]: {
       display: 'none',

--- a/packages/components/navbar/src/NavbarItem/NavbarItem.styles.ts
+++ b/packages/components/navbar/src/NavbarItem/NavbarItem.styles.ts
@@ -84,6 +84,7 @@ export const getNavbarItemStyles = ({ hasTitle }: { hasTitle: boolean }) => ({
   icon: css({
     height: '20px',
     width: '20px',
+    boxSizing: 'content-box',
     display: hasTitle ? 'none' : 'block',
     [mqs.small]: {
       height: '16px',

--- a/packages/components/navbar/src/NavbarItem/NavbarItem.styles.ts
+++ b/packages/components/navbar/src/NavbarItem/NavbarItem.styles.ts
@@ -3,10 +3,12 @@ import tokens from '@contentful/f36-tokens';
 import { hexToRGBA } from '@contentful/f36-utils';
 import { getGlowOnFocusStyles, increaseHitArea, mqs } from '../utils.styles';
 
+const borderWidth = '1px';
+
 export const getNavbarItemActiveStyles = () =>
   css({
     backgroundColor: tokens.blue100,
-    border: `1px solid ${tokens.blue400}`,
+    border: `${borderWidth} solid ${tokens.blue400}`,
     color: tokens.blue600,
     '&:hover': {
       backgroundColor: tokens.blue100,
@@ -16,19 +18,19 @@ export const getNavbarItemActiveStyles = () =>
 const commonItemStyles = {
   display: 'flex',
   justifyContent: 'center',
-  padding: `${tokens.spacing2Xs} ${tokens.spacingXs}`,
+  padding: `calc(${tokens.spacing2Xs} - ${borderWidth}) calc(${tokens.spacingXs} - ${borderWidth})`,
   alignItems: 'center',
   background: 'none',
   gap: tokens.spacing2Xs,
 };
 
-export const getNavbarItemStyles = ({ title }) => ({
+export const getNavbarItemStyles = ({ hasTitle }: { hasTitle: boolean }) => ({
   navbarItem: css(
     commonItemStyles,
     {
       appearance: 'none',
       background: 'none',
-      border: '1px solid transparent',
+      border: `${borderWidth} solid transparent`,
       margin: 0,
       outline: 'none',
       fontSize: tokens.fontSizeM,
@@ -44,6 +46,10 @@ export const getNavbarItemStyles = ({ title }) => ({
       boxSizing: 'border-box',
       transition: `color ${tokens.transitionDurationShort} ${tokens.transitionEasingCubicBezier}`,
       borderRadius: tokens.borderRadiusMedium,
+
+      padding: hasTitle
+        ? undefined
+        : `calc(${tokens.spacing2Xs} - ${borderWidth})`, // square button for icon-only items
 
       '&:hover': {
         backgroundColor: hexToRGBA(tokens.gray900, 0.05),
@@ -78,10 +84,11 @@ export const getNavbarItemStyles = ({ title }) => ({
   icon: css({
     height: '20px',
     width: '20px',
-    display: !title ? 'block' : 'none',
+    display: hasTitle ? 'none' : 'block',
     [mqs.small]: {
       height: '16px',
       width: '16px',
+      padding: hasTitle ? '2px 0' : '2px', // square for icon-only items
     },
     [mqs.large]: {
       display: 'block',

--- a/packages/components/navbar/src/NavbarItem/NavbarItem.tsx
+++ b/packages/components/navbar/src/NavbarItem/NavbarItem.tsx
@@ -56,19 +56,18 @@ function _NavbarItem(
     onClose,
     ...otherProps
   } = props;
-  const styles = getNavbarItemStyles({ title });
+  const styles = getNavbarItemStyles({ hasTitle: !!title });
   const isMenuTrigger = isNavbarItemHasMenu(props);
+  const showCaret = title && isMenuTrigger;
   const item = (
     <Comp
       {...otherProps}
       ref={ref}
       data-test-id={testId}
-      className={cx(
-        styles.navbarItem,
-        isMenuTrigger && styles.navbarItemMenuTrigger,
-        isActive && styles.isActive,
-        className,
-      )}
+      className={cx(styles.navbarItem, className, {
+        [styles.navbarItemMenuTrigger]: showCaret,
+        [styles.isActive]: isActive,
+      })}
       aria-label={title ? '' : label}
     >
       {icon && (
@@ -79,7 +78,7 @@ function _NavbarItem(
         />
       )}
       {title && <span>{title}</span>}
-      {title && isMenuTrigger && <CaretIcon size="tiny" isActive={isActive} />}
+      {showCaret && <CaretIcon size="tiny" isActive={isActive} />}
     </Comp>
   );
 

--- a/packages/components/navbar/src/NavbarItem/NavbarItemSkeleton.tsx
+++ b/packages/components/navbar/src/NavbarItem/NavbarItemSkeleton.tsx
@@ -14,14 +14,14 @@ export const NavbarItemSkeleton = ({
     <SkeletonContainer
       className={styles.itemSkeleton}
       svgWidth={estimatedWidth}
-      svgHeight={32}
+      svgHeight={28}
       backgroundColor={tokens.gray300}
       foregroundColor={tokens.gray200}
     >
       <SkeletonText
-        lineHeight={6}
+        lineHeight={18}
         numberOfLines={1}
-        offsetTop={10}
+        offsetTop={2}
         radiusX={tokens.borderRadiusSmall}
         radiusY={tokens.borderRadiusSmall}
       />

--- a/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcherSkeleton.tsx
+++ b/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcherSkeleton.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import {
-  SkeletonContainer,
-  SkeletonDisplayText,
-} from '@contentful/f36-skeleton';
+import { SkeletonContainer, SkeletonText } from '@contentful/f36-skeleton';
 import tokens from '@contentful/f36-tokens';
 
 export const NavbarSwitcherSkeleton = ({
@@ -16,7 +13,7 @@ export const NavbarSwitcherSkeleton = ({
     backgroundColor={tokens.gray300}
     foregroundColor={tokens.gray200}
   >
-    <SkeletonDisplayText
+    <SkeletonText
       lineHeight={18}
       numberOfLines={1}
       radiusX={tokens.borderRadiusSmall}

--- a/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcherSkeleton.tsx
+++ b/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcherSkeleton.tsx
@@ -12,15 +12,15 @@ export const NavbarSwitcherSkeleton = ({
 }) => (
   <SkeletonContainer
     svgWidth={estimatedWidth}
-    svgHeight={24}
+    svgHeight={18}
     backgroundColor={tokens.gray300}
     foregroundColor={tokens.gray200}
   >
     <SkeletonDisplayText
-      lineHeight={24}
+      lineHeight={18}
       numberOfLines={1}
-      radiusX={12}
-      radiusY={12}
+      radiusX={9}
+      radiusY={9}
     />
   </SkeletonContainer>
 );

--- a/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcherSkeleton.tsx
+++ b/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcherSkeleton.tsx
@@ -19,8 +19,8 @@ export const NavbarSwitcherSkeleton = ({
     <SkeletonDisplayText
       lineHeight={18}
       numberOfLines={1}
-      radiusX={9}
-      radiusY={9}
+      radiusX={tokens.borderRadiusSmall}
+      radiusY={tokens.borderRadiusSmall}
     />
   </SkeletonContainer>
 );

--- a/packages/components/navbar/stories/Navbar.stories.tsx
+++ b/packages/components/navbar/stories/Navbar.stories.tsx
@@ -547,11 +547,7 @@ export const LoadingSkeleton: Story<{}> = () => {
       <Navbar
         mobileNavigation={<MobileMenu />}
         account={<Navbar.AccountSkeleton ariaLabel="Loading account" />}
-        switcher={
-          <Navbar.Switcher>
-            <Navbar.SwitcherSkeleton estimatedWidth={148} />
-          </Navbar.Switcher>
-        }
+        switcher={<Navbar.SwitcherSkeleton estimatedWidth={148} />}
         mainNavigation={
           <>
             <Navbar.ItemSkeleton estimatedWidth={100} />


### PR DESCRIPTION
# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

This PR makes the navbar more consistent, also changes the spacing/sizes to be closer to the designs.

General:
- All navbars have a height of 60px now

Regular navbar
- All items have a total height of 28px. (Avatar has 24px, but will have 28px with the planned border)
- Fixed padding-right for icon-items with menus
- Icon buttons are closer together in the designs. But wit the 44px click size, we can't bring them any closer
- Icon buttons are square now

Loading
- Increased skeleton text height

Mobile menu button:
- Reduced height to 36px
- Reduced horizontal padding

It's best to check chromatic for the detailed changes

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
