### PR TITLE
chore: less jest-axe configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@testing-library/react-hooks": "^8.0.1",
         "@testing-library/user-event": "14.5.2",
         "@types/jest": "^29.2.2",
-        "@types/jest-axe": "3.5.4",
+        "@types/jest-axe": "3.5.9",
         "@types/storybook__react": "5.2.1",
         "@typescript-eslint/eslint-plugin": "^5.47.1",
         "@typescript-eslint/parser": "^5.37.0",
@@ -13226,7 +13226,9 @@
       }
     },
     "node_modules/@types/jest-axe": {
-      "version": "3.5.4",
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/@types/jest-axe/-/jest-axe-3.5.9.tgz",
+      "integrity": "sha512-z98CzR0yVDalCEuhGXXO4/zN4HHuSebAukXDjTLJyjEAgoUf1H1i+sr7SUB/mz8CRS/03/XChsx0dcLjHkndoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "14.5.2",
     "@types/jest": "^29.2.2",
-    "@types/jest-axe": "3.5.4",
+    "@types/jest-axe": "3.5.9",
     "@types/storybook__react": "5.2.1",
     "@typescript-eslint/eslint-plugin": "^5.47.1",
     "@typescript-eslint/parser": "^5.37.0",

--- a/packages/components/accordion/src/Accordion.test.tsx
+++ b/packages/components/accordion/src/Accordion.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Accordion } from '.';
 

--- a/packages/components/asset/src/Asset.test.tsx
+++ b/packages/components/asset/src/Asset.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Asset } from './Asset';
 

--- a/packages/components/asset/src/AssetIcon/AssetIcon.test.tsx
+++ b/packages/components/asset/src/AssetIcon/AssetIcon.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { AssetIcon } from './AssetIcon';
 

