### PR TITLE
deprecate(pill): mark Pill as deprecated in favor of PillNext

### DIFF
--- a/.changeset/deprecate-pill.md
+++ b/.changeset/deprecate-pill.md
@@ -1,0 +1,8 @@
+---
+'@contentful/f36-pill': minor
+---
+
+**Deprecated**
+
+- `Pill`: Deprecated in favor of `PillNext` from `@contentful/f36-pill-next`. Will be removed in the next major version (v7).
+- Migration guide available at: https://f36.contentful.com/components/pill#migration

--- a/DEPRECATIONLOG.md
+++ b/DEPRECATIONLOG.md
@@ -6,16 +6,14 @@ This log tracks all deprecated features and components in Forma 36. For details 
 
 ## Active Deprecations
 
-### Component Name / Feature Name
+### Pill (`@contentful/f36-pill`)
 
-<!-- Format example ---
-- **Deprecated**: YYYY-MM-DD
-- **Deprecated In**: v5.x.x
-- **Removal Planned**: next Major
-- **Reason**: [Brief explanation - e.g., "Replaced by improved component with better accessibility"]
-- **Migration**: Use `NewComponent` instead
-- **Guide**: [Migration documentation link]
--->
+- **Deprecated**: 2026-05-21
+- **Deprecated In**: v6.x.x
+- **Removal Planned**: next Major (v7)
+- **Reason**: Replaced by `PillNext` from `@contentful/f36-pill-next` with improved variant support, accessibility, and alignment with the refreshed design system
+- **Migration**: Use `PillNext` from `@contentful/f36-pill-next` instead
+- **Guide**: [Migration documentation](./packages/components/pill/MIGRATION.md)
 
 ---
 

