### PR TITLE
chore: bump remnants of vulnerable babel-runtime version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4266,12 +4266,6 @@
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
       "license": "MIT"
     },
-    "node_modules/@emotion/core/node_modules/csstype": {
-      "version": "2.6.21",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
-      "license": "MIT"
-    },
     "node_modules/@emotion/css": {
       "version": "10.0.27",
       "license": "MIT",
@@ -4298,12 +4292,6 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/css/node_modules/csstype": {
-      "version": "2.6.21",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
       "license": "MIT"
     },
     "node_modules/@emotion/hash": {
@@ -17228,12 +17216,6 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-      "license": "MIT"
-    },
-    "node_modules/create-emotion/node_modules/csstype": {
-      "version": "2.6.21",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
       "license": "MIT"
     },
     "node_modules/create-require": {
@@ -49411,7 +49393,7 @@
       "devDependencies": {
         "@contentful/rich-text-types": "^17.0.0",
         "@emotion/babel-preset-css-prop": "^10.2.1",
-        "@next/eslint-plugin-next": "^15.3.3",
+        "@next/eslint-plugin-next": "^15.1.7",
         "babel-plugin-emotion": "10.2.2",
         "broken-link-checker": "^0.7.8",
         "dotenv": "^16.0.3",
@@ -55469,7 +55451,7 @@
         "@emotion/core": "^10.0.17",
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^2.1.1",
-        "@next/eslint-plugin-next": "15.3.3",
+        "@next/eslint-plugin-next": "^15.1.7",
         "@next/mdx": "^14.2.13",
         "@segment/snippet": "^4.15.3",
         "babel-plugin-emotion": "10.2.2",
@@ -55830,7 +55812,7 @@
       "requires": {
         "@babel/plugin-transform-react-jsx": "^7.12.1",
         "@babel/plugin-transform-react-jsx-development": "^7.12.1",
-        "@babel/runtime": "^7.5.5",
+        "@babel/runtime": "^7.27.1",
         "@emotion/babel-plugin-jsx-pragmatic": "^0.1.5",
         "babel-plugin-emotion": "^10.0.27"
       }
@@ -55847,7 +55829,7 @@
     "@emotion/core": {
       "version": "10.3.1",
       "requires": {
-        "@babel/runtime": "^7.5.5",
+        "@babel/runtime": "^7.27.1",
         "@emotion/cache": "^10.0.27",
         "@emotion/css": "^10.0.27",
         "@emotion/serialize": "^0.11.15",
@@ -55864,18 +55846,13 @@
             "@emotion/memoize": "0.7.4",
             "@emotion/unitless": "0.7.5",
             "@emotion/utils": "0.11.3",
-            "csstype": "^2.5.7"
+            "csstype": "3.1.3"
           }
         },
         "@emotion/unitless": {
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
           "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
-        },
-        "csstype": {
-          "version": "2.6.21",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-          "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
         }
       }
     },
@@ -55896,18 +55873,13 @@
             "@emotion/memoize": "0.7.4",
             "@emotion/unitless": "0.7.5",
             "@emotion/utils": "0.11.3",
-            "csstype": "^2.5.7"
+            "csstype": "3.1.3"
           }
         },
         "@emotion/unitless": {
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
           "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
-        },
-        "csstype": {
-          "version": "2.6.21",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-          "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
         }
       }
     },
@@ -57348,7 +57320,7 @@
       "version": "1.1.0",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.5.5",
+        "@babel/runtime": "^7.27.1",
         "@types/node": "^12.7.1",
         "find-up": "^4.1.0",
         "fs-extra": "^8.1.0"
@@ -58614,13 +58586,13 @@
     "@radix-ui/react-direction": {
       "version": "1.0.0",
       "requires": {
-        "@babel/runtime": "^7.13.10"
+        "@babel/runtime": "^7.27.1"
       }
     },
     "@radix-ui/react-presence": {
       "version": "1.0.0",
       "requires": {
-        "@babel/runtime": "^7.13.10",
+        "@babel/runtime": "^7.27.1",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-use-layout-effect": "1.0.0"
       },
@@ -58628,7 +58600,7 @@
         "@radix-ui/react-compose-refs": {
           "version": "1.0.0",
           "requires": {
-            "@babel/runtime": "^7.13.10"
+            "@babel/runtime": "^7.27.1"
           }
         }
       }
@@ -58636,7 +58608,7 @@
     "@radix-ui/react-use-layout-effect": {
       "version": "1.0.0",
       "requires": {
-        "@babel/runtime": "^7.13.10"
+        "@babel/runtime": "^7.27.1"
       }
     },
     "@react-hook/intersection-observer": {
@@ -59432,7 +59404,7 @@
         "ts-dedent": "^2.0.0",
         "url-loader": "^4.1.1",
         "util-deprecate": "^1.0.2",
-        "webpack": "4",
+        "webpack": "5",
         "webpack-dev-middleware": "^3.7.3",
         "webpack-filter-warnings-plugin": "^1.2.1",
         "webpack-hot-middleware": "^2.25.1",
@@ -60149,7 +60121,7 @@
         "ts-dedent": "^2.0.0",
         "util-deprecate": "^1.0.2",
         "watchpack": "^2.2.0",
-        "webpack": "4",
+        "webpack": "5",
         "ws": "^8.2.3",
         "x-default-browser": "^0.4.0"
       },
