### PR TITLE
fix: use gray500 instead of gray400

### DIFF
--- a/.changeset/loud-numbers-report.md
+++ b/.changeset/loud-numbers-report.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-avatar': patch
+---
+
+Improves contrast ratio of Avatar default border color.

--- a/packages/components/avatar/src/Avatar/utils.ts
+++ b/packages/components/avatar/src/Avatar/utils.ts
@@ -16,7 +16,7 @@ export const avatarColorMap = {
   orange: tokens.orange400,
   yellow: tokens.yellow500,
   purple: tokens.purple400,
-  gray: tokens.gray400,
+  gray: tokens.gray500,
   pink: '#FF77AE',
   emerald: '#00B8A2',
   lavender: '#9095FF',


### PR DESCRIPTION
Changes the color of the default Avatar Border from `gray400` to `gray500` for better contrast ratio

**Before**:
![image](https://github.com/user-attachments/assets/e03c2996-4d18-4b1a-a9f7-3b2993cb0565)


**After**
![image](https://github.com/user-attachments/assets/621994db-85da-4911-bb06-365e7a53deae)
