### PR TITLE
fix: remove excluded package from changelog

### DIFF
--- a/.changeset/witty-chefs-itch.md
+++ b/.changeset/witty-chefs-itch.md
@@ -1,5 +1,4 @@
 ---
-"@contentful/f36-website": patch
 "@contentful/f36-button": patch
 ---
 


### PR DESCRIPTION
# Purpose of PR

In #2940, the generated changelog added the public website, which is excluded from releases.

This results in the IconButton components being blocked from being released.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
