### PR TITLE
feat(navbar): add purple variant to navbar switcher for trial spaces [ALT-1511]

### DIFF
--- a/packages/components/navbar/package.json
+++ b/packages/components/navbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-navbar",
-  "version": "5.0.0-alpha.41",
+  "version": "5.0.0-alpha.42",
   "description": "Forma 36: Navbar component",
   "scripts": {
     "build": "tsup"

--- a/packages/components/navbar/src/NavbarSwitcher/NavbarEnvVariant.tsx
+++ b/packages/components/navbar/src/NavbarSwitcher/NavbarEnvVariant.tsx
@@ -3,6 +3,7 @@ import { NavbarSwitcherProps } from '../NavbarSwitcher/NavbarSwitcher';
 import {
   EnvironmentAliasIcon,
   EnvironmentIcon,
+  FlaskIcon,
   RocketLaunchIcon,
 } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
@@ -19,6 +20,12 @@ export function NavbarEnvVariant({
   envVariant,
   className,
 }: NavbarEnvVariantProps) {
+  if (envVariant === 'trial') {
+    return (
+      <FlaskIcon color={tokens.purple700} className={className} size="medium" />
+    );
+  }
+
   const isMaster = envVariant === 'master';
   const color = isMaster ? tokens.green700 : tokens.orange700;
 
@@ -30,9 +37,7 @@ export function NavbarEnvVariant({
     return (
       <EnvironmentAliasIcon color={color} className={className} size="medium" />
     );
-  } else {
-    return (
-      <EnvironmentIcon color={color} className={className} size="medium" />
-    );
   }
+
+  return <EnvironmentIcon color={color} className={className} size="medium" />;
 }

--- a/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcher.styles.ts
+++ b/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcher.styles.ts
@@ -100,9 +100,10 @@ export const getNavbarIconColor = (variant: EnvVariant) => {
       return tokens.purple700;
     case 'non-master':
       return tokens.orange700;
+    default:
+      // Default to master variant
+      return tokens.green700;
   }
-  // Default for master
-  return tokens.green700;
 };
 
 const getEnvVariantColor = (variant: EnvVariant) => {
@@ -132,17 +133,18 @@ const getEnvVariantColor = (variant: EnvVariant) => {
           backgroundColor: tokens.orange200,
         },
       };
+    default:
+      // Default to master variant
+      return {
+        ...sharedStyles,
+        color: tokens.green700,
+        backgroundColor: tokens.green100,
+        border: `${BORDER_WIDTH}px solid ${tokens.green400}`,
+        '&:hover, &:active': {
+          backgroundColor: tokens.green200,
+        },
+      };
   }
