### PR TITLE
chore: rename phosphor icons to have icon prefix

### DIFF
--- a/packages/components/icons/src/vendor/phosphor/ArrowCounterClockwiseIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ArrowCounterClockwiseIcon.tsx
@@ -1,5 +1,5 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ArrowCounterClockwise } from '@phosphor-icons/react';
+import { ArrowCounterClockwiseIcon as ArrowCounterClockwise } from '@phosphor-icons/react';
 
 export const ArrowCounterClockwiseIcon = generateForma36Icon(
   ArrowCounterClockwise,

--- a/packages/components/icons/src/vendor/phosphor/ArrowDownIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ArrowDownIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ArrowDown } from '@phosphor-icons/react';
+import { ArrowDownIcon as ArrowDown } from '@phosphor-icons/react';
 
 export const ArrowDownIcon = generateForma36Icon(ArrowDown);

--- a/packages/components/icons/src/vendor/phosphor/ArrowLeftIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ArrowLeftIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ArrowLeft } from '@phosphor-icons/react';
+import { ArrowLeftIcon as ArrowLeft } from '@phosphor-icons/react';
 
 export const ArrowLeftIcon = generateForma36Icon(ArrowLeft);

--- a/packages/components/icons/src/vendor/phosphor/ArrowRightIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ArrowRightIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ArrowRight } from '@phosphor-icons/react';
+import { ArrowRightIcon as ArrowRight } from '@phosphor-icons/react';
 
 export const ArrowRightIcon = generateForma36Icon(ArrowRight);

--- a/packages/components/icons/src/vendor/phosphor/ArrowSquareOutIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ArrowSquareOutIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ArrowSquareOut } from '@phosphor-icons/react';
+import { ArrowSquareOutIcon as ArrowSquareOut } from '@phosphor-icons/react';
 
 export const ArrowSquareOutIcon = generateForma36Icon(ArrowSquareOut);

--- a/packages/components/icons/src/vendor/phosphor/ArrowUUpLeftIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ArrowUUpLeftIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ArrowUUpLeft } from '@phosphor-icons/react';
+import { ArrowUUpLeftIcon as ArrowUUpLeft } from '@phosphor-icons/react';
 
 export const ArrowUUpLeftIcon = generateForma36Icon(ArrowUUpLeft);

--- a/packages/components/icons/src/vendor/phosphor/ArrowUUpRightIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ArrowUUpRightIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ArrowUUpRight } from '@phosphor-icons/react';
+import { ArrowUUpRightIcon as ArrowUUpRight } from '@phosphor-icons/react';
 
 export const ArrowUUpRightIcon = generateForma36Icon(ArrowUUpRight);

--- a/packages/components/icons/src/vendor/phosphor/ArrowUpIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ArrowUpIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ArrowUp } from '@phosphor-icons/react';
+import { ArrowUpIcon as ArrowUp } from '@phosphor-icons/react';
 
 export const ArrowUpIcon = generateForma36Icon(ArrowUp);

--- a/packages/components/icons/src/vendor/phosphor/ArrowsLeftRightIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ArrowsLeftRightIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ArrowsLeftRight } from '@phosphor-icons/react';
+import { ArrowsLeftRightIcon as ArrowsLeftRight } from '@phosphor-icons/react';
 
 export const ArrowsLeftRightIcon = generateForma36Icon(ArrowsLeftRight);

--- a/packages/components/icons/src/vendor/phosphor/ArrowsSplitIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ArrowsSplitIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ArrowsSplit } from '@phosphor-icons/react';
+import { ArrowsSplitIcon as ArrowsSplit } from '@phosphor-icons/react';
 
 export const ArrowsSplitIcon = generateForma36Icon(ArrowsSplit);

--- a/packages/components/icons/src/vendor/phosphor/BellIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/BellIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Bell } from '@phosphor-icons/react';
+import { BellIcon as Bell } from '@phosphor-icons/react';
 
 export const BellIcon = generateForma36Icon(Bell);

--- a/packages/components/icons/src/vendor/phosphor/BookOpenIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/BookOpenIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { BookOpen } from '@phosphor-icons/react';
+import { BookOpenIcon as BookOpen } from '@phosphor-icons/react';
 
 export const BookOpenIcon = generateForma36Icon(BookOpen);

--- a/packages/components/icons/src/vendor/phosphor/BookmarkSimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/BookmarkSimpleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { BookmarkSimple } from '@phosphor-icons/react';
+import { BookmarkSimpleIcon as BookmarkSimple } from '@phosphor-icons/react';
 
 export const BookmarkSimpleIcon = generateForma36Icon(BookmarkSimple);

--- a/packages/components/icons/src/vendor/phosphor/BracketsCurlyIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/BracketsCurlyIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { BracketsCurly } from '@phosphor-icons/react';
+import { BracketsCurlyIcon as BracketsCurly } from '@phosphor-icons/react';
 
 export const BracketsCurlyIcon = generateForma36Icon(BracketsCurly);

--- a/packages/components/icons/src/vendor/phosphor/CalendarBlankIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CalendarBlankIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CalendarBlank } from '@phosphor-icons/react';
+import { CalendarBlankIcon as CalendarBlank } from '@phosphor-icons/react';
 
 export const CalendarBlankIcon = generateForma36Icon(CalendarBlank);

--- a/packages/components/icons/src/vendor/phosphor/CalendarDotsIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CalendarDotsIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CalendarDots } from '@phosphor-icons/react';
+import { CalendarDotsIcon as CalendarDots } from '@phosphor-icons/react';
 
 export const CalendarDotsIcon = generateForma36Icon(CalendarDots);

