### PR TITLE
chore: fix release step

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,6 @@
   ],
   "ignore": [
     "@contentful/f36-cdn",
-    "@contentful/f36-i18n-utils",
     "@contentful/f36-layout",
     "@contentful/f36-progress-stepper",
     "@contentful/f36-navlist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45917,7 +45917,7 @@
     },
     "packages/f36-i18n-utils": {
       "name": "@contentful/f36-i18n-utils",
-      "version": "1.0.0-alpha.0",
+      "version": "1.0.0-alpha.1",
       "license": "MIT"
     },
     "packages/forma-36-codemod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45917,7 +45917,7 @@
     },
     "packages/f36-i18n-utils": {
       "name": "@contentful/f36-i18n-utils",
-      "version": "0.1.0-alpha.0",
+      "version": "1.0.0-alpha.0",
       "license": "MIT"
     },
     "packages/forma-36-codemod": {
@@ -55869,7 +55869,7 @@
       "requires": {
         "@babel/plugin-transform-react-jsx": "^7.12.1",
         "@babel/plugin-transform-react-jsx-development": "^7.12.1",
-        "@babel/runtime": "^7.5.5",
+        "@babel/runtime": "^7.27.1",
         "@emotion/babel-plugin-jsx-pragmatic": "^0.1.5",
         "babel-plugin-emotion": "^10.0.27"
       }
@@ -55886,7 +55886,7 @@
     "@emotion/core": {
       "version": "10.3.1",
       "requires": {
-        "@babel/runtime": "^7.5.5",
+        "@babel/runtime": "^7.27.1",
         "@emotion/cache": "^10.0.27",
         "@emotion/css": "^10.0.27",
         "@emotion/serialize": "^0.11.15",
@@ -55903,7 +55903,7 @@
             "@emotion/memoize": "0.7.4",
             "@emotion/unitless": "0.7.5",
             "@emotion/utils": "0.11.3",
-            "csstype": "^2.5.7"
+            "csstype": "3.1.3"
           }
         },
         "@emotion/unitless": {
@@ -55930,7 +55930,7 @@
             "@emotion/memoize": "0.7.4",
             "@emotion/unitless": "0.7.5",
             "@emotion/utils": "0.11.3",
-            "csstype": "^2.5.7"
+            "csstype": "3.1.3"
           }
         },
         "@emotion/unitless": {
@@ -57379,7 +57379,7 @@
       "version": "1.1.0",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.5.5",
+        "@babel/runtime": "^7.27.1",
         "@types/node": "^12.7.1",
         "find-up": "^4.1.0",
         "fs-extra": "^8.1.0"
@@ -58645,13 +58645,13 @@
     "@radix-ui/react-direction": {
       "version": "1.0.0",
       "requires": {
-        "@babel/runtime": "^7.13.10"
+        "@babel/runtime": "^7.27.1"
       }
     },
     "@radix-ui/react-presence": {
       "version": "1.0.0",
       "requires": {
-        "@babel/runtime": "^7.13.10",
+        "@babel/runtime": "^7.27.1",
         "@radix-ui/react-compose-refs": "1.0.0",
         "@radix-ui/react-use-layout-effect": "1.0.0"
       },
@@ -58659,7 +58659,7 @@
         "@radix-ui/react-compose-refs": {
           "version": "1.0.0",
           "requires": {
-            "@babel/runtime": "^7.13.10"
+            "@babel/runtime": "^7.27.1"
           }
         }
       }
@@ -58667,7 +58667,7 @@
     "@radix-ui/react-use-layout-effect": {
       "version": "1.0.0",
       "requires": {
-        "@babel/runtime": "^7.13.10"
+        "@babel/runtime": "^7.27.1"
       }
     },
     "@react-hook/intersection-observer": {
@@ -59469,7 +59469,7 @@
         "ts-dedent": "^2.0.0",
         "url-loader": "^4.1.1",
         "util-deprecate": "^1.0.2",
-        "webpack": "4",
+        "webpack": "5",
         "webpack-dev-middleware": "^3.7.3",
         "webpack-filter-warnings-plugin": "^1.2.1",
         "webpack-hot-middleware": "^2.25.1",
@@ -60186,7 +60186,7 @@
         "ts-dedent": "^2.0.0",
         "util-deprecate": "^1.0.2",
         "watchpack": "^2.2.0",
-        "webpack": "4",
+        "webpack": "5",
         "ws": "^8.2.3",
         "x-default-browser": "^0.4.0"
       },
@@ -60325,7 +60325,7 @@
         "ts-dedent": "^2.0.0",
         "url-loader": "^4.1.1",
         "util-deprecate": "^1.0.2",
-        "webpack": "4",
+        "webpack": "5",
         "webpack-dev-middleware": "^3.7.3",
         "webpack-virtual-modules": "^0.2.2"
       },
@@ -60978,7 +60978,7 @@
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
+        "@babel/runtime": "^7.27.1",
         "@types/aria-query": "^4.2.0",
         "aria-query": "^5.0.0",
         "chalk": "^4.1.0",
@@ -61198,7 +61198,7 @@
       "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
       "dev": true,
       "requires": {
-        "@types/react": "*",
+        "@types/react": "16.14.22",
         "hoist-non-react-statics": "^3.3.0"
       }
     },
@@ -64687,7 +64687,7 @@
             "@emotion/memoize": "0.7.4",
             "@emotion/unitless": "0.7.5",
             "@emotion/utils": "0.11.3",
