### PR TITLE
chore(CI): exclude website from link-checker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           command: npx wait-on http://localhost:3000
       - run:
           name: Run links checker
-          command: npx blc http://localhost:3000 -ro --exclude "https://medium.com/contentful-design" --exclude "https://github.com/contentful/forma-36" --exclude "https://www.figma.com/@contentful"
+          command: npx blc http://localhost:3000 -ro --exclude "https://medium.com/contentful-design" --exclude "https://github.com/contentful/forma-36" --exclude "https://www.figma.com/@contentful" --exclude "https://react-hook-form.com"
 
   deploy_chromatic:
     docker:


### PR DESCRIPTION
# Purpose of PR

Excludes the website from the link-checker CI job.

While the link is valid and reachable, it is facing too many requests and ultimately fails the job.