### PR TITLE
fix(Avatar): don't overlap image with color border

### DIFF
--- a/.changeset/chilled-shrimps-occur.md
+++ b/.changeset/chilled-shrimps-occur.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-avatar': patch
+---
+
+Shrink image to reduce overlapping with the color border

--- a/.changeset/nasty-queens-laugh.md
+++ b/.changeset/nasty-queens-laugh.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-avatar': patch
+---
+
+Round overlay icon for app variant

--- a/packages/components/avatar/src/Avatar/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar/Avatar.styles.ts
@@ -37,6 +37,9 @@ export const getAvatarStyles = ({
   colorVariant: ColorVariant;
 }) => {
   const borderRadius = variant === 'app' ? APP_BORDER_RADIUS : '100%';
+
+  // The inner border radius is smaller than the outer border radius
+  // See https://github.com/webuild-community/advent-of-sharing/blob/main/2022/day-06.md
   const innerBorderRadius =
     variant === 'app'
       ? APP_BORDER_RADIUS - getTotalBorderWidth(colorVariant)

--- a/packages/components/avatar/src/Avatar/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar/Avatar.styles.ts
@@ -81,7 +81,7 @@ export const getAvatarStyles = ({
 
       // color variant border
       '&::after': {
-        borderRadius: borderRadius,
+        borderRadius,
         bottom: 0,
         content: '""',
         display: 'block',

--- a/packages/components/avatar/src/Avatar/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar/Avatar.styles.ts
@@ -2,21 +2,24 @@ import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 import { type AvatarProps } from './Avatar';
 import {
+  APP_BORDER_RADIUS,
   applyMuted,
   avatarColorMap,
-  getSizeInPixels,
+  getColorWidth,
+  getTotalBorderWidth,
+  parseSize,
   type ColorVariant,
 } from './utils';
 
 export const getColorVariantStyles = (colorVariant: ColorVariant) => {
   const colorToken: string = avatarColorMap[colorVariant];
 
-  const colorWidth = ['muted', 'gray'].includes(colorVariant) ? 1 : 2;
-
   return {
     boxShadow: [
-      `0px 0px 0px ${colorWidth}px ${colorToken} inset`,
-      `0px 0px 0px ${colorWidth + 1}px ${tokens.colorWhite} inset`,
+      `0px 0px 0px ${getColorWidth(colorVariant)}px ${colorToken} inset`,
+      `0px 0px 0px ${getTotalBorderWidth(colorVariant)}px ${
+        tokens.colorWhite
+      } inset`,
     ].join(', '),
   };
 };
@@ -33,8 +36,11 @@ export const getAvatarStyles = ({
   variant: AvatarProps['variant'];
   colorVariant: ColorVariant;
 }) => {
-  const borderRadius = variant === 'app' ? tokens.borderRadiusSmall : '100%';
-  const finalSize = getSizeInPixels(size);
+  const borderRadius = variant === 'app' ? APP_BORDER_RADIUS : '100%';
+  const innerBorderRadius =
+    variant === 'app'
+      ? APP_BORDER_RADIUS - getTotalBorderWidth(colorVariant)
+      : '100%';
 
   const isMuted = colorVariant === 'muted';
 
@@ -51,20 +57,26 @@ export const getAvatarStyles = ({
       fontSize: `${getInitialsFontSize(size)}px`,
     }),
     image: css({
-      borderRadius,
+      borderRadius: innerBorderRadius,
       display: 'block',
     }),
     root: css({
       borderRadius,
-      height: finalSize,
+      height: parseSize(size),
+      width: parseSize(size),
       overflow: 'hidden',
       position: 'relative',
-      width: finalSize,
+      padding: getTotalBorderWidth(colorVariant),
+
+      // image loading skeleton
       svg: {
-        borderRadius,
+        borderRadius: innerBorderRadius,
+        rect: { rx: 0, ry: 0 }, // has a default 4px border radius
       },
+
+      // color variant border
       '&::after': {
-        borderRadius,
+        borderRadius: borderRadius,
         bottom: 0,
         content: '""',
         display: 'block',

--- a/packages/components/avatar/src/Avatar/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar/Avatar.styles.ts
@@ -8,6 +8,7 @@ import {
   getColorWidth,
   getTotalBorderWidth,
   parseSize,
+  toPixels,
   type ColorVariant,
 } from './utils';
 
@@ -24,11 +25,10 @@ export const getColorVariantStyles = (colorVariant: ColorVariant) => {
   };
 };
 
-const getInitialsFontSize = (sizePixels: string) =>
-  Math.round(Number(sizePixels.replace('px', '')) / 2);
+const getInitialsFontSize = (size: number) => Math.round(size / 2);
 
 export const getAvatarStyles = ({
-  size,
+  size: sizeOption,
   variant,
   colorVariant,
 }: {
@@ -47,6 +47,8 @@ export const getAvatarStyles = ({
 
   const isMuted = colorVariant === 'muted';
 
+  const size = parseSize(sizeOption);
+
   return {
     fallback: css({
       backgroundColor: isMuted ? applyMuted(tokens.gray300) : tokens.gray300,
@@ -57,7 +59,7 @@ export const getAvatarStyles = ({
       alignItems: 'center',
       justifyContent: 'center',
       fontStretch: 'semi-condensed',
-      fontSize: `${getInitialsFontSize(size)}px`,
+      fontSize: toPixels(getInitialsFontSize(size)),
     }),
     image: css({
       borderRadius: innerBorderRadius,
@@ -71,8 +73,8 @@ export const getAvatarStyles = ({
     }),
     root: css({
       borderRadius,
-      height: parseSize(size),
-      width: parseSize(size),
+      height: size,
+      width: size,
       overflow: 'hidden',
       position: 'relative',
       padding: getTotalBorderWidth(colorVariant),

--- a/packages/components/avatar/src/Avatar/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar/Avatar.styles.ts
@@ -59,6 +59,12 @@ export const getAvatarStyles = ({
     image: css({
       borderRadius: innerBorderRadius,
       display: 'block',
+
+      // loading skeleton
+      '& + svg': {
+        borderRadius: innerBorderRadius,
+        rect: { rx: 0, ry: 0 }, // has a default 4px border radius
+      },
     }),
     root: css({
       borderRadius,
@@ -67,12 +73,6 @@ export const getAvatarStyles = ({
       overflow: 'hidden',
       position: 'relative',
       padding: getTotalBorderWidth(colorVariant),
-
-      // image loading skeleton
-      svg: {
-        borderRadius: innerBorderRadius,
-        rect: { rx: 0, ry: 0 }, // has a default 4px border radius
-      },
 
       // color variant border
       '&::after': {

--- a/packages/components/avatar/src/Avatar/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar/Avatar.tsx
@@ -10,12 +10,7 @@ import {
 } from '@contentful/f36-tooltip';
 
 import { getAvatarStyles } from './Avatar.styles';
-import {
-  getSizeInPixels,
-  type ColorVariant,
-  type Size,
-  type SizeInPixel,
-} from './utils';
+import { type ColorVariant, type Size, type SizeInPixel } from './utils';
 
 export type Variant = 'app' | 'user';
 
@@ -68,8 +63,7 @@ function _Avatar(
 ) {
   // Only render the fallback when `src` is undefined or an empty string
   const isFallback = Boolean(!isLoading && !src);
-  const finalSize = getSizeInPixels(size);
-  const styles = getAvatarStyles({ size: finalSize, variant, colorVariant });
+  const styles = getAvatarStyles({ size, variant, colorVariant });
 
   const content = (
     <div
@@ -88,9 +82,9 @@ function _Avatar(
         <Image
           alt={alt}
           className={styles.image}
-          height={finalSize}
           src={src}
-          width={finalSize}
+          height="100%"
+          width="100%"
         />
       )}
       {!!icon && <span className={styles.overlayIcon}>{icon}</span>}

--- a/packages/components/avatar/src/Avatar/utils.ts
+++ b/packages/components/avatar/src/Avatar/utils.ts
@@ -8,6 +8,9 @@ export type SizeInPixel = `${number}px`;
 
 export type ColorVariant = keyof typeof avatarColorMap;
 
+export const APP_BORDER_RADIUS = 4;
+const WHITE_BORDER_WIDTH = 1;
+
 export const avatarColorMap = {
   primary: tokens.blue500,
   muted: applyMuted(tokens.gray500),
@@ -40,39 +43,36 @@ export function applyMuted(color: string): string {
   // return `color-mix(in srgb, ${color}, ${tokens.colorWhite} 50%)`;
 }
 
-/**
- * Type guard for size variants
- *
- * @param size
- * @returns true/false if the size is a valid size variant
- */
-export const isSizeVariant = (size: string): size is Size => {
-  return SIZES.includes(size as Size);
-};
+export function getColorWidth(colorVariant: ColorVariant): number {
+  return ['muted', 'gray'].includes(colorVariant) ? 1 : 2;
+}
+
+export function getTotalBorderWidth(colorVariant: ColorVariant): number {
+  return getColorWidth(colorVariant) + WHITE_BORDER_WIDTH;
+}
 
 /**
  * Converts the variant size to pixels
  *
  * @param size
- * @returns the variant size value in pixels
+ * @returns the size in pixels
  */
-export const convertSizeToPixels = (size: AvatarProps['size']): SizeInPixel => {
-  const sizes: Record<Size, SizeInPixel> = {
-    tiny: '20px',
-    small: '24px',
-    medium: '32px',
-    large: '48px',
+export const parseSize = (size: AvatarProps['size']): number => {
+  const sizeMap = {
+    tiny: 20,
+    small: 24,
+    medium: 32,
+    large: 48,
   };
 
-  return sizes[size];
+  return sizeMap[size] ?? parseInt(size.slice(0, -2), 10);
 };
 
 /**
- * Utility function to convert the given size variant/custom size to pixels
  *
  * @param size
- * @returns The variant or custom size in pixels, e.g. '32px'
+ * @returns the size in pixels with the 'px' suffix
  */
-export function getSizeInPixels(size: AvatarProps['size']): SizeInPixel {
-  return isSizeVariant(size) ? convertSizeToPixels(size) : size;
+export function toPixels(size: number): SizeInPixel {
+  return `${size}px`;
 }

--- a/packages/components/avatar/src/AvatarGroup/AvatarGroup.styles.ts
+++ b/packages/components/avatar/src/AvatarGroup/AvatarGroup.styles.ts
@@ -1,7 +1,7 @@
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 import { type AvatarProps } from '../Avatar/';
-import { convertSizeToPixels } from '../Avatar/utils';
+import { parseSize, toPixels } from '../Avatar/utils';
 
 export const getAvatarGroupStyles = (size: AvatarProps['size']) => {
   return {
@@ -26,8 +26,8 @@ export const getAvatarGroupStyles = (size: AvatarProps['size']) => {
       border: 'none',
       boxShadow: `0px 0px 0px 1px ${tokens.gray200} inset`,
       borderRadius: '99999999em',
-      height: convertSizeToPixels(size),
-      width: convertSizeToPixels(size),
+      height: toPixels(parseSize(size)),
+      width: toPixels(parseSize(size)),
       overflow: 'hidden',
       zIndex: 0,
     }),


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

In the current version of the avatar component, the colored border overlaps with the image. The colored border is about 2 or 3px wide, so a total of 6px horizontal and vertical could be covered. With this PR, the size of the image is reduced to reduce overlaps.

The existing implementation was mixing size numbers with size strings. To shrink the image correctly, its size must be calculated. I, therefore, changed methods to always return numbers and to only add the `px` suffix at the very last moment. Imo, it's now way easier to understand when a variable is a number or a string.

Additionally, the overlay icon is round again.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## Screenshot

![image](https://github.com/user-attachments/assets/50f2af2b-c1c7-4c36-a126-f8e57d7b8d4a)


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
