### PR TITLE
feat: increase white padding for app avatars

### DIFF
--- a/.changeset/fair-rockets-sing.md
+++ b/.changeset/fair-rockets-sing.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-avatar': minor
+---
+
+increase inner white padding for app variant

--- a/packages/components/avatar/src/Avatar/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar/Avatar.styles.ts
@@ -1,26 +1,32 @@
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
-import { type AvatarProps } from './Avatar';
+import { type AvatarProps, type Variant } from './Avatar';
 import {
-  APP_BORDER_RADIUS,
   applyMuted,
   avatarColorMap,
   getColorWidth,
+  getInnerRadius,
+  getOuterRadius,
   getTotalBorderWidth,
   parseSize,
   toPixels,
   type ColorVariant,
 } from './utils';
 
-export const getColorVariantStyles = (colorVariant: ColorVariant) => {
+export const getColorVariantStyles = (
+  variant: Variant,
+  colorVariant: ColorVariant,
+  size: number,
+) => {
   const colorToken: string = avatarColorMap[colorVariant];
+
+  const colorWidth = getColorWidth(colorVariant);
+  const totalBorderWidth = getTotalBorderWidth(variant, colorVariant, size);
 
   return {
     boxShadow: [
-      `0px 0px 0px ${getColorWidth(colorVariant)}px ${colorToken} inset`,
-      `0px 0px 0px ${getTotalBorderWidth(colorVariant)}px ${
-        tokens.colorWhite
-      } inset`,
+      `0px 0px 0px ${colorWidth}px ${colorToken} inset`,
+      `0px 0px 0px ${totalBorderWidth}px ${tokens.colorWhite} inset`,
     ].join(', '),
   };
 };
@@ -33,21 +39,16 @@ export const getAvatarStyles = ({
   colorVariant,
 }: {
   size: AvatarProps['size'];
-  variant: AvatarProps['variant'];
+  variant: Variant;
   colorVariant: ColorVariant;
 }) => {
-  const borderRadius = variant === 'app' ? APP_BORDER_RADIUS : '100%';
-
-  // The inner border radius is smaller than the outer border radius
-  // See https://github.com/webuild-community/advent-of-sharing/blob/main/2022/day-06.md
-  const innerBorderRadius =
-    variant === 'app'
-      ? APP_BORDER_RADIUS - getTotalBorderWidth(colorVariant)
-      : '100%';
-
-  const isMuted = colorVariant === 'muted';
+  const borderRadius = getOuterRadius(variant);
+  const innerBorderRadius = getInnerRadius(variant);
 
   const size = parseSize(sizeOption);
+  const totalBorderWidth = getTotalBorderWidth(variant, colorVariant, size);
+
+  const isMuted = colorVariant === 'muted';
 
   return {
     fallback: css({
@@ -77,7 +78,7 @@ export const getAvatarStyles = ({
       width: size,
       overflow: 'hidden',
       position: 'relative',
-      padding: getTotalBorderWidth(colorVariant),
+      padding: totalBorderWidth,
 
       // color variant border
       '&::after': {
@@ -89,7 +90,7 @@ export const getAvatarStyles = ({
         position: 'absolute',
         top: 0,
         right: 0,
-        ...getColorVariantStyles(colorVariant),
+        ...getColorVariantStyles(variant, colorVariant, size),
       },
     }),
     imageContainer: css(

--- a/packages/components/avatar/src/Avatar/Avatar.styles.ts
+++ b/packages/components/avatar/src/Avatar/Avatar.styles.ts
@@ -1,6 +1,7 @@
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
-import { type AvatarProps, type Variant } from './Avatar';
+import { type AvatarProps } from './Avatar';
+import { type Variant } from './types';
 import {
   applyMuted,
   avatarColorMap,

--- a/packages/components/avatar/src/Avatar/Avatar.tsx
+++ b/packages/components/avatar/src/Avatar/Avatar.tsx
@@ -11,8 +11,8 @@ import {
 
 import { getAvatarStyles } from './Avatar.styles';
 import { type ColorVariant, type Size, type SizeInPixel } from './utils';
-
-export type Variant = 'app' | 'user';
+import type { Variant } from './types';
+export { type Variant } from './types';
 
 export interface AvatarProps extends CommonProps {
   alt?: ImageProps['alt'];

--- a/packages/components/avatar/src/Avatar/types.ts
+++ b/packages/components/avatar/src/Avatar/types.ts
@@ -1,0 +1,1 @@
+export type Variant = 'app' | 'user';

--- a/packages/components/avatar/src/Avatar/utils.ts
+++ b/packages/components/avatar/src/Avatar/utils.ts
@@ -1,15 +1,12 @@
 import tokens from '@contentful/f36-tokens';
 
-import { AvatarProps } from './Avatar';
+import { AvatarProps, type Variant } from './Avatar';
 
 export const SIZES = ['tiny', 'small', 'medium', 'large'] as const;
 export type Size = (typeof SIZES)[number];
 export type SizeInPixel = `${number}px`;
 
 export type ColorVariant = keyof typeof avatarColorMap;
-
-export const APP_BORDER_RADIUS = 4;
-const WHITE_BORDER_WIDTH = 1;
 
 export const avatarColorMap = {
   primary: tokens.blue500,
@@ -43,12 +40,24 @@ export function applyMuted(color: string): string {
   // return `color-mix(in srgb, ${color}, ${tokens.colorWhite} 50%)`;
 }
 
+export function getWhiteBorderWidth(variant: Variant, size: number): number {
+  if (variant === 'user') {
+    return 1;
+  }
+
+  return size >= 48 ? 3 : 2;
+}
+
 export function getColorWidth(colorVariant: ColorVariant): number {
   return ['muted', 'gray'].includes(colorVariant) ? 1 : 2;
 }
 
-export function getTotalBorderWidth(colorVariant: ColorVariant): number {
-  return getColorWidth(colorVariant) + WHITE_BORDER_WIDTH;
+export function getTotalBorderWidth(
+  variant: Variant,
+  colorVariant: ColorVariant,
+  size: number,
+): number {
+  return getColorWidth(colorVariant) + getWhiteBorderWidth(variant, size);
 }
 
 /**
@@ -75,4 +84,12 @@ export const parseSize = (size: AvatarProps['size']): number => {
  */
 export function toPixels(size: number): SizeInPixel {
   return `${size}px`;
+}
+
+export function getOuterRadius(variant: Variant): string {
+  return variant === 'app' ? '4px' : '100%';
+}
+
+export function getInnerRadius(variant: Variant): string {
+  return variant === 'app' ? '1px' : '100%';
 }

--- a/packages/components/avatar/src/Avatar/utils.ts
+++ b/packages/components/avatar/src/Avatar/utils.ts
@@ -1,6 +1,7 @@
 import tokens from '@contentful/f36-tokens';
 
-import { AvatarProps, type Variant } from './Avatar';
+import { AvatarProps } from './Avatar';
+import { type Variant } from './types';
 
 export const SIZES = ['tiny', 'small', 'medium', 'large'] as const;
 export type Size = (typeof SIZES)[number];


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

Increasing the inner white padding for app avatars

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
