### PR TITLE
chore: bump estimo to 3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "eslint-plugin-rulesdir": "0.2.2",
         "eslint-plugin-testing-library": "^5.11.0",
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0",
-        "estimo": "^3.0.4",
+        "estimo": "^3.0.5",
         "fast-glob": "^3.2.12",
         "globby": "^11.0.2",
         "inquirer": "^9.1.1",
@@ -7268,12 +7268,12 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.10.6",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.6.tgz",
-      "integrity": "sha512-pHUn6ZRt39bP3698HFQlu2ZHCkS/lPcpv7fVQcGBSzNNygw171UXAKrCUhy+TEMw4lEttOKDgNpb04hwUAJeiQ==",
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.10.tgz",
+      "integrity": "sha512-3ZG500+ZeLql8rE0hjfhkycJjDj0pI/btEh3L9IkWUYcOrgP0xCNRq3HbtbqOPbvDhFaAWD88pDFtlLv8ns8gA==",
       "dev": true,
       "dependencies": {
-        "debug": "^4.4.1",
+        "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
@@ -12764,12 +12764,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
-      "dev": true
-    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "license": "MIT",
@@ -13263,22 +13257,31 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
-      "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.0.tgz",
+      "integrity": "sha512-AOhh6Bg5QmFIXdViHbMc2tLDsBIRxdkIaIddPslJF9Z5De3APBScuqGP2uThXnIpqFrgoxMNC6km7uXNIMLHXA==",
       "dev": true,
-      "optional": true
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
     },
     "node_modules/bare-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.2.0.tgz",
-      "integrity": "sha512-oRfrw7gwwBVAWx9S5zPMo2iiOjxyiZE12DmblmMQREgcogbNO0AFaZ+QBxxkEXiPspcpvO/Qtqn8LabUx4uYXg==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.4.10.tgz",
+      "integrity": "sha512-arqVF+xX/rJHwrONZaSPhlzleT2gXwVs9rsAe1p1mIVwWZI2A76/raio+KwwxfWMO8oV9Wo90EaUkS2QwVmy4w==",
       "dev": true,
       "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4"
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
       },
       "engines": {
         "bare": ">=1.16.0"
@@ -13293,9 +13296,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
-      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -13332,6 +13335,16 @@
         "bare-events": {
           "optional": true
         }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.2.2.tgz",
+      "integrity": "sha512-g+ueNGKkrjMazDG3elZO1pNs3HY5+mMmOet1jtKyhOaCnkLzitxf26z7hoAEkDNgdNmnc1KIlt/dw6Po6xZMpA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base": {
@@ -14523,9 +14536,9 @@
       "license": "0BSD"
     },
     "node_modules/chromium-bidi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-7.2.0.tgz",
-      "integrity": "sha512-gREyhyBstermK+0RbcJLbFhcQctg92AGgDe/h/taMJEOLRdtSswBAO9KmvltFSQWgM2LrwWu5SIuEUbdm3JsyQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-8.0.0.tgz",
+      "integrity": "sha512-d1VmE0FD7lxZQHzcDUCKZSNRtRwISXDsdg4HjdTR5+Ll5nQ/vzU12JeNmupD6VWffrPSlrnGhEWlLESKH3VO+g==",
       "dev": true,
       "dependencies": {
         "mitt": "^3.0.1",
@@ -16264,9 +16277,9 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -17055,9 +17068,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1464554",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1464554.tgz",
-      "integrity": "sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==",
+      "version": "0.0.1495869",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
+      "integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
       "dev": true
     },
     "node_modules/diff": {
@@ -18669,16 +18682,16 @@
       }
     },
     "node_modules/estimo": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/estimo/-/estimo-3.0.4.tgz",
-      "integrity": "sha512-3OSMcjOfEAZw5x4hPY3fUJ2W2ddwobmGjZqY4pSJycCjrDeacOCWFGC5aL2JLg13k6LeTvrjdDw77Oi6Gl4Qsw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/estimo/-/estimo-3.0.5.tgz",
+      "integrity": "sha512-Q9asaAAM3KZc4Ckr8GMcJWYc3hNCf0KnmhkfzHuAWmqGoPssQoe5Mb8et1CYmmkeMfPTlUyeBHRi53Bedvnl1Q==",
       "dev": true,
       "dependencies": {
         "@sitespeed.io/tracium": "0.3.3",
         "commander": "12.0.0",
-        "find-chrome-bin": "2.0.3",
+        "find-chrome-bin": "2.0.4",
         "nanoid": "5.1.5",
-        "puppeteer-core": "24.15.0"
+        "puppeteer-core": "24.22.0"
       },
       "bin": {
         "estimo": "scripts/cli.js"
@@ -18875,6 +18888,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/exec-sh": {
@@ -19465,12 +19487,12 @@
       }
     },
     "node_modules/find-chrome-bin": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/find-chrome-bin/-/find-chrome-bin-2.0.3.tgz",
