### PR TITLE
feat: enable i18n for Multiselect Component [UFO-1750]

### DIFF
--- a/.changeset/petite-radios-speak.md
+++ b/.changeset/petite-radios-speak.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-multiselect': patch
+---
+
+Enable localisation of the Multiselect component by offering new optional properties

--- a/packages/components/multiselect/src/Multiselect.tsx
+++ b/packages/components/multiselect/src/Multiselect.tsx
@@ -62,7 +62,8 @@ export interface MultiselectProps extends CommonProps {
   toggleRef?: React.Ref<HTMLButtonElement>;
 
   /**
-   * Aria label for toggle button that opens the list
+   * Aria label for the toggle button that opens the list
+   * @default 'Toggle Multiselect'
    */
   toggleButtonAriaLabel?: string;
 

--- a/packages/components/multiselect/src/Multiselect.tsx
+++ b/packages/components/multiselect/src/Multiselect.tsx
@@ -17,6 +17,20 @@ import FocusLock from 'react-focus-lock';
 import type { MultiselectSearchProps as SearchProps } from './MultiselectSearch';
 import { MultiselectSearch } from './MultiselectSearch';
 
+type ClearButtonProps = {
+  /**
+   * Aria label for the clear button
+   * @default 'Clear selection'
+   */
+  ariaLabel?: string;
+
+  /**
+   * Tooltip for the clear button
+   * @default 'Clear selection'
+   */
+  tooltip?: string;
+};
+
 export interface MultiselectProps extends CommonProps {
   /** Select Options */
   children?: React.ReactNode;
@@ -46,6 +60,11 @@ export interface MultiselectProps extends CommonProps {
    * Use this prop to get a ref to the toggle button of the component
    */
   toggleRef?: React.Ref<HTMLButtonElement>;
+
+  /**
+   * Aria label for toggle button that opens the list
+   */
+  toggleButtonAriaLabel?: string;
 
   /**
    * Props to pass to the optional search field
@@ -112,6 +131,12 @@ export interface MultiselectProps extends CommonProps {
    * If no function is provided the clear button is not shown
    */
   onClearSelection?: () => void;
+
+  /**
+   * Clear Button Props used for localization
+   * @default { ariaLabel: 'Clear selection', tooltip: 'Clear selection' }
+   */
+  clearButtonProps?: ClearButtonProps;
 }
 
 // Scan through the whole hierachy until `filter` returns true and apply `transform`
@@ -161,6 +186,7 @@ function _Multiselect(props: MultiselectProps, ref: React.Ref<HTMLDivElement>) {
     placeholder = 'Select one or more Items',
     currentSelection = [],
     toggleRef,
+    toggleButtonAriaLabel = 'Toggle Multiselect',
     isLoading = false,
     testId = 'cf-multiselect',
     noMatchesMessage = 'No matches found',
@@ -169,6 +195,10 @@ function _Multiselect(props: MultiselectProps, ref: React.Ref<HTMLDivElement>) {
     children,
     onBlur,
     onClearSelection,
+    clearButtonProps = {
+      tooltip: 'Clear selection',
+      ariaLabel: 'Clear selection',
+    },
   } = props;
 
   const { listMaxHeight = 180, listRef, onClose } = popoverProps;
@@ -301,7 +331,7 @@ function _Multiselect(props: MultiselectProps, ref: React.Ref<HTMLDivElement>) {
         <Flex alignItems="center">
           <Popover.Trigger>
             <Button
-              aria-label="Toggle Multiselect"
+              aria-label={toggleButtonAriaLabel}
               ref={toggleRef}
               onClick={() => setIsOpen(!isOpen)}
               startIcon={startIcon}
@@ -315,7 +345,7 @@ function _Multiselect(props: MultiselectProps, ref: React.Ref<HTMLDivElement>) {
           {showClearButton && (
             <div className={styles.clearSelectionButton}>
               <Tooltip
-                content="Clear selection"
+                content={clearButtonProps.tooltip}
                 showDelay={800}
                 placement="top"
                 as="div"
@@ -323,7 +353,7 @@ function _Multiselect(props: MultiselectProps, ref: React.Ref<HTMLDivElement>) {
                 <IconButton
                   onClick={handleClearSelection}
                   icon={<CloseIcon />}
-                  aria-label="Clear selection"
+                  aria-label={clearButtonProps.ariaLabel}
                   size="small"
                 />
               </Tooltip>

--- a/packages/components/multiselect/src/Multiselect.tsx
+++ b/packages/components/multiselect/src/Multiselect.tsx
@@ -346,7 +346,11 @@ function _Multiselect(props: MultiselectProps, ref: React.Ref<HTMLDivElement>) {
           {showClearButton && (
             <div className={styles.clearSelectionButton}>
               <Tooltip
-                content={clearButtonProps.tooltip}
+                content={
+                  clearButtonProps.tooltip
+                    ? clearButtonProps.tooltip
+                    : 'Clear selection'
+                }
                 showDelay={800}
                 placement="top"
                 as="div"
@@ -354,7 +358,11 @@ function _Multiselect(props: MultiselectProps, ref: React.Ref<HTMLDivElement>) {
                 <IconButton
                   onClick={handleClearSelection}
                   icon={<CloseIcon />}
-                  aria-label={clearButtonProps.ariaLabel}
+                  aria-label={
+                    clearButtonProps.ariaLabel
+                      ? clearButtonProps.ariaLabel
+                      : 'Clear selection'
+                  }
                   size="small"
                 />
               </Tooltip>

--- a/packages/components/multiselect/src/SelectAllOption.tsx
+++ b/packages/components/multiselect/src/SelectAllOption.tsx
@@ -3,6 +3,22 @@ import { MultiselectOption, MultiselectOptionProps } from './MultiselectOption';
 import { getMultiselectStyles } from './Multiselect.styles';
 import { cx } from 'emotion';
 
+/**
+ * Labels for the select all option
+ */
+type SelectAllOptionLabel = {
+  /**
+   * Label for the select all option when it is checked
+   * @default 'Deselect all'
+   */
+  checked: string;
+
+  /**
+   * Label for the select all option when it is unchecked
+   * @default 'Select all'
+   */
+  unchecked: string;
+};
 export interface SelectAllOptionProps
   extends Omit<
     MultiselectOptionProps,
@@ -10,6 +26,7 @@ export interface SelectAllOptionProps
   > {
   label?: string;
   itemId?: string;
+  selectAllOptionLabel?: SelectAllOptionLabel;
 }
 
 export const SelectAllOption = ({
@@ -17,11 +34,18 @@ export const SelectAllOption = ({
   itemId = 'SelectAll',
   onSelectItem,
   isChecked = false,
+  selectAllOptionLabel = {
+    checked: 'Deselect all',
+    unchecked: 'Select all',
+  },
   className,
   ...otherProps
 }: SelectAllOptionProps) => {
   const styles = getMultiselectStyles();
-  const displayLabel = label || isChecked ? 'Deselect all' : 'Select all';
+  const displayLabel =
+    label || isChecked
+      ? selectAllOptionLabel.checked
+      : selectAllOptionLabel.unchecked;
   return (
     <MultiselectOption
       value="all"

--- a/packages/components/multiselect/stories/Multiselect.stories.tsx
+++ b/packages/components/multiselect/stories/Multiselect.stories.tsx
@@ -480,6 +480,10 @@ export const WithSelectAll = () => {
           <Multiselect.SelectAll
             onSelectItem={toggleAll}
             isChecked={areAllSelected}
+            selectAllOptionLabel={{
+              checked: 'Selektion aufheben',
+              unchecked: 'Alle markieren',
+            }}
           />
           {produce.map((item) => {
             return (
@@ -534,6 +538,10 @@ export const WithClearAll = () => {
         placeholder="Select many fruits"
         currentSelection={selectedFruits}
         onClearSelection={handleClearSelection}
+        clearButtonProps={{
+          tooltip: 'Auswahl aufheben',
+          ariaLabel: 'Auswahl jetzt aufheben',
+        }}
       >
         <div>
           <SectionHeading marginLeft="spacingXs" marginBottom="spacingXs">


### PR DESCRIPTION
# Purpose of PR

Enables localisation of the Multiselect Component by offering new optional properties.

For Multiselect Component
```
clearButtonProps = {
  /**
   * Aria label for the clear button
   * @default 'Clear selection'
   */
  ariaLabel?: string;

  /**
   * Tooltip for the clear button
   * @default 'Clear selection'
   */
  tooltip?: string;
};

/**
   * Aria label for toggle button that opens the list
   */
  toggleButtonAriaLabel?: string;
```

For Multiselect.SelectAllOption
```
selectAllOptionLabel? = {
  /**
   * Label for the select all option when it is checked
   * @default 'Deselect all'
   */
  checked: string;

  /**
   * Label for the select all option when it is unchecked
   * @default 'Select all'
   */
  unchecked: string;
};
```
No visual differences
