### PR TITLE
fix(menu): don’t focus menu if menu has just been removed

### DIFF
--- a/.changeset/seven-mails-kiss.md
+++ b/.changeset/seven-mails-kiss.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-menu': patch
+---
+
+Don’t focus menu if menu has just been removed

--- a/packages/components/menu/src/Menu.tsx
+++ b/packages/components/menu/src/Menu.tsx
@@ -103,7 +103,7 @@ export function Menu(props: MenuProps) {
         }, 0);
       } else {
         setTimeout(() => {
-          menuListRef.current.focus({ preventScroll: false });
+          menuListRef.current?.focus({ preventScroll: false });
         }, 0);
       }
     }


### PR DESCRIPTION
# Purpose of PR

Fix edge case where a menu is opened and removed from the DOM at the same time before we can focus it in the next tick.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
