### PR TITLE
fix(Avatar): avatar size and loading skeleton

### DIFF
--- a/.changeset/fuzzy-rules-pump.md
+++ b/.changeset/fuzzy-rules-pump.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-avatar": patch
+---
+
+Avatar size and loading skeleton

--- a/.changeset/hot-ears-crash.md
+++ b/.changeset/hot-ears-crash.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-avatar": feat
+---
+
+Allow custom size

--- a/packages/components/avatar/src/Avatar/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar/Avatar.styles.ts
@@ -1,7 +1,12 @@
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 import { type AvatarProps } from './Avatar';
-import { applyMuted, avatarColorMap, type ColorVariant } from './utils';
+import {
+  applyMuted,
+  avatarColorMap,
+  getSizeInPixels,
+  type ColorVariant,
+} from './utils';
 
 export const getColorVariantStyles = (colorVariant: ColorVariant) => {
   const colorToken: string = avatarColorMap[colorVariant];
@@ -16,14 +21,6 @@ export const getColorVariantStyles = (colorVariant: ColorVariant) => {
   };
 };
 
-export const convertSizeToPixels = (size: AvatarProps['size']) =>
-  ({
-    tiny: '20px',
-    small: '24px',
-    medium: '32px',
-    large: '48px',
-  }[size]);
-
 const getInitialsFontSize = (sizePixels: string) =>
   Math.round(Number(sizePixels.replace('px', '')) / 2);
 
