### PR TITLE
chore(Autocomplete): enable dynamic `aria-label` value

### DIFF
--- a/.changeset/lazy-bees-clap.md
+++ b/.changeset/lazy-bees-clap.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-autocomplete": patch
+---
+
+Enable dynamic `aria-label` value

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -183,6 +183,13 @@ export interface AutocompleteProps<ItemType>
    * Manually control when the button to clear the input value is shown
    */
   showClearButton?: boolean;
+  /**
+   * Additional aria attributes
+   */
+  aria?: {
+    showListIconLabel?: string;
+    clearSelectionIconLabel?: string;
+  };
 }
 
 function _Autocomplete<ItemType>(
@@ -227,6 +234,10 @@ function _Autocomplete<ItemType>(
     testId = 'cf-autocomplete',
     popoverTestId = 'cf-autocomplete-container',
     showClearButton: showClearButtonProp,
+    aria = {
+      clearSelectionIconLabel: 'Clear',
+      showListIconLabel: 'Show list',
+    },
   } = props;
 
   type GroupType = GenericGroupType<ItemType>;
@@ -410,7 +421,11 @@ function _Autocomplete<ItemType>(
             <IconButton
               {...toggleProps}
               ref={mergeRefs(toggleProps.ref, toggleRef)}
-              aria-label={showClearButton ? 'Clear' : 'Show list'}
+              aria-label={
+                showClearButton
+                  ? aria.clearSelectionIconLabel
+                  : aria.showListIconLabel
+              }
               className={styles.toggleButton}
               variant="transparent"
               icon={showClearButton ? <CloseIcon variant="muted" /> : icon}


### PR DESCRIPTION
# Purpose of PR

We want to prevent hardcoded strings so that our components are fully dynamic.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
