### PR TITLE
chore: ignore ai-components-package publishing while releasing [PIC-694]

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,8 @@
     "@contentful/f36-cdn",
     "@contentful/f36-i18n-utils",
     "@contentful/f36-codemod",
-    "@contentful/f36-website"
+    "@contentful/f36-website",
+    "@contentful/f36-ai-components"
   ],
   "commit": false,
   "fixed": [

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -58,8 +58,7 @@
       "@contentful/f36-tooltip",
       "@contentful/f36-typography",
       "@contentful/f36-usage-card",
-      "@contentful/f36-usage-count",
-      "@contentful/f36-ai-components"
+      "@contentful/f36-usage-count"
     ]
   ],
   "access": "public",

--- a/packages/f36-ai-components/package.json
+++ b/packages/f36-ai-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-ai-components",
-  "private": false,
+  "private": true,
   "version": "0.0.1",
   "description": "A collection of components for use in AI applications, such as conversational interfaces.",
   "license": "MIT",

--- a/packages/f36-ai-components/package.json
+++ b/packages/f36-ai-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-ai-components",
-  "private": true,
+  "private": false,
   "version": "0.0.1",
   "description": "A collection of components for use in AI applications, such as conversational interfaces.",
   "license": "MIT",


### PR DESCRIPTION
### Purpose

After merging [ai-components PR 
](https://github.com/contentful/forma-36/pull/3202), release step tries to publish it but since its a alpha package we do not want to publish it to npm

### Changes
- Added `ai-components` package to ignore in change set config
- Marked `ai-components` as private