### PR TITLE
chore: fix vulnerability in babel runtime 

### DIFF
--- a/.changeset/slimy-states-double.md
+++ b/.changeset/slimy-states-double.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-autocomplete': patch
+---
+
+Fix vulnerability issue with babel-runtime dev dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -39751,7 +39751,7 @@
     },
     "packages/components/multiselect": {
       "name": "@contentful/f36-multiselect",
-      "version": "4.26.0",
+      "version": "4.26.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.1",
@@ -43762,7 +43762,7 @@
         "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-image": "4.80.2",
         "@contentful/f36-layout": "^4.0.0-alpha.0",
-        "@contentful/f36-multiselect": "^4.26.0",
+        "@contentful/f36-multiselect": "^4.26.1",
         "@contentful/f36-navlist": "4.1.0-alpha.2",
         "@contentful/f36-progress-stepper": "4.0.0-alpha.4",
         "@contentful/f36-tokens": "^4.2.0",
@@ -50024,7 +50024,7 @@
         "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-image": "4.80.2",
         "@contentful/f36-layout": "^4.0.0-alpha.0",
-        "@contentful/f36-multiselect": "^4.26.0",
+        "@contentful/f36-multiselect": "^4.26.1",
         "@contentful/f36-navlist": "4.1.0-alpha.2",
         "@contentful/f36-progress-stepper": "4.0.0-alpha.4",
         "@contentful/f36-tokens": "^4.2.0",


### PR DESCRIPTION
# Purpose of PR

updates dependencies to babel-runtime to fix a vulnerability issue 
https://security.snyk.io/package/npm/%40babel%2Fruntime/7.22.15