### PR TITLE
docs: fix page rendering to resolve website build

### DIFF
--- a/packages/components/utils/src/getIconColorToken/getIconColorToken.mdx
+++ b/packages/components/utils/src/getIconColorToken/getIconColorToken.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'getIconColorToken'
-type:: 'component'
+type: 'component'
 slug: /utils/get-icon-color-token/
 section: 'utils'
 typescript: ./getIconColorToken.ts
@@ -9,11 +9,17 @@ typescript: ./getIconColorToken.ts
 The `getIconColorToken` utility function maps a given variant (such as `primary`, `negative`, etc.) to its corresponding icon color token from the design system.
 This ensures that icons always use the correct color for their variant, providing consistent icon coloring across all components by referencing the right color tokens.
 
-## Usage
+## Import
 
-## Example: Shared and Per-Component Usage
+```jsx static=true
+import { getIconColorToken } from '@contentful/f36-utils';
+```
 
-```ts
+## Example
+
+### Shared and Per-Component Usage
+
+```tsx static=true
 import { getIconColorToken, iconColorByVariant } from '@contentful/f36-utils';
 
 // Shared usage (universal variants)
@@ -24,7 +30,8 @@ const buttonIconColorByVariant = {
   ...iconColorByVariant,
   primary: 'colorWhite', // Button-specific override
 };
+
 const buttonColor = getIconColorToken('primary', buttonIconColorByVariant); // returns 'colorWhite'
 
-> The mapping object can be partial or custom for each component.
+// The mapping object can be partial or custom for each component.
 ```


### PR DESCRIPTION
# Purpose of PR

Fixes an issue with the `getIconColorToken` page on the documentation website.

A typo that slipped in #3182 broke the page rendering and prevented the build from being successful, blocking feature development.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information

## ToDo
- [ ] Port the changes to the v6 branch