### PR TITLE
fix: show hover styles also when button was just clicked and has focus [SPA-2867]

### DIFF
--- a/packages/components/accordion/src/AccordionHeader/AccordionHeader.styles.ts
+++ b/packages/components/accordion/src/AccordionHeader/AccordionHeader.styles.ts
@@ -26,9 +26,6 @@ const getHeaderStyles = ({ align }: StyleProps) =>
       cursor: 'pointer',
       transition: `background-color ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault},
         box-shadow ${tokens.transitionDurationShort} ${tokens.transitionEasingDefault}`,
-      '&:hover': {
-        backgroundColor: tokens.gray100,
-      },
       '&:focus': {
         backgroundColor: tokens.gray100,
         borderRadius: tokens.borderRadiusMedium,
@@ -44,6 +41,9 @@ const getHeaderStyles = ({ align }: StyleProps) =>
         backgroundColor: tokens.gray100,
         borderRadius: tokens.borderRadiusMedium,
         boxShadow: tokens.glowPrimary,
+      },
+      '&:hover, &:focus:hover, &:focus-visible:hover': {
+        backgroundColor: tokens.gray100,
       },
     }),
     align === 'end' &&


### PR DESCRIPTION
# Purpose of PR

When toggling an `AccordionHeader`, it has no `hover` style until I click away once.

Apparently, the CSS rules for `&:focus` and `&:focus-visible` have a higher specificity. By including those cases in the hover rule specification, they also have a regular hover effect when clicking them.


https://github.com/user-attachments/assets/0b96d1a6-4788-4636-81df-f793d383795a

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
