### PR TITLE
fix: auto reposition submenu when out of viewport [SPA-2627]

### DIFF
--- a/.changeset/itchy-rice-kneel.md
+++ b/.changeset/itchy-rice-kneel.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-menu': minor
+---
+
+Allow overwriting placement and isAutoalignmentEnabled for Submenu component

--- a/packages/components/menu/src/Submenu/Submenu.tsx
+++ b/packages/components/menu/src/Submenu/Submenu.tsx
@@ -5,25 +5,29 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Menu, MenuProps } from '../Menu';
+import { Menu, type MenuProps } from '../Menu';
 import { useMenuContext } from '../MenuContext';
-import { SubmenuContextProvider, SubmenuContextType } from '../SubmenuContext';
+import {
+  SubmenuContextProvider,
+  type SubmenuContextType,
+} from '../SubmenuContext';
 import { mergeRefs } from '@contentful/f36-core';
 
 const SUBMENU_OFFSET: [number, number] = [-8, 2];
 
 export type SubmenuProps = Omit<
   MenuProps,
-  | 'placement'
-  | 'offset'
-  | 'usePortal'
-  | 'isOpen'
-  | 'isAutoalignmentEnabled'
-  | 'defaultIsOpen'
+  'offset' | 'usePortal' | 'isOpen' | 'defaultIsOpen'
 >;
 
 export const Submenu = (props: SubmenuProps) => {
-  const { onClose, onOpen, ...otherProps } = props;
+  const {
+    onClose,
+    onOpen,
+    placement = 'right-start',
+    isAutoalignmentEnabled = false,
+    ...otherProps
+  } = props;
 
   const {
     isOpen: isParentMenuOpen,
@@ -111,7 +115,8 @@ export const Submenu = (props: SubmenuProps) => {
         isOpen={isOpen}
         onClose={handleClose}
         onOpen={handleOpen}
-        placement="right-start"
+        placement={placement}
+        isAutoalignmentEnabled={isAutoalignmentEnabled}
         offset={SUBMENU_OFFSET}
       />
     </SubmenuContextProvider>

--- a/packages/components/menu/src/Submenu/Submenu.tsx
+++ b/packages/components/menu/src/Submenu/Submenu.tsx
@@ -113,7 +113,6 @@ export const Submenu = (props: SubmenuProps) => {
         onOpen={handleOpen}
         placement="right-start"
         offset={SUBMENU_OFFSET}
-        isAutoalignmentEnabled={false}
       />
     </SubmenuContextProvider>
   );

--- a/packages/components/menu/stories/Menu.stories.tsx
+++ b/packages/components/menu/stories/Menu.stories.tsx
@@ -7,7 +7,7 @@ import {
   useHref,
   useLinkClickHandler,
 } from 'react-router-dom';
-
+import { css } from 'emotion';
 import { Menu, type MenuProps } from '../src';
 
 export default {
@@ -129,9 +129,10 @@ export const WithMaxHeight: Story<MenuProps> = (args) => {
         // You can pass a classname with maxHeight style or a style object directly
         style={{ maxHeight: '200px' }}
       >
-        {[...Array(20)].map((_, index) => (
-          <Menu.Item key={index}>Item {index}</Menu.Item>
-        ))}
+        {[...Array(20)].map((_, index) => {
+          const uniqueKey = `item-${index}`;
+          return <Menu.Item key={uniqueKey}>Item {index}</Menu.Item>;
+        })}
       </Menu.List>
     </Menu>
   );
@@ -151,9 +152,10 @@ export const WithStickyHeaderAndFooter: Story<MenuProps> = (args) => {
         <Menu.ListHeader>
           <Menu.Item>Item header</Menu.Item>
         </Menu.ListHeader>
-        {[...Array(10)].map((_, index) => (
-          <Menu.Item key={index}>Item {index}</Menu.Item>
-        ))}
+        {[...Array(10)].map((_, index) => {
+          const uniqueKey = `sticky-header-${index}`;
+          return <Menu.Item key={uniqueKey}>Item {index}</Menu.Item>;
+        })}
         <Menu.ListFooter>
           <Menu.Item>Item footer</Menu.Item>
         </Menu.ListFooter>
@@ -240,6 +242,52 @@ export const WithSubmenu: Story<MenuProps> = (args) => {
         <Menu.Item>Embed existing entry</Menu.Item>
       </Menu.List>
     </Menu>
+  );
+};
+export const WithSubmenuDifferentAlignments: Story<MenuProps> = (args) => {
+  const styles = {
+    container: css({
+      backgroundColor: 'lightblue',
+      display: 'flex',
+      justifyContent: 'center',
+      overflow: 'hidden',
+      width: '98vw',
+    }),
+    wrapper: css({
+      display: 'flex',
+      width: '95vw',
+      justifyContent: 'right',
+      backgroundColor: 'pink',
+      overflow: 'hidden',
+    }),
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.wrapper}>
+        <Menu {...args}>
+          <Menu.Trigger>
+            <IconButton
+              variant="secondary"
+              icon={<MenuIcon />}
+              aria-label="toggle menu"
+            />
+          </Menu.Trigger>
+          <Menu.List>
+            <Menu.Item>Create an entry</Menu.Item>
+            <Menu.Submenu isAutoalignmentEnabled>
+              <Menu.SubmenuTrigger>Remove an entry</Menu.SubmenuTrigger>
+              <Menu.List>
+                <Menu.Item>Sub item 1</Menu.Item>
+                <Menu.Item>Sub item 2</Menu.Item>
+                <Menu.Item>Sub item 3</Menu.Item>
+              </Menu.List>
+            </Menu.Submenu>
+            <Menu.Item>Embed existing entry</Menu.Item>
+          </Menu.List>
+        </Menu>
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
# Purpose of PR

When rendering a `<Submenu>` close to the border of the window, it might render out of bounds as it's currently forced to not auto align itself.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information

## Before

https://github.com/user-attachments/assets/644133cd-abcc-4578-9441-212f05a72336

## After

https://github.com/user-attachments/assets/b711559c-2868-48c3-b73f-ed6b51f7c8b8