-  // Default for master
-  return {
-    ...sharedStyles,
-    color: tokens.green700,
-    backgroundColor: tokens.green100,
-    border: `${BORDER_WIDTH}px solid ${tokens.green400}`,
-    '&:hover, &:active': {
-      backgroundColor: tokens.green200,
-    },
-  };
 };
 
 const getWrapperBackground = (variant: EnvVariant) => {
@@ -165,9 +167,10 @@ const getWrapperBackground = (variant: EnvVariant) => {
         )`,
         backgroundSize: '9px 9px',
       };
+    default:
+      // Default to master variant
+      return {
+        background: tokens.green300,
+      };
   }
-  // Default for master
-  return {
-    background: tokens.green300,
-  };
 };

--- a/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcher.styles.ts
+++ b/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcher.styles.ts
@@ -3,14 +3,11 @@ import tokens from '@contentful/f36-tokens';
 import { hexToRGBA } from '@contentful/f36-utils';
 
 import { getGlowOnFocusStyles, increaseHitArea, mqs } from '../utils.styles';
+import { EnvVariant } from './NavbarSwitcher';
 
 const BORDER_WIDTH = 1;
 
-export const getNavbarSwitcherStyles = ({
-  isMaster,
-}: {
-  isMaster: boolean;
-}) => ({
+export const getNavbarSwitcherStyles = (variant: EnvVariant) => ({
   navbarSwitcher: ({ showSpaceEnv }: { showSpaceEnv: boolean }) =>
     css(
       {
@@ -37,7 +34,7 @@ export const getNavbarSwitcherStyles = ({
           maxWidth: '600px',
         },
       },
-      showSpaceEnv && getEnvVariantColor(isMaster),
+      showSpaceEnv && getEnvVariantColor(variant),
       getGlowOnFocusStyles(),
       increaseHitArea(),
     ),
@@ -58,19 +55,7 @@ export const getNavbarSwitcherStyles = ({
         height: showSpaceEnv ? '26px' : 'unset',
         borderTopLeftRadius: `calc(${tokens.borderRadiusMedium} - ${BORDER_WIDTH}px)`,
         borderBottomLeftRadius: `calc(${tokens.borderRadiusMedium} - ${BORDER_WIDTH}px)`,
-        background: isMaster
-          ? tokens.green300
-          : `linear-gradient(
-          -45deg, 
-          ${tokens.orange300} 28.57%, 
-          transparent 28.57%, 
-          transparent 50%, 
-          ${tokens.orange300} 50%, 
-          ${tokens.orange300} 78.57%, 
-          transparent 78.57%, 
-          transparent 100%
-        )`,
-        backgroundSize: isMaster ? 'inherit' : '9px 9px',
+        ...getWrapperBackground(variant),
         backgroundPosition: 'bottom',
       }),
     }),
@@ -109,16 +94,80 @@ export const getNavbarSwitcherStyles = ({
   }),
 });
 
-const getEnvVariantColor = (isMaster: boolean) => ({
-  padding: '0',
-  paddingRight: tokens.spacingXs,
-  color: isMaster ? tokens.green700 : tokens.orange700,
-  backgroundColor: isMaster ? tokens.green100 : tokens.orange100,
-  border: `${BORDER_WIDTH}px solid ${
-    isMaster ? tokens.green400 : tokens.orange400
-  }`,
+export const getNavbarIconColor = (variant: EnvVariant) => {
+  switch (variant) {
+    case 'trial':
+      return tokens.purple700;
+    case 'non-master':
+      return tokens.orange700;
+  }
+  // Default for master
+  return tokens.green700;
+};
 
-  '&:hover, &:active': {
-    backgroundColor: isMaster ? tokens.green200 : tokens.orange200,
-  },
-});
+const getEnvVariantColor = (variant: EnvVariant) => {
+  const sharedStyles = {
+    padding: '0',
+    paddingRight: tokens.spacingXs,
+  };
+
+  switch (variant) {
+    case 'trial':
+      return {
+        ...sharedStyles,
+        color: tokens.purple700,
+        backgroundColor: tokens.purple100,
+        border: `${BORDER_WIDTH}px solid ${tokens.purple400}`,
+        '&:hover, &:active': {
+          backgroundColor: tokens.purple200,
+        },
+      };
+    case 'non-master':
+      return {
+        ...sharedStyles,
+        color: tokens.orange700,
+        backgroundColor: tokens.orange100,
+        border: `${BORDER_WIDTH}px solid ${tokens.orange400}`,
+        '&:hover, &:active': {
+          backgroundColor: tokens.orange200,
+        },
+      };
+  }
+  // Default for master
+  return {
+    ...sharedStyles,
+    color: tokens.green700,
+    backgroundColor: tokens.green100,
+    border: `${BORDER_WIDTH}px solid ${tokens.green400}`,
+    '&:hover, &:active': {
+      backgroundColor: tokens.green200,
+    },
+  };
+};
+
+const getWrapperBackground = (variant: EnvVariant) => {
+  switch (variant) {
+    case 'trial':
+      return {
+        background: tokens.purple300,
+      };
+    case 'non-master':
+      return {
+        background: `linear-gradient(
+          -45deg,
+          ${tokens.orange300} 28.57%,
+          transparent 28.57%,
+          transparent 50%,
+          ${tokens.orange300} 50%,
+          ${tokens.orange300} 78.57%,
+          transparent 78.57%,
+          transparent 100%
+        )`,
+        backgroundSize: '9px 9px',
+      };
+  }
+  // Default for master
+  return {
+    background: tokens.green300,
+  };
+};

--- a/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcher.tsx
+++ b/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcher.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { getNavbarSwitcherStyles } from './NavbarSwitcher.styles';
+import {
+  getNavbarIconColor,
+  getNavbarSwitcherStyles,
+} from './NavbarSwitcher.styles';
 import { Button } from '@contentful/f36-button';
 import {
   Flex,
@@ -12,9 +15,8 @@ import { NavbarEnvVariant } from './NavbarEnvVariant';
 import { NavbarSwitcherSkeleton } from './NavbarSwitcherSkeleton';
 import { CaretRightIcon } from '@contentful/f36-icons';
 import { Text } from '@contentful/f36-typography';
-import tokens from '@contentful/f36-tokens';
 
-export type EnvVariant = 'master' | 'non-master';
+export type EnvVariant = 'master' | 'non-master' | 'trial';
 
 type NavbarLoadingProps =
   | {
@@ -59,8 +61,7 @@ function _NavbarSwitcher(
     isLoading,
     ...otherProps
   } = props;
-  const isMaster = envVariant === 'master';
-  const styles = getNavbarSwitcherStyles({ isMaster });
+  const styles = getNavbarSwitcherStyles(envVariant);
 
   return (
     <Button
@@ -102,7 +103,7 @@ function _NavbarSwitcher(
                     <Flex className={styles.switcherCaret}>
                       <CaretRightIcon
                         size="tiny"
-                        color={isMaster ? tokens.green700 : tokens.orange700}
+                        color={getNavbarIconColor(envVariant)}
                       />
                     </Flex>
                     <Text className={styles.switcherLabel}>{environment}</Text>

--- a/packages/components/navbar/stories/Navbar.stories.tsx
+++ b/packages/components/navbar/stories/Navbar.stories.tsx
@@ -603,6 +603,21 @@ export const WithDifferentEnvironments: Story<{
           account={<Account {...args} />}
         />
       </Flex>
+
+      <Flex flexDirection="column">
+        <SectionHeading as="h3" marginBottom="spacingS">
+          Trial
+        </SectionHeading>
+
+        <Navbar
+          mobileNavigation={<MobileMenu />}
+          mainNavigation={<MainItems />}
+          switcher={
+            <Switcher envVariant="trial" space="Trial" environment="master" />
+          }
+          account={<Account {...args} />}
+        />
+      </Flex>
     </Flex>
   );
 };


### PR DESCRIPTION
# Purpose of PR

As part of the Studio Trials work, we are adding a new purple "trial" variant to the navbar switcher:

Normal state:

![Screenshot 2025-01-03 at 10 52 52 AM](https://github.com/user-attachments/assets/1ca705e4-fea2-48c5-b361-2264d34136a0)

Hover state:

![Screenshot 2025-01-03 at 10 55 02 AM](https://github.com/user-attachments/assets/77ce2300-47ae-4ab5-b717-064e4242f653)

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
