### PR TITLE
fix: Makes quota of type string and number []

### DIFF
--- a/.changeset/wide-games-raise.md
+++ b/.changeset/wide-games-raise.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-usage-count': minor
+---
+
+Makes quota of type string and number

--- a/package-lock.json
+++ b/package-lock.json
@@ -41724,14 +41724,14 @@
     },
     "packages/components/accordion": {
       "name": "@contentful/f36-accordion",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-collapse": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
+        "@contentful/f36-collapse": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -41741,14 +41741,14 @@
     },
     "packages/components/asset": {
       "name": "@contentful/f36-asset",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icon": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icon": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -41758,17 +41758,17 @@
     },
     "packages/components/autocomplete": {
       "name": "@contentful/f36-autocomplete",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-forms": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
-        "@contentful/f36-popover": "^5.1.0",
-        "@contentful/f36-skeleton": "^5.1.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-forms": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
+        "@contentful/f36-popover": "^5.3.0",
+        "@contentful/f36-skeleton": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "@contentful/f36-utils": "^5.1.0",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -41780,14 +41780,14 @@
     },
     "packages/components/avatar": {
       "name": "@contentful/f36-avatar",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-image": "^5.1.0",
-        "@contentful/f36-menu": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-image": "^5.3.0",
+        "@contentful/f36-menu": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.3.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -41797,16 +41797,16 @@
     },
     "packages/components/badge": {
       "name": "@contentful/f36-badge",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^5.1.0"
+        "@contentful/f36-typography": "^5.3.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -41815,19 +41815,19 @@
     },
     "packages/components/button": {
       "name": "@contentful/f36-button",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-spinner": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-spinner": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.3.0",
         "@contentful/f36-utils": "^5.1.0",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-icon": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0"
+        "@contentful/f36-icon": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -41836,21 +41836,21 @@
     },
     "packages/components/card": {
       "name": "@contentful/f36-card",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-asset": "^5.1.0",
-        "@contentful/f36-badge": "^5.1.0",
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-drag-handle": "^5.1.0",
-        "@contentful/f36-icon": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
-        "@contentful/f36-menu": "^5.1.0",
-        "@contentful/f36-skeleton": "^5.1.0",
+        "@contentful/f36-asset": "^5.3.0",
+        "@contentful/f36-badge": "^5.3.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-drag-handle": "^5.3.0",
+        "@contentful/f36-icon": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
+        "@contentful/f36-menu": "^5.3.0",
+        "@contentful/f36-skeleton": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.3.0",
+        "@contentful/f36-typography": "^5.3.0",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -41861,10 +41861,10 @@
     },
     "packages/components/collapse": {
       "name": "@contentful/f36-collapse",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -41875,14 +41875,14 @@
     },
     "packages/components/copybutton": {
       "name": "@contentful/f36-copybutton",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.3.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -41892,16 +41892,16 @@
     },
     "packages/components/datepicker": {
       "name": "@contentful/f36-datepicker",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-forms": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
-        "@contentful/f36-popover": "^5.1.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-forms": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
+        "@contentful/f36-popover": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -41914,10 +41914,10 @@
     },
     "packages/components/datetime": {
       "name": "@contentful/f36-datetime",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -41929,11 +41929,11 @@
     },
     "packages/components/drag-handle": {
       "name": "@contentful/f36-drag-handle",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "@contentful/f36-utils": "^5.1.0",
         "emotion": "^10.0.17"
@@ -41945,11 +41945,11 @@
     },
     "packages/components/empty-state": {
       "name": "@contentful/f36-empty-state",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -41959,19 +41959,19 @@
     },
     "packages/components/entity-list": {
       "name": "@contentful/f36-entity-list",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-badge": "^5.1.0",
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-drag-handle": "^5.1.0",
-        "@contentful/f36-icon": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
-        "@contentful/f36-menu": "^5.1.0",
-        "@contentful/f36-skeleton": "^5.1.0",
+        "@contentful/f36-badge": "^5.3.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-drag-handle": "^5.3.0",
+        "@contentful/f36-icon": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
+        "@contentful/f36-menu": "^5.3.0",
+        "@contentful/f36-skeleton": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -41981,13 +41981,13 @@
     },
     "packages/components/forms": {
       "name": "@contentful/f36-forms",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "@contentful/f36-utils": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42002,14 +42002,14 @@
     },
     "packages/components/header": {
       "name": "@contentful/f36-header",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42019,10 +42019,10 @@
     },
     "packages/components/icon": {
       "name": "@contentful/f36-icon",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "@phosphor-icons/react": "2.1.8",
         "emotion": "^10.0.17"
@@ -42041,11 +42041,11 @@
     },
     "packages/components/icons": {
       "name": "@contentful/f36-icons",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icon": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icon": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "@phosphor-icons/react": "2.1.8",
         "emotion": "^10.0.17"
@@ -42064,11 +42064,11 @@
     },
     "packages/components/image": {
       "name": "@contentful/f36-image",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-skeleton": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-skeleton": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42079,11 +42079,11 @@
     },
     "packages/components/layout": {
       "name": "@contentful/f36-layout",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-header": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-header": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42094,10 +42094,10 @@
     },
     "packages/components/list": {
       "name": "@contentful/f36-list",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42108,14 +42108,14 @@
     },
     "packages/components/menu": {
       "name": "@contentful/f36-menu",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
-        "@contentful/f36-popover": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
+        "@contentful/f36-popover": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "@contentful/f36-utils": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42126,14 +42126,14 @@
     },
     "packages/components/modal": {
       "name": "@contentful/f36-modal",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -42169,19 +42169,19 @@
     },
     "packages/components/multiselect": {
       "name": "@contentful/f36-multiselect",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.1",
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-forms": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
-        "@contentful/f36-popover": "^5.1.0",
-        "@contentful/f36-skeleton": "^5.1.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-forms": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
+        "@contentful/f36-popover": "^5.3.0",
+        "@contentful/f36-skeleton": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.3.0",
+        "@contentful/f36-typography": "^5.3.0",
         "@contentful/f36-utils": "^5.1.0",
         "emotion": "^10.0.17",
         "react-focus-lock": "^2.9.5"
@@ -42228,19 +42228,19 @@
     },
     "packages/components/navbar": {
       "name": "@contentful/f36-navbar",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-avatar": "^5.1.0",
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icon": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
-        "@contentful/f36-menu": "^5.1.0",
-        "@contentful/f36-skeleton": "^5.1.0",
+        "@contentful/f36-avatar": "^5.3.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icon": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
+        "@contentful/f36-menu": "^5.3.0",
+        "@contentful/f36-skeleton": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.3.0",
+        "@contentful/f36-typography": "^5.3.0",
         "@contentful/f36-utils": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42251,10 +42251,10 @@
     },
     "packages/components/navlist": {
       "name": "@contentful/f36-navlist",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42265,15 +42265,15 @@
     },
     "packages/components/note": {
       "name": "@contentful/f36-note",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icon": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icon": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42283,15 +42283,15 @@
     },
     "packages/components/notification": {
       "name": "@contentful/f36-notification",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
-        "@contentful/f36-text-link": "^5.1.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
+        "@contentful/f36-text-link": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
       },