-      "integrity": "sha512-LfMPOlRfP8pOSk2gIY0KWAXBFO5h6ZF4FlLj8QHw1fAwGpPquUIrB8d35Rswf2yhmCmeqQhLBsbhB8+8U7iuKw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/find-chrome-bin/-/find-chrome-bin-2.0.4.tgz",
+      "integrity": "sha512-iKiqIb7FsA0hwnq0vvDay4RsmHUFLvWVquTb59XVlxfHS68XaWZfEjriF2vTZ3k/plicyKZxMJLqxKt10kSOtQ==",
       "dev": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.10.6"
+        "@puppeteer/browsers": "2.10.10"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -34684,16 +34706,17 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.15.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.15.0.tgz",
-      "integrity": "sha512-2iy0iBeWbNyhgiCGd/wvGrDSo73emNFjSxYOcyAqYiagkYt5q4cPfVXaVDKBsukgc2fIIfLAalBZlaxldxdDYg==",
+      "version": "24.22.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.22.0.tgz",
+      "integrity": "sha512-oUeWlIg0pMz8YM5pu0uqakM+cCyYyXkHBxx9di9OUELu9X9+AYrNGGRLK9tNME3WfN3JGGqQIH3b4/E9LGek/w==",
       "dev": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.10.6",
-        "chromium-bidi": "7.2.0",
-        "debug": "^4.4.1",
-        "devtools-protocol": "0.0.1464554",
+        "@puppeteer/browsers": "2.10.10",
+        "chromium-bidi": "8.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1495869",
         "typed-query-selector": "^2.12.0",
+        "webdriver-bidi-protocol": "0.2.11",
         "ws": "^8.18.3"
       },
       "engines": {
@@ -38514,16 +38537,14 @@
       "license": "MIT"
     },
     "node_modules/streamx": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
