### PR TITLE
docs: add deprecation process description

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -141,7 +141,7 @@ if (process.env.NODE_ENV === 'development' && oldProp !== undefined) {
 
 - Announce deprecation in release notes
 - Consider posting in community channels
-- For major deprecations, consider a blog post
+- Consider a blog post for deprecations that affect more than one component
 
 ## Implementation Guidelines
 

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -108,7 +108,7 @@ Include deprecation notices in the package CHANGELOG:
 - **ComponentName**: Deprecated in favor of NewComponent. Will be removed in next major version
 ```
 
-### Deprecationlog
+### Deprecation Log
 
 Document the deprecated feature or component in the Deprecation log
 

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -54,6 +54,7 @@ We follow a **gradual deprecation approach** aligned with [semantic versioning](
 - Remove the deprecated feature in the next major version
 - Update documentation and examples
 - Update migration guides
+- Update deprecation log
 
 ### Example Timeline
 
@@ -93,7 +94,7 @@ Update the following locations:
 Add a prominent deprecation notice at the top of the component page:
 
 ```markdown
-> **⚠️ Deprecated**: This component is deprecated and will be removed in v5.0.0.
+> **⚠️ Deprecated**: This component is deprecated and will be removed in next major version
 > Please use [NewComponent](link) instead. See the [migration guide](#migration).
 ```
 
@@ -104,7 +105,7 @@ Include deprecation notices in the package CHANGELOG:
 ```markdown
 ### Deprecated
 
-- **ComponentName**: Deprecated in favor of NewComponent. Will be removed in v5.0.0.
+- **ComponentName**: Deprecated in favor of NewComponent. Will be removed in next major version
 ```
 
 ### Deprecationlog
@@ -118,7 +119,7 @@ Add console warnings in development mode:
 ```typescript
 if (process.env.NODE_ENV === 'development') {
   console.warn(
-    'Warning: `OldComponent` is deprecated and will be removed in v5.0.0. ' +
+    'Warning: `OldComponent` is deprecated and will be removed in next major version ' +
       'Please use `NewComponent` instead. ' +
       'See migration guide: https://f36.contentful.com/components/old-component#migration',
   );
@@ -130,7 +131,7 @@ For deprecated props on components still in use:
 ```typescript
 if (process.env.NODE_ENV === 'development' && oldProp !== undefined) {
   console.warn(
-    '`oldProp` on ComponentName is deprecated and will be removed in v5.0.0. ' +
+    '`oldProp` on ComponentName is deprecated and will be removed in next major version ' +
       'Please use `newProp` instead.',
   );
 }
@@ -198,7 +199,7 @@ Structure the changeset with clear messaging:
 
 ### Changeset Guidelines
 
-- **Version bump**: Deprecations are `minor` or `feature` changes (new warnings, not breaking)
+- **Version bump**: Deprecations are `minor` changes (new warnings, not breaking)
 - **Label clearly**: Start with `**Deprecated**` in the description
 - **Provide context**: Explain what's deprecated and what to use instead
 - **Link to docs**: Always include a link to migration guidance
@@ -217,7 +218,7 @@ Every deprecation must include a migration guide. The guide should contain:
 ### 2. Before/After Examples
 
 ```tsx
-// ❌ Deprecated - will be removed in v5.0.0
+// ❌ Deprecated - will be removed in next major version
 <OldButton type="primary">Click me</OldButton>
 
 // ✅ Recommended
@@ -290,7 +291,12 @@ export const Button: React.FC<ButtonProps> = ({
   if (process.env.NODE_ENV === 'development' && buttonType) {
     console.warn(
       'Button: `buttonType` prop is deprecated. Use `variant` instead. ' +
-      'This prop will be removed in v5.0.0.'
+      'This prop will be removed in the next major version'
+    );
+  } else if ( process.env.NODE_ENV === 'development' && buttonType && variant) {
+     console.warn(
+      'Button: `buttonType` prop is deprecated in favor of `variant` and will be ignored.' +
+      'This prop will be removed in the next major version'
     );
   }
 
@@ -313,7 +319,7 @@ import { Card } from './Card';
 
 /**
  * @deprecated Use `Card` from '@contentful/f36-card' instead.
- * Will be removed in v5.0.0.
+ * Will be removed in next Major Version
  *
  * @see {@link Card} for the replacement component
  * @example
@@ -328,7 +334,7 @@ import { Card } from './Card';
 export const LegacyCard: React.FC<LegacyCardProps> = (props) => {
   if (process.env.NODE_ENV === 'development') {
     console.warn(
-      'LegacyCard is deprecated and will be removed in v5.0.0. ' +
+      'LegacyCard is deprecated and will be removed in next major version ' +
       'Please migrate to Card. ' +
       'See: https://f36.contentful.com/components/card#migration'
     );

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -1,0 +1,411 @@
+# Deprecation Process
+
+This document outlines the process for deprecating components, props, and features in Forma 36. Following a consistent deprecation process ensures that consumers of the design system have adequate time to migrate away from deprecated APIs while maintaining stability and clear communication.
+
+## Table of Contents
+
+- [When to Deprecate](#when-to-deprecate)
+- [Deprecation Timeline](#deprecation-timeline)
+- [Communication Process](#communication-process)
+- [Implementation Guidelines](#implementation-guidelines)
+- [Creating Changesets for Deprecations](#creating-changesets-for-deprecations)
+- [Migration Guide Requirements](#migration-guide-requirements)
+- [Examples](#examples)
+
+## When to Deprecate
+
+**Deprecation is specifically for breaking changes.** The deprecation process allows us to introduce breaking changes in a controlled manner by giving consumers advance notice and time to migrate. If a change can be made without breaking existing functionality (e.g., adding new props, extending accepted values, adding new components), it does not require deprecation.
+
+Consider deprecating a component, prop, or feature when:
+
+- **Replacement available**: A better alternative exists that provides the same or improved functionality
+- **Design system evolution**: The component no longer aligns with current design principles
+- **Performance issues**: A more performant solution is available
+- **Accessibility improvements**: A more accessible alternative exists
+- **API simplification**: Consolidating similar functionality to reduce confusion
+- **Technical debt**: Removing outdated patterns or dependencies
+
+**Do NOT deprecate when:**
+
+- No clear migration path exists
+- The feature is still widely used without a suitable alternative
+- The change would cause excessive disruption without significant benefit
+- The change can be performed non-breaking e.g. adding additional properties or extending accepted values
+
+## Deprecation Timeline
+
+We follow a **graduated deprecation approach** aligned with [semantic versioning](https://semver.org/):
+
+### Phase 1: Deprecation (Minor Release)
+
+- Mark the feature as deprecated
+- Add runtime console warnings (development only)
+- Update documentation with deprecation notices
+- Provide migration guide
+- Feature remains fully functional
+
+**Minimum duration**: At least **one major version cycle** or **6 months**, whichever is longer
+
+### Phase 2: Removal (Major Release)
+
+- Remove the deprecated feature in the next major version
+- Update documentation and examples
+- Update migration guides
+- Create codemod if applicable (for complex migrations)
+
+### Example Timeline
+
+```text
+v4.10.0 (Minor) - Component deprecated, warnings added
+v4.11.0 - v4.x  - Deprecated but functional
+v5.0.0  (Major) - Component removed
+```
+
+## Communication Process
+
+Effective communication is crucial for successful deprecations. Follow these steps:
+
+### 1. Internal Discussion
+
+- Discuss deprecation with the team
+- Document reasons and alternatives
+- Plan migration strategy
+- Consider impact on known consumers
+
+### 2. Documentation Updates
+
+Update the following locations:
+
+#### Component Documentation
+
+Add a prominent deprecation notice at the top of the component page:
+
+```markdown
+> **⚠️ Deprecated**: This component is deprecated and will be removed in v5.0.0.
+> Please use [NewComponent](link) instead. See the [migration guide](#migration).
+```
+
+#### API Documentation
+
+Mark deprecated props with JSDoc comments:
+
+```typescript
+/**
+ * @deprecated Use `newProp` instead. This prop will be removed in v5.0.0.
+ */
+oldProp?: string;
+```
+
+#### Changelog
+
+Include deprecation notices in the package CHANGELOG:
+
+```markdown
+### Deprecated
+
+- **ComponentName**: Deprecated in favor of NewComponent. Will be removed in v5.0.0.
+```
+
+### 3. Runtime Warnings
+
+Add console warnings in development mode:
+
+```typescript
+if (process.env.NODE_ENV === 'development') {
+  console.warn(
+    'Warning: `OldComponent` is deprecated and will be removed in v5.0.0. ' +
+      'Please use `NewComponent` instead. ' +
+      'See migration guide: https://f36.contentful.com/components/old-component#migration',
+  );
+}
+```
+
+For deprecated props on components still in use:
+
+```typescript
+if (process.env.NODE_ENV === 'development' && oldProp !== undefined) {
+  console.warn(
+    '`oldProp` on ComponentName is deprecated and will be removed in v5.0.0. ' +
+      'Please use `newProp` instead.',
+  );
+}
+```
+
+### 4. Community Communication
+
+- Announce deprecation in release notes
+- Consider posting in community channels
+- For major deprecations, consider a blog post
+
+## Implementation Guidelines
+
+### TypeScript Support
+
+Use TypeScript's `@deprecated` JSDoc tag for IDE support:
+
+```typescript
+/**
+ * @deprecated Use NewComponent instead. Will be removed in v5.0.0.
+ * @see {@link NewComponent}
+ */
+export const OldComponent: React.FC<OldComponentProps> = (props) => {
+  // Implementation
+};
+```
+
+### Prop Deprecation
+
+For individual props, keep the prop functional but add type annotations:
+
+```typescript
+export interface ComponentProps {
+  /**
+   * @deprecated Use `variant` prop instead. Will be removed in v5.0.0.
+   */
+  type?: 'primary' | 'secondary';
+
+  /** The variant of the component */
+  variant?: 'primary' | 'secondary';
+}
+```
+
+### Component Deprecation
+
+Create a wrapper that imports the new component:
+
+```typescript
+import { NewComponent } from './NewComponent';
+
+/**
+ * @deprecated Use NewComponent instead. Will be removed in v5.0.0.
+ */
+
+export const OldComponent: React.FC<OldComponentProps> = (props) => {
+  if (process.env.NODE_ENV === 'development') {
+    console.warn('OldComponent is deprecated...');
+  }
+  return <NewComponent {...convertProps(props)} />;
+};
+```
+
+### Export Strategy
+
+Keep deprecated exports available but marked:
+
+```typescript
+// src/index.ts
+export { NewComponent } from './NewComponent';
+
+/**
+ * @deprecated Use NewComponent instead
+ */
+export { OldComponent } from './OldComponent';
+```
+
+## Creating Changesets for Deprecations
+
+When adding a deprecation, create a changeset that clearly indicates the deprecation:
+
+```bash
+npx changeset
+```
+
+Structure the changeset with clear messaging:
+
+```markdown
+---
+'@contentful/f36-components': minor
+'@contentful/f36-button': minor
+---
+
+**Deprecated**
+
+- `OldButton`: Deprecated in favor of `Button` with `variant` prop. Will be removed in v5.0.0
+- Migration guide available at: https://f36.contentful.com/components/button#migration
+```
+
+### Changeset Guidelines
+
+- **Version bump**: Deprecations are `minor` changes (new warnings, not breaking)
+- **Label clearly**: Start with `**Deprecated**` in the description
+- **Provide context**: Explain what's deprecated and what to use instead
+- **Link to docs**: Always include a link to migration guidance
+- **Removal is major**: When actually removing, use `major` version bump
+
+## Migration Guide Requirements
+
+Every deprecation must include a migration guide. The guide should contain:
+
+### 1. Clear Statement
+
+- What is being deprecated
+- When it will be removed
+- Why it's being deprecated
+
+### 2. Before/After Examples
+
+```tsx
+// ❌ Deprecated - will be removed in v5.0.0
+<OldButton type="primary">Click me</OldButton>
+
+// ✅ Recommended
+<Button variant="primary">Click me</Button>
+```
+
+### 3. Prop Mapping Table
+
+For complex components, provide a mapping:
+
+| Old Prop     | New Prop   | Notes                   |
+| ------------ | ---------- | ----------------------- |
+| `type`       | `variant`  | Direct replacement      |
+| `size`       | `size`     | Unchanged               |
+| `isDisabled` | `disabled` | Renamed for consistency |
+
+### 4. Edge Cases and Gotchas
+
+Document any behavioral differences:
+
+```markdown
+### Important Changes
+
+- The new component uses CSS Grid instead of Flexbox
+- Default spacing has changed from 16px to 12px
+- Event handlers now receive synthetic events (previously native)
+```
+
+### 5. Codemod Availability
+
+If a codemod is available, provide instructions:
+
+```bash
+npx @contentful/forma-36-codemod old-button-to-button path/to/files
+```
+
+### 6. Support Contact
+
+Provide a way to get help:
+
+```markdown
+If you encounter issues during migration, please:
+
+- Check our [GitHub Issues](https://github.com/contentful/forma-36/issues)
+- Send us direct feedback via [our form](https://forms.gle/j3oC9GuhxEJ1DF4k6)
+```
+
+## Examples
+
+### Example 1: Deprecating a Component Prop
+
+```typescript
+export interface ButtonProps {
+  /**
+   * The visual style of the button
+   */
+  variant?: 'primary' | 'secondary' | 'positive' | 'negative';
+
+  /**
+   * @deprecated Use `variant` instead. Will be removed in v5.0.0.
+   */
+  buttonType?: 'primary' | 'secondary' | 'positive' | 'negative';
+}
+
+export const Button: React.FC<ButtonProps> = ({
+  variant,
+  buttonType,
+  ...props
+}) => {
+  if (process.env.NODE_ENV === 'development' && buttonType) {
+    console.warn(
+      'Button: `buttonType` prop is deprecated. Use `variant` instead. ' +
+      'This prop will be removed in v5.0.0.'
+    );
+  }
+
+  const actualVariant = variant ?? buttonType ?? 'primary';
+
+  return <button className={`button-${actualVariant}`} {...props} />;
+};
+```
+
+### Example 2: Deprecating an Entire Component
+
+````typescript
+// NewCard.tsx - The replacement component
+export const Card: React.FC<CardProps> = (props) => {
+  // New implementation
+};
+
+// OldCard.tsx - The deprecated component
+import { Card } from './Card';
+
+/**
+ * @deprecated Use `Card` from '@contentful/f36-card' instead.
+ * Will be removed in v5.0.0.
+ *
+ * @see {@link Card} for the replacement component
+ * @example
+ * ```tsx
+ * // Before
+ * <LegacyCard padding="large">Content</LegacyCard>
+ *
+ * // After
+ * <Card padding="12px">Content</Card>
+ * ```
+ */
+export const LegacyCard: React.FC<LegacyCardProps> = (props) => {
+  if (process.env.NODE_ENV === 'development') {
+    console.warn(
+      'LegacyCard is deprecated and will be removed in v5.0.0. ' +
+      'Please migrate to Card. ' +
+      'See: https://f36.contentful.com/components/card#migration'
+    );
+  }
+
+  // Map old props to new props
+  const newProps = {
+    padding: props.padding === 'large' ? '24px' : '12px',
+    ...props,
+  };
+
+  return <Card {...newProps} />;
+};
+````
+
+### Example 3: Changeset for Deprecation
+
+`.changeset/deprecate-legacy-card.md`:
+
+```markdown
+---
+'@contentful/f36-card': minor
+'@contentful/f36-components': minor
+---
+
+**Deprecated**
+
+- `LegacyCard`: This component is deprecated in favor of the new `Card` component which provides better performance and accessibility. The `LegacyCard` will be removed in v5.0.0.
+  - Use `Card` instead with updated prop names
+  - See migration guide: https://f36.contentful.com/components/card#migration-from-legacy-card
+  - Console warnings added in development mode to help identify usage
+```
+
+## Related Documentation
+
+- [Releases Process](./RELEASES.md) - How to create changesets and publish releases
+- [Migration Guides](./MIGRATION.md) - Existing migration documentation
+- [Contributing Guidelines](https://f36.contentful.com/introduction/contributing) - General contribution process
+- [Semantic Versioning](https://semver.org/) - Versioning specification we follow
+
+## Questions?
+
+If you have questions about the deprecation process:
+
+1. Check existing deprecation examples in the codebase
+2. Ask in the team's internal channels
+3. Review previous deprecation PRs for reference
+4. Consult with the design system team leads
+
+---
+
+**Remember**: Deprecation is about making change manageable, not avoiding it. Clear communication and adequate transition time are key to maintaining trust with the community.

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -39,13 +39,13 @@ We follow a **gradual deprecation approach** aligned with [semantic versioning](
 ### Phase 1: Deprecation (Minor Release)
 
 - Mark the feature as deprecated
-- Add an entry for this feature / component into the deprecation log
+- Add an entry for this feature or component into the deprecation log
 - Add runtime console warnings (development only)
 - Update documentation with deprecation notices
 - Provide migration guide
-- Create codemod if applicable (for complex migrations)
+- Create codemod if applicable
 - Feature remains fully functional
-- Feature is in maintenance mode and will receive security updates as well as bug fixes
+- Feature is in maintenance mode and will receive security updates
 
 **Minimum duration**: At least **one major version cycle** or **6 months**, whichever is longer
 
@@ -144,13 +144,13 @@ if (process.env.NODE_ENV === 'development' && oldProp !== undefined) {
 
 ## Implementation Guidelines
 
-### TypeScript Support
+### Component Deprecation
 
 Use TypeScript's `@deprecated` JSDoc tag for IDE support:
 
 ```typescript
 /**
- * @deprecated Use NewComponent instead. Will be removed in v5.0.0.
+ * @deprecated Use NewComponent instead. Will be removed in the next major version.
  * @see {@link NewComponent}
  */
 export const OldComponent: React.FC<OldComponentProps> = (props) => {
@@ -162,31 +162,16 @@ export const OldComponent: React.FC<OldComponentProps> = (props) => {
 
 For individual props, keep the prop functional but add type annotations:
 
-````typescript
+```typescript
 export interface ComponentProps {
   /**
-   * @deprecated Use `variant` prop instead. Will be removed in v5.0.0.
+   * @deprecated Use `variant` prop instead. Will be removed in the next major version.
    */
   type?: 'primary' | 'secondary';
 
   /** The variant of the component */
   variant?: 'primary' | 'secondary';
 }
-```rop?: string;
-````
-
-### Export Strategy
-
-Keep deprecated exports available but marked:
-
-```typescript
-// src/index.ts
-export { NewComponent } from './NewComponent';
-
-/**
- * @deprecated Use NewComponent instead
- */
-export { OldComponent } from './OldComponent';
 ```
 
 ## Creating Changesets for Deprecations
@@ -213,7 +198,7 @@ Structure the changeset with clear messaging:
 
 ### Changeset Guidelines
 
-- **Version bump**: Deprecations are `minor` changes (new warnings, not breaking)
+- **Version bump**: Deprecations are `minor` or `feature` changes (new warnings, not breaking)
 - **Label clearly**: Start with `**Deprecated**` in the description
 - **Provide context**: Explain what's deprecated and what to use instead
 - **Link to docs**: Always include a link to migration guidance
@@ -276,8 +261,8 @@ Provide a way to get help:
 ```markdown
 If you encounter issues during migration, please:
 
-- Check our [GitHub Issues](https://github.com/contentful/forma-36/issues)
-- Send us direct feedback via [our form](https://forms.gle/j3oC9GuhxEJ1DF4k6)
+- Check our [GitHub Issues](https://github.com/contentful/forma-36/issues) or create a new one
+- Send us direct feedback via our feedback form on our [website](https://f36.contentful.com/)
 ```
 
 ## Examples
@@ -292,7 +277,7 @@ export interface ButtonProps {
   variant?: 'primary' | 'secondary' | 'positive' | 'negative';
 
   /**
-   * @deprecated Use `variant` instead. Will be removed in v5.0.0.
+   * @deprecated Use `variant` instead. Will be removed in the next Major version.
    */
   buttonType?: 'primary' | 'secondary' | 'positive' | 'negative';
 }
@@ -358,24 +343,6 @@ export const LegacyCard: React.FC<LegacyCardProps> = (props) => {
   return <Card {...newProps} />;
 };
 ````
-
-### Example 3: Changeset for Deprecation
-
-`.changeset/deprecate-legacy-card.md`:
-
-```markdown
----
-'@contentful/f36-card': minor
-'@contentful/f36-components': minor
----
-
-**Deprecated**
-
-- `LegacyCard`: This component is deprecated in favor of the new `Card` component which provides better performance and accessibility. The `LegacyCard` will be removed in v5.0.0.
-  - Use `Card` instead with updated prop names
-  - See migration guide: https://f36.contentful.com/components/card#migration-from-legacy-card
-  - Console warnings added in development mode to help identify usage
-```
 
 ## Related Documentation
 

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -39,7 +39,7 @@ We follow a **gradual deprecation approach** aligned with [semantic versioning](
 ### Phase 1: Deprecation (Minor Release)
 
 - Mark the feature as deprecated
-- Add an entry for this feature or component into the deprecation log
+- Add an entry for this feature or component in the deprecation log
 - Add runtime console warnings (development only)
 - Update documentation with deprecation notices
 - Provide migration guide

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -80,7 +80,7 @@ Effective communication is crucial for successful deprecations. Follow these ste
 
 ### 1. Internal Discussion
 
-- Discuss deprecation with the team
+- Discuss deprecation with the forma36 owners
 - Document reasons and alternatives
 - Plan migration strategy
 - Consider impact on known consumers

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -34,15 +34,18 @@ Consider deprecating a component, prop, or feature when:
 
 ## Deprecation Timeline
 
-We follow a **graduated deprecation approach** aligned with [semantic versioning](https://semver.org/):
+We follow a **gradual deprecation approach** aligned with [semantic versioning](https://semver.org/):
 
 ### Phase 1: Deprecation (Minor Release)
 
 - Mark the feature as deprecated
+- Add an entry for this feature / component into the deprecation log
 - Add runtime console warnings (development only)
 - Update documentation with deprecation notices
 - Provide migration guide
+- Create codemod if applicable (for complex migrations)
 - Feature remains fully functional
+- Feature is in maintenance mode and will receive security updates as well as bug fixes
 
 **Minimum duration**: At least **one major version cycle** or **6 months**, whichever is longer
 
@@ -51,7 +54,6 @@ We follow a **graduated deprecation approach** aligned with [semantic versioning
 - Remove the deprecated feature in the next major version
 - Update documentation and examples
 - Update migration guides
-- Create codemod if applicable (for complex migrations)
 
 ### Example Timeline
 
@@ -59,6 +61,16 @@ We follow a **graduated deprecation approach** aligned with [semantic versioning
 v4.10.0 (Minor) - Component deprecated, warnings added
 v4.11.0 - v4.x  - Deprecated but functional
 v5.0.0  (Major) - Component removed
+```
+
+Or if the next major version is sooner than 6 months
+
+```text
+v4.10.0 (Minor) - Component deprecated, warnings added
+v4.11.0 - v4.x  - Deprecated but functional
+v5.0.0 (Major)  - Deprecated but functional
+v5.0.0 - v5.x   - Deprecated but functional
+v6.0.0  (Major) - Component removed
 ```
 
 ## Communication Process
@@ -85,17 +97,6 @@ Add a prominent deprecation notice at the top of the component page:
 > Please use [NewComponent](link) instead. See the [migration guide](#migration).
 ```
 
-#### API Documentation
-
-Mark deprecated props with JSDoc comments:
-
-```typescript
-/**
- * @deprecated Use `newProp` instead. This prop will be removed in v5.0.0.
- */
-oldProp?: string;
-```
-
 #### Changelog
 
 Include deprecation notices in the package CHANGELOG:
@@ -105,6 +106,10 @@ Include deprecation notices in the package CHANGELOG:
 
 - **ComponentName**: Deprecated in favor of NewComponent. Will be removed in v5.0.0.
 ```
+
+### Deprecationlog
+
+Document the deprecated feature or component in the Deprecation log
 
 ### 3. Runtime Warnings
 
@@ -157,7 +162,7 @@ export const OldComponent: React.FC<OldComponentProps> = (props) => {
 
 For individual props, keep the prop functional but add type annotations:
 
-```typescript
+````typescript
 export interface ComponentProps {
   /**
    * @deprecated Use `variant` prop instead. Will be removed in v5.0.0.
@@ -167,26 +172,8 @@ export interface ComponentProps {
   /** The variant of the component */
   variant?: 'primary' | 'secondary';
 }
-```
-
-### Component Deprecation
-
-Create a wrapper that imports the new component:
-
-```typescript
-import { NewComponent } from './NewComponent';
-
-/**
- * @deprecated Use NewComponent instead. Will be removed in v5.0.0.
- */
-
-export const OldComponent: React.FC<OldComponentProps> = (props) => {
-  if (process.env.NODE_ENV === 'development') {
-    console.warn('OldComponent is deprecated...');
-  }
-  return <NewComponent {...convertProps(props)} />;
-};
-```
+```rop?: string;
+````
 
 ### Export Strategy
 

--- a/DEPRECATIONLOG.md
+++ b/DEPRECATIONLOG.md
@@ -1,0 +1,31 @@
+# Deprecation Log
+
+This log tracks all deprecated features and components in Forma 36. For details on the deprecation process, see [DEPRECATION.md](DEPRECATION.md).
+
+---
+
+## Active Deprecations
+
+### Component Name / Feature Name
+
+<!-- Format example ---
+- **Deprecated**: YYYY-MM-DD
+- **Deprecated In**: v5.x.x
+- **Removal Planned**: v6.0.0
+- **Reason**: [Brief explanation - e.g., "Replaced by improved component with better accessibility"]
+- **Migration**: Use `NewComponent` instead
+- **Guide**: [Migration documentation link]
+-->
+
+---
+
+## Removed Deprecations
+
+### Previously Deprecated Item
+
+<!-- Format example
+- **Deprecated**: YYYY-MM-DD
+- **Deprecated In**: v3.x.x
+- **Removed In**: v4.0.0
+- **Reason**: [Brief explanation]
+-->

--- a/DEPRECATIONLOG.md
+++ b/DEPRECATIONLOG.md
@@ -11,7 +11,7 @@ This log tracks all deprecated features and components in Forma 36. For details 
 <!-- Format example ---
 - **Deprecated**: YYYY-MM-DD
 - **Deprecated In**: v5.x.x
-- **Removal Planned**: v6.0.0
+- **Removal Planned**: next Major
 - **Reason**: [Brief explanation - e.g., "Replaced by improved component with better accessibility"]
 - **Migration**: Use `NewComponent` instead
 - **Guide**: [Migration documentation link]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [Development](#development)
   - [Storybook for f36-components](#storybook-for-f36-components)
 - [Commits & releases](#commits--releases)
+- [Deprecation process](#deprecation-process)
 - [Testing with your own project locally](#testing-with-your-own-project-locally)
 - [Get involved](#get-involved)
 - [Reach out to us](#reach-out-to-us)
@@ -44,6 +45,12 @@ We use storybook with our react component library to develop components. You can
 Use `npm run-script commit`. This uses the [Commitzen](https://github.com/commitizen/cz-cli) CLI to create a conventional commit message based on your changes. CI is setup to release all new commits on the main branch that contains a new [changeset](https://github.com/changesets/changesets).
 
 Read more about changeset [here](RELEASES.md)
+
+## Deprecation process
+
+We follow a structured deprecation process to ensure smooth transitions when components or APIs are being phased out. Deprecations are announced at least one major version in advance, with clear migration paths and runtime warnings.
+
+Read more about our deprecation guidelines [here](DEPRECATION.md)
 
 ## Testing with your own project locally
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Read more about changeset [here](RELEASES.md)
 
 ## Deprecation process
 
-We follow a structured deprecation process to ensure smooth transitions when components or APIs are being phased out. Deprecations are announced at least one major version in advance, with clear migration paths and runtime warnings.
+We follow a structured deprecation process to ensure smooth transitions when components, props, and features are being phased out. Deprecations are announced at least one major version in advance, with clear migration paths and runtime warnings.
 
 Read more about our deprecation guidelines [here](DEPRECATION.md)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,8 @@ The release and versioning of our packages is done using [changesets](https://gi
 
 Our CI is configured to automatically bump the version and publish the packages on all new commits in `main` branch that contains a new changeset added.
 
+> **Note**: For information about deprecating components or features, see our [Deprecation Process](DEPRECATION.md) guide.
+
 ## Adding changesets
 
 We use the `changeset-bot` to comment on PRs when a changeset is found or not.


### PR DESCRIPTION
## Purpose

Forma 36 lacked a documented deprecation process, leaving it unclear how and when to phase out components, props, and features. This PR establishes a consistent, transparent process that gives consumers adequate migration time while keeping the design system moving forward.

By defining explicit timelines, consumers gain the predictability they need to plan migrations on their own schedule, without being caught off guard by sudden breaking changes.

## Changes

### New: `DEPRECATION.md`
A comprehensive guide covering:
- **When to deprecate** — deprecation is reserved for breaking changes only; non-breaking additions don't require it
- **Two-phase timeline** — deprecate in a minor release (minimum one major version cycle or 6 months), remove in a major release
- **Implementation patterns** — TypeScript `@deprecated` JSDoc tags, dev-only `console.warn` examples for both components and props
- **Changeset conventions** — deprecations are `minor` bumps, removals are `major`
- **Migration guide requirements** — before/after examples, prop mapping tables, codemod instructions, and support contacts

### New: `DEPRECATIONLOG.md`
A structured log to track the lifecycle of all deprecated features — from the deprecation date and version through to planned or completed removal. Gives consumers and contributors a single place to check what's currently deprecated and when it is scheduled for removal, making it easier to prioritize migrations.

### Updated: `README.md`
Adds a "Deprecation process" section with a short summary and a link to `DEPRECATION.md`.

### Updated: `RELEASES.md`
Adds a note linking to the deprecation guide for contributors creating changesets.

