### PR TITLE
chore: add github action policies to vault secrets

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -1,5 +1,9 @@
 version: 1
 services:
+  github-action:
+    policies:
+      - packages-read
+      - semantic-release
   circleci:
     policies:
       - semantic-release


### PR DESCRIPTION
# Purpose of PR

To allow github actions to publish packages we need to be able to fetch secrets from contentful vault.

This adds the policies to fetch policies from contentful vault in github actions