--- a/packages/components/icons/src/vendor/phosphor/CaretCircleDoubleUpIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CaretCircleDoubleUpIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CaretCircleDoubleUp } from '@phosphor-icons/react';
+import { CaretCircleDoubleUpIcon as CaretCircleDoubleUp } from '@phosphor-icons/react';
 
 export const CaretCircleDoubleUpIcon = generateForma36Icon(CaretCircleDoubleUp);

--- a/packages/components/icons/src/vendor/phosphor/CaretCircleUpIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CaretCircleUpIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CaretCircleUp } from '@phosphor-icons/react';
+import { CaretCircleUpIcon as CaretCircleUp } from '@phosphor-icons/react';
 
 export const CaretCircleUpIcon = generateForma36Icon(CaretCircleUp);

--- a/packages/components/icons/src/vendor/phosphor/CaretDownIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CaretDownIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CaretDown } from '@phosphor-icons/react';
+import { CaretDownIcon as CaretDown } from '@phosphor-icons/react';
 
 export const CaretDownIcon = generateForma36Icon(CaretDown);

--- a/packages/components/icons/src/vendor/phosphor/CaretLeftIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CaretLeftIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CaretLeft } from '@phosphor-icons/react';
+import { CaretLeftIcon as CaretLeft } from '@phosphor-icons/react';
 
 export const CaretLeftIcon = generateForma36Icon(CaretLeft);

--- a/packages/components/icons/src/vendor/phosphor/CaretRightIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CaretRightIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CaretRight } from '@phosphor-icons/react';
+import { CaretRightIcon as CaretRight } from '@phosphor-icons/react';
 
 export const CaretRightIcon = generateForma36Icon(CaretRight);

--- a/packages/components/icons/src/vendor/phosphor/CaretUpDownIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CaretUpDownIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CaretUpDown } from '@phosphor-icons/react';
+import { CaretUpDownIcon as CaretUpDown } from '@phosphor-icons/react';
 
 export const CaretUpDownIcon = generateForma36Icon(CaretUpDown);

--- a/packages/components/icons/src/vendor/phosphor/CaretUpIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CaretUpIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CaretUp } from '@phosphor-icons/react';
+import { CaretUpIcon as CaretUp } from '@phosphor-icons/react';
 
 export const CaretUpIcon = generateForma36Icon(CaretUp);

--- a/packages/components/icons/src/vendor/phosphor/ChatIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ChatIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Chat } from '@phosphor-icons/react';
+import { ChatIcon as Chat } from '@phosphor-icons/react';
 
 export const ChatIcon = generateForma36Icon(Chat);

--- a/packages/components/icons/src/vendor/phosphor/CheckCircleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CheckCircleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CheckCircle } from '@phosphor-icons/react';
+import { CheckCircleIcon as CheckCircle } from '@phosphor-icons/react';
 
 export const CheckCircleIcon = generateForma36Icon(CheckCircle);

--- a/packages/components/icons/src/vendor/phosphor/CheckIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CheckIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Check } from '@phosphor-icons/react';
+import { CheckIcon as Check } from '@phosphor-icons/react';
 
 export const CheckIcon = generateForma36Icon(Check);

--- a/packages/components/icons/src/vendor/phosphor/CircleHalfIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CircleHalfIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CircleHalf } from '@phosphor-icons/react';
+import { CircleHalfIcon as CircleHalf } from '@phosphor-icons/react';
 
 export const CircleHalfIcon = generateForma36Icon(CircleHalf);

--- a/packages/components/icons/src/vendor/phosphor/ClockCounterClockwiseIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ClockCounterClockwiseIcon.tsx
@@ -1,5 +1,5 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ClockCounterClockwise } from '@phosphor-icons/react';
+import { ClockCounterClockwiseIcon as ClockCounterClockwise } from '@phosphor-icons/react';
 
 export const ClockCounterClockwiseIconIcon = generateForma36Icon(
   ClockCounterClockwise,

--- a/packages/components/icons/src/vendor/phosphor/ClockIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ClockIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Clock } from '@phosphor-icons/react';
+import { ClockIcon as Clock } from '@phosphor-icons/react';
 
 export const ClockIcon = generateForma36Icon(Clock);

--- a/packages/components/icons/src/vendor/phosphor/CloudArrowUpIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CloudArrowUpIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CloudArrowUp } from '@phosphor-icons/react';
+import { CloudArrowUpIcon as CloudArrowUp } from '@phosphor-icons/react';
 
 export const CloudArrowUpIcon = generateForma36Icon(CloudArrowUp);

--- a/packages/components/icons/src/vendor/phosphor/CodeSimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CodeSimpleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CodeSimple } from '@phosphor-icons/react';
+import { CodeSimpleIcon as CodeSimple } from '@phosphor-icons/react';
 
 export const CodeSimpleIcon = generateForma36Icon(CodeSimple);

--- a/packages/components/icons/src/vendor/phosphor/CopySimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CopySimpleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CopySimple } from '@phosphor-icons/react';
+import { CopySimpleIcon as CopySimple } from '@phosphor-icons/react';
 
 export const CopySimpleIcon = generateForma36Icon(CopySimple);

