### PR TITLE
chore: [UFO-1740] Add Icon from Phosphor Icons to replace custom Product Icon

### DIFF
--- a/packages/components/icons/package.json
+++ b/packages/components/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-icons",
-  "version": "5.0.0-alpha.45",
+  "version": "5.0.0-alpha.46",
   "description": "Forma 36: Icon components",
   "license": "MIT",
   "exports": {

--- a/packages/components/icons/src/index.ts
+++ b/packages/components/icons/src/index.ts
@@ -55,6 +55,7 @@ export * from './vendor/phosphor/CheckIcon.js';
 export * from './vendor/phosphor/CircleHalfIcon.js';
 export * from './vendor/phosphor/ClockCounterClockwiseIcon.js';
 export * from './vendor/phosphor/ClockIcon.js';
+export * from './vendor/phosphor/CloudArrowDownIcon.js';
 export * from './vendor/phosphor/CloudArrowUpIcon.js';
 export * from './vendor/phosphor/CodeSimpleIcon.js';
 export * from './vendor/phosphor/CopySimpleIcon.js';

--- a/packages/components/icons/src/vendor/phosphor/CloudArrowDownIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/CloudArrowDownIcon.tsx
@@ -1,0 +1,4 @@
+import { generateForma36Icon } from '@contentful/f36-icon';
+import { CloudArrowDownIcon as CloudArrowDown } from '@phosphor-icons/react';
+
+export const CloudArrowDownIcon = generateForma36Icon(CloudArrowDown);


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

- Adds `https://phosphoricons.com/?q=CloudArrowdown` from Phosphor to replace `ApisIcon` custom product icon

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
