### PR TITLE
fix(get-string-match): trim strings

### DIFF
--- a/.changeset/neat-kings-tie.md
+++ b/.changeset/neat-kings-tie.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-utils": patch
+---
+
+fix(get-string-match): trim strings

--- a/packages/components/utils/src/getStringMatch/getStringMatch.test.ts
+++ b/packages/components/utils/src/getStringMatch/getStringMatch.test.ts
@@ -1,7 +1,7 @@
 import { getStringMatch } from './getStringMatch';
 
 describe('getStringMatch', () => {
-  it('should return before, match, and after', () => {
+  it('returns before, match, and after', () => {
     const base = 'some test string';
     const match = 'test';
     expect(getStringMatch(base, match)).toEqual({
@@ -10,7 +10,7 @@ describe('getStringMatch', () => {
       after: ' string',
     });
   });
-  it('should work with special characters', () => {
+  it('works with special characters', () => {
     const base = 'string with regex characters (test)';
     const match = '(test';
     expect(getStringMatch(base, match)).toEqual({
@@ -19,12 +19,30 @@ describe('getStringMatch', () => {
       after: ')',
     });
   });
-  it('should work with any regex special character', () => {
+  it('works with any regex special character', () => {
     const base = '.*+?^${}()|[]\\';
     const characters = base.split('');
     characters.forEach((character) => {
       const { match } = getStringMatch(base, character);
       expect(match).toEqual(character);
+    });
+  });
+  it('works with whitespace', () => {
+    const base = 'Component - Author';
+    const match = 'author ';
+    expect(getStringMatch(base, match)).toEqual({
+      before: 'Component - ',
+      match: 'Author',
+      after: '',
+    });
+  });
+  it('ignores capitalisation', () => {
+    const base = 'Author';
+    const match = 'author';
+    expect(getStringMatch(base, match)).toEqual({
+      before: '',
+      match: base,
+      after: '',
     });
   });
 });

--- a/packages/components/utils/src/getStringMatch/getStringMatch.ts
+++ b/packages/components/utils/src/getStringMatch/getStringMatch.ts
@@ -16,7 +16,7 @@ export interface MatchObj {
  */
 export function getStringMatch(base: string, match: string): MatchObj {
   const matchResult = { before: '', match: '', after: '' };
-  const escapedMatch = match.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escapedMatch = match.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
   const regex = new RegExp(
     `(?<before>.*?)(?<match>${escapedMatch})(?<after>.*)`,


### PR DESCRIPTION
# Purpose of PR

There's a case where `getStringMatch` returns no matches 