--- a/packages/components/icons/src/vendor/phosphor/CrosshairSimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CrosshairSimpleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { CrosshairSimple } from '@phosphor-icons/react';
+import { CrosshairSimpleIcon as CrosshairSimple } from '@phosphor-icons/react';
 
 export const CrosshairSimpleIcon = generateForma36Icon(CrosshairSimple);

--- a/packages/components/icons/src/vendor/phosphor/DesktopIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/DesktopIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Desktop } from '@phosphor-icons/react';
+import { DesktopIcon as Desktop } from '@phosphor-icons/react';
 
 export const DesktopIcon = generateForma36Icon(Desktop);

--- a/packages/components/icons/src/vendor/phosphor/DeviceMobileCameraIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/DeviceMobileCameraIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { DeviceMobileCamera } from '@phosphor-icons/react';
+import { DeviceMobileCameraIcon as DeviceMobileCamera } from '@phosphor-icons/react';
 
 export const DeviceMobileCameraIcon = generateForma36Icon(DeviceMobileCamera);

--- a/packages/components/icons/src/vendor/phosphor/DeviceTabletIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/DeviceTabletIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { DeviceTablet } from '@phosphor-icons/react';
+import { DeviceTabletIcon as DeviceTablet } from '@phosphor-icons/react';
 
 export const DeviceTabletIcon = generateForma36Icon(DeviceTablet);

--- a/packages/components/icons/src/vendor/phosphor/DiamondIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/DiamondIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Diamond } from '@phosphor-icons/react';
+import { DiamondIcon as Diamond } from '@phosphor-icons/react';
 
 export const DiamondIcon = generateForma36Icon(Diamond);

--- a/packages/components/icons/src/vendor/phosphor/DiamondsFourIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/DiamondsFourIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { DiamondsFour } from '@phosphor-icons/react';
+import { DiamondsFourIcon as DiamondsFour } from '@phosphor-icons/react';
 
 export const DiamondsFourIcon = generateForma36Icon(DiamondsFour);

--- a/packages/components/icons/src/vendor/phosphor/DotsSixVerticalIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/DotsSixVerticalIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { DotsSixVertical } from '@phosphor-icons/react';
+import { DotsSixVerticalIcon as DotsSixVertical } from '@phosphor-icons/react';
 
 export const DotsSixVerticalIcon = generateForma36Icon(DotsSixVertical);

--- a/packages/components/icons/src/vendor/phosphor/DotsThreeIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/DotsThreeIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { DotsThree } from '@phosphor-icons/react';
+import { DotsThreeIcon as DotsThree } from '@phosphor-icons/react';
 
 export const DotsThreeIcon = generateForma36Icon(DotsThree);

--- a/packages/components/icons/src/vendor/phosphor/DotsThreeVerticalIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/DotsThreeVerticalIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { DotsThreeVertical } from '@phosphor-icons/react';
+import { DotsThreeVerticalIcon as DotsThreeVertical } from '@phosphor-icons/react';
 
 export const DotsThreeVerticalIcon = generateForma36Icon(DotsThreeVertical);

--- a/packages/components/icons/src/vendor/phosphor/DownloadSimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/DownloadSimpleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { DownloadSimple } from '@phosphor-icons/react';
+import { DownloadSimpleIcon as DownloadSimple } from '@phosphor-icons/react';
 
 export const DownloadSimpleIcon = generateForma36Icon(DownloadSimple);

--- a/packages/components/icons/src/vendor/phosphor/EnvelopeIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/EnvelopeIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Envelope } from '@phosphor-icons/react';
+import { EnvelopeIcon as Envelope } from '@phosphor-icons/react';
 
 export const EnvelopeIcon = generateForma36Icon(Envelope);

--- a/packages/components/icons/src/vendor/phosphor/EyeClosedIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/EyeClosedIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { EyeClosed } from '@phosphor-icons/react';
+import { EyeClosedIcon as EyeClosed } from '@phosphor-icons/react';
 
 export const EyeClosedIcon = generateForma36Icon(EyeClosed);

--- a/packages/components/icons/src/vendor/phosphor/EyeIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/EyeIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Eye } from '@phosphor-icons/react';
+import { EyeIcon as Eye } from '@phosphor-icons/react';
 
 export const EyeIcon = generateForma36Icon(Eye);

--- a/packages/components/icons/src/vendor/phosphor/FileArchive.tsx
+++ b/packages/components/icons/src/vendor/phosphor/FileArchive.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { FileArchive } from '@phosphor-icons/react';
+import { FileArchiveIcon as FileArchive } from '@phosphor-icons/react';
 
 export const FileArchiveIcon = generateForma36Icon(FileArchive);

--- a/packages/components/icons/src/vendor/phosphor/FileAudioIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/FileAudioIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { FileAudio } from '@phosphor-icons/react';
+import { FileAudioIcon as FileAudio } from '@phosphor-icons/react';
 
 export const FileAudioIcon = generateForma36Icon(FileAudio);

--- a/packages/components/icons/src/vendor/phosphor/FileCodeIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/FileCodeIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { FileCode } from '@phosphor-icons/react';
+import { FileCodeIcon as FileCode } from '@phosphor-icons/react';
 
 export const FileCodeIcon = generateForma36Icon(FileCode);

--- a/packages/components/icons/src/vendor/phosphor/FileIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/FileIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { File } from '@phosphor-icons/react';
+import { FileIcon as File } from '@phosphor-icons/react';
 
 export const FileIcon = generateForma36Icon(File);

