### PR TITLE
fix: fix null pointer error on list item when is children is not defi…

### DIFF
--- a/packages/f36-ai-components/src/AIChatMessage/AIChatMessage.tsx
+++ b/packages/f36-ai-components/src/AIChatMessage/AIChatMessage.tsx
@@ -62,7 +62,10 @@ function _AIChatMessage(props: AIChatMessageProps, ref: Ref<HTMLDivElement>) {
             a: TextLink,
             ul: (props) => <List {...props} as={'ul'} />,
             ol: (props) => <List {...props} as={'ol'} />,
-            li: List.Item,
+            // tmp fix needed until https://github.com/contentful/forma-36/pull/3227 is shipped
+            li: (props) => (
+              <List.Item children={props.children || <></>} {...props} />
+            ),
             table: (props) => <Table {...props} />,
             tbody: (props) => <Table.Body {...props} />,
             thead: (props) => <Table.Head {...props} />,


### PR DESCRIPTION
# Purpose of PR

In this PR, I fix a bug that was in the `<List.Item>` component. 

When steaming markdown text, and rendering it with Forma components, we can have a case where a `<List.Item>` will not have any children when they are being streamed.

However, before this fix, the `<List.Item>` component would throw an error when `children` was `undefined`


## PR Checklist

- [x ] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
