### PR TITLE
fix: hide only endIcon when Button is in loading state

### DIFF
--- a/.changeset/thick-dolphins-hang.md
+++ b/.changeset/thick-dolphins-hang.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-button': patch
+---
+
+We keep startIcon visible even when isLoading flag is true, we replace only endIcon with loading icon

--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -66,27 +66,25 @@ function _Button<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
     };
 
     return (
-      !isLoading && (
-        <Flex
-          as="span"
-          className={styles.buttonIcon({ hasChildren: !!children, variant })}
-        >
-          {React.cloneElement(icon, {
-            size: icon.props.size ?? `${size === 'large' ? 'medium' : 'small'}`,
-            // We need to pass the color to the icons to enable the usaged of the V5 icons
-            // it may change in the future
-            color:
-              (variant === 'transparent' &&
-                icon.props.variant === undefined &&
-                icon.props.color) ||
-              'currentColor',
-            // we want to allow variants for icons for transparent buttons
-            variant:
-              (variant === 'transparent' && icon.props.variant) ||
-              defaultIconColor[variant],
-          })}
-        </Flex>
-      )
+      <Flex
+        as="span"
+        className={styles.buttonIcon({ hasChildren: !!children, variant })}
+      >
+        {React.cloneElement(icon, {
+          size: icon.props.size ?? `${size === 'large' ? 'medium' : 'small'}`,
+          // We need to pass the color to the icons to enable the usaged of the V5 icons
+          // it may change in the future
+          color:
+            (variant === 'transparent' &&
+              icon.props.variant === undefined &&
+              icon.props.color) ||
+            'currentColor',
+          // we want to allow variants for icons for transparent buttons
+          variant:
+            (variant === 'transparent' && icon.props.variant) ||
+            defaultIconColor[variant],
+        })}
+      </Flex>
     );
   };
 
@@ -98,7 +96,7 @@ function _Button<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
           {children}
         </Box>
       )}
-      {endIcon && iconContent(endIcon)}
+      {endIcon && !isLoading && iconContent(endIcon)}
       {isLoading && (
         <Box
           as="span"

--- a/packages/components/button/src/IconButton/IconButton.tsx
+++ b/packages/components/button/src/IconButton/IconButton.tsx
@@ -93,7 +93,8 @@ function _IconButton<
       variant={variant}
       className={cx(styles.iconButton, className)}
       size={size}
-      startIcon={icon}
+      // we pass the icon as endIcon prop to have it replaced with loading icon, when isLoading prop is true
+      endIcon={icon}
       aria-label={ariaLabel}
       {...otherProps}
     />


### PR DESCRIPTION
# Purpose of PR

- we don't need to hide `startIcon` when Button is in loading state.