### PR TITLE
fix: don't enforce text case transform

### DIFF
--- a/.changeset/seven-impalas-fly.md
+++ b/.changeset/seven-impalas-fly.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-typography': patch
+---
+
+Remove enforced text transform

--- a/.changeset/seven-impalas-fly.md
+++ b/.changeset/seven-impalas-fly.md
@@ -2,4 +2,4 @@
 '@contentful/f36-typography': patch
 ---
 
-Remove enforced text transform
+Remove enforced text transformations which caused wrong formatting for uppercase words insie the SectionHeading component

--- a/packages/components/typography/src/SectionHeading/SectionHeading.tsx
+++ b/packages/components/typography/src/SectionHeading/SectionHeading.tsx
@@ -35,7 +35,7 @@ function _SectionHeading<
     marginBottom = 'spacingL',
     ...otherProps
   }: SectionHeadingProps<E>,
-  ref: React.Ref<any>,
+  ref: React.Ref<HTMLHeadingElement>,
 ) {
   const density = useDensity();
   const Element: React.ElementType = as || SECTION_HEADING_DEFAULT_TAG;
@@ -52,10 +52,6 @@ function _SectionHeading<
       className={cx(
         css({
           letterSpacing: tokens.letterSpacingDefault,
-          textTransform: 'lowercase',
-          '&:first-letter': {
-            textTransform: 'uppercase',
-          },
         }),
         className,
       )}

--- a/packages/components/typography/stories/SectionHeading.stories.tsx
+++ b/packages/components/typography/stories/SectionHeading.stories.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps } from 'react';
+import React, { type ComponentProps } from 'react';
 import { Flex } from '@contentful/f36-core';
 import { type Density, DensityProvider } from '@contentful/f36-utils';
 import { Heading } from '@contentful/f36-typography';
@@ -21,7 +21,7 @@ export const Basic = (props: ComponentProps<typeof SectionHeading>) => (
 
 Basic.args = {
   children:
-    'The quick brown fox jumps over the lazy dog like an over-motivated frog.',
+    'The quick brown fox jumps over the lazy dog named Henry like an over-motivated frog.',
 };
 
 export const WithDensitySupport = (
@@ -60,5 +60,5 @@ export const WithDensitySupport = (
 
 WithDensitySupport.args = {
   children:
-    'The quick brown fox jumps over the lazy dog like an over-motivated frog.',
+    'The quick brown fox jumps over the lazy dog named Henry like an over-motivated frog.',
 };


### PR DESCRIPTION
# Purpose of PR

For translation purposes it is important that text can contain upper and lower cases. By enforcing lower case for the whole headline, we would end up with wrong upper cases as a language like german uses uppercase for all nouns. 
