### PR TITLE
feat(NotificationItem): enable localization

### DIFF
--- a/.changeset/selfish-pots-unite.md
+++ b/.changeset/selfish-pots-unite.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-notification": patch
+---
+
+Enables localization of NotificationItem component by offering new optional props for aria-label on the close button.

--- a/packages/components/notification/src/NotificationItem/NotificationItem.tsx
+++ b/packages/components/notification/src/NotificationItem/NotificationItem.tsx
@@ -32,6 +32,11 @@ export interface NotificationItemProps extends CommonProps {
    */
   withCloseButton?: boolean;
   /**
+   * Aria label for close button
+   * @default 'Dismiss'
+   */
+  closeButtonAriaLabel?: string;
+  /**
    * Function that will be triggered when close button is clicked
    */
   onClose?: Function;
@@ -40,7 +45,7 @@ export interface NotificationItemProps extends CommonProps {
    */
   title?: string;
   /**
-   * Content of the notificaiton
+   * Content of the notification
    */
   children: React.ReactNode;
   /**
@@ -55,6 +60,7 @@ const _NotificationItem = (props: ExpandProps<NotificationItemProps>, ref) => {
     children,
     cta,
     withCloseButton = true,
+    closeButtonAriaLabel = 'Dismiss',
     variant = 'positive',
     onClose,
     testId = 'cf-ui-notification',
@@ -124,7 +130,7 @@ const _NotificationItem = (props: ExpandProps<NotificationItemProps>, ref) => {
               onClose && onClose();
             }}
             testId="cf-ui-notification-close"
-            aria-label="Dismiss"
+            aria-label={closeButtonAriaLabel}
           />
         </Box>
       )}

--- a/packages/components/notification/stories/Notification.stories.tsx
+++ b/packages/components/notification/stories/Notification.stories.tsx
@@ -30,6 +30,7 @@ basic.args = {
   },
   onClose: action('onClose'),
   children: 'Body for the notification',
+  closeButtonAriaLabel: 'Schließen',
 };
 
 export const WithButtons = ({ notificationText, duration, ...args }) => {


### PR DESCRIPTION
# Purpose of PR

This enables the full localization of the `NotificationItem` component by handing over the new optional prop `closeButtonAriaLabel`, with the 'Dismiss' default value.

No visual differences.