### PR TITLE
chore(CopyButton): enable dynamic `aria-label` values

### DIFF
--- a/.changeset/dull-brooms-begin.md
+++ b/.changeset/dull-brooms-begin.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-copybutton": patch
+---
+
+Enable dynamic `aria-label` values.

--- a/packages/components/copybutton/src/CopyButton.tsx
+++ b/packages/components/copybutton/src/CopyButton.tsx
@@ -64,7 +64,7 @@ function _CopyButton(
     onCopy,
     size = 'medium',
     testId = 'cf-ui-copy-button',
-    tooltipCopiedText = 'Copied!',
+    tooltipCopiedText = 'Value copied to clipboard',
     tooltipProps,
     tooltipText = 'Copy to clipboard',
     value,
@@ -119,9 +119,7 @@ function _CopyButton(
       isDisabled={isDisabled}
     >
       <Button
-        aria-label={
-          copied ? 'Value copied to clipboard' : label ?? `Copy to clipboard`
-        }
+        aria-label={copied ? tooltipCopiedText : label ?? tooltipText}
         aria-live="assertive"
         className={cx(styles.button, className)}
         isDisabled={isLoading || isDisabled}

--- a/packages/components/copybutton/stories/CopyButton.stories.tsx
+++ b/packages/components/copybutton/stories/CopyButton.stories.tsx
@@ -18,7 +18,7 @@ export const Default: Story<CopyButtonProps> = (args) => {
 
 Default.args = {
   value: 'Lorem Ipsum',
-  tooltipCopiedText: 'Copied!',
+  tooltipCopiedText: 'Value copied to clipboard',
   tooltipText: 'Copy to clipboard',
   onCopy: action('onCopy'),
   tooltipProps: {


### PR DESCRIPTION
# Purpose of PR

We want to prevent hardcoded strings for our components to be fully dynamic.

## Current proposal

I replaced the hardcoded `aria-label` strings with the `tooltipCopiedText` and `tooltipText` values, it made sense to reuse them to keep values in sync and prevent introducing more properties.

But, I also discovered there is a `label` prop in this component API which sets the `aria-label` value on the initial state (`Copy to clipboard`). In the current proposal, the `tooltipCopiedText` would be applied only if no `label` value is set.

## We have two options: 
- Deprecate the `label` property and solely rely on the tooltip props values.
- Be explicit about setting `aria-label` values and add another property for the copied state.

I am favorable of the first option but if we want to be explicit about how these values are set we could lean towards the second option.

Also, because we extend the default properties in most (if not all) of our components, one could already pass the `aria-label` property when using the component `<Foo aria-label="bar" />`, which we could access via `props['aria-label']`, so the `label` property wasn't necessary in the first place.

Finally, from a quick search, we also sometimes use a custom `ariaLabel` prop in some components. So we have a real mix of API taxonomy here 🫤 . We could soft-deprecate one and align on the same for all.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