-            "csstype": "^2.5.7"
+            "csstype": "3.1.3"
           }
         },
         "@emotion/unitless": {
@@ -65156,7 +65156,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "requires": {
-        "@babel/runtime": "^7.21.0"
+        "@babel/runtime": "^7.27.1"
       }
     },
     "dateformat": {
@@ -65925,7 +65925,7 @@
     "downshift": {
       "version": "6.1.12",
       "requires": {
-        "@babel/runtime": "^7.14.8",
+        "@babel/runtime": "^7.27.1",
         "compute-scroll-into-view": "^1.0.17",
         "prop-types": "^15.7.2",
         "react-is": "^17.0.2",
@@ -66089,7 +66089,7 @@
           "version": "4.1.0",
           "dev": true,
           "requires": {
-            "cross-spawn": "^7.0.0",
+            "cross-spawn": "^7.0.6",
             "get-stream": "^5.0.0",
             "human-signals": "^1.1.1",
             "is-stream": "^2.0.0",
@@ -67147,7 +67147,7 @@
     "execa": {
       "version": "5.1.1",
       "requires": {
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.6",
         "get-stream": "^6.0.0",
         "human-signals": "^2.1.0",
         "is-stream": "^2.0.0",
@@ -67777,7 +67777,7 @@
       "version": "2.0.0",
       "dev": true,
       "requires": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^3.0.2"
       }
     },
@@ -75185,7 +75185,7 @@
           "version": "3.1.0",
           "dev": true,
           "requires": {
-            "@babel/runtime": "^7.12.5",
+            "@babel/runtime": "^7.27.1",
             "cosmiconfig": "^7.0.0",
             "resolve": "^1.19.0"
           }
@@ -77280,7 +77280,7 @@
       "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.17.8"
+        "@babel/runtime": "^7.27.1"
       }
     },
     "posix-character-classes": {
@@ -78254,7 +78254,7 @@
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.7.tgz",
       "integrity": "sha512-gce9m0Pk/xYYMEojRI9bgvqQAkl6hm7ozQvqWPyQx+kULiatdHgkNM1QG4DQRx5N9BAzWSCJmt9mMV8/KsdgVg==",
       "requires": {
-        "@babel/runtime": "^7.12.13"
+        "@babel/runtime": "^7.27.1"
       }
     },
     "react-copy-to-clipboard": {
@@ -78361,7 +78361,7 @@
       "integrity": "sha512-GURDaYzoLbW8pMGXwYPDBIv6nqei4kK7LPRZ9q9HCZF54wqXz/dnylBp/kfE9XmekBhHvLDdcYeyIwSrvtOiWg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.0.0",
+        "@babel/runtime": "^7.27.1",
         "is-dom": "^1.0.0",
         "prop-types": "^15.0.0"
       }
@@ -78966,7 +78966,7 @@
       "version": "0.14.5",
       "devOptional": true,
       "requires": {
-        "@babel/runtime": "^7.8.4"
+        "@babel/runtime": "^7.27.1"
       }
     },
     "regex-not": {
@@ -80060,7 +80060,7 @@
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "^6.0.0",
+            "cross-spawn": "^7.0.6",
             "get-stream": "^4.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",

--- a/packages/f36-i18n-utils/package.json
+++ b/packages/f36-i18n-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentful/f36-i18n-utils",
   "description": "Forma 36 i18n utilities",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "license": "MIT",
   "files": [
     "package.json",

--- a/packages/f36-i18n-utils/package.json
+++ b/packages/f36-i18n-utils/package.json
@@ -2,7 +2,6 @@
   "name": "@contentful/f36-i18n-utils",
   "description": "Forma 36 i18n utilities",
   "version": "1.0.0-alpha.1",
-  "private": true,
   "license": "MIT",
   "files": [
     "package.json",

--- a/packages/f36-i18n-utils/package.json
+++ b/packages/f36-i18n-utils/package.json
@@ -2,6 +2,7 @@
   "name": "@contentful/f36-i18n-utils",
   "description": "Forma 36 i18n utilities",
   "version": "1.0.0-alpha.1",
+  "private": true,
   "license": "MIT",
   "files": [
     "package.json",
@@ -10,7 +11,6 @@
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
-  "source": "src/index.ts",
   "sideEffects": false,
   "browserslist": "extends @contentful/browserslist-config",
   "repository": {

--- a/packages/f36-i18n-utils/package.json
+++ b/packages/f36-i18n-utils/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@contentful/f36-i18n-utils",
+  "description": "Forma 36 i18n utilities",
   "version": "0.1.0-alpha.0",
   "license": "MIT",
   "files": [

--- a/packages/f36-i18n-utils/package.json
+++ b/packages/f36-i18n-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentful/f36-i18n-utils",
   "description": "Forma 36 i18n utilities",
-  "version": "0.1.0-alpha.0",
+  "version": "1.0.0-alpha.0",
   "license": "MIT",
   "files": [
     "package.json",

--- a/scripts/changesets/changelog-generate.js
+++ b/scripts/changesets/changelog-generate.js
@@ -15,7 +15,6 @@ const ignorePkgs = [
   '@contentful/f36-cdn',
   '@contentful/f36-website',
   '@contentful/f36-docs-utils',
-  '@contentful/f36-i18n-utils',
 ];
 
 // Format package names as Start Case


### PR DESCRIPTION
# Purpose of PR
we currently do not want the i18n-utils package to be automatically released as it is still considered alpha. Therefore we have to set the package to private.