--- a/packages/components/icons/src/vendor/phosphor/FilePdfIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/FilePdfIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { FilePdf } from '@phosphor-icons/react';
+import { FilePdfIcon as FilePdf } from '@phosphor-icons/react';
 
 export const FilePdfIcon = generateForma36Icon(FilePdf);

--- a/packages/components/icons/src/vendor/phosphor/FileTextIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/FileTextIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { FileText } from '@phosphor-icons/react';
+import { FileTextIcon as FileText } from '@phosphor-icons/react';
 
 export const FileTextIcon = generateForma36Icon(FileText);

--- a/packages/components/icons/src/vendor/phosphor/FileVideoIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/FileVideoIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { FileVideo } from '@phosphor-icons/react';
+import { FileVideoIcon as FileVideo } from '@phosphor-icons/react';
 
 export const FileVideoIcon = generateForma36Icon(FileVideo);

--- a/packages/components/icons/src/vendor/phosphor/FlaskIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/FlaskIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Flask } from '@phosphor-icons/react';
+import { FlaskIcon as Flask } from '@phosphor-icons/react';
 
 export const FlaskIcon = generateForma36Icon(Flask);

--- a/packages/components/icons/src/vendor/phosphor/FolderOpenIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/FolderOpenIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { FolderOpen } from '@phosphor-icons/react';
+import { FolderOpenIcon as FolderOpen } from '@phosphor-icons/react';
 
 export const FolderOpenIcon = generateForma36Icon(FolderOpen);

--- a/packages/components/icons/src/vendor/phosphor/FolderSimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/FolderSimpleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { FolderSimple } from '@phosphor-icons/react';
+import { FolderSimpleIcon as FolderSimple } from '@phosphor-icons/react';
 
 export const FolderSimpleIcon = generateForma36Icon(FolderSimple);

--- a/packages/components/icons/src/vendor/phosphor/FolderSimplePlusIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/FolderSimplePlusIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { FolderSimplePlus } from '@phosphor-icons/react';
+import { FolderSimplePlusIcon as FolderSimplePlus } from '@phosphor-icons/react';
 
 export const FolderSimplePlusIcon = generateForma36Icon(FolderSimplePlus);

--- a/packages/components/icons/src/vendor/phosphor/FrameCornersIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/FrameCornersIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { FrameCorners } from '@phosphor-icons/react';
+import { FrameCornersIcon as FrameCorners } from '@phosphor-icons/react';
 
 export const FrameCornersIcon = generateForma36Icon(FrameCorners);

--- a/packages/components/icons/src/vendor/phosphor/FunnelSimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/FunnelSimpleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { FunnelSimple } from '@phosphor-icons/react';
+import { FunnelSimpleIcon as FunnelSimple } from '@phosphor-icons/react';
 
 export const FunnelSimpleIcon = generateForma36Icon(FunnelSimple);

--- a/packages/components/icons/src/vendor/phosphor/GearSixIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/GearSixIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { GearSix } from '@phosphor-icons/react';
+import { GearSixIcon as GearSix } from '@phosphor-icons/react';
 
 export const GearSixIcon = generateForma36Icon(GearSix);

--- a/packages/components/icons/src/vendor/phosphor/GiftIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/GiftIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Gift } from '@phosphor-icons/react';
+import { GiftIcon as Gift } from '@phosphor-icons/react';
 
 export const GiftIcon = generateForma36Icon(Gift);

--- a/packages/components/icons/src/vendor/phosphor/GlobeIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/GlobeIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Globe } from '@phosphor-icons/react';
+import { GlobeIcon as Globe } from '@phosphor-icons/react';
 
 export const GlobeIcon = generateForma36Icon(Globe);

--- a/packages/components/icons/src/vendor/phosphor/HashStraightIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/HashStraightIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { HashStraight } from '@phosphor-icons/react';
+import { HashStraightIcon as HashStraight } from '@phosphor-icons/react';
 
 export const HashStraightIcon = generateForma36Icon(HashStraight);

--- a/packages/components/icons/src/vendor/phosphor/ImageSquareIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ImageSquareIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ImageSquare } from '@phosphor-icons/react';
+import { ImageSquareIcon as ImageSquare } from '@phosphor-icons/react';
 
 export const ImageSquareIcon = generateForma36Icon(ImageSquare);

--- a/packages/components/icons/src/vendor/phosphor/InfoIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/InfoIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Info } from '@phosphor-icons/react';
+import { InfoIcon as Info } from '@phosphor-icons/react';
 
 export const InfoIcon = generateForma36Icon(Info);

--- a/packages/components/icons/src/vendor/phosphor/KeyIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/KeyIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Key } from '@phosphor-icons/react';
+import { KeyIcon as Key } from '@phosphor-icons/react';
 
 export const KeyIcon = generateForma36Icon(Key);

--- a/packages/components/icons/src/vendor/phosphor/LaptopIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/LaptopIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Laptop } from '@phosphor-icons/react';
+import { LaptopIcon as Laptop } from '@phosphor-icons/react';
 
 export const LaptopIcon = generateForma36Icon(Laptop);

--- a/packages/components/icons/src/vendor/phosphor/LightbulbIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/LightbulbIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Lightbulb } from '@phosphor-icons/react';
+import { LightbulbIcon as Lightbulb } from '@phosphor-icons/react';
 
 export const LightbulbIcon = generateForma36Icon(Lightbulb);

--- a/packages/components/icons/src/vendor/phosphor/LightningIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/LightningIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Lightning } from '@phosphor-icons/react';
+import { LightningIcon as Lightning } from '@phosphor-icons/react';
 
 export const LightningIcon = generateForma36Icon(Lightning);

