### PR TITLE
refactor: enable children on navbar switcher

### DIFF
--- a/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcher.tsx
+++ b/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcher.tsx
@@ -48,11 +48,13 @@ function splitString(
 type NavbarLoadingProps =
   | {
       isLoading?: true;
+      children?: React.ReactNode;
       environment?: never;
       space?: never;
     }
   | {
       isLoading?: false;
+      children?: never;
       environment?: string;
       space?: string;
     };
@@ -122,6 +124,7 @@ function _NavbarSwitcher(
   ref: React.Ref<HTMLButtonElement>,
 ) {
   const {
+    children,
     className,
     envVariant,
     isAlias,
@@ -161,14 +164,20 @@ function _NavbarSwitcher(
           <NavbarSwitcherSkeleton estimatedWidth={148} />
         ) : (
           <Flex gap={tokens.spacing2Xs} alignItems="center">
-            <SwitcherLabel type="space" value={space} styles={styles} />
-            <CaretRightIcon size="tiny" color={tokens.gray500} />
-            <SwitcherLabel
-              envVariant={envVariant}
-              type="environment"
-              value={environment}
-              styles={styles}
-            />
+            {children ? (
+              <Text fontColor="gray600">{children}</Text>
+            ) : (
+              <>
+                <SwitcherLabel type="space" value={space} styles={styles} />
+                <CaretRightIcon size="tiny" color={tokens.gray500} />
+                <SwitcherLabel
+                  envVariant={envVariant}
+                  type="environment"
+                  value={environment}
+                  styles={styles}
+                />
+              </>
+            )}
           </Flex>
         )}
       </Flex>

--- a/packages/components/navbar/stories/Navbar.stories.tsx
+++ b/packages/components/navbar/stories/Navbar.stories.tsx
@@ -573,3 +573,16 @@ export const LoadingSkeleton: Story<{}> = () => {
 };
 
 LoadingSkeleton.args = {};
+
+export const NoSpaceContext: Story<{}> = () => {
+  return (
+    <div>
+      <Navbar
+        mobileNavigation={<MobileMenu />}
+        account={<Account />}
+        switcher={<Navbar.Switcher>Account Settings</Navbar.Switcher>}
+        mainNavigation={<MainItems />}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
# Purpose of PR

In some use cases we don't have space and environment, in those cases we pass a string that will appear on the switcher

### Preview
<img width="834" alt="image" src="https://github.com/user-attachments/assets/840ea459-210a-406a-ba13-28015d04feac">
