### PR TITLE
fix(f36-ai-components): combine AIChatArtifactMessage className with internal style

### DIFF
--- a/packages/f36-ai-components/src/AIChatArtifactMessage/AIChatArtifactMessage.tsx
+++ b/packages/f36-ai-components/src/AIChatArtifactMessage/AIChatArtifactMessage.tsx
@@ -26,6 +26,7 @@ function _AIChatArtifactMessage(
     children,
     icon,
     title,
+    className,
     testId = 'cf-ui-ai-chat-artifact-message',
     ...otherProps
   } = props;
@@ -40,7 +41,7 @@ function _AIChatArtifactMessage(
     <Box
       data-test-id={testId}
       ref={ref}
-      className={cx(styles.container, props.className)}
+      className={cx(styles.container, className)}
       {...otherProps}
     >
       <Box className={styles.header}>


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

This PR fixes a bug with `AIChatArtifactMessage` in which if a `className` prop was provided it would overwrite all internal container styles. This was due to `className` not being present in the prop destructuring, and therefore being included in the spread of `otherProps` and overwriting the explicit setting of the `className` prop on the Box component.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
