### PR TITLE
Fix: Current Color overwritten for Icons in Buttons

### DIFF
--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -66,14 +66,23 @@ function ButtonBase<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
   };
 
   const iconContent = (icon: React.ReactElement<IconProps>) => {
+    const hasVariant = props.variant !== undefined;
+
+    const iconColor = hasVariant
+      ? tokens[getIconColorToken(variant as Variant, buttonIconColorByVariant)]
+      : 'currentColor';
+
     return (
       <Flex
         as="span"
-        className={styles.buttonIcon({ hasChildren: !!children, variant })}
+        className={styles.buttonIcon({
+          hasChildren: !!children,
+          variant,
+        })}
       >
         {React.cloneElement(icon, {
           size: icon.props.size ?? `${size === 'large' ? 'medium' : 'small'}`,
-          color: tokens[getIconColorToken(variant, buttonIconColorByVariant)],
+          color: iconColor,
         })}
       </Flex>
     );

--- a/packages/components/button/stories/ButtonComponent.stories.tsx
+++ b/packages/components/button/stories/ButtonComponent.stories.tsx
@@ -513,6 +513,18 @@ export const Overview = {
             </Stack>
           </div>
         </Flex>
+
+        <Flex flexDirection="column" marginBottom="spacingL">
+          <SectionHeading as="h3" marginBottom="spacingS">
+            with custom styles
+          </SectionHeading>
+          <Button
+            style={{ color: tokens.colorWhite, background: tokens.purple800 }}
+            endIcon={<Icon as={icons.CaretDownIcon} />}
+          >
+            Positive
+          </Button>
+        </Flex>
       </>
     );
   },


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

Before:

<img width="650" height="155" alt="Screenshot 2025-11-24 at 14 55 05" src="https://github.com/user-attachments/assets/8046cbe4-bd3b-4407-bad1-f88b6939c07b" />

After:

<img width="625" height="136" alt="Screenshot 2025-11-24 at 14 57 00" src="https://github.com/user-attachments/assets/7b33b494-4b19-44bb-8031-62cc009660e2" />


## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information