-      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
       "dev": true,
       "dependencies": {
+        "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
-      },
-      "optionalDependencies": {
-        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -39054,9 +39075,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
       "dependencies": {
         "pump": "^3.0.0",
@@ -39076,6 +39097,20 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/tar/node_modules/chownr": {
@@ -39331,6 +39366,20 @@
       "dev": true,
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/text-extensions": {
@@ -41199,6 +41248,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.2.11.tgz",
+      "integrity": "sha512-Y9E1/oi4XMxcR8AT0ZC4OvYntl34SPgwjmELH+owjBr0korAX4jKgZULBWILGCVGdVCQ0dodTToIETozhG8zvA==",
+      "dev": true
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "dev": true,
@@ -41724,14 +41779,14 @@
     },
     "packages/components/accordion": {
       "name": "@contentful/f36-accordion",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-collapse": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
+        "@contentful/f36-collapse": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
+        "@contentful/f36-typography": "^5.6.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -41741,14 +41796,14 @@
     },
     "packages/components/asset": {
       "name": "@contentful/f36-asset",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icon": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icon": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
+        "@contentful/f36-typography": "^5.6.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -41758,18 +41813,18 @@
     },
     "packages/components/autocomplete": {
       "name": "@contentful/f36-autocomplete",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-forms": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
-        "@contentful/f36-popover": "^5.5.0",
-        "@contentful/f36-skeleton": "^5.5.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-forms": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
+        "@contentful/f36-popover": "^5.6.0",
+        "@contentful/f36-skeleton": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-typography": "^5.6.0",
+        "@contentful/f36-utils": "^5.2.0",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       },
@@ -41780,14 +41835,14 @@
     },
     "packages/components/avatar": {
       "name": "@contentful/f36-avatar",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-image": "^5.5.0",
-        "@contentful/f36-menu": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-image": "^5.6.0",
+        "@contentful/f36-menu": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.5.0",
+        "@contentful/f36-tooltip": "^5.6.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -41797,17 +41852,17 @@
     },
     "packages/components/badge": {
       "name": "@contentful/f36-badge",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-utils": "^5.2.0",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^5.5.0"
+        "@contentful/f36-typography": "^5.6.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -41816,19 +41871,19 @@
     },
     "packages/components/button": {
       "name": "@contentful/f36-button",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-spinner": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-spinner": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.5.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.6.0",
+        "@contentful/f36-utils": "^5.2.0",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-icon": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0"
+        "@contentful/f36-icon": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -41837,21 +41892,21 @@
     },
     "packages/components/card": {
       "name": "@contentful/f36-card",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-asset": "^5.5.0",
-        "@contentful/f36-badge": "^5.5.0",
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-drag-handle": "^5.5.0",
-        "@contentful/f36-icon": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
-        "@contentful/f36-menu": "^5.5.0",
-        "@contentful/f36-skeleton": "^5.5.0",
+        "@contentful/f36-asset": "^5.6.0",
+        "@contentful/f36-badge": "^5.6.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-drag-handle": "^5.6.0",
+        "@contentful/f36-icon": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
+        "@contentful/f36-menu": "^5.6.0",
+        "@contentful/f36-skeleton": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.5.0",
-        "@contentful/f36-typography": "^5.5.0",
+        "@contentful/f36-tooltip": "^5.6.0",
+        "@contentful/f36-typography": "^5.6.0",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -41862,10 +41917,10 @@
     },
     "packages/components/collapse": {
       "name": "@contentful/f36-collapse",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -41876,14 +41931,14 @@
     },
     "packages/components/copybutton": {
       "name": "@contentful/f36-copybutton",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.5.0",
+        "@contentful/f36-tooltip": "^5.6.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -41893,16 +41948,16 @@
     },
     "packages/components/datepicker": {
       "name": "@contentful/f36-datepicker",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-forms": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
-        "@contentful/f36-popover": "^5.5.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-forms": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
+        "@contentful/f36-popover": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
+        "@contentful/f36-typography": "^5.6.0",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -41915,10 +41970,10 @@
     },
     "packages/components/datetime": {
       "name": "@contentful/f36-datetime",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -41930,13 +41985,13 @@
     },
     "packages/components/drag-handle": {
       "name": "@contentful/f36-drag-handle",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-utils": "^5.2.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -41946,11 +42001,11 @@
     },
     "packages/components/empty-state": {
       "name": "@contentful/f36-empty-state",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
+        "@contentful/f36-typography": "^5.6.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -41960,19 +42015,19 @@
     },
     "packages/components/entity-list": {
       "name": "@contentful/f36-entity-list",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-badge": "^5.5.0",
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-drag-handle": "^5.5.0",
-        "@contentful/f36-icon": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
-        "@contentful/f36-menu": "^5.5.0",
-        "@contentful/f36-skeleton": "^5.5.0",
+        "@contentful/f36-badge": "^5.6.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-drag-handle": "^5.6.0",
+        "@contentful/f36-icon": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
+        "@contentful/f36-menu": "^5.6.0",
+        "@contentful/f36-skeleton": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
+        "@contentful/f36-typography": "^5.6.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -41982,14 +42037,14 @@
     },
     "packages/components/forms": {
       "name": "@contentful/f36-forms",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-typography": "^5.6.0",
+        "@contentful/f36-utils": "^5.2.0",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
@@ -42003,14 +42058,14 @@
     },
     "packages/components/header": {
       "name": "@contentful/f36-header",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
+        "@contentful/f36-typography": "^5.6.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42020,10 +42075,10 @@
     },
     "packages/components/icon": {
       "name": "@contentful/f36-icon",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
         "@phosphor-icons/react": "2.1.8",
         "emotion": "^10.0.17"
@@ -42042,11 +42097,11 @@
     },
     "packages/components/icons": {
       "name": "@contentful/f36-icons",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icon": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icon": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
         "@phosphor-icons/react": "2.1.8",
         "emotion": "^10.0.17"
@@ -42065,11 +42120,11 @@
     },
     "packages/components/image": {
       "name": "@contentful/f36-image",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-skeleton": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-skeleton": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42080,11 +42135,11 @@
     },
     "packages/components/layout": {
       "name": "@contentful/f36-layout",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-header": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-header": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42095,10 +42150,10 @@
     },
     "packages/components/list": {
       "name": "@contentful/f36-list",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42109,15 +42164,15 @@
     },
     "packages/components/menu": {
       "name": "@contentful/f36-menu",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
-        "@contentful/f36-popover": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
+        "@contentful/f36-popover": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-typography": "^5.6.0",
+        "@contentful/f36-utils": "^5.2.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42127,14 +42182,14 @@
     },
     "packages/components/modal": {
       "name": "@contentful/f36-modal",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
+        "@contentful/f36-typography": "^5.6.0",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -42170,20 +42225,20 @@
     },
     "packages/components/multiselect": {
       "name": "@contentful/f36-multiselect",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.1",
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-forms": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
-        "@contentful/f36-popover": "^5.5.0",
-        "@contentful/f36-skeleton": "^5.5.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-forms": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
+        "@contentful/f36-popover": "^5.6.0",
+        "@contentful/f36-skeleton": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.5.0",
-        "@contentful/f36-typography": "^5.5.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.6.0",
+        "@contentful/f36-typography": "^5.6.0",
+        "@contentful/f36-utils": "^5.2.0",
         "emotion": "^10.0.17",
         "react-focus-lock": "^2.9.5"
       },