@@ -37,7 +34,8 @@ export const getAvatarStyles = ({
   colorVariant: ColorVariant;
 }) => {
   const borderRadius = variant === 'app' ? tokens.borderRadiusSmall : '100%';
-  const sizePixels = convertSizeToPixels(size);
+  const finalSize = getSizeInPixels(size);
+
   const isMuted = colorVariant === 'muted';
 
   return {
@@ -50,7 +48,7 @@ export const getAvatarStyles = ({
       alignItems: 'center',
       justifyContent: 'center',
       fontStretch: 'semi-condensed',
-      fontSize: `${getInitialsFontSize(sizePixels)}px`,
+      fontSize: `${getInitialsFontSize(size)}px`,
     }),
     image: css({
       borderRadius,
@@ -58,10 +56,13 @@ export const getAvatarStyles = ({
     }),
     root: css({
       borderRadius,
-      height: sizePixels,
+      height: finalSize,
       overflow: 'hidden',
       position: 'relative',
-      width: sizePixels,
+      width: finalSize,
+      svg: {
+        borderRadius,
+      },
       '&::after': {
         borderRadius,
         bottom: 0,

--- a/packages/components/avatar/src/Avatar/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar/Avatar.tsx
@@ -10,7 +10,12 @@ import {
 } from '@contentful/f36-tooltip';
 
 import { getAvatarStyles } from './Avatar.styles';
-import { getSizeInPixels, type Size, type ColorVariant } from './utils';
+import {
+  getSizeInPixels,
+  type ColorVariant,
+  type Size,
+  type SizeInPixel,
+} from './utils';
 
 export type Variant = 'app' | 'user';
 
@@ -21,10 +26,10 @@ export interface AvatarProps extends CommonProps {
    */
   isLoading?: boolean;
   /**
-   * Use the available sizes or a numerical custom one, e.g. '52' or '52px'
+   * Use the available sizes or a numerical custom one, e.g. '52px'
    * @default 'medium'
    */
-  size?: Size | string;
+  size?: Size | SizeInPixel;
   initials?: string;
   src?: ImageProps['src'];
   /**

--- a/packages/components/avatar/src/Avatar/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar/Avatar.tsx
@@ -9,10 +9,8 @@ import {
   type WithEnhancedContent,
 } from '@contentful/f36-tooltip';
 
-import { convertSizeToPixels, getAvatarStyles } from './Avatar.styles';
-import type { ColorVariant } from './utils';
-
-export type Size = 'tiny' | 'small' | 'medium' | 'large';
+import { getAvatarStyles } from './Avatar.styles';
+import { getSizeInPixels, type Size, type ColorVariant } from './utils';
 
 export type Variant = 'app' | 'user';
 
@@ -23,9 +21,10 @@ export interface AvatarProps extends CommonProps {
    */
   isLoading?: boolean;
   /**
+   * Use the available sizes or a numerical custom one, e.g. '52' or '52px'
    * @default 'medium'
    */
-  size?: Size;
+  size?: Size | string;
   initials?: string;
   src?: ImageProps['src'];
   /**
@@ -64,8 +63,8 @@ function _Avatar(
 ) {
   // Only render the fallback when `src` is undefined or an empty string
   const isFallback = Boolean(!isLoading && !src);
-  const styles = getAvatarStyles({ size, variant, colorVariant });
-  const sizePixels = convertSizeToPixels(size);
+  const finalSize = getSizeInPixels(size);
+  const styles = getAvatarStyles({ size: finalSize, variant, colorVariant });
 
   const content = (
     <div
@@ -84,9 +83,9 @@ function _Avatar(
         <Image
           alt={alt}
           className={styles.image}
-          height={sizePixels}
+          height={finalSize}
           src={src}
-          width={sizePixels}
+          width={finalSize}
         />
       )}
       {!!icon && <span className={styles.overlayIcon}>{icon}</span>}

--- a/packages/components/avatar/src/Avatar/utils.ts
+++ b/packages/components/avatar/src/Avatar/utils.ts
@@ -73,8 +73,6 @@ export const convertSizeToPixels = (size: AvatarProps['size']): SizeInPixel => {
  * @param size
  * @returns The variant or custom size in pixels, e.g. '32px'
  */
-export function getSizeInPixels(
-  size: AvatarProps['size'],
-): AvatarProps['size'] {
+export function getSizeInPixels(size: AvatarProps['size']): SizeInPixel {
   return isSizeVariant(size) ? convertSizeToPixels(size) : size;
 }

--- a/packages/components/avatar/src/Avatar/utils.ts
+++ b/packages/components/avatar/src/Avatar/utils.ts
@@ -1,5 +1,10 @@
 import tokens from '@contentful/f36-tokens';
 
+import { AvatarProps } from './Avatar';
+
+export const SIZES = ['tiny', 'small', 'medium', 'large'] as const;
+export type Size = (typeof SIZES)[number];
+
 export type ColorVariant = keyof typeof avatarColorMap;
 
 export const avatarColorMap = {
@@ -32,4 +37,42 @@ export function applyMuted(color: string): string {
 
   // Eventually we should use `color-mix`
   // return `color-mix(in srgb, ${color}, ${tokens.colorWhite} 50%)`;
+}
+
+/**
+ * Type guard for size variants
+ *
+ * @param size
+ * @returns true/false if the size is a valid size variant
+ */
+export const isSizeVariant = (size: string): size is Size => {
+  return SIZES.includes(size as Size);
+};
+
+/**
+ * Converts the variant size to pixels
+ *
+ * @param size
+ * @returns the variant size value in pixels
+ */
+export const convertSizeToPixels = (size: AvatarProps['size']) =>
+  ({
+    tiny: '20px',
+    small: '24px',
+    medium: '32px',
+    large: '48px',
+  }[size]);
+
+/**
+ * Utility function to convert the given size variant/custom size to pixels
+ *
+ * @param size
+ * @returns The variant or custom size in pixels, e.g. '32px'
+ */
+export function getSizeInPixels(size: AvatarProps['size']): string {
+  return isSizeVariant(size)
+    ? convertSizeToPixels(size)
+    : size.includes('px')
+    ? size
+    : `${size}px`;
 }

--- a/packages/components/avatar/src/Avatar/utils.ts
+++ b/packages/components/avatar/src/Avatar/utils.ts
@@ -4,6 +4,7 @@ import { AvatarProps } from './Avatar';
 
 export const SIZES = ['tiny', 'small', 'medium', 'large'] as const;
 export type Size = (typeof SIZES)[number];
+export type SizeInPixel = `${number}px`;
 
 export type ColorVariant = keyof typeof avatarColorMap;
 
@@ -55,13 +56,16 @@ export const isSizeVariant = (size: string): size is Size => {
  * @param size
  * @returns the variant size value in pixels
  */
-export const convertSizeToPixels = (size: AvatarProps['size']) =>
-  ({
+export const convertSizeToPixels = (size: AvatarProps['size']): SizeInPixel => {
+  const sizes: Record<Size, SizeInPixel> = {
     tiny: '20px',
     small: '24px',
     medium: '32px',
     large: '48px',
-  }[size]);
+  };
+
+  return sizes[size];
+};
 
 /**
  * Utility function to convert the given size variant/custom size to pixels
@@ -69,10 +73,8 @@ export const convertSizeToPixels = (size: AvatarProps['size']) =>
  * @param size
  * @returns The variant or custom size in pixels, e.g. '32px'
  */
-export function getSizeInPixels(size: AvatarProps['size']): string {
-  return isSizeVariant(size)
-    ? convertSizeToPixels(size)
-    : size.includes('px')
-    ? size
-    : `${size}px`;
+export function getSizeInPixels(
+  size: AvatarProps['size'],
+): AvatarProps['size'] {
+  return isSizeVariant(size) ? convertSizeToPixels(size) : size;
 }

--- a/packages/components/avatar/src/AvatarGroup/AvatarGroup.styles.ts
+++ b/packages/components/avatar/src/AvatarGroup/AvatarGroup.styles.ts
@@ -1,7 +1,7 @@
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 import { type AvatarProps } from '../Avatar/';
-import { convertSizeToPixels } from '../Avatar/Avatar.styles';
+import { convertSizeToPixels } from '../Avatar/utils';
 
 export const getAvatarGroupStyles = (size: AvatarProps['size']) => {
   return {

--- a/packages/components/avatar/stories/Avatar.stories.tsx
+++ b/packages/components/avatar/stories/Avatar.stories.tsx
@@ -51,6 +51,17 @@ export const Overview: Story<AvatarProps> = (args) => {
         />
         <Avatar
           {...args}
+          size="75"
+          icon={<CheckCircleIcon variant="positive" />}
+        />
+        <Avatar
+          {...args}
+          size="75"
+          variant="app"
+          icon={<CheckCircleIcon variant="positive" />}
+        />
+        <Avatar
+          {...args}
           size="large"
           variant="app"
           icon={<CheckCircleIcon variant="positive" />}
@@ -89,6 +100,8 @@ export const Overview: Story<AvatarProps> = (args) => {
         <Avatar isLoading size="small" variant="user" />
         <Avatar isLoading size="medium" variant="user" />
         <Avatar isLoading size="large" variant="user" />
+        <Avatar isLoading size="75" variant="user" />
+        <Avatar isLoading size="75" variant="app" />
         <Avatar isLoading size="large" variant="app" />
         <Avatar isLoading size="medium" variant="app" />
         <Avatar isLoading size="small" variant="app" />
@@ -186,7 +199,7 @@ export const BorderColors: Story<AvatarProps> = (args) => {
             {/* prettier-ignore */}
             <Avatar {...argsNoSrc} colorVariant={color} size="small" variant="app" />
             {/* prettier-ignore */}
-            <Avatar {...argsNoSrc}  colorVariant={color}size="tiny" variant="app" />
+            <Avatar {...argsNoSrc} colorVariant={color} size="tiny" variant="app" />
             {/* prettier-ignore */}
             <Avatar {...args} colorVariant={color} size="tiny" />
             {/* prettier-ignore */}

--- a/packages/components/avatar/stories/Avatar.stories.tsx
+++ b/packages/components/avatar/stories/Avatar.stories.tsx
@@ -90,7 +90,6 @@ export const Overview: Story<AvatarProps> = (args) => {
         <Avatar size="medium" variant="user" />
         <Avatar isLoading size="large" variant="user" />
         <Avatar size="large" variant="app" />
-        <Avatar size="large" variant="user" />
         <Avatar size="medium" variant="app" />
         <Avatar size="small" variant="app" />
         <Avatar size="tiny" variant="app" />

--- a/packages/components/avatar/stories/Avatar.stories.tsx
+++ b/packages/components/avatar/stories/Avatar.stories.tsx
@@ -109,6 +109,28 @@ export const Overview: Story<AvatarProps> = (args) => {
       </Flex>
 
       <SectionHeading as="h3" marginBottom="spacingS">
+        With a broken source, the loading skeleton is also rendered
+      </SectionHeading>
+
+      <Flex
+        alignItems="center"
+        flexDirection="row"
+        gap="spacingS"
+        marginBottom="spacingM"
+      >
+        <Avatar src="#" size="tiny" variant="user" />
+        <Avatar src="#" size="small" variant="user" />
+        <Avatar src="#" size="medium" variant="user" />
+        <Avatar src="#" size="large" variant="user" />
+        <Avatar src="#" size="75px" variant="user" />
+        <Avatar src="#" size="75px" variant="app" />
+        <Avatar src="#" size="large" variant="app" />
+        <Avatar src="#" size="medium" variant="app" />
+        <Avatar src="#" size="small" variant="app" />
+        <Avatar src="#" size="tiny" variant="app" />
+      </Flex>
+
+      <SectionHeading as="h3" marginBottom="spacingS">
         Indicator properties
       </SectionHeading>
       <Flex

--- a/packages/components/avatar/stories/Avatar.stories.tsx
+++ b/packages/components/avatar/stories/Avatar.stories.tsx
@@ -85,14 +85,14 @@ export const Overview: Story<AvatarProps> = (args) => {
         gap="spacingS"
         marginBottom="spacingM"
       >
-        <Avatar size="tiny" variant="user" />
-        <Avatar size="small" variant="user" />
-        <Avatar size="medium" variant="user" />
+        <Avatar isLoading size="tiny" variant="user" />
+        <Avatar isLoading size="small" variant="user" />
+        <Avatar isLoading size="medium" variant="user" />
         <Avatar isLoading size="large" variant="user" />
-        <Avatar size="large" variant="app" />
-        <Avatar size="medium" variant="app" />
-        <Avatar size="small" variant="app" />
-        <Avatar size="tiny" variant="app" />
+        <Avatar isLoading size="large" variant="app" />
+        <Avatar isLoading size="medium" variant="app" />
+        <Avatar isLoading size="small" variant="app" />
+        <Avatar isLoading size="tiny" variant="app" />
       </Flex>
 
       <SectionHeading as="h3" marginBottom="spacingS">

--- a/packages/components/avatar/stories/Avatar.stories.tsx
+++ b/packages/components/avatar/stories/Avatar.stories.tsx
@@ -51,12 +51,12 @@ export const Overview: Story<AvatarProps> = (args) => {
         />
         <Avatar
           {...args}
-          size="75"
+          size="75px"
           icon={<CheckCircleIcon variant="positive" />}
         />
         <Avatar
           {...args}
-          size="75"
+          size="75px"
           variant="app"
           icon={<CheckCircleIcon variant="positive" />}
         />
@@ -100,8 +100,8 @@ export const Overview: Story<AvatarProps> = (args) => {
         <Avatar isLoading size="small" variant="user" />
         <Avatar isLoading size="medium" variant="user" />
         <Avatar isLoading size="large" variant="user" />
-        <Avatar isLoading size="75" variant="user" />
-        <Avatar isLoading size="75" variant="app" />
+        <Avatar isLoading size="75px" variant="user" />
+        <Avatar isLoading size="75px" variant="app" />
         <Avatar isLoading size="large" variant="app" />
         <Avatar isLoading size="medium" variant="app" />
         <Avatar isLoading size="small" variant="app" />


### PR DESCRIPTION
# Purpose of PR

Fixes the Avatar's loading skeleton rendering.

We extend the size property to receive custom sizes. This should prevent people from using custom styling that does not deeply apply to the Avatar > Image > Skeleton loader component, see below:

**Current rendering with custom styling**

https://github.com/user-attachments/assets/2cfe3e24-d050-4745-a06d-739236e8bb25

## Loading skeleton

> [!TIP]
> One can observe the loading skeleton before/after in the deployed Storybook by blocking the request to the avatar image:
> - In the Avatar stories
> - In the Navbar stories

**Before**

https://github.com/user-attachments/assets/1a4c6edc-870b-45c6-a7ff-a65fa9bdd64a

**After**

https://github.com/user-attachments/assets/fde616f5-b3e9-488c-b890-f0772b043c3d

## Storybook update

- Add loading state to all `Loading` section
- Includes custom size via props examples

https://github.com/user-attachments/assets/477eba63-f937-4aff-9fa2-5116d4fb6296

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
