### PR TITLE
fix: checkout repo before running gh

### DIFF
--- a/.github/workflows/remove-stale.yml
+++ b/.github/workflows/remove-stale.yml
@@ -15,6 +15,9 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Remove stale label
         run: gh issue edit $ISSUE --remove-label $LABEL
         env:


### PR DESCRIPTION
# Purpose of PR

This is an attempt to fix our failing `remove_stale` action.

`failed to run git: fatal: not a git repository (or any of the parent directories): .git`

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
