### PR TITLE
fix(EntityListItem): skeleton loader height, drag handle, and card wrapping

### DIFF
--- a/.changeset/wicked-chefs-doubt.md
+++ b/.changeset/wicked-chefs-doubt.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-entity-list": patch
+---
+
+fix(EntityListItem): skeleton loader height, drag handle shrinking, and card action and badge wrapping

--- a/packages/components/entity-list/src/EntityListItem/EntityListItem.styles.ts
+++ b/packages/components/entity-list/src/EntityListItem/EntityListItem.styles.ts
@@ -25,6 +25,7 @@ export const getEntityListItemStyles = () => ({
     css({
       display: 'flex',
       textDecoration: 'none',
+      minWidth: 0,
       width: '100%',
       minHeight: tokens.spacing3Xl,
       padding: tokens.spacingXs,

--- a/packages/components/entity-list/src/EntityListItem/EntityListItem.tsx
+++ b/packages/components/entity-list/src/EntityListItem/EntityListItem.tsx
@@ -178,7 +178,10 @@ export const EntityListItem = ({
       {renderCardDragHandle()}
       {isLoading ? (
         <article className={styles.card(false)}>
-          <Skeleton.Container clipId="f36-entity-list-item-skeleton">
+          <Skeleton.Container
+            svgHeight={46}
+            clipId="f36-entity-list-item-skeleton"
+          >
             <Skeleton.Image height={46} width={46} />
             <Skeleton.BodyText
               numberOfLines={2}

--- a/packages/components/entity-list/stories/EntityList.stories.tsx
+++ b/packages/components/entity-list/stories/EntityList.stories.tsx
@@ -7,6 +7,13 @@ import { MenuItem, MenuSectionTitle } from '@contentful/f36-components';
 export default {
   title: 'Components/EntityList/EntityList',
   component: EntityList,
+  decorators: [
+    (StoryComponent) => (
+      <div style={{ maxWidth: '600px' }}>
+        <StoryComponent />
+      </div>
+    ),
+  ],
   argTypes: {
     className: { control: { disable: true } },
     testId: { control: { disable: true } },
@@ -91,10 +98,11 @@ export const withDragHandle = () => (
       contentType="My content type"
       status="published"
       withDragHandle
+      isLoading
     />
     <EntityList.Item
       title="Entry 2"
-      description="Description"
+      description="This is a long description to showcase what happens when we are running out of space."
       contentType="My content type"
       status="draft"
       withDragHandle


### PR DESCRIPTION
# Purpose of PR

Fixes issues with the EntityListItem component where:

- The skeleton loader height would be too big
- The drag handle would shrink when texts are too long
- The badge and the action menu were cut off when texts were too long

| - | Before | After |
|--------|--------|--------|
| Action menu (missing) | <img width="428" alt="basic-wrap-before" src="https://github.com/user-attachments/assets/85537c9c-a977-4c54-bdb6-e044b25ca71c" /> | <img width="426" alt="basic-wrap-after" src="https://github.com/user-attachments/assets/073a3138-310e-4bc2-9500-259ed126674a" /> |
| Skeleton, badge, drag handle | <img width="623" alt="drag-wrap-before" src="https://github.com/user-attachments/assets/4218a477-7413-43e6-b6e1-377dcf131759" /> | <img width="423" alt="drag-wrap-after" src="https://github.com/user-attachments/assets/5d98aacc-4275-4cdf-a784-1108c6078a5d" /> | 

## Additional updates

The component is now wrapped with a max width in the story to showcase the truncation and wrapping effects and prevent further regression.

## Further work down the road

There is still a mismatch between the component styling and iconography with the Figma library that we need to revisit.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