@@ -42302,15 +42302,15 @@
     },
     "packages/components/pagination": {
       "name": "@contentful/f36-pagination",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-forms": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-forms": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42320,15 +42320,15 @@
     },
     "packages/components/pill": {
       "name": "@contentful/f36-pill",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-drag-handle": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-drag-handle": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.3.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42338,10 +42338,10 @@
     },
     "packages/components/popover": {
       "name": "@contentful/f36-popover",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "@contentful/f36-utils": "^5.1.0",
         "@popperjs/core": "^2.11.5",
@@ -42355,14 +42355,14 @@
     },
     "packages/components/progress-stepper": {
       "name": "@contentful/f36-progress-stepper",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42372,11 +42372,11 @@
     },
     "packages/components/skeleton": {
       "name": "@contentful/f36-skeleton",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-table": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-table": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42387,15 +42387,15 @@
     },
     "packages/components/spinner": {
       "name": "@contentful/f36-spinner",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^5.1.0"
+        "@contentful/f36-typography": "^5.3.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -42404,13 +42404,13 @@
     },
     "packages/components/table": {
       "name": "@contentful/f36-table",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "@contentful/f36-utils": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42421,10 +42421,10 @@
     },
     "packages/components/tabs": {
       "name": "@contentful/f36-tabs",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -42572,15 +42572,15 @@
     },
     "packages/components/text-link": {
       "name": "@contentful/f36-text-link",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-icons": "^5.1.0"
+        "@contentful/f36-icons": "^5.3.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -42589,10 +42589,10 @@
     },
     "packages/components/tooltip": {
       "name": "@contentful/f36-tooltip",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "@contentful/f36-utils": "^5.1.0",
         "@popperjs/core": "^2.11.5",
@@ -42607,10 +42607,10 @@
     },
     "packages/components/typography": {
       "name": "@contentful/f36-typography",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "@contentful/f36-utils": "^5.1.0",
         "emotion": "^10.0.17"
@@ -42622,16 +42622,16 @@
     },
     "packages/components/usage-card": {
       "name": "@contentful/f36-usage-card",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-card": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
-        "@contentful/f36-text-link": "^5.1.0",
+        "@contentful/f36-card": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
+        "@contentful/f36-text-link": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.3.0",
+        "@contentful/f36-typography": "^5.3.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42641,12 +42641,12 @@
     },
     "packages/components/usage-count": {
       "name": "@contentful/f36-usage-count",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.1.0",
+        "@contentful/f36-core": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
+        "@contentful/f36-typography": "^5.3.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42687,7 +42687,7 @@
     },
     "packages/core": {
       "name": "@contentful/f36-core",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^5.1.0",
@@ -42978,51 +42978,51 @@
     },
     "packages/forma-36-react-components": {
       "name": "@contentful/f36-components",
-      "version": "5.1.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-accordion": "^5.1.0",
-        "@contentful/f36-asset": "^5.1.0",
-        "@contentful/f36-autocomplete": "^5.1.0",
-        "@contentful/f36-avatar": "^5.1.0",
-        "@contentful/f36-badge": "^5.1.0",
-        "@contentful/f36-button": "^5.1.0",
-        "@contentful/f36-card": "^5.1.0",
-        "@contentful/f36-collapse": "^5.1.0",
-        "@contentful/f36-copybutton": "^5.1.0",
-        "@contentful/f36-core": "^5.1.0",
-        "@contentful/f36-datepicker": "^5.1.0",
-        "@contentful/f36-datetime": "^5.1.0",
-        "@contentful/f36-drag-handle": "^5.1.0",
-        "@contentful/f36-empty-state": "^5.1.0",
-        "@contentful/f36-entity-list": "^5.1.0",
-        "@contentful/f36-forms": "^5.1.0",
-        "@contentful/f36-header": "^5.1.0",
-        "@contentful/f36-icon": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
-        "@contentful/f36-image": "^5.1.0",
-        "@contentful/f36-layout": "^5.1.0",
-        "@contentful/f36-list": "^5.1.0",
-        "@contentful/f36-menu": "^5.1.0",
-        "@contentful/f36-modal": "^5.1.0",
-        "@contentful/f36-multiselect": "^5.1.0",
-        "@contentful/f36-navlist": "^5.1.0",
-        "@contentful/f36-note": "^5.1.0",
-        "@contentful/f36-notification": "^5.1.0",
-        "@contentful/f36-pagination": "^5.1.0",
-        "@contentful/f36-pill": "^5.1.0",
-        "@contentful/f36-popover": "^5.1.0",
-        "@contentful/f36-progress-stepper": "^5.1.0",
-        "@contentful/f36-skeleton": "^5.1.0",
-        "@contentful/f36-spinner": "^5.1.0",
-        "@contentful/f36-table": "^5.1.0",
-        "@contentful/f36-tabs": "^5.1.0",
-        "@contentful/f36-text-link": "^5.1.0",
+        "@contentful/f36-accordion": "^5.3.0",
+        "@contentful/f36-asset": "^5.3.0",
+        "@contentful/f36-autocomplete": "^5.3.0",
+        "@contentful/f36-avatar": "^5.3.0",
+        "@contentful/f36-badge": "^5.3.0",
+        "@contentful/f36-button": "^5.3.0",
+        "@contentful/f36-card": "^5.3.0",
+        "@contentful/f36-collapse": "^5.3.0",
+        "@contentful/f36-copybutton": "^5.3.0",
+        "@contentful/f36-core": "^5.3.0",
+        "@contentful/f36-datepicker": "^5.3.0",
+        "@contentful/f36-datetime": "^5.3.0",
+        "@contentful/f36-drag-handle": "^5.3.0",
+        "@contentful/f36-empty-state": "^5.3.0",
+        "@contentful/f36-entity-list": "^5.3.0",
+        "@contentful/f36-forms": "^5.3.0",
+        "@contentful/f36-header": "^5.3.0",
+        "@contentful/f36-icon": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
+        "@contentful/f36-image": "^5.3.0",
+        "@contentful/f36-layout": "^5.3.0",
+        "@contentful/f36-list": "^5.3.0",
+        "@contentful/f36-menu": "^5.3.0",
+        "@contentful/f36-modal": "^5.3.0",
+        "@contentful/f36-multiselect": "^5.3.0",
+        "@contentful/f36-navlist": "^5.3.0",
+        "@contentful/f36-note": "^5.3.0",
+        "@contentful/f36-notification": "^5.3.0",
+        "@contentful/f36-pagination": "^5.3.0",
+        "@contentful/f36-pill": "^5.3.0",
+        "@contentful/f36-popover": "^5.3.0",
+        "@contentful/f36-progress-stepper": "^5.3.0",
+        "@contentful/f36-skeleton": "^5.3.0",
+        "@contentful/f36-spinner": "^5.3.0",
+        "@contentful/f36-table": "^5.3.0",
+        "@contentful/f36-tabs": "^5.3.0",
+        "@contentful/f36-text-link": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.1.0",
-        "@contentful/f36-typography": "^5.1.0",
-        "@contentful/f36-usage-card": "^5.1.0",
-        "@contentful/f36-usage-count": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.3.0",
+        "@contentful/f36-typography": "^5.3.0",
+        "@contentful/f36-usage-card": "^5.3.0",
+        "@contentful/f36-usage-count": "^5.3.0",
         "@contentful/f36-utils": "^5.1.0"
       },
       "devDependencies": {
@@ -46213,19 +46213,19 @@
       "version": "1.0.0",
       "dependencies": {
         "@codesandbox/sandpack-react": "^1.17.0",
-        "@contentful/f36-avatar": "^5.1.0",
-        "@contentful/f36-components": "^5.1.0",
+        "@contentful/f36-avatar": "^5.3.0",
+        "@contentful/f36-components": "^5.3.0",
         "@contentful/f36-docs-utils": "^4.0.2",
-        "@contentful/f36-empty-state": "^5.1.0",
-        "@contentful/f36-header": "^5.1.0",
-        "@contentful/f36-icon": "^5.1.0",
-        "@contentful/f36-icons": "^5.1.0",
-        "@contentful/f36-image": "^5.1.0",
-        "@contentful/f36-layout": "^5.1.0",
-        "@contentful/f36-multiselect": "^5.1.0",
-        "@contentful/f36-navbar": "5.1.0",
-        "@contentful/f36-navlist": "^5.1.0",
-        "@contentful/f36-progress-stepper": "^5.1.0",
+        "@contentful/f36-empty-state": "^5.3.0",
+        "@contentful/f36-header": "^5.3.0",
+        "@contentful/f36-icon": "^5.3.0",
+        "@contentful/f36-icons": "^5.3.0",
+        "@contentful/f36-image": "^5.3.0",
+        "@contentful/f36-layout": "^5.3.0",
+        "@contentful/f36-multiselect": "^5.3.0",
+        "@contentful/f36-navbar": "5.3.0",
+        "@contentful/f36-navlist": "^5.3.0",
+        "@contentful/f36-progress-stepper": "^5.3.0",
         "@contentful/f36-tokens": "^5.1.0",
         "@contentful/f36-utils": "^5.1.0",
         "@contentful/rich-text-react-renderer": "^16.0.0",

--- a/packages/components/usage-count/src/UsageCount.tsx
+++ b/packages/components/usage-count/src/UsageCount.tsx
@@ -40,7 +40,7 @@ type usageCountType =
   | {
       valueDescription?: never;
       periodType?: never;
-      quota: number;
+      quota: number | string;
       variant: PickUnion<Variant, 'entitlement'>;
       includedLabel?: string;
     };


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

This makes `quota` prop of UsageCount component `string | number`.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