@@ -60288,7 +60260,7 @@
         "ts-dedent": "^2.0.0",
         "url-loader": "^4.1.1",
         "util-deprecate": "^1.0.2",
-        "webpack": "4",
+        "webpack": "5",
         "webpack-dev-middleware": "^3.7.3",
         "webpack-virtual-modules": "^0.2.2"
       },
@@ -60941,7 +60913,7 @@
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
+        "@babel/runtime": "^7.27.1",
         "@types/aria-query": "^4.2.0",
         "aria-query": "^5.0.0",
         "chalk": "^4.1.0",
@@ -61161,7 +61133,7 @@
       "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
       "dev": true,
       "requires": {
-        "@types/react": "*",
+        "@types/react": "16.14.22",
         "hoist-non-react-statics": "^3.3.0"
       }
     },
@@ -64641,18 +64613,13 @@
             "@emotion/memoize": "0.7.4",
             "@emotion/unitless": "0.7.5",
             "@emotion/utils": "0.11.3",
-            "csstype": "^2.5.7"
+            "csstype": "3.1.3"
           }
         },
         "@emotion/unitless": {
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
           "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
-        },
-        "csstype": {
-          "version": "2.6.21",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-          "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
         }
       }
     },
@@ -65115,7 +65082,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "requires": {
-        "@babel/runtime": "^7.21.0"
+        "@babel/runtime": "^7.27.1"
       }
     },
     "dateformat": {
@@ -65882,7 +65849,7 @@
     "downshift": {
       "version": "6.1.12",
       "requires": {
-        "@babel/runtime": "^7.14.8",
+        "@babel/runtime": "^7.27.1",
         "compute-scroll-into-view": "^1.0.17",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2",
@@ -66046,7 +66013,7 @@
           "version": "4.1.0",
           "dev": true,
           "requires": {
-            "cross-spawn": "^7.0.0",
+            "cross-spawn": "^7.0.6",
             "get-stream": "^5.0.0",
             "human-signals": "^1.1.1",
             "is-stream": "^2.0.0",
@@ -67097,7 +67064,7 @@
     "execa": {
       "version": "5.1.1",
       "requires": {
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.6",
         "get-stream": "^6.0.0",
         "human-signals": "^2.1.0",
         "is-stream": "^2.0.0",
@@ -67727,7 +67694,7 @@
       "version": "2.0.0",
       "dev": true,
       "requires": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^3.0.2"
       }
     },
@@ -75142,7 +75109,7 @@
           "version": "3.1.0",
           "dev": true,
           "requires": {
-            "@babel/runtime": "^7.12.5",
+            "@babel/runtime": "^7.27.1",
             "cosmiconfig": "^7.0.0",
             "resolve": "^1.19.0"
           }
@@ -77226,7 +77193,7 @@
       "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.17.8"
+        "@babel/runtime": "^7.27.1"
       }
     },
     "posix-character-classes": {
@@ -78200,7 +78167,7 @@
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.7.tgz",
       "integrity": "sha512-gce9m0Pk/xYYMEojRI9bgvqQAkl6hm7ozQvqWPyQx+kULiatdHgkNM1QG4DQRx5N9BAzWSCJmt9mMV8/KsdgVg==",
       "requires": {
-        "@babel/runtime": "^7.12.13"
+        "@babel/runtime": "^7.27.1"
       }
     },
     "react-copy-to-clipboard": {
@@ -78307,7 +78274,7 @@
       "integrity": "sha512-GURDaYzoLbW8pMGXwYPDBIv6nqei4kK7LPRZ9q9HCZF54wqXz/dnylBp/kfE9XmekBhHvLDdcYeyIwSrvtOiWg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.0.0",
+        "@babel/runtime": "^7.27.1",
         "is-dom": "^1.0.0",
         "prop-types": "^15.0.0"
       }
@@ -78912,7 +78879,7 @@
       "version": "0.14.5",
       "devOptional": true,
       "requires": {
-        "@babel/runtime": "^7.8.4"
+        "@babel/runtime": "^7.27.1"
       }
     },
     "regex-not": {
@@ -80002,7 +79969,7 @@
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "^6.0.0",
+            "cross-spawn": "^7.0.6",
             "get-stream": "^4.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",


### PR DESCRIPTION
# Purpose of PR

Reconstructed the lock file to ensure all peer dependencies rely on the latest & secure `@babel/runtime`.