### PR TITLE
fix: stripe env variables from CDN build

### DIFF
--- a/packages/cdn/README.md
+++ b/packages/cdn/README.md
@@ -6,7 +6,7 @@ The `public` folder is hosted at `cdn.f36.contentful.com`.
 
 Run `npm run serve` to start the server locally
 
-## Updating the Geist font to the latest version
+### Updating the Geist font to the latest version
 
 > [!IMPORTANT]  
 > Do not remove, rename or overwrite old versions of the font.
@@ -16,3 +16,7 @@ Run `npm run serve` to start the server locally
 1. Rename the files to include the version: `geist-(mono|sans)-x.x.x.woff2`
 1. Create a PR and wait for review
 1. Merge the PR. The files are automatically deployed to the CDN
+
+### Build Script
+
+The server is compiled with `js-compute-runtime input.js output.wasm`. The compiled `.wasm` file inlines all environment variables. This is a security risk as the binary might contain api keys. With `env -i`, the server is compiled with a new environment without any environment variables.

--- a/packages/cdn/package.json
+++ b/packages/cdn/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "deploy": "fastly compute deploy",
     "prebuild": "npx compute-js-static-publish --build-static",
-    "build": "js-compute-runtime ./src/index.js ./bin/main.wasm",
+    "build": "env -i $(which node) ./node_modules/.bin/js-compute-runtime ./src/index.js ./bin/main.wasm",
     "serve": "fastly compute serve"
   }
 }


### PR DESCRIPTION
The CDN build currently inlines environment variables. This could be a security issue. This PR ensures that no environment variables (and therefore secrets) are inlined into the binary.

The issue was detected by the netlify secret scanner.