### PR TITLE
feat: Allow overriding onClick of ProgressStepper on child Steps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43397,7 +43397,7 @@
     },
     "packages/components/progress-stepper": {
       "name": "@contentful/f36-progress-stepper",
-      "version": "4.0.0-alpha.3",
+      "version": "4.0.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-button": "^4.77.3",
@@ -47225,7 +47225,7 @@
         "@contentful/f36-layout": "^4.0.0-alpha.0",
         "@contentful/f36-multiselect": "^4.25.0",
         "@contentful/f36-navlist": "4.1.0-alpha.2",
-        "@contentful/f36-progress-stepper": "4.0.0-alpha.3",
+        "@contentful/f36-progress-stepper": "4.0.0-alpha.4",
         "@contentful/f36-tokens": "^4.2.0",
         "@contentful/f36-utils": "^4.24.3",
         "@contentful/rich-text-react-renderer": "^16.0.0",
@@ -53998,7 +53998,7 @@
         "@contentful/f36-layout": "^4.0.0-alpha.0",
         "@contentful/f36-multiselect": "^4.25.0",
         "@contentful/f36-navlist": "4.1.0-alpha.2",
-        "@contentful/f36-progress-stepper": "4.0.0-alpha.3",
+        "@contentful/f36-progress-stepper": "4.0.0-alpha.4",
         "@contentful/f36-tokens": "^4.2.0",
         "@contentful/f36-utils": "^4.24.3",
         "@contentful/rich-text-react-renderer": "^16.0.0",
@@ -54047,17 +54047,6 @@
         "wait-on": "^6.0.0"
       },
       "dependencies": {
-        "@contentful/f36-progress-stepper": {
-          "version": "https://npm.pkg.github.com/download/@contentful/f36-progress-stepper/4.0.0-alpha.2/33b18d08be0cf1b05a2e719b46d542be36cd32fb",
-          "integrity": "sha512-Czq6Px4wG8lVceI3flAcprMq7h00BUhy3ELdqtB2k27aPnkaXIjxWW29tDpyosQ2zYMyLxT2g6uHEJgsqqOm5A==",
-          "requires": {
-            "@contentful/f36-core": "^4.71.0",
-            "@contentful/f36-icons": "^4.29.0",
-            "@contentful/f36-tokens": "^4.0.0",
-            "@contentful/f36-typography": "^4.71.0",
-            "emotion": "^10.0.17"
-          }
-        },
         "@contentful/rich-text-react-renderer": {
           "version": "16.0.0",
           "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-react-renderer/16.0.0/6d3f7d594bb9149acf88f9c1b2190475603b0967",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6520,13 +6520,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@mdx-js/mdx/node_modules/@babel/plugin-syntax-jsx/node_modules/@babel/helper-plugin-utils": {
-      "version": "7.18.9",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@mdx-js/mdx/node_modules/babel-plugin-apply-mdx-type-prop": {
       "version": "1.6.22",
       "license": "MIT",
@@ -36267,13 +36260,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/remark-mdx/node_modules/@babel/plugin-proposal-object-rest-spread/node_modules/@babel/helper-plugin-utils": {
-      "version": "7.18.9",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/remark-mdx/node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.12.1",
       "license": "MIT",
@@ -36282,13 +36268,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/remark-mdx/node_modules/@babel/plugin-syntax-jsx/node_modules/@babel/helper-plugin-utils": {
-      "version": "7.18.9",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/remark-mdx/node_modules/bail": {
@@ -47246,7 +47225,7 @@
         "@contentful/f36-layout": "^4.0.0-alpha.0",
         "@contentful/f36-multiselect": "^4.25.0",
         "@contentful/f36-navlist": "4.1.0-alpha.2",
-        "@contentful/f36-progress-stepper": "4.0.0-alpha.2",
+        "@contentful/f36-progress-stepper": "4.0.0-alpha.3",
         "@contentful/f36-tokens": "^4.2.0",
         "@contentful/f36-utils": "^4.24.3",
         "@contentful/rich-text-react-renderer": "^16.0.0",
@@ -47295,22 +47274,6 @@
         "prettier": "^2.8.8",
         "ts-node": "^10.9.1",
         "wait-on": "^6.0.0"
-      }
-    },
-    "packages/website/node_modules/@contentful/f36-progress-stepper": {
-      "version": "4.0.0-alpha.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-progress-stepper/4.0.0-alpha.2/33b18d08be0cf1b05a2e719b46d542be36cd32fb",
-      "integrity": "sha512-Czq6Px4wG8lVceI3flAcprMq7h00BUhy3ELdqtB2k27aPnkaXIjxWW29tDpyosQ2zYMyLxT2g6uHEJgsqqOm5A==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.71.0",
-        "@contentful/f36-icons": "^4.29.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.71.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
       }
     },
     "packages/website/node_modules/@contentful/rich-text-react-renderer": {
@@ -54035,7 +53998,7 @@
         "@contentful/f36-layout": "^4.0.0-alpha.0",
         "@contentful/f36-multiselect": "^4.25.0",
         "@contentful/f36-navlist": "4.1.0-alpha.2",
-        "@contentful/f36-progress-stepper": "4.0.0-alpha.2",
+        "@contentful/f36-progress-stepper": "4.0.0-alpha.3",
         "@contentful/f36-tokens": "^4.2.0",
         "@contentful/f36-utils": "^4.24.3",
         "@contentful/rich-text-react-renderer": "^16.0.0",
@@ -54085,8 +54048,7 @@
       },
       "dependencies": {
         "@contentful/f36-progress-stepper": {
-          "version": "4.0.0-alpha.2",
-          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-progress-stepper/4.0.0-alpha.2/33b18d08be0cf1b05a2e719b46d542be36cd32fb",
+          "version": "https://npm.pkg.github.com/download/@contentful/f36-progress-stepper/4.0.0-alpha.2/33b18d08be0cf1b05a2e719b46d542be36cd32fb",
           "integrity": "sha512-Czq6Px4wG8lVceI3flAcprMq7h00BUhy3ELdqtB2k27aPnkaXIjxWW29tDpyosQ2zYMyLxT2g6uHEJgsqqOm5A==",
           "requires": {
             "@contentful/f36-core": "^4.71.0",
@@ -55728,11 +55690,6 @@
           "version": "7.12.1",
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.18.9"
-            }
           }
         },
         "babel-plugin-apply-mdx-type-prop": {
@@ -75811,22 +75768,12 @@
             "@babel/helper-plugin-utils": "^7.10.4",
             "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
             "@babel/plugin-transform-parameters": "^7.12.1"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.18.9"
-            }
           }
         },
         "@babel/plugin-syntax-jsx": {
           "version": "7.12.1",
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
-          },
-          "dependencies": {
-            "@babel/helper-plugin-utils": {
-              "version": "7.18.9"
-            }
           }
         },
         "bail": {

--- a/packages/components/progress-stepper/README.mdx
+++ b/packages/components/progress-stepper/README.mdx
@@ -82,6 +82,14 @@ Example of the ProgressStepper with clickable steps.
 
 ```
 
+### Only previous steps clickable Example
+
+Example of the ProgressStepper with only previous steps clickable.
+
+```jsx file=./examples/ProgressStepperOnlyPreviousStepsClickableExample.tsx
+
+```
+
 ### Horizontal Label Width Limitation
 
 When the ProgressStepper renders in the horizontal orientation with labels, the component will have extra width on the sides of the first and last steps.

--- a/packages/components/progress-stepper/examples/ProgressStepperOnlyPreviousStepsClickableExample.tsx
+++ b/packages/components/progress-stepper/examples/ProgressStepperOnlyPreviousStepsClickableExample.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { ProgressStepper } from '@contentful/f36-progress-stepper';
 
-export default function ProgressStepperClickableExample() {
+export default function ProgressStepperOnlyPreviousStepsClickableExample() {
   const [activeStep, setActiveStep] = useState(2);
 
   const handleStepClick = (stepNumber) => {
@@ -28,8 +28,14 @@ export default function ProgressStepperClickableExample() {
 
   const getSteps = () => {
     return steps.map((step, index) => {
+      const onClickStep =
+        activeStep > index
+          ? (stepIndex) => handleStepClick(stepIndex)
+          : undefined;
+
       return React.cloneElement(step, {
         state: getStepState(index),
+        onClick: onClickStep,
       });
     });
   };
@@ -38,7 +44,6 @@ export default function ProgressStepperClickableExample() {
     <ProgressStepper
       activeStep={activeStep}
       ariaLabel="Clickable progress stepper"
-      onClick={(stepNumber) => handleStepClick(stepNumber)}
     >
       {getSteps()}
     </ProgressStepper>

--- a/packages/components/progress-stepper/package.json
+++ b/packages/components/progress-stepper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-progress-stepper",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0-alpha.4",
   "description": "Forma 36: ProgressStepper component",
   "scripts": {
     "build": "tsup"

--- a/packages/components/progress-stepper/src/CompoundProgressStepper.test.tsx
+++ b/packages/components/progress-stepper/src/CompoundProgressStepper.test.tsx
@@ -101,4 +101,18 @@ describe('CompoundProgressStepper', function () {
 
     expect(links).toHaveLength(3);
   });
+
+  it('renders only a set of steps as clickable', () => {
+    render(
+      <ProgressStepper ariaLabel="Clickable progress stepper" activeStep={1}>
+        <ProgressStepper.Step state="complete" onClick={() => {}} />
+        <ProgressStepper.Step state="error" />
+        <ProgressStepper.Step state="warning" />
+      </ProgressStepper>,
+    );
+
+    const links = screen.queryAllByRole('button');
+
+    expect(links).toHaveLength(1);
+  });
 });

--- a/packages/components/progress-stepper/src/ProgressStepper.tsx
+++ b/packages/components/progress-stepper/src/ProgressStepper.tsx
@@ -60,6 +60,7 @@ function _ProgressStepper(
         key: `steps-rendered-${index}`,
         stepNumber: index,
         onClick,
+        ...(child as React.ReactElement).props,
       });
       return stepChild;
     });

--- a/packages/website/components/Playground/SandpackRenderer.tsx
+++ b/packages/website/components/Playground/SandpackRenderer.tsx
@@ -98,7 +98,7 @@ export function SandpackRenderer({
           '@contentful/f36-layout': '^4.0.0-alpha.0', // Remove when added to f36-components
           '@contentful/f36-multiselect': '^4.0.0', // Remove when added to f36-components
           '@contentful/f36-navlist': '^4.1.0-alpha.0', // Remove when added to f36-components
-          '@contentful/f36-progress-stepper': '^4.0.0-alpha.3', // Remove when added to f36-components
+          '@contentful/f36-progress-stepper': '^4.0.0-alpha.4', // Remove when added to f36-components
           '@contentful/f36-tokens': '^4.0.0',
           '@contentful/f36-icons': '^4.0.0',
           '@contentful/f36-core': '^4.0.0',

--- a/packages/website/components/Playground/SandpackRenderer.tsx
+++ b/packages/website/components/Playground/SandpackRenderer.tsx
@@ -98,7 +98,7 @@ export function SandpackRenderer({
           '@contentful/f36-layout': '^4.0.0-alpha.0', // Remove when added to f36-components
           '@contentful/f36-multiselect': '^4.0.0', // Remove when added to f36-components
           '@contentful/f36-navlist': '^4.1.0-alpha.0', // Remove when added to f36-components
-          '@contentful/f36-progress-stepper': '^4.0.0-alpha.2', // Remove when added to f36-components
+          '@contentful/f36-progress-stepper': '^4.0.0-alpha.3', // Remove when added to f36-components
           '@contentful/f36-tokens': '^4.0.0',
           '@contentful/f36-icons': '^4.0.0',
           '@contentful/f36-core': '^4.0.0',

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -21,7 +21,7 @@
     "@contentful/f36-layout": "^4.0.0-alpha.0",
     "@contentful/f36-multiselect": "^4.25.0",
     "@contentful/f36-navlist": "4.1.0-alpha.2",
-    "@contentful/f36-progress-stepper": "4.0.0-alpha.2",
+    "@contentful/f36-progress-stepper": "4.0.0-alpha.3",
     "@contentful/f36-tokens": "^4.2.0",
     "@contentful/f36-utils": "^4.24.3",
     "@contentful/rich-text-react-renderer": "^16.0.0",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -21,7 +21,7 @@
     "@contentful/f36-layout": "^4.0.0-alpha.0",
     "@contentful/f36-multiselect": "^4.25.0",
     "@contentful/f36-navlist": "4.1.0-alpha.2",
-    "@contentful/f36-progress-stepper": "4.0.0-alpha.3",
+    "@contentful/f36-progress-stepper": "4.0.0-alpha.4",
     "@contentful/f36-tokens": "^4.2.0",
     "@contentful/f36-utils": "^4.24.3",
     "@contentful/rich-text-react-renderer": "^16.0.0",


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

To allow client to use the `onClick` functionality with a bit more of flexibility, I am forwarding now all props from child component to the cloned Step. 
In this way, now it is possible to instead of adding a global `onClick` to have it on `Step` level, allowing us to control for example that **only previous steps are clickable**.

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