--- a/packages/components/icons/src/vendor/phosphor/LinkBreakIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/LinkBreakIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { LinkBreak } from '@phosphor-icons/react';
+import { LinkBreakIcon as LinkBreak } from '@phosphor-icons/react';
 
 export const LinkBreakIcon = generateForma36Icon(LinkBreak);

--- a/packages/components/icons/src/vendor/phosphor/LinkSimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/LinkSimpleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { LinkSimple } from '@phosphor-icons/react';
+import { LinkSimpleIcon as LinkSimple } from '@phosphor-icons/react';
 
 export const LinkSimpleIcon = generateForma36Icon(LinkSimple);

--- a/packages/components/icons/src/vendor/phosphor/ListBulletsIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ListBulletsIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ListBullets } from '@phosphor-icons/react';
+import { ListBulletsIcon as ListBullets } from '@phosphor-icons/react';
 
 export const ListBulletsIcon = generateForma36Icon(ListBullets);

--- a/packages/components/icons/src/vendor/phosphor/ListIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ListIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { List } from '@phosphor-icons/react';
+import { ListIcon as List } from '@phosphor-icons/react';
 
 export const ListIcon = generateForma36Icon(List);

--- a/packages/components/icons/src/vendor/phosphor/ListNumbersIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ListNumbersIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ListNumbers } from '@phosphor-icons/react';
+import { ListNumbersIcon as ListNumbers } from '@phosphor-icons/react';
 
 export const ListNumbersIcon = generateForma36Icon(ListNumbers);

--- a/packages/components/icons/src/vendor/phosphor/LockSimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/LockSimpleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { LockSimple } from '@phosphor-icons/react';
+import { LockSimpleIcon as LockSimple } from '@phosphor-icons/react';
 
 export const LockSimpleIcon = generateForma36Icon(LockSimple);

--- a/packages/components/icons/src/vendor/phosphor/LockSimpleOpenIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/LockSimpleOpenIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { LockSimpleOpen } from '@phosphor-icons/react';
+import { LockSimpleOpenIcon as LockSimpleOpen } from '@phosphor-icons/react';
 
 export const LockSimpleOpenIcon = generateForma36Icon(LockSimpleOpen);

--- a/packages/components/icons/src/vendor/phosphor/MagnifyingGlassIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/MagnifyingGlassIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { MagnifyingGlass } from '@phosphor-icons/react';
+import { MagnifyingGlassIcon as MagnifyingGlass } from '@phosphor-icons/react';
 
 export const MagnifyingGlassIcon = generateForma36Icon(MagnifyingGlass);

--- a/packages/components/icons/src/vendor/phosphor/MapPinLineIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/MapPinLineIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { MapPinLine } from '@phosphor-icons/react';
+import { MapPinLineIcon as MapPinLine } from '@phosphor-icons/react';
 
 export const MapPinLineIcon = generateForma36Icon(MapPinLine);

--- a/packages/components/icons/src/vendor/phosphor/MegaphoneSimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/MegaphoneSimpleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { MegaphoneSimple } from '@phosphor-icons/react';
+import { MegaphoneSimpleIcon as MegaphoneSimple } from '@phosphor-icons/react';
 
 export const MegaphoneSimpleIcon = generateForma36Icon(MegaphoneSimple);

--- a/packages/components/icons/src/vendor/phosphor/MicrosoftTeamsLogoIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/MicrosoftTeamsLogoIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { MicrosoftTeamsLogo } from '@phosphor-icons/react';
+import { MicrosoftTeamsLogoIcon as MicrosoftTeamsLogo } from '@phosphor-icons/react';
 
 export const MicrosoftTeamsLogoIcon = generateForma36Icon(MicrosoftTeamsLogo);

--- a/packages/components/icons/src/vendor/phosphor/MinusCircleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/MinusCircleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { MinusCircle } from '@phosphor-icons/react';
+import { MinusCircleIcon as MinusCircle } from '@phosphor-icons/react';
 
 export const MinusCircleIcon = generateForma36Icon(MinusCircle);

--- a/packages/components/icons/src/vendor/phosphor/MinusIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/MinusIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Minus } from '@phosphor-icons/react';
+import { MinusIcon as Minus } from '@phosphor-icons/react';
 
 export const MinusIcon = generateForma36Icon(Minus);

--- a/packages/components/icons/src/vendor/phosphor/OpenAiLogoIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/OpenAiLogoIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { OpenAiLogo } from '@phosphor-icons/react';
+import { OpenAiLogoIcon as OpenAiLogo } from '@phosphor-icons/react';
 
 export const OpenAiLogoIcon = generateForma36Icon(OpenAiLogo);

--- a/packages/components/icons/src/vendor/phosphor/PaintBrushIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/PaintBrushIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { PaintBrush } from '@phosphor-icons/react';
+import { PaintBrushIcon as PaintBrush } from '@phosphor-icons/react';
 
 export const PaintBrushIcon = generateForma36Icon(PaintBrush);

--- a/packages/components/icons/src/vendor/phosphor/PaperPlaneTiltIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/PaperPlaneTiltIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { PaperPlaneTilt } from '@phosphor-icons/react';
+import { PaperPlaneTiltIcon as PaperPlaneTilt } from '@phosphor-icons/react';
 
 export const PaperPlaneTiltIcon = generateForma36Icon(PaperPlaneTilt);

