### PR TITLE
fix: add fixed height to navbar

### DIFF
--- a/packages/components/navbar/package.json
+++ b/packages/components/navbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-navbar",
-  "version": "5.0.0-alpha.35",
+  "version": "5.0.0-alpha.36",
   "description": "Forma 36: Navbar component",
   "scripts": {
     "build": "tsup"

--- a/packages/components/navbar/src/Navbar.styles.ts
+++ b/packages/components/navbar/src/Navbar.styles.ts
@@ -2,8 +2,7 @@ import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 import { mqs } from './utils.styles';
 import { NavbarProps } from './Navbar';
-
-export const NAVBAR_HEIGHT = 60;
+import { NAVBAR_HEIGHT } from './constants';
 
 export const getNavbarStyles = ({
   contentMaxWidth,

--- a/packages/components/navbar/src/Navbar.styles.ts
+++ b/packages/components/navbar/src/Navbar.styles.ts
@@ -3,6 +3,8 @@ import tokens from '@contentful/f36-tokens';
 import { mqs } from './utils.styles';
 import { NavbarProps } from './Navbar';
 
+export const NAVBAR_HEIGHT = 60;
+
 export const getNavbarStyles = ({
   contentMaxWidth,
   variant,
@@ -25,7 +27,7 @@ export const getNavbarStyles = ({
     width: '100%',
     maxWidth: variant === 'wide' ? '1920px' : contentMaxWidth,
     padding: `${tokens.spacingS} ${tokens.spacingM}`,
-    minHeight: tokens.spacingL,
+    height: `${NAVBAR_HEIGHT}px`,
     [mqs.small]: {
       padding: `${tokens.spacingM} ${tokens.spacingL}`,
     },

--- a/packages/components/navbar/src/constants.ts
+++ b/packages/components/navbar/src/constants.ts
@@ -1,0 +1,1 @@
+export const NAVBAR_HEIGHT = 60;

--- a/packages/components/navbar/src/index.ts
+++ b/packages/components/navbar/src/index.ts
@@ -1,3 +1,5 @@
+export { NAVBAR_HEIGHT } from './Navbar.styles';
+
 export { Navbar } from './CompoundNavbar';
 export type { NavbarProps } from './Navbar';
 export { getNavbarItemActiveStyles } from './NavbarItem/NavbarItem.styles';

--- a/packages/components/navbar/src/index.ts
+++ b/packages/components/navbar/src/index.ts
@@ -1,4 +1,4 @@
-export { NAVBAR_HEIGHT } from './Navbar.styles';
+export { NAVBAR_HEIGHT } from './constants';
 
 export { Navbar } from './CompoundNavbar';
 export type { NavbarProps } from './Navbar';


### PR DESCRIPTION
this pr is related to https://github.com/contentful/forma-36/pull/2859 it adds a fixed height to the light navbar and exports it, so it is useable in other components