--- a/packages/components/avatar/src/AvatarGroup/AvatarGroup.test.tsx
+++ b/packages/components/avatar/src/AvatarGroup/AvatarGroup.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import UserEvent from '@testing-library/user-event/';
 import { Avatar } from '../Avatar';
 import { AvatarGroup } from './AvatarGroup';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 jest.mock('@contentful/f36-image', () => ({
   Image: jest.fn((props) => <img alt="fallback avatar" {...props} />),

--- a/packages/components/badge/src/Badge/Badge.test.tsx
+++ b/packages/components/badge/src/Badge/Badge.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { PreviewIcon } from '@contentful/f36-icons';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 import { Badge } from './Badge';
 
 describe('Badge', function () {

--- a/packages/components/badge/src/EntityStatusBadge/EntityStatusBadge.test.tsx
+++ b/packages/components/badge/src/EntityStatusBadge/EntityStatusBadge.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 import { EntityStatusBadge } from './EntityStatusBadge';
 
 describe('EntityStatusBadge', function () {

--- a/packages/components/button/src/Button/Button.test.tsx
+++ b/packages/components/button/src/Button/Button.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
 import { PreviewIcon } from '@contentful/f36-icons';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 import { Button } from './Button';
 
 describe('Button', function () {

--- a/packages/components/button/src/ToggleButton/ToggleButton.test.tsx
+++ b/packages/components/button/src/ToggleButton/ToggleButton.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PreviewIcon } from '@contentful/f36-icons';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { ToggleButton } from '.';
 

--- a/packages/components/card/src/Card/Card.test.tsx
+++ b/packages/components/card/src/Card/Card.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Card } from './Card';
 

--- a/packages/components/copybutton/src/CopyButton.test.tsx
+++ b/packages/components/copybutton/src/CopyButton.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 
 import { CopyButton } from './CopyButton';

--- a/packages/components/entity-list/src/EntityList.test.tsx
+++ b/packages/components/entity-list/src/EntityList.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { EntityList } from '.';
 

--- a/packages/components/entity-list/src/EntityListItem/EntityListItem.test.tsx
+++ b/packages/components/entity-list/src/EntityListItem/EntityListItem.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { EntityListItem } from '..';
 import { MenuItem, MenuSectionTitle } from '@contentful/f36-menu';

--- a/packages/components/forms/src/BaseCheckbox/BaseCheckbox.test.tsx
+++ b/packages/components/forms/src/BaseCheckbox/BaseCheckbox.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { BaseCheckbox } from './BaseCheckbox';
 

--- a/packages/components/forms/src/BaseInput/BaseInput.test.tsx
+++ b/packages/components/forms/src/BaseInput/BaseInput.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { BaseInput } from './BaseInput';
 

--- a/packages/components/forms/src/Checkbox/Checkbox.test.tsx
+++ b/packages/components/forms/src/Checkbox/Checkbox.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Checkbox } from './Checkbox';
 

--- a/packages/components/forms/src/Checkbox/CheckboxGroup.test.tsx
+++ b/packages/components/forms/src/Checkbox/CheckboxGroup.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Checkbox } from './Checkbox';
 import { CheckboxGroup } from './CheckboxGroup';

--- a/packages/components/forms/src/FormLabel/FormLabel.test.tsx
+++ b/packages/components/forms/src/FormLabel/FormLabel.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { FormLabel } from './FormLabel';
 

--- a/packages/components/forms/src/HelpText/HelpText.test.tsx
+++ b/packages/components/forms/src/HelpText/HelpText.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 import { HelpText } from './HelpText';
 
 describe('HelpText', function () {

--- a/packages/components/forms/src/Radio/Radio.test.tsx
+++ b/packages/components/forms/src/Radio/Radio.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Radio } from './Radio';
 

--- a/packages/components/forms/src/Radio/RadioGroup.test.tsx
+++ b/packages/components/forms/src/Radio/RadioGroup.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Radio } from './Radio';
 import { RadioGroup } from './RadioGroup';

--- a/packages/components/forms/src/Select/Select.test.tsx
+++ b/packages/components/forms/src/Select/Select.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Select } from './CompoundSelect';
 

--- a/packages/components/forms/src/Switch/Switch.test.tsx
+++ b/packages/components/forms/src/Switch/Switch.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Switch } from './Switch';
 

--- a/packages/components/forms/src/TextInput/input-group/InputGroup.test.tsx
+++ b/packages/components/forms/src/TextInput/input-group/InputGroup.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { InputGroup } from './InputGroup';
 import { TextInput } from '@contentful/f36-forms';

--- a/packages/components/forms/src/Textarea/Textarea.test.tsx
+++ b/packages/components/forms/src/Textarea/Textarea.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Textarea } from './Textarea';
 

--- a/packages/components/forms/src/ValidationMessage/ValidationMessage.test.tsx
+++ b/packages/components/forms/src/ValidationMessage/ValidationMessage.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { ValidationMessage } from './ValidationMessage';
 

--- a/packages/components/modal/src/Modal.test.tsx
+++ b/packages/components/modal/src/Modal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Modal } from './Modal';
 

--- a/packages/components/modal/src/ModalConfirm/ModalConfirm.test.tsx
+++ b/packages/components/modal/src/ModalConfirm/ModalConfirm.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { ModalConfirm } from './ModalConfirm';
 

--- a/packages/components/multiselect/src/Multiselect.test.tsx
+++ b/packages/components/multiselect/src/Multiselect.test.tsx
@@ -8,7 +8,7 @@ import {
   cleanup,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 import { Multiselect } from './CompoundMultiselect';
 import { MultiselectProps } from './Multiselect';
 

--- a/packages/components/note/src/Note.test.tsx
+++ b/packages/components/note/src/Note.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { Note } from './Note';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 describe('Note', function () {
   const noteText =

--- a/packages/components/notification/src/NotificationItem.test.tsx
+++ b/packages/components/notification/src/NotificationItem.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { NotificationItem } from './NotificationItem';
 

--- a/packages/components/pill/src/Pill.test.tsx
+++ b/packages/components/pill/src/Pill.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 import tokens from '@contentful/f36-tokens';
 
 import { Pill } from './Pill';

--- a/packages/components/popover/src/Popover.test.tsx
+++ b/packages/components/popover/src/Popover.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Popover } from '.';
 import { Button } from '@contentful/f36-button';

--- a/packages/components/skeleton/src/SkeletonBodyText/SkeletonBodyText.test.tsx
+++ b/packages/components/skeleton/src/SkeletonBodyText/SkeletonBodyText.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Skeleton } from '../index';
 

--- a/packages/components/skeleton/src/SkeletonContainer/SkeletonContainer.test.tsx
+++ b/packages/components/skeleton/src/SkeletonContainer/SkeletonContainer.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Skeleton } from '../index';
 

--- a/packages/components/skeleton/src/SkeletonDisplayText/SkeletonDisplayText.test.tsx
+++ b/packages/components/skeleton/src/SkeletonDisplayText/SkeletonDisplayText.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Skeleton } from '../index';
 

--- a/packages/components/skeleton/src/SkeletonImage/SkeletonImage.test.tsx
+++ b/packages/components/skeleton/src/SkeletonImage/SkeletonImage.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Skeleton } from '../index';
 

