### PR TITLE
fix: remove default `wrap` value from `Text` `textWrap` property

### DIFF
--- a/.changeset/twenty-keys-invite.md
+++ b/.changeset/twenty-keys-invite.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-typography": patch
+---
+
+fix: removed default `wrap` value from typography components' `textWrap` property

--- a/packages/components/typography/src/Text/Text.tsx
+++ b/packages/components/typography/src/Text/Text.tsx
@@ -74,7 +74,7 @@ function TextBase<E extends React.ElementType = typeof TEXT_DEFAULT_TAG>(
     className,
     margin = 'none',
     testId = 'cf-ui-text',
-    textWrap = 'wrap',
+    textWrap,
     ...otherProps
   } = props;
   const Element: React.ElementType = as || TEXT_DEFAULT_TAG;


### PR DESCRIPTION
# Purpose of PR

This PR fixes an issue introduced with the introduction of the `textWrap` property in the typography components. By setting the `textWrap` property to `wrap` by default, typography components previously relying on inheriting the `text-wrap` CSS property were now set to `wrap` instead. An example of this is the `Header` components.

## Preview

### Header component with breadcrumbs

| Before | After |
|--------|--------|
| <img width="1306" height="600" alt="CleanShot 2026-04-24 at 13 18 56@2x" src="https://github.com/user-attachments/assets/eb7293ac-a521-467f-a514-71ed74768459" /> | <img width="1306" height="600" alt="CleanShot 2026-04-24 at 13 19 25@2x" src="https://github.com/user-attachments/assets/7cec0444-1bcb-4fdb-b479-7cf4f0c7f140" /> | 


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
