### PR TITLE
fix(icons): pin phosphor to version with new names and working ESM build

### DIFF
--- a/.changeset/healthy-beds-study.md
+++ b/.changeset/healthy-beds-study.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-icons": patch
+---
+
+fix(icons): pin phosphor to version with new names and working ESM build

--- a/package-lock.json
+++ b/package-lock.json
@@ -7191,7 +7191,7 @@
       }
     },
     "node_modules/@phosphor-icons/react": {
-      "version": "2.1.10",
+      "version": "2.1.8",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -42024,7 +42024,7 @@
       "dependencies": {
         "@contentful/f36-core": "^5.1.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "^2.1.5",
+        "@phosphor-icons/react": "2.1.8",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
@@ -42047,7 +42047,7 @@
         "@contentful/f36-core": "^5.1.0",
         "@contentful/f36-icon": "^5.1.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "^2.1.4",
+        "@phosphor-icons/react": "2.1.8",
         "emotion": "^10.0.17"
       },
       "devDependencies": {

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@contentful/f36-core": "^5.1.0",
     "@contentful/f36-tokens": "^5.1.0",
-    "@phosphor-icons/react": "^2.1.5",
+    "@phosphor-icons/react": "2.1.8",
     "emotion": "^10.0.17"
   },
   "devDependencies": {

--- a/packages/components/icons/package.json
+++ b/packages/components/icons/package.json
@@ -34,7 +34,7 @@
     "@contentful/f36-core": "^5.1.0",
     "@contentful/f36-icon": "^5.1.0",
     "@contentful/f36-tokens": "^5.1.0",
-    "@phosphor-icons/react": "^2.1.4",
+    "@phosphor-icons/react": "2.1.8",
     "emotion": "^10.0.17"
   },
   "peerDependencies": {


### PR DESCRIPTION
# Purpose of PR

Pin the version of Phosphor react package to the first version of the package that implements the new export names with the `Icon` suffix. This version is also the latest version that has a working CJS and ESM build so rather than allowing versions above `2.1.8` I pinned it.