### PR TITLE
fix: unify dropdown styles [UFO-1572]

### DIFF
--- a/packages/components/autocomplete/src/Autocomplete.styles.ts
+++ b/packages/components/autocomplete/src/Autocomplete.styles.ts
@@ -28,7 +28,7 @@ export const getAutocompleteStyles = (listMaxHeight: number) => ({
   }),
   list: css({
     listStyle: 'none',
-    padding: `${tokens.spacingXs} 0`,
+    padding: `${tokens.spacingXs} ${tokens.spacing2Xs}`,
     margin: 0,
   }),
   groupTitle: css({
@@ -41,17 +41,23 @@ export const getAutocompleteStyles = (listMaxHeight: number) => ({
   }),
   item: css({
     display: 'block',
-    padding: `${tokens.spacingXs} ${tokens.spacingM}`,
+    // Magic number to get a height of 32px on the item
+    padding: `6px ${tokens.spacingXs}`,
     wordBreak: 'break-word',
     whiteSpace: 'break-spaces',
     cursor: 'pointer',
     hyphens: 'auto',
-
+    color: tokens.gray700,
+    borderRadius: tokens.borderRadiusSmall,
+    fontSize: tokens.fontSizeM,
+    lineHeight: tokens.lineHeightM,
+    fontWeight: tokens.fontWeightNormal,
     '&:focus, &:hover': {
       backgroundColor: tokens.gray100,
     },
     '&:active': {
       backgroundColor: tokens.gray200,
+      color: tokens.gray900,
     },
   }),
   disabled: css({

--- a/packages/components/autocomplete/src/Autocomplete.styles.ts
+++ b/packages/components/autocomplete/src/Autocomplete.styles.ts
@@ -1,5 +1,6 @@
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import tokens from '@contentful/f36-tokens';
+import { getMenuItemStyles } from '@contentful/f36-core';
 
 export const getAutocompleteStyles = (listMaxHeight: number) => ({
   autocomplete: css({
@@ -39,34 +40,13 @@ export const getAutocompleteStyles = (listMaxHeight: number) => ({
     color: tokens.gray500,
     margin: `${tokens.spacingM} 0 ${tokens.spacingM} 0`,
   }),
-  item: css({
-    display: 'block',
-    // Magic number to get a height of 32px on the item
-    padding: `6px ${tokens.spacingXs}`,
-    wordBreak: 'break-word',
-    whiteSpace: 'break-spaces',
-    cursor: 'pointer',
-    hyphens: 'auto',
-    color: tokens.gray700,
-    borderRadius: tokens.borderRadiusSmall,
-    fontSize: tokens.fontSizeM,
-    lineHeight: tokens.lineHeightM,
-    fontWeight: tokens.fontWeightNormal,
-    '&:focus, &:hover': {
-      backgroundColor: tokens.gray100,
-    },
-    '&:active': {
-      backgroundColor: tokens.gray200,
-      color: tokens.gray900,
-    },
-  }),
-  disabled: css({
-    opacity: 0.5,
-    pointerEvents: 'none',
-  }),
-  highlighted: css({
-    backgroundColor: tokens.gray100,
-  }),
+  item: ({
+    isActive = false,
+    isDisabled = false,
+  }: {
+    isActive?: boolean;
+    isDisabled?: boolean;
+  }) => cx(getMenuItemStyles({ isActive, isDisabled })),
   hidden: css({
     display: 'none',
   }),

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -451,13 +451,16 @@ function _Autocomplete<ItemType>(
           >
             {isLoading &&
               [...Array(3)].map((_, index) => (
-                <div key={index} className={cx(styles.item, styles.disabled)}>
+                <div
+                  key={index}
+                  className={cx(styles.item({ isDisabled: true }))}
+                >
                   <ListItemLoadingState />
                 </div>
               ))}
 
             {!isLoading && isShowingNoMatches && (
-              <div className={styles.item}>
+              <div className={styles.item({})}>
                 <Subheading className={styles.noMatchesTitle}>
                   {noMatchesMessage}
                 </Subheading>

--- a/packages/components/autocomplete/src/AutocompleteItems.tsx
+++ b/packages/components/autocomplete/src/AutocompleteItems.tsx
@@ -43,10 +43,7 @@ export const AutocompleteItems = <ItemType,>(
             {...itemProps}
             as="li"
             key={itemIndex}
-            className={cx([
-              styles.item,
-              highlightedIndex === itemIndex && styles.highlighted,
-            ])}
+            className={cx([styles.item({})])}
             data-test-id={`cf-autocomplete-list-item-${itemIndex}`}
           >
             {renderItem ? (

--- a/packages/components/autocomplete/stories/Autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/Autocomplete.stories.tsx
@@ -85,7 +85,7 @@ export const Basic = (args: AutocompleteProps<string>) => {
 
   return (
     <Stack
-      style={{ width: '150px' }}
+      style={{ width: '180px' }}
       flexDirection="column"
       spacing="spacingM"
       alignItems="start"

--- a/packages/components/menu/src/MenuItem/MenuItem.styles.ts
+++ b/packages/components/menu/src/MenuItem/MenuItem.styles.ts
@@ -1,22 +1,7 @@
-import { css, type ObjectInterpolation } from 'emotion';
-import tokens from '@contentful/f36-tokens';
+import { css, cx } from 'emotion';
+import { getMenuItemStyles as globalGetMenuItemStyles } from '@contentful/f36-core';
 import type { MenuItemProps } from './MenuItem';
-
-const activeStyle: ObjectInterpolation<undefined> = {
-  backgroundColor: tokens.gray200,
-  fontWeight: tokens.fontWeightMedium,
-  '&:hover': {
-    backgroundColor: tokens.gray200,
-  },
-};
-
-const disabledStyle: ObjectInterpolation<undefined> = {
-  opacity: 0.5,
-  cursor: 'auto',
-  '&:hover': {
-    backgroundColor: 'unset',
-  },
-};
+import tokens from '@contentful/f36-tokens';
 
 export const getMenuItemStyles = ({
   isActive,
@@ -24,59 +9,12 @@ export const getMenuItemStyles = ({
 }: {
   isActive: MenuItemProps['isActive'];
   isDisabled: MenuItemProps['isDisabled'];
-}) => {
-  return {
-    root: css(
-      [
-        {
-          alignItems: 'center',
-          gap: tokens.spacingXs,
-          display: 'flex',
-          width: `calc(100% - 2 * ${tokens.spacing2Xs})`,
-          background: 'none',
-          border: 0,
-          borderRadius: tokens.borderRadiusMedium,
-          margin: `0 ${tokens.spacing2Xs}`,
-          outline: 'none',
-          fontSize: tokens.fontSizeM,
-          lineHeight: tokens.lineHeightM,
-          fontWeight: tokens.fontWeightNormal,
-          position: 'relative',
-          textAlign: 'left',
-          // Magic number to get a height of 32px on the item
-          padding: `6px ${tokens.spacingXs}`,
-          wordBreak: 'break-word',
-          whiteSpace: 'break-spaces',
-          cursor: 'pointer',
-          hyphens: 'auto',
-          minWidth: '150px',
-          textDecoration: 'none',
-          color: tokens.gray900,
-
-          '[role="menuitem"] + &': {
-            marginTop: '2px',
-          },
-
-          '&:hover': {
-            backgroundColor: tokens.gray100,
-          },
-          '&:focus': {
-            boxShadow: `inset ${tokens.glowPrimary}`,
-          },
-          '&:focus:not(:focus-visible)': {
-            boxShadow: 'unset',
-          },
-          '&:focus-visible': {
-            boxShadow: `inset ${tokens.glowPrimary}`,
-          },
-          '&:active': {
-            backgroundColor: tokens.gray200,
-          },
-          '&:disabled': disabledStyle,
-        },
-      ],
-      isActive && activeStyle,
-      isDisabled && disabledStyle,
-    ),
-  };
-};
+}) =>
+  cx(
+    globalGetMenuItemStyles({ isActive, isDisabled }),
+    css({
+      width: `calc(100% - 2 * ${tokens.spacing2Xs})`,
+      margin: `0 ${tokens.spacing2Xs}`,
+      gap: tokens.spacingXs,
+    }),
+  );

--- a/packages/components/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/components/menu/src/MenuItem/MenuItem.tsx
@@ -76,7 +76,7 @@ function _MenuItem<E extends React.ElementType = typeof MENU_ITEM_DEFAULT_TAG>(
       {...otherProps}
       {...getMenuItemProps(otherProps)}
       disabled={isDisabled ?? props.disabled}
-      className={cx(styles.root, className)}
+      className={cx(styles, className)}
       data-test-id={itemTestId}
       ref={mergeRefs(itemRef, ref)}
       tabIndex={-1}

--- a/packages/components/multiselect/src/Multiselect.styles.ts
+++ b/packages/components/multiselect/src/Multiselect.styles.ts
@@ -1,5 +1,6 @@
-import { css } from 'emotion';
+import { css, cx } from 'emotion';
 import tokens from '@contentful/f36-tokens';
+import { getMenuItemStyles } from '@contentful/f36-core';
 
 export const getMultiselectStyles = () => ({
   multiselect: css({
@@ -89,50 +90,23 @@ export const getMultiselectStyles = () => ({
     margin: '1px 0',
   }),
   optionText: css({
-    color: tokens.gray700,
-    '&:active': {
-      color: tokens.gray900,
-    },
     b: {
       color: tokens.gray900,
     },
   }),
-  optionCheck: css({
-    label: {
-      // Magic number to get a height of 32px on the item
-      padding: `6px ${tokens.spacingXs}`,
-      width: '100%',
-      wordBreak: 'break-word',
-      whiteSpace: 'break-spaces',
-      hyphens: 'auto',
-      display: 'flex',
-      flexDirection: 'row',
-      alignItems: 'center',
-      borderRadius: tokens.borderRadiusSmall,
-      border: 0,
-      cursor: 'pointer',
-      fontSize: tokens.fontSizeM,
-      lineHeight: tokens.lineHeightM,
-      fontWeight: tokens.fontWeightNormal,
-      '&:focus, &:hover': {
-        backgroundColor: tokens.gray100,
-      },
-      '&:active': {
-        backgroundColor: tokens.gray200,
-      },
-      '&:focus': {
-        boxShadow: tokens.glowPrimary,
-      },
-      '&:focus:not(:focus-visible)': {
-        boxShadow: 'unset',
-      },
-      '&:focus-visible': {
-        boxShadow: tokens.glowPrimary,
-      },
-    },
-  }),
-  disabled: css({
-    opacity: 0.5,
-    cursor: 'not-allowed',
-  }),
+  optionCheck: ({
+    isActive,
+    isDisabled,
+  }: {
+    isActive?: boolean;
+    isDisabled?: boolean;
+  }) =>
+    css({
+      label: cx(
+        getMenuItemStyles({ isActive, isDisabled }),
+        css({
+          width: '100%',
+        }),
+      ),
+    }),
 });

--- a/packages/components/multiselect/src/Multiselect.styles.ts
+++ b/packages/components/multiselect/src/Multiselect.styles.ts
@@ -90,6 +90,9 @@ export const getMultiselectStyles = () => ({
   }),
   optionText: css({
     color: tokens.gray700,
+    '&:active': {
+      color: tokens.gray900,
+    },
     b: {
       color: tokens.gray900,
     },
@@ -105,7 +108,7 @@ export const getMultiselectStyles = () => ({
       display: 'flex',
       flexDirection: 'row',
       alignItems: 'center',
-      borderRadius: tokens.borderRadiusMedium,
+      borderRadius: tokens.borderRadiusSmall,
       border: 0,
       cursor: 'pointer',
       fontSize: tokens.fontSizeM,

--- a/packages/components/multiselect/src/MultiselectOption.tsx
+++ b/packages/components/multiselect/src/MultiselectOption.tsx
@@ -37,7 +37,7 @@ export const MultiselectOption = ({
         onChange={(event) => onSelectItem(event)}
         isChecked={isChecked}
         isDisabled={isDisabled}
-        className={cx(styles.optionCheck, isDisabled && styles.disabled)}
+        className={styles.optionCheck({ isActive: isChecked, isDisabled })}
       >
         <Text
           className={styles.optionText}

--- a/packages/components/navlist/src/NavListItem/NavListItem.styles.ts
+++ b/packages/components/navlist/src/NavListItem/NavListItem.styles.ts
@@ -1,23 +1,7 @@
-import { css, type ObjectInterpolation } from 'emotion';
+import { css, cx } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 import type { NavListItemProps } from './NavListItem';
-
-const activeStyle: ObjectInterpolation<undefined> = {
-  backgroundColor: tokens.gray200,
-  color: tokens.gray900,
-  fontWeight: tokens.fontWeightMedium,
-  '&:hover': {
-    backgroundColor: tokens.gray200,
-  },
-};
-
-const disabledStyle: ObjectInterpolation<undefined> = {
-  opacity: 0.5,
-  cursor: 'not-allowed',
-  '&:hover': {
-    backgroundColor: 'unset',
-  },
-};
+import { getMenuItemStyles } from '@contentful/f36-core';
 
 export const getNavListItemStyles = ({
   isActive,
@@ -27,52 +11,11 @@ export const getNavListItemStyles = ({
   isDisabled: NavListItemProps['isDisabled'];
 }) => {
   return {
-    root: css(
-      [
-        {
-          alignItems: 'center',
-          gap: tokens.spacingXs,
-          display: 'flex',
-          background: 'none',
-          border: 0,
-          borderRadius: tokens.borderRadiusMedium,
-          margin: 0,
-          outline: 'none',
-          fontSize: tokens.fontSizeM,
-          lineHeight: tokens.lineHeightM,
-          fontWeight: tokens.fontWeightNormal,
-          position: 'relative',
-          textAlign: 'left',
-          // Magic number to get a height of 32px on the item
-          padding: `6px ${tokens.spacingXs}`,
-          wordBreak: 'break-word',
-          whiteSpace: 'break-spaces',
-          cursor: 'pointer',
-          hyphens: 'auto',
-          minWidth: '150px',
-          textDecoration: 'none',
-          color: tokens.gray700,
-
-          '&:hover': {
-            backgroundColor: tokens.gray100,
-          },
-          '&:focus': {
-            boxShadow: `inset ${tokens.glowPrimary}`,
-          },
-          '&:focus:not(:focus-visible)': {
-            boxShadow: 'unset',
-          },
-          '&:focus-visible': {
-            boxShadow: `inset ${tokens.glowPrimary}`,
-          },
-          '&:active': {
-            backgroundColor: tokens.gray200,
-          },
-          '&:disabled': disabledStyle,
-        },
-      ],
-      isActive && activeStyle,
-      isDisabled && disabledStyle,
+    root: cx(
+      getMenuItemStyles({ isActive, isDisabled }),
+      css({
+        gap: tokens.spacingXs,
+      }),
     ),
   };
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,3 +30,4 @@ export { useControllableState, useId, useImageLoaded } from './hooks';
 export type { UseControllableStateProps } from './hooks';
 export { mergeRefs } from './utils/mergeRefs';
 export { getEntityStatusStyles } from './utils/getEntityStatusStyles';
+export { getMenuItemStyles } from './utils/getMenuItem.styles';

--- a/packages/core/src/utils/getMenuItem.styles.ts
+++ b/packages/core/src/utils/getMenuItem.styles.ts
@@ -1,0 +1,73 @@
+import { css, cx, type ObjectInterpolation } from 'emotion';
+import tokens from '@contentful/f36-tokens';
+
+const activeStyle: ObjectInterpolation<undefined> = {
+  backgroundColor: tokens.gray200,
+  fontWeight: tokens.fontWeightMedium,
+  '&:hover': {
+    backgroundColor: tokens.gray200,
+  },
+};
+
+const disabledStyle: ObjectInterpolation<undefined> = {
+  opacity: 0.5,
+  cursor: 'auto',
+  '&:hover': {
+    backgroundColor: 'unset',
+  },
+};
+
+export const getMenuItemStyles = ({
+  isActive = false,
+  isDisabled = false,
+}: {
+  isActive?: boolean;
+  isDisabled?: boolean;
+}) =>
+  cx(
+    css({
+      alignItems: 'center',
+      display: 'flex',
+      background: 'none',
+      border: 0,
+      borderRadius: tokens.borderRadiusSmall,
+      outline: 'none',
+      fontSize: tokens.fontSizeM,
+      lineHeight: tokens.lineHeightM,
+      fontWeight: tokens.fontWeightNormal,
+      position: 'relative',
+      textAlign: 'left',
+      // Magic number to get a height of 32px on the item
+      padding: `6px ${tokens.spacingXs}`,
+      wordBreak: 'break-word',
+      whiteSpace: 'break-spaces',
+      cursor: 'pointer',
+      hyphens: 'auto',
+      minWidth: '150px',
+      textDecoration: 'none',
+      color: tokens.gray700,
+      '[role="menuitem"] + &': {
+        marginTop: '2px',
+      },
+
+      '&:focus, &:hover': {
+        backgroundColor: tokens.gray100,
+      },
+      '&:focus': {
+        boxShadow: `inset ${tokens.glowPrimary}`,
+      },
+      '&:focus:not(:focus-visible)': {
+        boxShadow: 'unset',
+      },
+      '&:focus-visible': {
+        boxShadow: `inset ${tokens.glowPrimary}`,
+      },
+      '&:active': {
+        color: tokens.gray700,
+        backgroundColor: tokens.gray200,
+      },
+      '&:disabled': disabledStyle,
+    }),
+    isActive && css(activeStyle),
+    isDisabled && css(disabledStyle),
+  );


### PR DESCRIPTION
# Purpose of PR

We have multiple components based on pop-out lists with hover and active style. They all should share the exact same style. 
This PR exposes a new utility style function `getMenuItemStyles({isActive?: boolean, isDisabled?: boolean})` for these components.
Based on the components specific setup, some need small overwrites to acomodate for their html structure.

The overall goal of this PR is to unify the style, not only visually but also make their similarity obvious on the code level, by all of them making use of the same utility style class.

# Comparing visual changes

Autocomplete *before*
 <img width="192" alt="Bildschirmfoto 2025-02-17 um 13 21 57" src="https://github.com/user-attachments/assets/af6d2b93-b47b-4e14-ba1f-4d1803103ddc" />

*after*
<img width="243" alt="Bildschirmfoto 2025-02-17 um 13 22 27" src="https://github.com/user-attachments/assets/3de06d0a-77f9-457f-be06-96df4a0ac246" />

Menu *before*
<img width="300" alt="Bildschirmfoto 2025-02-17 um 13 19 54" src="https://github.com/user-attachments/assets/b64702a0-e8d6-49c1-ba40-25802b2efab9" />

*after*
<img width="268" alt="Bildschirmfoto 2025-02-17 um 13 20 33" src="https://github.com/user-attachments/assets/e4443320-8bb8-4469-b534-7288a58aa6ea" />

Multiselect *before*
<img width="265" alt="Bildschirmfoto 2025-02-17 um 13 25 42" src="https://github.com/user-attachments/assets/d4e4fb62-10be-48c5-8033-74e163ee01b5" />

*after*
<img width="219" alt="Bildschirmfoto 2025-02-17 um 13 25 52" src="https://github.com/user-attachments/assets/bdc0ae6e-d54a-46e6-a003-18c2537d29c2" />


NavlistItem *before*
<img width="396" alt="Bildschirmfoto 2025-02-17 um 13 27 15" src="https://github.com/user-attachments/assets/77a3c18c-c0e5-4a45-884e-15800670a0f5" />

*after*
<img width="381" alt="Bildschirmfoto 2025-02-17 um 13 27 27" src="https://github.com/user-attachments/assets/3c8164b0-826b-433c-8bcb-6eae564d5736" />

