### PR TITLE
chore: fix changeset to trigger release

### DIFF
--- a/.changeset/hot-ears-crash.md
+++ b/.changeset/hot-ears-crash.md
@@ -1,5 +1,5 @@
 ---
-"@contentful/f36-avatar": feat
+"@contentful/f36-avatar": minor
 ---
 
 Allow custom size


### PR DESCRIPTION
# Purpose of PR

In #2880 I added 2 changesets: one to reflect the `fix`, and the other to reflect the `feat`.

Using the changeset bot link, I manually edited the text from `patch` (added by default) to `feat` but it should have been `minor`.

This should fix the release on the CI.