### PR TITLE
feat: Update Note Component Styles

### DIFF
--- a/packages/components/note/src/Note.styles.tsx
+++ b/packages/components/note/src/Note.styles.tsx
@@ -10,55 +10,31 @@ const variantToStyles = (variant: NoteVariant) => {
       return {
         backgroundColor: tokens.blue100,
         borderColor: tokens.blue300,
-
-        a: {
-          color: tokens.blue700,
-        },
       };
     case 'positive':
       return {
         backgroundColor: tokens.green100,
         borderColor: tokens.green300,
-
-        a: {
-          color: tokens.blue700,
-        },
       };
     case 'negative':
       return {
         backgroundColor: tokens.red100,
         borderColor: tokens.red300,
-
-        a: {
-          color: tokens.blue700,
-        },
       };
     case 'warning':
       return {
         backgroundColor: tokens.orange100,
         borderColor: tokens.orange300,
-
-        a: {
-          color: tokens.blue700,
-        },
       };
     case 'neutral':
       return {
         backgroundColor: tokens.gray100,
         borderColor: tokens.gray300,
-
-        a: {
-          color: tokens.blue700,
-        },
       };
     case 'premium':
       return {
         backgroundColor: tokens.purple100,
         borderColor: tokens.purple300,
-
-        a: {
-          color: tokens.blue700,
-        },
       };
     default:
       return {};

--- a/packages/components/note/stories/Note.stories.tsx
+++ b/packages/components/note/stories/Note.stories.tsx
@@ -234,5 +234,19 @@ export const Overview = () => (
         </Paragraph>
       </Note>
     </Flex>
+
+    <SectionHeading as="h3" marginBottom="spacingS">
+      Note premium with TextLink as premium
+    </SectionHeading>
+
+    <Flex marginBottom="spacingM">
+      <Note variant="premium" title="Short, yet succinct title" withCloseButton>
+        <Paragraph>
+          A piece of information that is relevant to the context the user is
+          currently in. If you like it then you should put{' '}
+          <TextLink variant="premium"> a link</TextLink> in it.
+        </Paragraph>
+      </Note>
+    </Flex>
   </Flex>
 );


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

This PR removes the link color overrides in the Note component and allows `TextLink` used in Note component to be styled as desired

- First Note (Plain TextLink) 
- Second Note (Text Link with variant set to premium)

<img width="1012" height="321" alt="Screenshot 2025-11-12 at 13 00 37" src="https://github.com/user-attachments/assets/e1e12d5a-c282-48f3-a885-4538d4dea07f" />

