### PR TITLE
docs: navbar import documentation

### DIFF
--- a/packages/components/navbar/README.mdx
+++ b/packages/components/navbar/README.mdx
@@ -62,8 +62,6 @@ The `Navbar.Switcher` component is used for displaying the current space and env
 ## Import
 
 ```jsx static=true
-import { Navbar } from '@contentful/f36-components';
-// or
 import { Navbar } from '@contentful/f36-navbar';
 ```
 


### PR DESCRIPTION
# Purpose of PR
Navbar is no longer importable via the `f36-components` package