@@ -42229,20 +42284,20 @@
     },
     "packages/components/navbar": {
       "name": "@contentful/f36-navbar",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-avatar": "^5.5.0",
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icon": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
-        "@contentful/f36-menu": "^5.5.0",
-        "@contentful/f36-skeleton": "^5.5.0",
+        "@contentful/f36-avatar": "^5.6.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icon": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
+        "@contentful/f36-menu": "^5.6.0",
+        "@contentful/f36-skeleton": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.5.0",
-        "@contentful/f36-typography": "^5.5.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.6.0",
+        "@contentful/f36-typography": "^5.6.0",
+        "@contentful/f36-utils": "^5.2.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42252,10 +42307,10 @@
     },
     "packages/components/navlist": {
       "name": "@contentful/f36-navlist",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42266,16 +42321,16 @@
     },
     "packages/components/note": {
       "name": "@contentful/f36-note",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icon": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icon": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-typography": "^5.6.0",
+        "@contentful/f36-utils": "^5.2.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42285,15 +42340,15 @@
     },
     "packages/components/notification": {
       "name": "@contentful/f36-notification",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
-        "@contentful/f36-text-link": "^5.5.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
+        "@contentful/f36-text-link": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
+        "@contentful/f36-typography": "^5.6.0",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
       },
