### PR TITLE
docs(progress-stepper): add horizontal width limitation example

### DIFF
--- a/packages/components/progress-stepper/README.mdx
+++ b/packages/components/progress-stepper/README.mdx
@@ -74,6 +74,16 @@ Example of the ProgressStepper with buttons to move between steps.
 
 ```
 
+### Horizontal Label Width Limitation
+
+When the ProgressStepper renders in the horizontal orientation with labels, the component will have extra width on the sides of the first and last steps.
+This extra width is necessary in order to accommodate the centering of the labels under each step.
+This example demonstrates this extra width so that consumers of this component can plan accordingly in designs, as the ProgressStepper component will not be the same width as the content area.
+
+```jsx file=./examples/ProgressStepperHorizontalWidthLimitation.tsx
+
+```
+
 ## Props (API reference)
 
 ### ProgressStepper

--- a/packages/components/progress-stepper/examples/ProgressStepperHorizontalWidthLimitation.tsx
+++ b/packages/components/progress-stepper/examples/ProgressStepperHorizontalWidthLimitation.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { ProgressStepper } from '@contentful/f36-progress-stepper';
+import { Box, Header } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+export default function ProgressStepperHorizontalWidthLimitation() {
+  const styles = {
+    root: css({
+      border: `1px solid ${tokens.gray300}`,
+    }),
+    stepperContainer: css({
+      padding: `${tokens.spacingS} 0`,
+    }),
+    headerContainer: css({
+      borderTop: `1px solid ${tokens.gray300}`,
+    }),
+  };
+
+  return (
+    <Box className={styles.root}>
+      <Box className={styles.stepperContainer}>
+        <ProgressStepper
+          activeStep={2}
+          ariaLabel="Horizontal progress stepper width limitation example"
+        >
+          <ProgressStepper.Step state="complete" labelText="Label 1" />
+          <ProgressStepper.Step state="complete" labelText="Label 2" />
+          <ProgressStepper.Step state="active" labelText="Label 3" />
+          <ProgressStepper.Step labelText="Label 4" />
+          <ProgressStepper.Step labelText="Label 5" />
+        </ProgressStepper>
+      </Box>
+      <Box className={styles.headerContainer}>
+        <Header title="Header within the same parent container" />
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

This PR adds to the website documentation for the ProgressStepper component by adding an example explaining the extra width that appears on the component when rendered in the horizontal orientation. We added a new example with borders to visually demonstrate this, as well as an explanation.

Screenshot of changes to the website:

<img width="764" alt="Screenshot 2024-10-29 at 4 22 10 PM" src="https://github.com/user-attachments/assets/5a134b7c-7d1b-4829-959e-2086555d8bca">

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
