### PR TITLE
feat: enable i18n for Pill component [UFO-1301]

### DIFF
--- a/.changeset/some-colts-invite.md
+++ b/.changeset/some-colts-invite.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-pill': minor
+---
+
+Enables localisation of Pill component by offering new optional props for aria-label on the close button.

--- a/packages/components/pill/src/Pill.tsx
+++ b/packages/components/pill/src/Pill.tsx
@@ -25,6 +25,13 @@ export type PillInternalProps = CommonProps & {
    * Function that handles when the close icon is clicked. Close icon visibility depends on if this property is set.
    */
   onClose?: () => void;
+
+  /**
+   * Aria label for close button
+   * @default 'Close'
+   */
+  closeButtonAriaLabel?: string;
+
   /**
    * Function that handles when the pill is dragged. Drag icon is rendered when this property is set.
    */
@@ -48,6 +55,7 @@ export const Pill = React.forwardRef<HTMLDivElement, ExpandProps<PillProps>>(
       isDraggable,
       label,
       onClose,
+      closeButtonAriaLabel = 'Close',
       testId = 'cf-ui-pill',
       onDrag,
       className,
@@ -97,7 +105,7 @@ export const Pill = React.forwardRef<HTMLDivElement, ExpandProps<PillProps>>(
             type="button"
             variant="transparent"
             startIcon={<CloseIcon />}
-            aria-label="Close"
+            aria-label={closeButtonAriaLabel}
             onClick={onClose}
             className={styles.closeButton}
           />

--- a/packages/components/pill/stories/Pill.stories.tsx
+++ b/packages/components/pill/stories/Pill.stories.tsx
@@ -57,7 +57,12 @@ export const Overview: Story<PillInternalProps> = (args) => (
 
       <Flex flexDirection="row" marginBottom="spacingM">
         <Box marginRight="spacingXs">
-          <Pill label="Idle" variant="idle" onClose={args.onClose} />
+          <Pill
+            label="Idle"
+            variant="idle"
+            onClose={args.onClose}
+            closeButtonAriaLabel="Remove"
+          />
         </Box>
         <Box marginRight="spacingXs">
           <Pill label="Active" variant="active" onClose={args.onClose} />


### PR DESCRIPTION
# Purpose of PR
This enables the full localization of the Pill component by handing over the new optional prop `closeButtonAriaLabel` the default of the aria-label is 'Close'

No visual differences.