### PR TITLE
feat(header): render title as h1

### DIFF
--- a/.changeset/fluffy-files-matter.md
+++ b/.changeset/fluffy-files-matter.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-header": minor
+---
+
+feat(header): render title as h1

--- a/packages/components/header/src/Header.tsx
+++ b/packages/components/header/src/Header.tsx
@@ -93,7 +93,9 @@ function _Header<E extends ElementType = typeof HEADER_DEFAULT_TAG>(
                 {isValidElement(title) ? (
                   title
                 ) : (
-                  <Subheading className={styles.title}>{title}</Subheading>
+                  <Subheading as="h1" className={styles.title}>
+                    {title}
+                  </Subheading>
                 )}
               </div>
             )}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

Render the `title` prop of `Header` as an `h1` heading by default.