### PR TITLE
fix(ProgressStepper): add className prop

### DIFF
--- a/packages/components/progress-stepper/src/ProgressStepper.tsx
+++ b/packages/components/progress-stepper/src/ProgressStepper.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
+import { cx } from 'emotion';
 import { type CommonProps, type MarginProps } from '@contentful/f36-core';
 import { getStyles } from './ProgressStepper.styles';
 
 export interface ProgressStepperProps extends CommonProps, MarginProps {
   children: React.ReactNode;
+  /**
+   * string for additional classNames
+   */
+  className?: string;
   /**
    * @default horizontal
    */
@@ -28,6 +33,7 @@ function _ProgressStepper(
 ) {
   const {
     children,
+    className,
     orientation = 'horizontal',
     stepStyle = 'number',
     activeStep = 0,
@@ -56,7 +62,10 @@ function _ProgressStepper(
 
   return (
     <nav
-      className={orientation === 'vertical' ? styles.verticalNav : ''}
+      className={cx(
+        className,
+        orientation === 'vertical' && styles.verticalNav,
+      )}
       data-test-id={hydratedTestId}
       ref={ref}
       aria-label={ariaLabel}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

[Form36 docs ](https://f36.contentful.com/components/progress-stepper) listed className as a prop for this component, but it wasn't being passed. I added it. 

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
