### PR TITLE
feat: add format truncated string list to i18n utils

### DIFF
--- a/packages/f36-i18n-utils/package.json
+++ b/packages/f36-i18n-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentful/f36-i18n-utils",
   "description": "Forma 36 i18n utilities",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "private": true,
   "license": "MIT",
   "files": [

--- a/packages/f36-i18n-utils/src/formatters.test.ts
+++ b/packages/f36-i18n-utils/src/formatters.test.ts
@@ -1,4 +1,9 @@
-import { formatNumber, formatNumberList, formatStringList } from '.';
+import {
+  formatNumber,
+  formatNumberList,
+  formatStringList,
+  formatTruncatedStringList,
+} from '.';
 
 describe('I18n utility functions', function () {
   describe('formatNumber', () => {
@@ -118,6 +123,64 @@ describe('I18n utility functions', function () {
       expect(formatStringList('fr-FR', list)).toBe(
         'one, two, three, four et five',
       );
+    });
+  });
+
+  describe('formatTruncatedStringList', () => {
+    it('returns full list when maxLength is equal to the list length', () => {
+      const list = ['one', 'two', 'three'];
+
+      expect(formatTruncatedStringList('en-US', list, 3)).toBe(
+        'one, two and three',
+      );
+      expect(formatTruncatedStringList('de-DE', list, 3)).toBe(
+        'one, two und three',
+      );
+      expect(formatTruncatedStringList('fr-FR', list, 3)).toBe(
+        'one, two et three',
+      );
+    });
+
+    it('returns full list when maxLength is bigger than the list length', () => {
+      const list = ['one', 'two'];
+
+      expect(formatTruncatedStringList('en-US', list, 5)).toBe('one and two');
+      expect(formatTruncatedStringList('de-DE', list, 5)).toBe('one und two');
+      expect(formatTruncatedStringList('fr-FR', list, 5)).toBe('one et two');
+    });
+
+    it('returns truncated list when maxLength is less than the list length', () => {
+      const list = ['one', 'two', 'three', 'four', 'five'];
+      expect(formatTruncatedStringList('en-US', list, 2)).toBe(
+        'one, two and 3 more',
+      );
+      expect(formatTruncatedStringList('de-DE', list, 2)).toBe(
+        'one, two und 3 weitere',
+      );
+      expect(formatTruncatedStringList('fr-FR', list, 2)).toBe(
+        'one, two et 3 autres',
+      );
+    });
+
+    it('reduces maxLength when list has exactly one more item than maxLength', () => {
+      const list = ['one', 'two', 'three'];
+      expect(formatTruncatedStringList('en-US', list, 2)).toBe(
+        'one and 2 more',
+      );
+      expect(formatTruncatedStringList('de-DE', list, 2)).toBe(
+        'one und 2 weitere',
+      );
+      expect(formatTruncatedStringList('fr-FR', list, 2)).toBe(
+        'one et 2 autres',
+      );
+    });
+
+    it('handles case where list has exactly one more item', () => {
+      const list = ['one', 'two'];
+
+      expect(formatTruncatedStringList('en-US', list, 1)).toBe('one and two');
+      expect(formatTruncatedStringList('de-DE', list, 1)).toBe('one und two');
+      expect(formatTruncatedStringList('fr-FR', list, 1)).toBe('one et two');
     });
   });
 });

--- a/packages/f36-i18n-utils/src/formatters.ts
+++ b/packages/f36-i18n-utils/src/formatters.ts
@@ -15,6 +15,34 @@ export function formatStringList(locale: string, items: string[]): string {
   }`;
 }
 
+/**
+ * Joins the strings with commas and a final 'and X more' (determined by maxLength).
+ * The sentence is localized based on the provided locale.
+ *
+ * formatTruncatedStringList('en-US', ['a', 'b', 'c', 'd'], 2)
+ * // => 'a, b and 2 more'
+ */
+export function formatTruncatedStringList(
+  locale: string,
+  list: string[],
+  maxLength: number,
+) {
+  if (list.length <= maxLength) {
+    return formatStringList(locale, list);
+  }
+
+  // This prevents finishing the sentence with 'and 1 more'
+  if (list.length === maxLength + 1) {
+    if (maxLength === 1) return formatStringList(locale, list);
+    maxLength = maxLength - 1;
+  }
+
+  const restLength = list.length - maxLength;
+  const initialList = list.slice(0, maxLength);
+  initialList.push(`${restLength} ${getLocalizeMore(locale)}`);
+  return formatStringList(locale, initialList);
+}
+
 export function formatNumberList(locale: string, items: number[]): string {
   return formatStringList(
     locale,
@@ -30,4 +58,14 @@ function getLocalizeAnd(locale: string) {
       return 'et';
   }
   return 'and';
+}
+
+function getLocalizeMore(locale: string) {
+  switch (locale) {
+    case 'de-DE':
+      return 'weitere';
+    case 'fr-FR':
+      return 'autres';
+  }
+  return 'more';
 }


### PR DESCRIPTION
# Purpose of PR
Adds `formatTruncatedStringList` in order to replace the [joinAndTruncate](https://github.com/contentful/user_interface/blob/e0b547580791fd90d42360af73f5c384ad2e97a0/src/javascripts/utils/StringUtils.ts#L116) function from `user_interface`.

This function joins a string list with commas, adding "and X more" to the end of the sentence (localized). 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
