### PR TITLE
feat: add BuildingBlock icon

### DIFF
--- a/.changeset/soft-tigers-deny.md
+++ b/.changeset/soft-tigers-deny.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-icons": patch
+---
+
+feat: add Lego icon

--- a/.changeset/soft-tigers-deny.md
+++ b/.changeset/soft-tigers-deny.md
@@ -2,4 +2,4 @@
 "@contentful/f36-icons": patch
 ---
 
-feat: add Lego icon
+feat: add BuildingBlock icon

--- a/packages/components/icons/src/index.ts
+++ b/packages/components/icons/src/index.ts
@@ -160,6 +160,7 @@ export * from './vendor/phosphor/KeyIcon.js';
 export * from './vendor/phosphor/KeyReturnIcon.js';
 export * from './vendor/phosphor/KeyholeIcon.js';
 export * from './vendor/phosphor/LaptopIcon.js';
+export * from './vendor/phosphor/LegoIcon.js';
 export * from './vendor/phosphor/LifebuoyIcon.js';
 export * from './vendor/phosphor/LightbulbIcon.js';
 export * from './vendor/phosphor/LightningIcon.js';

--- a/packages/components/icons/src/index.ts
+++ b/packages/components/icons/src/index.ts
@@ -160,7 +160,7 @@ export * from './vendor/phosphor/KeyIcon.js';
 export * from './vendor/phosphor/KeyReturnIcon.js';
 export * from './vendor/phosphor/KeyholeIcon.js';
 export * from './vendor/phosphor/LaptopIcon.js';
-export * from './vendor/phosphor/LegoIcon.js';
+export * from './vendor/phosphor/BuildingBlockIcon.js';
 export * from './vendor/phosphor/LifebuoyIcon.js';
 export * from './vendor/phosphor/LightbulbIcon.js';
 export * from './vendor/phosphor/LightningIcon.js';

--- a/packages/components/icons/src/vendor/phosphor/BuildingBlockIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/BuildingBlockIcon.tsx
@@ -1,4 +1,4 @@
 import { generateForma36Icon } from '@contentful/f36-icon';
 import { LegoIcon as Lego } from '@phosphor-icons/react';
 
-export const LegoIcon = generateForma36Icon(Lego);
+export const BuildingBlockIcon = generateForma36Icon(Lego);

--- a/packages/components/icons/src/vendor/phosphor/LegoIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/LegoIcon.tsx
@@ -1,0 +1,4 @@
+import { generateForma36Icon } from '@contentful/f36-icon';
+import { LegoIcon as Lego } from '@phosphor-icons/react';
+
+export const LegoIcon = generateForma36Icon(Lego);


### PR DESCRIPTION
# Purpose of PR

Add Phosphor's `Lego` icon as `BuildingBlockIcon`.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