--- a/packages/components/pill/MIGRATION.md
+++ b/packages/components/pill/MIGRATION.md
@@ -1,0 +1,122 @@
+# Migration from Pill to PillNext
+
+## Summary of Change
+
+The `Pill` component from `@contentful/f36-pill` is deprecated. Use `PillNext` from the new `@contentful/f36-pill-next` package instead. `Pill` will be removed in the next major version.
+
+## Why
+
+`PillNext` is a ground-up rewrite that:
+
+- Supports four visual variants (secondary, primary, warning, negative) instead of two (idle, active, deleted)
+- Uses `IconButton` for the close action with proper circular hover and disabled states
+- Adds leading-icon support with keyboard-accessible tooltip for warning/negative variants
+- Removes the drag-handle concern — pill is now indication-first, not reorderable
+- Aligns with the refreshed Figma design spec
+
+## Installation
+
+```bash
+npm install @contentful/f36-pill-next
+```
+
+## Before → After
+
+### Basic usage
+
+```tsx
+// ❌ Deprecated
+import { Pill } from '@contentful/f36-pill';
+
+<Pill label="Category" onClose={() => {}} />;
+
+// ✅ Recommended
+import { PillNext } from '@contentful/f36-pill-next';
+
+<PillNext label="Category" onRemove={() => {}} />;
+```
+
+### Variants
+
+```tsx
+// ❌ Deprecated
+<Pill label="Active tag" variant="active" />
+<Pill label="Deleted tag" variant="deleted" />
+
+// ✅ Recommended
+<PillNext label="Active tag" variant="primary" />
+<PillNext label="Deleted tag" variant="negative" />
+```
+
+### Disabled close button
+
+```tsx
+// ❌ Deprecated (Pill has no disabled state for close)
+<Pill label="Tag" onClose={() => {}} />
+
+// ✅ Recommended
+<PillNext label="Tag" onRemove={() => {}} isDisabled />
+```
+
+### Drag handle
+
+PillNext intentionally does not support drag handles. If you need drag-and-drop reordering, wrap PillNext in a drag container from your drag-and-drop library (e.g. dnd-kit).
+
+```tsx
+// ❌ Deprecated
+<Pill label="Draggable" isDraggable onDrag={handleDrag} />;
+
+// ✅ Recommended — use dnd-kit or similar
+import { useSortable } from '@dnd-kit/sortable';
+
+function DraggablePill({ label }) {
+  const { attributes, listeners, setNodeRef } = useSortable({ id: label });
+  return (
+    <PillNext ref={setNodeRef} label={label} {...attributes} {...listeners} />
+  );
+}
+```
+
+## Prop Mapping
+
+| Pill (deprecated)      | PillNext              | Notes                                                              |
+| ---------------------- | --------------------- | ------------------------------------------------------------------ |
+| `label`                | `label`               | Unchanged                                                          |
+| `onClose`              | `onRemove`            | Renamed                                                            |
+| `closeButtonAriaLabel` | `removeButtonLabel`   | Renamed, default changed from "Close" to "Remove"                  |
+| `variant="idle"`       | `variant="secondary"` | Default variant                                                    |
+| `variant="active"`     | `variant="primary"`   | Highlighted state                                                  |
+| `variant="deleted"`    | `variant="negative"`  | Error/deleted state                                                |
+| —                      | `variant="warning"`   | New variant, no equivalent in old Pill                             |
+| `isDraggable`          | —                     | Removed, use external drag library                                 |
+| `onDrag`               | —                     | Removed, use external drag library                                 |
+| `dragHandleComponent`  | —                     | Removed, use external drag library                                 |
+| —                      | `isDisabled`          | New, disables the remove button                                    |
+| —                      | `tooltipContent`      | New, tooltip on leading icon (warning/negative)                    |
+| —                      | `tooltipProps`        | New, override tooltip placement etc.                               |
+| `testId`               | `testId`              | Unchanged (default changes from "cf-ui-pill" to "cf-ui-pill-next") |
+| `className`            | `className`           | Unchanged                                                          |
+
+## Important Differences
+
+- **No drag handle**: PillNext is indication-only. If you need drag-and-drop, wrap PillNext in a sortable container.
+- **Remove vs Close**: The callback is named `onRemove` (not `onClose`) and the button uses `IconButton` with a circular hover state.
+- **Leading icons**: Warning and negative variants automatically show a leading icon (WarningIcon / WarningOctagonIcon). No configuration needed.
+- **No label truncation**: PillNext does not truncate labels. The pill expands to accommodate the full text.
+- **Default test ID**: Changes from `cf-ui-pill` to `cf-ui-pill-next`.
+
+## Validation Checklist
+
+- [ ] All `@contentful/f36-pill` `Pill` imports replaced with `@contentful/f36-pill-next` `PillNext`
+- [ ] `onClose` renamed to `onRemove`
+- [ ] `closeButtonAriaLabel` renamed to `removeButtonLabel`
+- [ ] Variant values mapped (`idle` → `secondary`, `active` → `primary`, `deleted` → `negative`)
+- [ ] Drag-related props removed and replaced with external drag library if needed
+- [ ] Test IDs updated if hardcoded assertions reference `cf-ui-pill`
+
+## Support
+
+If you encounter issues during migration:
+
+- Check our [GitHub Issues](https://github.com/contentful/forma-36/issues) or create a new one
+- Send us direct feedback via our feedback form on our [website](https://f36.contentful.com/)

--- a/packages/components/pill/README.mdx
+++ b/packages/components/pill/README.mdx
@@ -1,12 +1,15 @@
 ---
 title: 'Pill'
 type: 'component'
-status: 'stable'
+status: 'deprecated'
 slug: /components/pill/
 github: 'https://github.com/contentful/forma-36/tree/main/packages/components/pill'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-pill--basic'
 typescript: ./src/Pill.tsx
 ---
+
+> **⚠️ Deprecated**: This component is deprecated and will be removed in the next major version.
+> Please use [PillNext](/components/pill-next/) from `@contentful/f36-pill-next` instead. See the [migration guide](./MIGRATION.md).
 
 `Pill` component allows to represent a set of one or multiple objects which can be entered or changed by the user. For example, tags. `Pill` can be integrated with a drag-and-drop solution.
 

--- a/packages/components/pill/README.mdx
+++ b/packages/components/pill/README.mdx
@@ -9,7 +9,7 @@ typescript: ./src/Pill.tsx
 ---
 
 > **⚠️ Deprecated**: This component is deprecated and will be removed in the next major version.
-> Please use [PillNext](/components/pill-next/) from `@contentful/f36-pill-next` instead. See the [migration guide](./MIGRATION.md).
+> Please use [PillNext](/components/pill-next) from `@contentful/f36-pill-next` instead. See the [migration guide](https://github.com/contentful/forma-36/blob/main/packages/components/pill/MIGRATION.md).
 
 `Pill` component allows to represent a set of one or multiple objects which can be entered or changed by the user. For example, tags. `Pill` can be integrated with a drag-and-drop solution.
 

--- a/packages/components/pill/src/Pill.tsx
+++ b/packages/components/pill/src/Pill.tsx
@@ -12,6 +12,12 @@ import { DragHandle } from '@contentful/f36-drag-handle';
 import { PillVariants } from './types';
 import { getPillStyles } from './Pill.styles';
 
+/**
+ * @deprecated Use `PillNext` from `@contentful/f36-pill-next` instead.
+ * Will be removed in the next major version.
+ *
+ * @see {@link https://f36.contentful.com/components/pill-next} for the replacement component
+ */
 export type PillInternalProps = CommonProps & {
   /**
    * Mark the pill as draggable. Drag icon is rendered when this property is set.
@@ -49,8 +55,22 @@ export type PillInternalProps = CommonProps & {
 
 export type PillProps = PropsWithHTMLElement<PillInternalProps, 'div'>;
 
+/**
+ * @deprecated Use `PillNext` from `@contentful/f36-pill-next` instead.
+ * Will be removed in the next major version.
+ *
+ * @see {@link https://f36.contentful.com/components/pill-next} for the replacement component
+ */
 export const Pill = React.forwardRef<HTMLDivElement, ExpandProps<PillProps>>(
   (props, ref) => {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn(
+        'Pill is deprecated and will be removed in the next major version. ' +
+          'Please migrate to PillNext from @contentful/f36-pill-next. ' +
+          'See: https://f36.contentful.com/components/pill#migration',
+      );
+    }
+
     const {
       isDraggable,
       label,


### PR DESCRIPTION
## Summary

- Marks `Pill` from `@contentful/f36-pill` as deprecated with `@deprecated` JSDoc and runtime `console.warn` in development
- Adds `MIGRATION.md` with full prop mapping, before/after examples, and drag-handle removal guidance
- Updates `README.mdx` with deprecation notice pointing to `PillNext` from `@contentful/f36-pill-next`
- Adds entry to `DEPRECATIONLOG.md`
- Includes changeset for minor version bump

Follows the deprecation process documented in `DEPRECATION.md`. No functionality is removed — Pill remains fully operational.

**Spec:** Task 1b in spec 2026-05-forma36-tag-pill/tasks.md
**Ticket:** GROOT-2759

## Test plan

- [ ] `Pill` shows `@deprecated` in IDE tooltips
- [ ] `console.warn` fires in development when rendering `Pill`
- [ ] README displays deprecated status on docs site
- [ ] MIGRATION.md prop mapping is accurate and examples work
- [ ] Existing Pill tests still pass unchanged
- [ ] No breaking changes to consumer code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GROOT-2759]: https://contentful.atlassian.net/browse/GROOT-2759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