### PR TITLE
feat(calendar-dots-icon): adding calendar dots icon []

### DIFF
--- a/packages/components/icons/package.json
+++ b/packages/components/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-icons",
-  "version": "5.0.0-alpha.34",
+  "version": "5.0.0-alpha.35",
   "description": "Forma 36: Icon components",
   "license": "MIT",
   "exports": {

--- a/packages/components/icons/src/index.ts
+++ b/packages/components/icons/src/index.ts
@@ -37,6 +37,7 @@ export * from './vendor/phosphor/BookOpenIcon.js';
 export * from './vendor/phosphor/BookmarkSimpleIcon.js';
 export * from './vendor/phosphor/BracketsCurlyIcon.js';
 export * from './vendor/phosphor/CalendarBlankIcon.js';
+export * from './vendor/phosphor/CalendarDotsIcon.js';
 export * from './vendor/phosphor/CaretDownIcon.js';
 export * from './vendor/phosphor/CaretLeftIcon.js';
 export * from './vendor/phosphor/CaretRightIcon.js';

--- a/packages/components/icons/src/vendor/phosphor/CalendarDotsIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CalendarDotsIcon.tsx
@@ -1,0 +1,4 @@
+import { generateForma36Icon } from '@contentful/f36-icon-alpha';
+import { CalendarDots } from '@phosphor-icons/react';
+
+export const CalendarDotsIcon = generateForma36Icon(CalendarDots);


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

Adding the calendar dots icon from Phosphor

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
