### PR TITLE
fix(formatters): handle empty items array

### DIFF
--- a/packages/f36-i18n-utils/package.json
+++ b/packages/f36-i18n-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentful/f36-i18n-utils",
   "description": "Forma 36 i18n utilities",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "private": true,
   "license": "MIT",
   "files": [

--- a/packages/f36-i18n-utils/src/formatters.test.ts
+++ b/packages/f36-i18n-utils/src/formatters.test.ts
@@ -40,6 +40,14 @@ describe('I18n utility functions', function () {
   });
 
   describe('formatNumberList', () => {
+    it('returns empty string if list is empty', () => {
+      const list = [];
+
+      expect(formatNumberList('de-DE', list)).toBe('');
+      expect(formatNumberList('en-US', list)).toBe('');
+      expect(formatNumberList('fr-FR', list)).toBe('');
+    });
+
     it('returns string if list has one element', () => {
       const list = [123];
 
@@ -83,6 +91,14 @@ describe('I18n utility functions', function () {
   });
 
   describe('formatStringList', () => {
+    it('returns an empty string if list is empty', () => {
+      const list: string[] = [];
+
+      expect(formatStringList('de-DE', list)).toBe('');
+      expect(formatStringList('en-US', list)).toBe('');
+      expect(formatStringList('fr-FR', list)).toBe('');
+    });
+
     it('returns string if list has one element', () => {
       const list = ['one'];
 

--- a/packages/f36-i18n-utils/src/formatters.ts
+++ b/packages/f36-i18n-utils/src/formatters.ts
@@ -3,6 +3,9 @@ export function formatNumber(locale: string, value: number): string {
 }
 
 export function formatStringList(locale: string, items: string[]): string {
+  if (items.length === 0) {
+    return '';
+  }
   if (items.length === 1) {
     return items[0];
   }


### PR DESCRIPTION
# Purpose of PR
Currently `formatStringList` does not handle empty arrays:

<img width="229" height="40" alt="image" src="https://github.com/user-attachments/assets/a41efb22-d528-4766-a291-5133a2a97399" />

This updates the function to return an empty string instead.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
