### PR TITLE
chore: filter out Dependabot from CDN deploy workflow

### DIFF
--- a/.github/workflows/deploy-cdn.yml
+++ b/.github/workflows/deploy-cdn.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Purpose of PR

Because Dependabot can't access the `FASTLY_API_TOKEN` secret, the workflow fails on all Dependabot merges to `main` and creates a lot of noise in our ci alerting channel.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