@@ -42304,15 +42359,15 @@
     },
     "packages/components/pagination": {
       "name": "@contentful/f36-pagination",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-forms": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-forms": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
+        "@contentful/f36-typography": "^5.6.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42322,15 +42377,15 @@
     },
     "packages/components/pill": {
       "name": "@contentful/f36-pill",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-drag-handle": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-drag-handle": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.5.0",
+        "@contentful/f36-tooltip": "^5.6.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42340,12 +42395,12 @@
     },
     "packages/components/popover": {
       "name": "@contentful/f36-popover",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-utils": "^5.2.0",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
@@ -42357,14 +42412,14 @@
     },
     "packages/components/progress-stepper": {
       "name": "@contentful/f36-progress-stepper",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
+        "@contentful/f36-typography": "^5.6.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42374,11 +42429,11 @@
     },
     "packages/components/skeleton": {
       "name": "@contentful/f36-skeleton",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-table": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-table": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
@@ -42389,15 +42444,15 @@
     },
     "packages/components/spinner": {
       "name": "@contentful/f36-spinner",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^5.5.0"
+        "@contentful/f36-typography": "^5.6.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -42406,14 +42461,14 @@
     },
     "packages/components/table": {
       "name": "@contentful/f36-table",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-typography": "^5.6.0",
+        "@contentful/f36-utils": "^5.2.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42423,10 +42478,10 @@
     },
     "packages/components/tabs": {
       "name": "@contentful/f36-tabs",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -42574,15 +42629,15 @@
     },
     "packages/components/text-link": {
       "name": "@contentful/f36-text-link",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
         "emotion": "^10.0.17"
       },
       "devDependencies": {
-        "@contentful/f36-icons": "^5.5.0"
+        "@contentful/f36-icons": "^5.6.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -42591,12 +42646,12 @@
     },
     "packages/components/tooltip": {
       "name": "@contentful/f36-tooltip",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-utils": "^5.2.0",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
@@ -42609,12 +42664,12 @@
     },
     "packages/components/typography": {
       "name": "@contentful/f36-typography",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-utils": "^5.2.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42624,16 +42679,16 @@
     },
     "packages/components/usage-card": {
       "name": "@contentful/f36-usage-card",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-card": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
-        "@contentful/f36-text-link": "^5.5.0",
+        "@contentful/f36-card": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
+        "@contentful/f36-text-link": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.5.0",
-        "@contentful/f36-typography": "^5.5.0",
+        "@contentful/f36-tooltip": "^5.6.0",
+        "@contentful/f36-typography": "^5.6.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42643,12 +42698,12 @@
     },
     "packages/components/usage-count": {
       "name": "@contentful/f36-usage-count",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.5.0",
+        "@contentful/f36-core": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.5.0",
+        "@contentful/f36-typography": "^5.6.0",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -42658,7 +42713,7 @@
     },
     "packages/components/utils": {
       "name": "@contentful/f36-utils",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^5.1.0",
@@ -42690,7 +42745,7 @@
     },
     "packages/core": {
       "name": "@contentful/f36-core",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^5.1.0",
@@ -42981,52 +43036,52 @@
     },
     "packages/forma-36-react-components": {
       "name": "@contentful/f36-components",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-accordion": "^5.5.0",
-        "@contentful/f36-asset": "^5.5.0",
-        "@contentful/f36-autocomplete": "^5.5.0",
-        "@contentful/f36-avatar": "^5.5.0",
-        "@contentful/f36-badge": "^5.5.0",
-        "@contentful/f36-button": "^5.5.0",
-        "@contentful/f36-card": "^5.5.0",
-        "@contentful/f36-collapse": "^5.5.0",
-        "@contentful/f36-copybutton": "^5.5.0",
-        "@contentful/f36-core": "^5.5.0",
-        "@contentful/f36-datepicker": "^5.5.0",
-        "@contentful/f36-datetime": "^5.5.0",
-        "@contentful/f36-drag-handle": "^5.5.0",
-        "@contentful/f36-empty-state": "^5.5.0",
-        "@contentful/f36-entity-list": "^5.5.0",
-        "@contentful/f36-forms": "^5.5.0",
-        "@contentful/f36-header": "^5.5.0",
-        "@contentful/f36-icon": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
-        "@contentful/f36-image": "^5.5.0",
-        "@contentful/f36-layout": "^5.5.0",
-        "@contentful/f36-list": "^5.5.0",
-        "@contentful/f36-menu": "^5.5.0",
-        "@contentful/f36-modal": "^5.5.0",
-        "@contentful/f36-multiselect": "^5.5.0",
-        "@contentful/f36-navlist": "^5.5.0",
-        "@contentful/f36-note": "^5.5.0",
-        "@contentful/f36-notification": "^5.5.0",
-        "@contentful/f36-pagination": "^5.5.0",
-        "@contentful/f36-pill": "^5.5.0",
-        "@contentful/f36-popover": "^5.5.0",
-        "@contentful/f36-progress-stepper": "^5.5.0",
-        "@contentful/f36-skeleton": "^5.5.0",
-        "@contentful/f36-spinner": "^5.5.0",
-        "@contentful/f36-table": "^5.5.0",
-        "@contentful/f36-tabs": "^5.5.0",
-        "@contentful/f36-text-link": "^5.5.0",
+        "@contentful/f36-accordion": "^5.6.0",
+        "@contentful/f36-asset": "^5.6.0",
+        "@contentful/f36-autocomplete": "^5.6.0",
+        "@contentful/f36-avatar": "^5.6.0",
+        "@contentful/f36-badge": "^5.6.0",
+        "@contentful/f36-button": "^5.6.0",
+        "@contentful/f36-card": "^5.6.0",
+        "@contentful/f36-collapse": "^5.6.0",
+        "@contentful/f36-copybutton": "^5.6.0",
+        "@contentful/f36-core": "^5.6.0",
+        "@contentful/f36-datepicker": "^5.6.0",
+        "@contentful/f36-datetime": "^5.6.0",
+        "@contentful/f36-drag-handle": "^5.6.0",
+        "@contentful/f36-empty-state": "^5.6.0",
+        "@contentful/f36-entity-list": "^5.6.0",
+        "@contentful/f36-forms": "^5.6.0",
+        "@contentful/f36-header": "^5.6.0",
+        "@contentful/f36-icon": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
+        "@contentful/f36-image": "^5.6.0",
+        "@contentful/f36-layout": "^5.6.0",
+        "@contentful/f36-list": "^5.6.0",
+        "@contentful/f36-menu": "^5.6.0",
+        "@contentful/f36-modal": "^5.6.0",
+        "@contentful/f36-multiselect": "^5.6.0",
+        "@contentful/f36-navlist": "^5.6.0",
+        "@contentful/f36-note": "^5.6.0",
+        "@contentful/f36-notification": "^5.6.0",
+        "@contentful/f36-pagination": "^5.6.0",
+        "@contentful/f36-pill": "^5.6.0",
+        "@contentful/f36-popover": "^5.6.0",
+        "@contentful/f36-progress-stepper": "^5.6.0",
+        "@contentful/f36-skeleton": "^5.6.0",
+        "@contentful/f36-spinner": "^5.6.0",
+        "@contentful/f36-table": "^5.6.0",
+        "@contentful/f36-tabs": "^5.6.0",
+        "@contentful/f36-text-link": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.5.0",
-        "@contentful/f36-typography": "^5.5.0",
-        "@contentful/f36-usage-card": "^5.5.0",
-        "@contentful/f36-usage-count": "^5.5.0",
-        "@contentful/f36-utils": "^5.1.0"
+        "@contentful/f36-tooltip": "^5.6.0",
+        "@contentful/f36-typography": "^5.6.0",
+        "@contentful/f36-usage-card": "^5.6.0",
+        "@contentful/f36-usage-count": "^5.6.0",
+        "@contentful/f36-utils": "^5.2.0"
       },
       "devDependencies": {
         "microbundle": "^0.15.1",
@@ -46216,21 +46271,21 @@
       "version": "1.0.0",
       "dependencies": {
         "@codesandbox/sandpack-react": "^1.17.0",
-        "@contentful/f36-avatar": "^5.5.0",
-        "@contentful/f36-components": "^5.5.0",
+        "@contentful/f36-avatar": "^5.6.0",
+        "@contentful/f36-components": "^5.6.0",
         "@contentful/f36-docs-utils": "^4.0.2",
-        "@contentful/f36-empty-state": "^5.5.0",
-        "@contentful/f36-header": "^5.5.0",
-        "@contentful/f36-icon": "^5.5.0",
-        "@contentful/f36-icons": "^5.5.0",
-        "@contentful/f36-image": "^5.5.0",
-        "@contentful/f36-layout": "^5.5.0",
-        "@contentful/f36-multiselect": "^5.5.0",
-        "@contentful/f36-navbar": "5.5.0",
-        "@contentful/f36-navlist": "^5.5.0",
-        "@contentful/f36-progress-stepper": "^5.5.0",
+        "@contentful/f36-empty-state": "^5.6.0",
+        "@contentful/f36-header": "^5.6.0",
+        "@contentful/f36-icon": "^5.6.0",
+        "@contentful/f36-icons": "^5.6.0",
+        "@contentful/f36-image": "^5.6.0",
+        "@contentful/f36-layout": "^5.6.0",
+        "@contentful/f36-multiselect": "^5.6.0",
+        "@contentful/f36-navbar": "5.6.0",
+        "@contentful/f36-navlist": "^5.6.0",
+        "@contentful/f36-progress-stepper": "^5.6.0",
         "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.1.0",
+        "@contentful/f36-utils": "^5.2.0",
         "@contentful/rich-text-react-renderer": "^16.0.0",
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/sortable": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "eslint-plugin-rulesdir": "0.2.2",
     "eslint-plugin-testing-library": "^5.11.0",
     "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0",
-    "estimo": "^3.0.4",
+    "estimo": "^3.0.5",
     "fast-glob": "^3.2.12",
     "globby": "^11.0.2",
     "inquirer": "^9.1.1",


### PR DESCRIPTION
# Purpose of PR

Bump estimo dependency to 3.0.5 to address vulnerability alert for tar-fs 3.1.0

```
forma-36-monorepo
└─┬ estimo@3.0.5
  └─┬ find-chrome-bin@2.0.4
    └─┬ @puppeteer/browsers@2.10.10
      └── tar-fs@3.1.1
```

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
