### PR TITLE
feat(multiselect): handle items without match & trim search value

### DIFF
--- a/.changeset/neat-lizards-remember.md
+++ b/.changeset/neat-lizards-remember.md
@@ -2,4 +2,4 @@
 '@contentful/f36-multiselect': minor
 ---
 
-improve option text highlighting by trimming the search value
+improve option label highlighting by trimming the search value

--- a/.changeset/neat-lizards-remember.md
+++ b/.changeset/neat-lizards-remember.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-multiselect': minor
+---
+
+improve option text highlighting by trimming the search value

--- a/.changeset/proud-files-punch.md
+++ b/.changeset/proud-files-punch.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-multiselect': patch
+---
+
+show option if there is no match with the search value

--- a/.changeset/proud-files-punch.md
+++ b/.changeset/proud-files-punch.md
@@ -2,4 +2,4 @@
 '@contentful/f36-multiselect': patch
 ---
 
-show option if there is no match with the search value
+show option label if there is no match with the search value

--- a/packages/components/multiselect/src/Multiselect.test.tsx
+++ b/packages/components/multiselect/src/Multiselect.test.tsx
@@ -219,6 +219,46 @@ describe('Multiselect with search', () => {
     expect(screen.queryByText('No matches found')).not.toBeInTheDocument();
   });
 
+  it('trims search value', async () => {
+    const [{ user }] = renderComponent({
+      searchProps: {
+        onSearchValueChange: mockOnSearchValueChange,
+      },
+    });
+    await user.click(
+      screen.getByRole('button', { name: 'Toggle Multiselect' }),
+    );
+    const listFirstItem = screen.getByTestId('cf-multiselect-list-item-0');
+
+    await user.type(screen.getByRole('textbox', { name: 'Search' }), ' pp ');
+
+    expect(listFirstItem).toHaveTextContent('Apple');
+    expect(
+      within(listFirstItem).getByTestId('cf-multiselect-item-match'),
+    ).toHaveTextContent('pp');
+    expect(screen.queryByText('No matches found')).not.toBeInTheDocument();
+  });
+
+  it("renders item text without highlight, if search value doesn't match", async () => {
+    const [{ user }] = renderComponent({
+      searchProps: {
+        onSearchValueChange: mockOnSearchValueChange,
+      },
+    });
+    await user.click(
+      screen.getByRole('button', { name: 'Toggle Multiselect' }),
+    );
+    const listFirstItem = screen.getByTestId('cf-multiselect-list-item-0');
+
+    await user.type(screen.getByRole('textbox', { name: 'Search' }), 'Lemon');
+
+    expect(listFirstItem).toHaveTextContent('Apple');
+    expect(
+      within(listFirstItem).queryByTestId('cf-multiselect-item-match'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('No matches found')).not.toBeInTheDocument();
+  });
+
   it('shows the no matches found message when there are no elements', async () => {
     const [{ user }] = renderComponent(
       {

--- a/packages/components/multiselect/src/Multiselect.test.tsx
+++ b/packages/components/multiselect/src/Multiselect.test.tsx
@@ -239,7 +239,7 @@ describe('Multiselect with search', () => {
     expect(screen.queryByText('No matches found')).not.toBeInTheDocument();
   });
 
-  it("renders item text without highlight, if search value doesn't match", async () => {
+  it("renders option label without highlight, if search value doesn't match", async () => {
     const [{ user }] = renderComponent({
       searchProps: {
         onSearchValueChange: mockOnSearchValueChange,

--- a/packages/components/multiselect/src/MultiselectOption.tsx
+++ b/packages/components/multiselect/src/MultiselectOption.tsx
@@ -57,7 +57,12 @@ function HighlightedItem({
   item: string;
   inputValue?: string;
 }) {
-  const { before, match, after } = getStringMatch(item, inputValue);
+  const { before, match, after } = getStringMatch(item, inputValue.trim());
+
+  if (before.length + match.length + after.length === 0) {
+    return <>{item}</>;
+  }
+
   return (
     <>
       {before}


### PR DESCRIPTION
# Purpose of PR

Handles two edge cases:

1. When the search value doesn't match the option text

E.g. when an option with the label `Apple` is rendered while the search value is `Lemon`. Currently, the multiselect item is rendered without any label - only the checkbox. With this PR, the option option label is rendered without any highlighting.

2. The search value has leading or trailing white space

Currently,  when an option has the label `Apple` and the search value is ` pp ` (not the white space) only the checkbox is rendered without any text. With the fix mentioned above, `Apple` is rendered without any highlighting. By internally trimming the search value, `Apple` is rendered with `pp` highlighted.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