--- a/packages/components/icons/src/vendor/phosphor/PenNibIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/PenNibIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { PenNib } from '@phosphor-icons/react';
+import { PenNibIcon as PenNib } from '@phosphor-icons/react';
 
 export const PenNibIcon = generateForma36Icon(PenNib);

--- a/packages/components/icons/src/vendor/phosphor/PencilSimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/PencilSimpleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { PencilSimple } from '@phosphor-icons/react';
+import { PencilSimpleIcon as PencilSimple } from '@phosphor-icons/react';
 
 export const PencilSimpleIcon = generateForma36Icon(PencilSimple);

--- a/packages/components/icons/src/vendor/phosphor/PlusIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/PlusIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Plus } from '@phosphor-icons/react';
+import { PlusIcon as Plus } from '@phosphor-icons/react';
 
 export const PlusIcon = generateForma36Icon(Plus);

--- a/packages/components/icons/src/vendor/phosphor/PresentationIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/PresentationIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Presentation } from '@phosphor-icons/react';
+import { PresentationIcon as Presentation } from '@phosphor-icons/react';
 
 export const PresentationIcon = generateForma36Icon(Presentation);

--- a/packages/components/icons/src/vendor/phosphor/PuzzlePieceIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/PuzzlePieceIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { PuzzlePiece } from '@phosphor-icons/react';
+import { PuzzlePieceIcon as PuzzlePiece } from '@phosphor-icons/react';
 
 export const PuzzlePieceIcon = generateForma36Icon(PuzzlePiece);

--- a/packages/components/icons/src/vendor/phosphor/QuestionIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/QuestionIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Question } from '@phosphor-icons/react';
+import { QuestionIcon as Question } from '@phosphor-icons/react';
 
 export const QuestionIcon = generateForma36Icon(Question);

--- a/packages/components/icons/src/vendor/phosphor/QuotesIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/QuotesIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Quotes } from '@phosphor-icons/react';
+import { QuotesIcon as Quotes } from '@phosphor-icons/react';
 
 export const QuotesIcon = generateForma36Icon(Quotes);

--- a/packages/components/icons/src/vendor/phosphor/ReceiptIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ReceiptIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Receipt } from '@phosphor-icons/react';
+import { ReceiptIcon as Receipt } from '@phosphor-icons/react';
 
 export const ReceiptIcon = generateForma36Icon(Receipt);

--- a/packages/components/icons/src/vendor/phosphor/RepeatIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/RepeatIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Repeat } from '@phosphor-icons/react';
+import { RepeatIcon as Repeat } from '@phosphor-icons/react';
 
 export const RepeatIcon = generateForma36Icon(Repeat);

--- a/packages/components/icons/src/vendor/phosphor/RocketIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/RocketIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Rocket } from '@phosphor-icons/react';
+import { RocketIcon as Rocket } from '@phosphor-icons/react';
 
 export const RocketIcon = generateForma36Icon(Rocket);

--- a/packages/components/icons/src/vendor/phosphor/RocketLaunchIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/RocketLaunchIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { RocketLaunch } from '@phosphor-icons/react';
+import { RocketLaunchIcon as RocketLaunch } from '@phosphor-icons/react';
 
 export const RocketLaunchIcon = generateForma36Icon(RocketLaunch);

--- a/packages/components/icons/src/vendor/phosphor/SelectionIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/SelectionIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Selection } from '@phosphor-icons/react';
+import { SelectionIcon as Selection } from '@phosphor-icons/react';
 
 export const SelectionIcon = generateForma36Icon(Selection);

--- a/packages/components/icons/src/vendor/phosphor/ShoppingCartSimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ShoppingCartSimpleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ShoppingCartSimple } from '@phosphor-icons/react';
+import { ShoppingCartSimpleIcon as ShoppingCartSimple } from '@phosphor-icons/react';
 
 export const ShoppingCartSimpleIcon = generateForma36Icon(ShoppingCartSimple);

--- a/packages/components/icons/src/vendor/phosphor/SignInIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/SignInIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { SignIn } from '@phosphor-icons/react';
+import { SignInIcon as SignIn } from '@phosphor-icons/react';
 
 export const SignInIcon = generateForma36Icon(SignIn);

--- a/packages/components/icons/src/vendor/phosphor/SignOutIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/SignOutIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { SignOut } from '@phosphor-icons/react';
+import { SignOutIcon as SignOut } from '@phosphor-icons/react';
 
 export const SignOutIcon = generateForma36Icon(SignOut);

--- a/packages/components/icons/src/vendor/phosphor/SketchLogoIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/SketchLogoIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { SketchLogo } from '@phosphor-icons/react';
+import { SketchLogoIcon as SketchLogo } from '@phosphor-icons/react';
 
 export const SketchLogoIcon = generateForma36Icon(SketchLogo);

--- a/packages/components/icons/src/vendor/phosphor/SlackLogoIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/SlackLogoIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { SlackLogo } from '@phosphor-icons/react';
+import { SlackLogoIcon as SlackLogo } from '@phosphor-icons/react';
 
 export const SlackLogoIcon = generateForma36Icon(SlackLogo);

--- a/packages/components/icons/src/vendor/phosphor/SmileyIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/SmileyIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Smiley } from '@phosphor-icons/react';
+import { SmileyIcon as Smiley } from '@phosphor-icons/react';
 
 export const SmileyIcon = generateForma36Icon(Smiley);

