### PR TITLE
feat(table): enable localization of sortable table cell

### DIFF
--- a/.changeset/spotty-points-study.md
+++ b/.changeset/spotty-points-study.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-table': patch
+---
+
+Enables localization of sortable table cells by adding aria-label prop for sort button.

--- a/packages/components/table/src/TableCell/TableCell.tsx
+++ b/packages/components/table/src/TableCell/TableCell.tsx
@@ -34,6 +34,10 @@ export type TableCellInternalProps = CommonProps & {
   isSortable?: boolean;
   sortDirection?: TableCellSorting;
   width?: string | number;
+  /**
+   * Aria label for the sort button when isSortable is set
+   */
+  sortButtonAriaLabel?: string;
 } & Pick<TextProps, 'isTruncated' | 'isWordBreak'>;
 
 export type TableCellProps = PropsWithHTMLElement<
@@ -49,6 +53,7 @@ function _TableCell(
     isSortable,
     sortDirection,
     testId = 'cf-ui-table-cell',
+    sortButtonAriaLabel,
     ...otherProps
   }: TableCellProps,
   forwardedRef: React.Ref<any>,
@@ -84,11 +89,14 @@ function _TableCell(
   if (isSortable) {
     tableCellContent = (
       <button
-        aria-label={`Sort ${
-          sortDirection === TableCellSorting.Ascending
-            ? TableCellSorting.Descending
-            : TableCellSorting.Ascending
-        } by ${columnName}`}
+        aria-label={
+          sortButtonAriaLabel ??
+          `Sort ${
+            sortDirection === TableCellSorting.Ascending
+              ? TableCellSorting.Descending
+              : TableCellSorting.Ascending
+          } by ${columnName}`
+        }
         className={styles.button}
         type="button"
       >

--- a/packages/components/table/stories/Table.stories.tsx
+++ b/packages/components/table/stories/Table.stories.tsx
@@ -127,7 +127,11 @@ export const Overview: Story = () => (
             <Table.Cell>Name</Table.Cell>
             <Table.Cell>Email</Table.Cell>
             <Table.Cell>Organization role</Table.Cell>
-            <Table.Cell isSortable sortDirection={TableCellSorting.Descending}>
+            <Table.Cell
+              isSortable
+              sortDirection={TableCellSorting.Descending}
+              sortButtonAriaLabel="Nach letzter Aktivität aufsteigend sortieren"
+            >
               Last activity
             </Table.Cell>
           </Table.Row>
@@ -166,7 +170,11 @@ export const Overview: Story = () => (
             <Table.Cell>Name</Table.Cell>
             <Table.Cell>Email</Table.Cell>
             <Table.Cell>Organization role</Table.Cell>
-            <Table.Cell isSortable sortDirection={TableCellSorting.Ascending}>
+            <Table.Cell
+              isSortable
+              sortDirection={TableCellSorting.Ascending}
+              sortButtonAriaLabel="Nach letzter Aktivität absteigend sortieren"
+            >
               Last activity
             </Table.Cell>
           </Table.Row>


### PR DESCRIPTION
# Purpose of PR

Enable localization of sortable table cells by adding an optional `sortButtonAriaLabel` property that overwrites the default English label.

PS: It may look weird that I’m adding a single static prop to replace a computed value but the `sortDirection` is controlled from the outside anyway and the column name is available there as well so whoever has control over the table cell can easily implement logic similar to what the table cell does internally for the default value.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
