### PR TITLE
feat: set Geist as default font

### DIFF
--- a/.changeset/proud-bottles-cover.md
+++ b/.changeset/proud-bottles-cover.md
@@ -1,0 +1,6 @@
+---
+'@contentful/f36-tokens': minor
+'@contentful/f36-core': minor
+---
+
+add Geist typeface as new default

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Make sure to remove any credential from your code before sharing it.
 ## License
 
 This repository is published under the [MIT](LICENSE.md) license.
+The [Geist](packages/cdn/public/fonts) typeface included in this repository is covered by its own [license](packages/cdn/public/fonts/geist-license.txt).
 
 ## Code of Conduct
 

--- a/packages/cdn/public/fonts/geist-license.txt
+++ b/packages/cdn/public/fonts/geist-license.txt
@@ -1,0 +1,92 @@
+Copyright (c) 2023 Vercel, in collaboration with basement.studio
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION AND CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+   in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+   redistributed and/or sold with any software, provided that each copy
+   contains the above copyright notice and this license. These can be
+   included either as stand-alone text files, human-readable headers or
+   in the appropriate machine-readable metadata fields within text or
+   binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+   Name(s) unless explicit written permission is granted by the corresponding
+   Copyright Holder. This restriction only applies to the primary font name as
+   presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+   Software shall not be used to promote, endorse or advertise any
+   Modified Version, except to acknowledge the contribution(s) of the
+   Copyright Holder(s) and the Author(s) or with their explicit written
+   permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+   must be distributed entirely under this license, and must not be
+   distributed under any other license. The requirement for fonts to
+   remain under this license does not apply to any document created
+   using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,3 +1,6 @@
 # @contentful/f36-core
 
 This package is part of [Forma-36](https://github.com/contentful/forma-36). See the repo for more details.
+
+The [Geist](packages/cdn/public/fonts) typeface referenced by this package is licensed under
+[OFL](https://github.com/contentful/forma-36/tree/main/packages/cdn/public/fonts/geist-license.txt).

--- a/packages/core/src/GlobalStyles/GlobalStyles.tsx
+++ b/packages/core/src/GlobalStyles/GlobalStyles.tsx
@@ -93,6 +93,16 @@ export const GlobalStyles = ({
     <Global
       styles={css`
         ${withNormalize ? cssReset : undefined};
+        @font-face {
+          font-family: 'Geist Mono';
+          src: url('https://cdn.f36.contentful.com/fonts/geist-mono-1.4.01.woff2');
+        }
+
+        @font-face {
+          font-family: 'Geist Sans';
+          src: url('https://cdn.f36.contentful.com/fonts/geist-sans-1.4.01.woff2');
+        }
+
         html {
           border: 0;
           box-sizing: border-box;
@@ -105,6 +115,7 @@ export const GlobalStyles = ({
           font-family: ${tokens.fontStackPrimary};
           font-size: ${tokens.fontSizeM};
           line-height: ${tokens.lineHeightM};
+          font-synthesis-weight: none;
         }
 
         code {

--- a/packages/forma-36-tokens/src/tokens/typography/font-stack.js
+++ b/packages/forma-36-tokens/src/tokens/typography/font-stack.js
@@ -1,8 +1,8 @@
 const fontStack = {
   'font-stack-primary':
-    '-apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol',
+    'Geist Sans, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol',
   'font-stack-monospace':
-    'SFMono-Regular, Consolas, Liberation Mono, Menlo,monospace',
+    'Geist Mono, SFMono-Regular, Consolas, Liberation Mono, Menlo,monospace',
 };
 
 module.exports = fontStack;

--- a/packages/website/content/tokens/typography.mdx
+++ b/packages/website/content/tokens/typography.mdx
@@ -11,14 +11,13 @@ Typography is a foundational element in UI design. Good typography establishes a
 
 Forma 36 enables users to create clean, efficient user interfaces that utilize system UI fonts.
 
-### System UI font family
+### Geist font family
 
-![Typefaces demonstration, San Francisco, Lucida Grande, Neue Helvetica, Arial, and Segoe UI](/docs-images/typeface.png)
+Forma 36 uses [Geist](https://vercel.com/font) by Vercel as the primary typeface in our font stack to establish a distinct and cohesive visual identity.
+Inspired by the Swiss design movement, it combines simplicity with excellent legibility.
+System fonts serve as fallbacks to ensure performance, compatibility, and accessibility.
 
-Forma 36 uses system UI fonts. System UI fonts refer to the fonts used to render text in the UI of an operating system. When used on the web they offer familiarity, load with zero-latency, and support a wide number of character sets.
-
-**San Francisco** appears on Safari (Mac OS X and iOS); **Neue Helvetica** and **Lucida Grande** appears on older versions of Mac OS X;
-**Segoe UI** targets Windows and Windows phone; **Arial** is available on almost all operating systems.
+The Geist font file is served from our CDN at **cdn.f36.contentful.com**.
 
 ### Typeface tokens
 


### PR DESCRIPTION
# Purpose of PR

Add Geist as new default font to both the primary and monospace font stacks.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