--- a/packages/components/skeleton/src/SkeletonRow/SkeletonRow.test.tsx
+++ b/packages/components/skeleton/src/SkeletonRow/SkeletonRow.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { Table, TableBody } from '@contentful/f36-table';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Skeleton } from '../index';
 

--- a/packages/components/skeleton/src/SkeletonText/SkeletonText.test.tsx
+++ b/packages/components/skeleton/src/SkeletonText/SkeletonText.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Skeleton } from '../index';
 

--- a/packages/components/spinner/src/Spinner.test.tsx
+++ b/packages/components/spinner/src/Spinner.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Spinner } from '.';
 

--- a/packages/components/tabs/src/Tabs.test.tsx
+++ b/packages/components/tabs/src/Tabs.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Tabs } from '.';
 

--- a/packages/components/text-link/src/TextLink.test.tsx
+++ b/packages/components/text-link/src/TextLink.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ArrowDownIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 import { TextLink } from './TextLink';
 
 describe('TextLink', function () {

--- a/packages/components/tooltip/src/Tooltip.test.tsx
+++ b/packages/components/tooltip/src/Tooltip.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Tooltip } from './Tooltip';
 import { Paragraph } from '@contentful/f36-typography';

--- a/packages/components/typography/src/Caption/Caption.test.tsx
+++ b/packages/components/typography/src/Caption/Caption.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Caption } from './Caption';
 

--- a/packages/components/typography/src/DisplayText/DisplayText.test.tsx
+++ b/packages/components/typography/src/DisplayText/DisplayText.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { DisplayText } from './DisplayText';
 

--- a/packages/components/typography/src/Heading/Heading.test.tsx
+++ b/packages/components/typography/src/Heading/Heading.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Heading } from './Heading';
 

--- a/packages/components/typography/src/Paragraph/Paragraph.test.tsx
+++ b/packages/components/typography/src/Paragraph/Paragraph.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Paragraph } from './Paragraph';
 

--- a/packages/components/typography/src/SectionHeading/SectionHeading.test.tsx
+++ b/packages/components/typography/src/SectionHeading/SectionHeading.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { SectionHeading } from './SectionHeading';
 

--- a/packages/components/typography/src/Subheading/Subheading.test.tsx
+++ b/packages/components/typography/src/Subheading/Subheading.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Subheading } from './Subheading';
 

--- a/packages/core/src/Box/Box.test.tsx
+++ b/packages/core/src/Box/Box.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 import tokens from '@contentful/f36-tokens';
 
 import { Box } from './Box';

--- a/packages/core/src/Flex/Flex.test.tsx
+++ b/packages/core/src/Flex/Flex.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 import tokens from '@contentful/f36-tokens';
 
 import { Flex } from './Flex';

--- a/packages/core/src/Grid/Grid.test.tsx
+++ b/packages/core/src/Grid/Grid.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { Grid } from './Grid';
 

--- a/packages/core/src/Grid/GridItem/GridItem.test.tsx
+++ b/packages/core/src/Grid/GridItem/GridItem.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from '@/scripts/test/axeHelper';
+import { axe } from 'jest-axe';
 
 import { GridItem } from './GridItem';
 

--- a/scripts/test/axeHelper.js
+++ b/scripts/test/axeHelper.js
@@ -1,7 +1,0 @@
-import { configureAxe } from 'jest-axe';
-
-export const axe = configureAxe({
-  rules: {
-    region: { enabled: false },
-  },
-});

--- a/scripts/test/setupTests.ts
+++ b/scripts/test/setupTests.ts
@@ -1,13 +1,16 @@
 import '@testing-library/jest-dom';
 import 'jest-axe/extend-expect';
+import { configureAxe, toHaveNoViolations } from 'jest-axe';
 import { configure } from '@testing-library/react';
 
 configure({ testIdAttribute: 'data-test-id' });
+configureAxe({
+  rules: {
+    region: { enabled: false },
+  },
+});
 
-// We need to override window.getComputedStyle
-// See https://github.com/nickcolley/jest-axe/issues/147
-const { getComputedStyle } = window;
-window.getComputedStyle = (elt) => getComputedStyle(elt);
+expect.extend(toHaveNoViolations);
 
 // We shouldn't allow failed prop types in tests
 const error = console.error;


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

Clean up some jest-axe configuration which makes it possible to get rid of our `axeHelper` and do `import { axe } from 'jest-axe';` directly in tests.