### PR TITLE
chore: adjust the Chromatic anti-aliasing-threshold

### DIFF
--- a/scripts/.storybook/preview.js
+++ b/scripts/.storybook/preview.js
@@ -38,4 +38,7 @@ export const parameters = {
     hideNoControlsWarning: true,
     sort: 'requiredFirst',
   },
+  chromatic: {
+    diffThreshold: 0.8,
+  },
 };


### PR DESCRIPTION
# Purpose of PR

The asset used in our stories started to get false positives in Chromatic, this is due to anti-aliasing and can be adjusted via the `diffThreshold` [property](https://www.chromatic.com/docs/threshold).

If this does not help, the solution will be to update the asset for another one with a plain color.