### PR TITLE
chore: update downshift from version 6 to 9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9858,10 +9858,6 @@
         "dot-prop": "^5.1.0"
       }
     },
-    "node_modules/compute-scroll-into-view": {
-      "version": "1.0.20",
-      "license": "MIT"
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
@@ -10794,20 +10790,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/downshift": {
-      "version": "6.1.12",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.14.8",
-        "compute-scroll-into-view": "^1.0.17",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.12.0"
       }
     },
     "node_modules/dunder-proto": {
@@ -25583,12 +25565,40 @@
         "@contentful/f36-typography": "^6.0.0-alpha.0",
         "@contentful/f36-utils": "^6.0.0-alpha.0",
         "@emotion/css": "^11.13.5",
-        "downshift": "^6.1.12"
+        "downshift": "^9.0.10"
       },
       "peerDependencies": {
         "react": ">=19.1.0",
         "react-dom": ">=19.1.0"
       }
+    },
+    "packages/components/autocomplete/node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
+    "packages/components/autocomplete/node_modules/downshift": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.0.12.tgz",
+      "integrity": "sha512-kFq2pNHm3kmhFfW55RW7+lXliEHg98sKImodICvJfbtvRB6OUiLr138Z8MW5/8t5JaeGZ4Wtomi3Ds72EKVH2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.5",
+        "compute-scroll-into-view": "^3.1.0",
+        "prop-types": "^15.8.1",
+        "react-is": "18.2.0",
+        "tslib": "^2.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
+      }
+    },
+    "packages/components/autocomplete/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "license": "MIT"
     },
     "packages/components/avatar": {
       "name": "@contentful/f36-avatar",

--- a/packages/components/autocomplete/package.json
+++ b/packages/components/autocomplete/package.json
@@ -15,7 +15,7 @@
     "@contentful/f36-tokens": "^6.0.0-alpha.0",
     "@contentful/f36-typography": "^6.0.0-alpha.0",
     "@contentful/f36-utils": "^6.0.0-alpha.0",
-    "downshift": "^6.1.12",
+    "downshift": "^9.0.10",
     "@emotion/css": "^11.13.5"
   },
   "peerDependencies": {

--- a/packages/components/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/autocomplete/src/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { cx } from '@emotion/css';
 import { useCombobox } from 'downshift';
 
@@ -215,7 +215,7 @@ function AutocompleteBase<ItemType>(
     showEmptyList,
     noMatchesMessage = 'No matches found',
     placeholder = 'Search',
-    inputRef,
+    inputRef: inputRefProp,
     toggleRef,
     listRef,
     listWidth = 'auto',
@@ -239,6 +239,7 @@ function AutocompleteBase<ItemType>(
   const [_inputValue, setInputValue] = useState(defaultValue);
   const inputValue =
     typeof inputValueProp === 'undefined' ? _inputValue : inputValueProp;
+  const inputRef = useRef(null);
 
   const handleInputValueChange = useCallback(
     (value: string) => {
@@ -270,14 +271,12 @@ function AutocompleteBase<ItemType>(
     : items.length === 0;
 
   const {
-    getComboboxProps,
     getInputProps,
     getItemProps,
     getMenuProps,
     getToggleButtonProps,
     highlightedIndex,
     isOpen,
-    openMenu,
     toggleMenu,
   } = useCombobox({
     isOpen: isOpenProp,
@@ -359,8 +358,7 @@ function AutocompleteBase<ItemType>(
     'aria-labelledby': _labelledby,
     id: _inputId,
     ...inputProps
-  } = getInputProps();
-  const comboboxProps = getComboboxProps();
+  } = getInputProps({ ref: inputRef });
   const toggleProps = getToggleButtonProps();
   const menuProps = getMenuProps();
   let elementStartIndex = 0;
@@ -384,14 +382,13 @@ function AutocompleteBase<ItemType>(
         autoFocus={false}
         id={menuProps.id}
       >
-        <Popover.Trigger ref={comboboxProps.ref}>
+        <Popover.Trigger>
           <div>
             <TextInput
               className={styles.inputField}
               {...inputProps}
               onFocus={(e) => {
                 onFocus?.(e as React.FocusEvent<HTMLInputElement>);
-                openMenu();
               }}
               onBlur={(e) => {
                 onBlur?.(e as React.FocusEvent<HTMLInputElement>);
@@ -402,7 +399,7 @@ function AutocompleteBase<ItemType>(
               isDisabled={isDisabled}
               isRequired={isRequired}
               isReadOnly={isReadOnly}
-              ref={mergeRefs(inputProps.ref, inputRef)}
+              ref={mergeRefs(inputProps.ref, inputRefProp)}
               testId="cf-autocomplete-input"
               placeholder={placeholder}
               onChange={(event) => {


### PR DESCRIPTION
# Purpose of PR

Update `downshift` (used in Autocomplete) to the latest version and add a new input ref as downshift doesn’t create one internally anymore. All changes should be internal to the component so no changelog is required.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