--- a/packages/components/icons/src/vendor/phosphor/SortAscendingIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/SortAscendingIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { SortAscending } from '@phosphor-icons/react';
+import { SortAscendingIcon as SortAscending } from '@phosphor-icons/react';
 
 export const SortAscendingIcon = generateForma36Icon(SortAscending);

--- a/packages/components/icons/src/vendor/phosphor/SortDescendingIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/SortDescendingIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { SortDescending } from '@phosphor-icons/react';
+import { SortDescendingIcon as SortDescending } from '@phosphor-icons/react';
 
 export const SortDescendingIcon = generateForma36Icon(SortDescending);

--- a/packages/components/icons/src/vendor/phosphor/SquaresFourIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/SquaresFourIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { SquaresFour } from '@phosphor-icons/react';
+import { SquaresFourIcon as SquaresFour } from '@phosphor-icons/react';
 
 export const SquaresFourIcon = generateForma36Icon(SquaresFour);

--- a/packages/components/icons/src/vendor/phosphor/StackIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/StackIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Stack } from '@phosphor-icons/react';
+import { StackIcon as Stack } from '@phosphor-icons/react';
 
 export const StackIcon = generateForma36Icon(Stack);

--- a/packages/components/icons/src/vendor/phosphor/StarIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/StarIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Star } from '@phosphor-icons/react';
+import { StarIcon as Star } from '@phosphor-icons/react';
 
 export const StarIcon = generateForma36Icon(Star);

--- a/packages/components/icons/src/vendor/phosphor/SubtractIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/SubtractIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Subtract } from '@phosphor-icons/react';
+import { SubtractIcon as Subtract } from '@phosphor-icons/react';
 
 export const SubtractIcon = generateForma36Icon(Subtract);

--- a/packages/components/icons/src/vendor/phosphor/SwapIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/SwapIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Swap } from '@phosphor-icons/react';
+import { SwapIcon as Swap } from '@phosphor-icons/react';
 
 export const SwapIcon = generateForma36Icon(Swap);

--- a/packages/components/icons/src/vendor/phosphor/TableIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TableIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Table } from '@phosphor-icons/react';
+import { TableIcon as Table } from '@phosphor-icons/react';
 
 export const TableIcon = generateForma36Icon(Table);

--- a/packages/components/icons/src/vendor/phosphor/TabsIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TabsIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Tabs } from '@phosphor-icons/react';
+import { TabsIcon as Tabs } from '@phosphor-icons/react';
 
 export const TabsIcon = generateForma36Icon(Tabs);

--- a/packages/components/icons/src/vendor/phosphor/TagIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TagIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Tag } from '@phosphor-icons/react';
+import { TagIcon as Tag } from '@phosphor-icons/react';
 
 export const TagIcon = generateForma36Icon(Tag);

--- a/packages/components/icons/src/vendor/phosphor/TextAaIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextAaIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextAa } from '@phosphor-icons/react';
+import { TextAaIcon as TextAa } from '@phosphor-icons/react';
 
 export const TextAaIcon = generateForma36Icon(TextAa);

--- a/packages/components/icons/src/vendor/phosphor/TextBIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextBIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextB } from '@phosphor-icons/react';
+import { TextBIcon as TextB } from '@phosphor-icons/react';
 
 export const TextBIcon = generateForma36Icon(TextB);

--- a/packages/components/icons/src/vendor/phosphor/TextHFiveIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextHFiveIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextHFive } from '@phosphor-icons/react';
+import { TextHFiveIcon as TextHFive } from '@phosphor-icons/react';
 
 export const TextHFiveIcon = generateForma36Icon(TextHFive);

--- a/packages/components/icons/src/vendor/phosphor/TextHFourIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextHFourIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextHFour } from '@phosphor-icons/react';
+import { TextHFourIcon as TextHFour } from '@phosphor-icons/react';
 
 export const TextHFourIcon = generateForma36Icon(TextHFour);

--- a/packages/components/icons/src/vendor/phosphor/TextHIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextHIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextH } from '@phosphor-icons/react';
+import { TextHIcon as TextH } from '@phosphor-icons/react';
 
 export const TextHIcon = generateForma36Icon(TextH);

--- a/packages/components/icons/src/vendor/phosphor/TextHOneIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextHOneIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextHOne } from '@phosphor-icons/react';
+import { TextHOneIcon as TextHOne } from '@phosphor-icons/react';
 
 export const TextHOneIcon = generateForma36Icon(TextHOne);

--- a/packages/components/icons/src/vendor/phosphor/TextHSixIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextHSixIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextHSix } from '@phosphor-icons/react';
+import { TextHSixIcon as TextHSix } from '@phosphor-icons/react';
 
 export const TextHSixIcon = generateForma36Icon(TextHSix);

--- a/packages/components/icons/src/vendor/phosphor/TextHThreeIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextHThreeIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextHThree } from '@phosphor-icons/react';
+import { TextHThreeIcon as TextHThree } from '@phosphor-icons/react';
 
 export const TextHThreeIcon = generateForma36Icon(TextHThree);

--- a/packages/components/icons/src/vendor/phosphor/TextHTwoIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextHTwoIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextHTwo } from '@phosphor-icons/react';
+import { TextHTwoIcon as TextHTwo } from '@phosphor-icons/react';
 
 export const TextHTwoIcon = generateForma36Icon(TextHTwo);

