### PR TITLE
fix: implement type safety fallback

### DIFF
--- a/packages/website/pages/[...slug].tsx
+++ b/packages/website/pages/[...slug].tsx
@@ -295,9 +295,12 @@ export const getStaticPaths: GetStaticPaths = async () => {
           ?.sectionCollection?.items[0];
     }
 
+    const sectionSlug = section?.slug ?? 'default-section';
+    const itemSlug = item?.slug ?? 'default-item';
     const slug = item.authProtected
-      ? [section.slug, 'protected', item.slug]
-      : [section.slug, item.slug];
+      ? [sectionSlug, 'protected', itemSlug]
+      : [sectionSlug, itemSlug];
+
     return {
       params: {
         slug,


### PR DESCRIPTION
With some package update, typescript errors got interpreted as more strict. This implements the slug handling in a typesafe way with fallbacks.