--- a/packages/components/icons/src/vendor/phosphor/TextItalicIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextItalicIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextItalic } from '@phosphor-icons/react';
+import { TextItalicIcon as TextItalic } from '@phosphor-icons/react';
 
 export const TextItalicIcon = generateForma36Icon(TextItalic);

--- a/packages/components/icons/src/vendor/phosphor/TextSubscriptIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextSubscriptIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextSubscript } from '@phosphor-icons/react';
+import { TextSubscriptIcon as TextSubscript } from '@phosphor-icons/react';
 
 export const TextSubscriptIcon = generateForma36Icon(TextSubscript);

--- a/packages/components/icons/src/vendor/phosphor/TextSuperscriptIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextSuperscriptIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextSuperscript } from '@phosphor-icons/react';
+import { TextSuperscriptIcon as TextSuperscript } from '@phosphor-icons/react';
 
 export const TextSuperscriptIcon = generateForma36Icon(TextSuperscript);

--- a/packages/components/icons/src/vendor/phosphor/TextTIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextTIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextT } from '@phosphor-icons/react';
+import { TextTIcon as TextT } from '@phosphor-icons/react';
 
 export const TextTIcon = generateForma36Icon(TextT);

--- a/packages/components/icons/src/vendor/phosphor/TextUnderlineIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TextUnderlineIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TextUnderline } from '@phosphor-icons/react';
+import { TextUnderlineIcon as TextUnderline } from '@phosphor-icons/react';
 
 export const TextUnderlineIcon = generateForma36Icon(TextUnderline);

--- a/packages/components/icons/src/vendor/phosphor/ThumbsDownIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ThumbsDownIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ThumbsDown } from '@phosphor-icons/react';
+import { ThumbsDownIcon as ThumbsDown } from '@phosphor-icons/react';
 
 export const ThumbsDownIcon = generateForma36Icon(ThumbsDown);

--- a/packages/components/icons/src/vendor/phosphor/ThumbsUpIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ThumbsUpIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { ThumbsUp } from '@phosphor-icons/react';
+import { ThumbsUpIcon as ThumbsUp } from '@phosphor-icons/react';
 
 export const ThumbsUpIcon = generateForma36Icon(ThumbsUp);

--- a/packages/components/icons/src/vendor/phosphor/TranslateIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TranslateIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Translate } from '@phosphor-icons/react';
+import { TranslateIcon as Translate } from '@phosphor-icons/react';
 
 export const TranslateIcon = generateForma36Icon(Translate);

--- a/packages/components/icons/src/vendor/phosphor/TrashSimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TrashSimpleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TrashSimple } from '@phosphor-icons/react';
+import { TrashSimpleIcon as TrashSimple } from '@phosphor-icons/react';
 
 export const TrashSimpleIcon = generateForma36Icon(TrashSimple);

--- a/packages/components/icons/src/vendor/phosphor/TreeStructureIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TreeStructureIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TreeStructure } from '@phosphor-icons/react';
+import { TreeStructureIcon as TreeStructure } from '@phosphor-icons/react';
 
 export const TreeStructureIcon = generateForma36Icon(TreeStructure);

--- a/packages/components/icons/src/vendor/phosphor/TrendUpIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TrendUpIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { TrendUp } from '@phosphor-icons/react';
+import { TrendUpIcon as TrendUp } from '@phosphor-icons/react';
 
 export const TrendUpIcon = generateForma36Icon(TrendUp);

--- a/packages/components/icons/src/vendor/phosphor/TriangleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/TriangleIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Triangle } from '@phosphor-icons/react';
+import { TriangleIcon as Triangle } from '@phosphor-icons/react';
 
 export const TriangleIcon = generateForma36Icon(Triangle);

--- a/packages/components/icons/src/vendor/phosphor/UserIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/UserIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { User } from '@phosphor-icons/react';
+import { UserIcon as User } from '@phosphor-icons/react';
 
 export const UserIcon = generateForma36Icon(User);

--- a/packages/components/icons/src/vendor/phosphor/UsersIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/UsersIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Users } from '@phosphor-icons/react';
+import { UsersIcon as Users } from '@phosphor-icons/react';
 
 export const UsersIcon = generateForma36Icon(Users);

--- a/packages/components/icons/src/vendor/phosphor/VideoIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/VideoIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Video } from '@phosphor-icons/react';
+import { VideoIcon as Video } from '@phosphor-icons/react';
 
 export const VideoIcon = generateForma36Icon(Video);

--- a/packages/components/icons/src/vendor/phosphor/WarningIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/WarningIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Warning } from '@phosphor-icons/react';
+import { WarningIcon as Warning } from '@phosphor-icons/react';
 
 export const WarningIcon = generateForma36Icon(Warning);

--- a/packages/components/icons/src/vendor/phosphor/WarningOctagonIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/WarningOctagonIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { WarningOctagon } from '@phosphor-icons/react';
+import { WarningOctagonIcon as WarningOctagon } from '@phosphor-icons/react';
 
 export const WarningOctagonIcon = generateForma36Icon(WarningOctagon);

--- a/packages/components/icons/src/vendor/phosphor/WrenchIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/WrenchIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { Wrench } from '@phosphor-icons/react';
+import { WrenchIcon as Wrench } from '@phosphor-icons/react';
 
 export const WrenchIcon = generateForma36Icon(Wrench);

--- a/packages/components/icons/src/vendor/phosphor/XIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/XIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon-alpha';
-import { X } from '@phosphor-icons/react';
+import { XIcon as X } from '@phosphor-icons/react';
 
 export const XIcon = generateForma36Icon(X);


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
