### PR TITLE
feat(ai-components): add AiPill component

### DIFF
--- a/.changeset/add-ai-pill.md
+++ b/.changeset/add-ai-pill.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-ai-components": minor
+---
+
+feat: add AiPill component for AI-suggested tags with gradient treatment

--- a/package-lock.json
+++ b/package-lock.json
@@ -42622,7 +42622,7 @@
     },
     "packages/components/pill-next": {
       "name": "@contentful/f36-pill-next",
-      "version": "6.0.1-alpha.2",
+      "version": "6.0.1-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-button": "^6.8.0",
@@ -42846,7 +42846,7 @@
     },
     "packages/f36-ai-components": {
       "name": "@contentful/f36-ai-components",
-      "version": "0.0.1",
+      "version": "0.0.2-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-button": "^6.0.0",
@@ -42855,6 +42855,7 @@
         "@contentful/f36-header": "^6.0.0",
         "@contentful/f36-icons": "^6.0.0",
         "@contentful/f36-layout": "^6.0.0",
+        "@contentful/f36-pill-next": "*",
         "@contentful/f36-tokens": "^6.0.0",
         "@contentful/f36-typography": "^6.0.0",
         "@contentful/f36-utils": "^6.0.0",

--- a/packages/components/pill-next/package.json
+++ b/packages/components/pill-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-pill-next",
-  "version": "6.0.1-alpha.3",
+  "version": "6.0.1-alpha.4",
   "description": "Forma 36: PillNext component (alpha)",
   "scripts": {
     "build": "tsup"

--- a/packages/components/pill-next/src/PillNext.tsx
+++ b/packages/components/pill-next/src/PillNext.tsx
@@ -31,6 +31,10 @@ export type PillNextInternalProps = CommonProps & {
   >;
   /** Content rendered between label and remove button. */
   children?: React.ReactNode;
+  /** Additional className applied to the remove button. */
+  removeButtonClassName?: string;
+  /** Color of the remove icon. Defaults to currentColor (inherits from button). */
+  removeIconColor?: string;
 };
 
 export type PillNextProps = PropsWithHTMLElement<PillNextInternalProps, 'div'>;
@@ -63,6 +67,8 @@ export const PillNext = React.forwardRef<
     tooltipContent,
     tooltipProps,
     children,
+    removeButtonClassName,
+    removeIconColor,
     testId = 'cf-ui-pill-next',
     className,
     ...otherProps
@@ -115,11 +121,11 @@ export const PillNext = React.forwardRef<
         <IconButton
           variant="transparent"
           size="small"
-          icon={<XIcon size="small" />}
+          icon={<XIcon size="small" color={removeIconColor} />}
           aria-label={removeButtonLabel}
           onClick={onRemove}
           isDisabled={isDisabled}
-          className={styles.removeButton}
+          className={cx(styles.removeButton, removeButtonClassName)}
         />
       )}
     </div>

--- a/packages/f36-ai-components/README.md
+++ b/packages/f36-ai-components/README.md
@@ -3,3 +3,38 @@
 This package is a pre-release. This means it is unsupported and subject to breaking changes without warning.
 
 A collection of components for use in AI applications, such as conversational interfaces.
+
+## AiPill
+
+A pill component with AI-specific visual treatment. Composes `PillNext` from `@contentful/f36-pill-next` internally.
+
+### Import
+
+```js
+import { AiPill } from '@contentful/f36-ai-components';
+```
+
+### Usage
+
+```tsx
+<AiPill label="Machine learning" onRemove={() => {}} />
+```
+
+### Props
+
+| Prop                | Type         | Default           | Description                         |
+| ------------------- | ------------ | ----------------- | ----------------------------------- |
+| `label`             | `string`     | —                 | Text displayed in the pill          |
+| `onRemove`          | `() => void` | —                 | Callback when remove button clicked |
+| `removeButtonLabel` | `string`     | `"Remove"`        | Accessible label for remove button  |
+| `isDisabled`        | `boolean`    | `false`           | Disables the remove button          |
+| `className`         | `string`     | —                 | Additional class name for the pill  |
+| `testId`            | `string`     | `"cf-ui-ai-pill"` | Test ID for the root element        |
+
+### Visual treatment
+
+- Gradient border (AI Gradient/Default) via CSS mask technique
+- Gradient background (AI Gradient/Shimmer at 5% opacity)
+- Purple/600 (`#6c3ecf`) label and remove icon color
+- Purple/200 (`#EDE3FF`) hover background on remove button
+- Disabled state keeps the purple icon

--- a/packages/f36-ai-components/README.md
+++ b/packages/f36-ai-components/README.md
@@ -31,10 +31,6 @@ import { AiPill } from '@contentful/f36-ai-components';
 | `className`         | `string`     | —                 | Additional class name for the pill  |
 | `testId`            | `string`     | `"cf-ui-ai-pill"` | Test ID for the root element        |
 
-### Visual treatment
+### When to use AiPill vs PillNext
 
-- Gradient border (AI Gradient/Default) via CSS mask technique
-- Gradient background (AI Gradient/Shimmer at 5% opacity)
-- Purple/600 (`#6c3ecf`) label and remove icon color
-- Purple/200 (`#EDE3FF`) hover background on remove button
-- Disabled state keeps the purple icon
+Use `AiPill` for content that was generated or suggested by AI — it communicates to users that the item originates from an AI system. Use `PillNext` for user-created or system-defined metadata where the AI distinction is not relevant.

--- a/packages/f36-ai-components/package.json
+++ b/packages/f36-ai-components/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@contentful/f36-button": "^6.0.0",
+    "@contentful/f36-pill-next": "*",
     "@contentful/f36-components": "^6.0.0",
     "@contentful/f36-core": "^6.0.0",
     "@contentful/f36-header": "^6.0.0",

--- a/packages/f36-ai-components/package.json
+++ b/packages/f36-ai-components/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@contentful/f36-ai-components",
-  "private": false,
-  "version": "0.0.1",
+  "version": "0.0.2-alpha.1",
   "description": "A collection of components for use in AI applications, such as conversational interfaces.",
   "license": "MIT",
   "files": [

--- a/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
+++ b/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
@@ -7,44 +7,28 @@ const AI_GRADIENT =
 const AI_BACKGROUND =
   'linear-gradient(157.5deg, rgba(24,114,229,0.05) 0.77%, rgba(140,46,234,0.05) 31.5%, rgba(230,83,37,0.05) 62.3%, rgba(234,175,9,0.05) 93.9%)';
 
-export const aiPillOverrides = css`
-  && {
-    position: relative;
-    border: none;
-    background: ${AI_BACKGROUND};
-  }
+export const aiPillOverrides = css({
+  '&&': {
+    position: 'relative',
+    border: 'none',
+    background: AI_BACKGROUND,
+  },
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    inset: 0,
+    borderRadius: '16px',
+    padding: '1px',
+    background: AI_GRADIENT,
+    WebkitMask:
+      'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+    WebkitMaskComposite: 'xor',
+    maskComposite: 'exclude',
+    pointerEvents: 'none',
+  },
+  '& > span:first-of-type': {
+    color: '#6c3ecf',
+  },
+});
 
-  &::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: 16px;
-    padding: 1px;
-    background: ${AI_GRADIENT};
-    -webkit-mask:
-      linear-gradient(#fff 0 0) content-box,
-      linear-gradient(#fff 0 0);
-    -webkit-mask-composite: xor;
-    mask-composite: exclude;
-    pointer-events: none;
-  }
-
-  & > span:first-of-type {
-    color: #6c3ecf;
-  }
-
-  & button {
-    color: #6c3ecf !important;
-  }
-
-  & button:hover:not(:disabled) {
-    background-color: ${tokens.gray300};
-    mix-blend-mode: luminosity;
-  }
-
-  & button:disabled {
-    color: ${tokens.gray400} !important;
-    background-color: transparent;
-    mix-blend-mode: initial;
-  }
-`;
+export const aiPillRemoveButton = css({});

--- a/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
+++ b/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import tokens from '@contentful/f36-tokens';
 
 const AI_GRADIENT =
   'linear-gradient(157.5deg, #1872E5 0.77%, #8C2EEA 31.5%, #E65325 62.3%, #EAAF09 93.9%)';
@@ -19,19 +20,17 @@ export const aiPillOverrides = css({
     borderRadius: '16px',
     padding: '1px',
     background: AI_GRADIENT,
-    WebkitMask:
-      'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
-    WebkitMaskComposite: 'xor',
+    mask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
     maskComposite: 'exclude',
     pointerEvents: 'none',
   },
   '& > span:first-of-type': {
-    color: '#6c3ecf',
+    color: tokens.purple600,
   },
 });
 
 export const aiPillRemoveButton = css({
   '&&&:hover:not(:disabled)': {
-    backgroundColor: '#EDE3FF',
+    backgroundColor: tokens.purple200,
   },
 });

--- a/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
+++ b/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
@@ -30,15 +30,16 @@ export const aiPillOverrides = css({
   '& > span:first-of-type': {
     color: '#6c3ecf',
   },
-  // Remove button icon color + hover
-  '& button': {
+  // Remove button — needs &&& to beat PillNext's && specificity
+  '&&& button': {
     color: '#6c3ecf',
-  },
-  '& button:hover:not(:disabled)': {
-    backgroundColor: tokens.gray300,
     mixBlendMode: 'luminosity',
   },
-  '& button:disabled': {
+  '&&& button:hover:not(:disabled)': {
+    backgroundColor: tokens.gray300,
+  },
+  '&&& button:disabled': {
     color: tokens.gray400,
+    mixBlendMode: 'initial',
   },
 });

--- a/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
+++ b/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
@@ -1,0 +1,47 @@
+import { css } from '@emotion/css';
+import tokens from '@contentful/f36-tokens';
+
+export function getAiPillStyles(hasRemoveButton: boolean) {
+  return {
+    pill: css({
+      display: 'inline-flex',
+      alignItems: 'center',
+      borderRadius: '16px',
+      height: '32px',
+      paddingTop: tokens.spacing2Xs,
+      paddingBottom: tokens.spacing2Xs,
+      paddingLeft: tokens.spacingS,
+      paddingRight: hasRemoveButton ? tokens.spacing2Xs : tokens.spacingS,
+      border: '1px solid #1872e5',
+      background:
+        'linear-gradient(157.5deg, rgba(24,114,229,0.05) 0.77%, rgba(140,46,234,0.05) 31.5%, rgba(230,83,37,0.05) 62.3%, rgba(234,175,9,0.05) 93.9%)',
+      fontFamily: tokens.fontStackPrimary,
+      boxSizing: 'border-box',
+    }),
+    label: css({
+      fontSize: tokens.fontSizeM,
+      fontWeight: tokens.fontWeightMedium,
+      lineHeight: tokens.lineHeightM,
+      whiteSpace: 'nowrap',
+      color: '#6c3ecf',
+    }),
+    removeButton: css({
+      '&&': {
+        width: '24px',
+        height: '24px',
+        minHeight: 'auto',
+        minWidth: 'auto',
+        padding: tokens.spacing2Xs,
+        borderRadius: '50%',
+        marginLeft: tokens.spacingXs,
+      },
+      '&&:hover:not(:disabled)': {
+        backgroundColor: tokens.gray300,
+      },
+      '&&:disabled': {
+        backgroundColor: 'transparent',
+        color: tokens.gray400,
+      },
+    }),
+  };
+}

--- a/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
+++ b/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
@@ -30,4 +30,9 @@ export const aiPillOverrides = css({
   },
 });
 
-export const aiPillRemoveButton = css({});
+export const aiPillRemoveButton = css({
+  '&&:hover:not(:disabled)': {
+    backgroundColor: '#CFD9E0',
+    mixBlendMode: 'luminosity',
+  },
+});

--- a/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
+++ b/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
@@ -1,47 +1,44 @@
 import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
 
-export function getAiPillStyles(hasRemoveButton: boolean) {
-  return {
-    pill: css({
-      display: 'inline-flex',
-      alignItems: 'center',
-      borderRadius: '16px',
-      height: '32px',
-      paddingTop: tokens.spacing2Xs,
-      paddingBottom: tokens.spacing2Xs,
-      paddingLeft: tokens.spacingS,
-      paddingRight: hasRemoveButton ? tokens.spacing2Xs : tokens.spacingS,
-      border: '1px solid #1872e5',
-      background:
-        'linear-gradient(157.5deg, rgba(24,114,229,0.05) 0.77%, rgba(140,46,234,0.05) 31.5%, rgba(230,83,37,0.05) 62.3%, rgba(234,175,9,0.05) 93.9%)',
-      fontFamily: tokens.fontStackPrimary,
-      boxSizing: 'border-box',
-    }),
-    label: css({
-      fontSize: tokens.fontSizeM,
-      fontWeight: tokens.fontWeightMedium,
-      lineHeight: tokens.lineHeightM,
-      whiteSpace: 'nowrap',
-      color: '#6c3ecf',
-    }),
-    removeButton: css({
-      '&&': {
-        width: '24px',
-        height: '24px',
-        minHeight: 'auto',
-        minWidth: 'auto',
-        padding: tokens.spacing2Xs,
-        borderRadius: '50%',
-        marginLeft: tokens.spacingXs,
-      },
-      '&&:hover:not(:disabled)': {
-        backgroundColor: tokens.gray300,
-      },
-      '&&:disabled': {
-        backgroundColor: 'transparent',
-        color: tokens.gray400,
-      },
-    }),
-  };
-}
+const AI_GRADIENT =
+  'linear-gradient(157.5deg, #1872E5 0.77%, #8C2EEA 31.5%, #E65325 62.3%, #EAAF09 93.9%)';
+
+const AI_BACKGROUND =
+  'linear-gradient(157.5deg, rgba(24,114,229,0.05) 0.77%, rgba(140,46,234,0.05) 31.5%, rgba(230,83,37,0.05) 62.3%, rgba(234,175,9,0.05) 93.9%)';
+
+export const aiPillOverrides = css({
+  '&&': {
+    position: 'relative',
+    border: 'none',
+    background: AI_BACKGROUND,
+  },
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    inset: 0,
+    borderRadius: '16px',
+    padding: '1px',
+    background: AI_GRADIENT,
+    WebkitMask:
+      'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
+    WebkitMaskComposite: 'xor',
+    maskComposite: 'exclude',
+    pointerEvents: 'none',
+  },
+  // Label color
+  '& > span:first-of-type': {
+    color: '#6c3ecf',
+  },
+  // Remove button icon color + hover
+  '& button': {
+    color: '#6c3ecf',
+  },
+  '& button:hover:not(:disabled)': {
+    backgroundColor: tokens.gray300,
+    mixBlendMode: 'luminosity',
+  },
+  '& button:disabled': {
+    color: tokens.gray400,
+  },
+});

--- a/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
+++ b/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
@@ -7,39 +7,44 @@ const AI_GRADIENT =
 const AI_BACKGROUND =
   'linear-gradient(157.5deg, rgba(24,114,229,0.05) 0.77%, rgba(140,46,234,0.05) 31.5%, rgba(230,83,37,0.05) 62.3%, rgba(234,175,9,0.05) 93.9%)';
 
-export const aiPillOverrides = css({
-  '&&': {
-    position: 'relative',
-    border: 'none',
-    background: AI_BACKGROUND,
-  },
-  '&::before': {
-    content: '""',
-    position: 'absolute',
-    inset: 0,
-    borderRadius: '16px',
-    padding: '1px',
-    background: AI_GRADIENT,
-    WebkitMask:
-      'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
-    WebkitMaskComposite: 'xor',
-    maskComposite: 'exclude',
-    pointerEvents: 'none',
-  },
-  // Label color
-  '& > span:first-of-type': {
-    color: '#6c3ecf',
-  },
-  // Remove button — needs &&& to beat PillNext's && specificity
-  '&&& button': {
-    color: '#6c3ecf',
-    mixBlendMode: 'luminosity',
-  },
-  '&&& button:hover:not(:disabled)': {
-    backgroundColor: tokens.gray300,
-  },
-  '&&& button:disabled': {
-    color: tokens.gray400,
-    mixBlendMode: 'initial',
-  },
-});
+export const aiPillOverrides = css`
+  && {
+    position: relative;
+    border: none;
+    background: ${AI_BACKGROUND};
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 16px;
+    padding: 1px;
+    background: ${AI_GRADIENT};
+    -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    pointer-events: none;
+  }
+
+  & > span:first-of-type {
+    color: #6c3ecf;
+  }
+
+  & button {
+    color: #6c3ecf !important;
+  }
+
+  & button:hover:not(:disabled) {
+    background-color: ${tokens.gray300};
+    mix-blend-mode: luminosity;
+  }
+
+  & button:disabled {
+    color: ${tokens.gray400} !important;
+    background-color: transparent;
+    mix-blend-mode: initial;
+  }
+`;

--- a/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
+++ b/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
@@ -1,5 +1,4 @@
 import { css } from '@emotion/css';
-import tokens from '@contentful/f36-tokens';
 
 const AI_GRADIENT =
   'linear-gradient(157.5deg, #1872E5 0.77%, #8C2EEA 31.5%, #E65325 62.3%, #EAAF09 93.9%)';

--- a/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
+++ b/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
@@ -31,8 +31,7 @@ export const aiPillOverrides = css({
 });
 
 export const aiPillRemoveButton = css({
-  '&&:hover:not(:disabled)': {
-    backgroundColor: '#CFD9E0',
-    mixBlendMode: 'luminosity',
+  '&&&:hover:not(:disabled)': {
+    backgroundColor: '#EDE3FF',
   },
 });

--- a/packages/f36-ai-components/src/AiPill/AiPill.test.tsx
+++ b/packages/f36-ai-components/src/AiPill/AiPill.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { AiPill } from './AiPill';
+
+describe('AiPill', () => {
+  it('renders with label', () => {
+    render(<AiPill label="AI suggested" />);
+    expect(screen.getByText('AI suggested')).toBeTruthy();
+  });
+
+  it('renders with custom test id', () => {
+    render(<AiPill label="test" testId="custom-ai-pill" />);
+    expect(screen.getByTestId('custom-ai-pill')).toBeTruthy();
+  });
+
+  it('renders with additional class name', () => {
+    const { container } = render(<AiPill label="test" className="my-class" />);
+    expect(container.firstChild).toHaveClass('my-class');
+  });
+
+  it('renders gradient background', () => {
+    const { container } = render(<AiPill label="test" />);
+    const pill = container.firstChild as HTMLElement;
+    expect(pill.style || pill.className).toBeTruthy();
+  });
+
+  describe('remove button', () => {
+    it('renders remove button when onRemove is provided', () => {
+      render(<AiPill label="test" onRemove={() => {}} />);
+      expect(screen.getByRole('button', { name: 'Remove' })).toBeTruthy();
+    });
+
+    it('does not render remove button when onRemove is not provided', () => {
+      render(<AiPill label="test" />);
+      expect(screen.queryByRole('button')).toBeNull();
+    });
+
+    it('calls onRemove when remove button is clicked', () => {
+      const mockOnRemove = jest.fn();
+      render(<AiPill label="test" onRemove={mockOnRemove} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+      expect(mockOnRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses custom remove button label', () => {
+      render(
+        <AiPill
+          label="test"
+          onRemove={() => {}}
+          removeButtonLabel="Delete suggestion"
+        />,
+      );
+      expect(
+        screen.getByRole('button', { name: 'Delete suggestion' }),
+      ).toBeTruthy();
+    });
+
+    it('disables remove button when isDisabled is true', () => {
+      render(<AiPill label="test" onRemove={() => {}} isDisabled />);
+      expect(screen.getByRole('button', { name: 'Remove' })).toBeDisabled();
+    });
+
+    it('does not call onRemove when disabled', () => {
+      const mockOnRemove = jest.fn();
+      render(<AiPill label="test" onRemove={mockOnRemove} isDisabled />);
+      fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+      expect(mockOnRemove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has no a11y violations with label only', async () => {
+      const { container } = render(<AiPill label="test" />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no a11y violations with remove button', async () => {
+      const { container } = render(<AiPill label="test" onRemove={() => {}} />);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no a11y violations with disabled remove button', async () => {
+      const { container } = render(
+        <AiPill label="test" onRemove={() => {}} isDisabled />,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/f36-ai-components/src/AiPill/AiPill.tsx
+++ b/packages/f36-ai-components/src/AiPill/AiPill.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { cx } from '@emotion/css';
+import type { CommonProps } from '@contentful/f36-core';
+import { IconButton } from '@contentful/f36-button';
+import { XIcon } from '@contentful/f36-icons';
+import { getAiPillStyles } from './AiPill.styles';
+
+export interface AiPillProps extends CommonProps {
+  label: string;
+  onRemove?: () => void;
+  /** @default "Remove" */
+  removeButtonLabel?: string;
+  isDisabled?: boolean;
+  className?: string;
+}
+
+export const AiPill = React.forwardRef<HTMLDivElement, AiPillProps>(
+  (props, ref) => {
+    const {
+      label,
+      onRemove,
+      removeButtonLabel = 'Remove',
+      isDisabled = false,
+      testId = 'cf-ui-ai-pill',
+      className,
+      ...otherProps
+    } = props;
+
+    const styles = getAiPillStyles(Boolean(onRemove));
+
+    return (
+      <div
+        className={cx(styles.pill, className)}
+        data-test-id={testId}
+        ref={ref}
+        {...otherProps}
+      >
+        <span className={styles.label}>{label}</span>
+
+        {onRemove && (
+          <IconButton
+            variant="transparent"
+            size="small"
+            icon={<XIcon size="small" />}
+            aria-label={removeButtonLabel}
+            onClick={onRemove}
+            isDisabled={isDisabled}
+            className={styles.removeButton}
+          />
+        )}
+      </div>
+    );
+  },
+);
+
+AiPill.displayName = 'AiPill';

--- a/packages/f36-ai-components/src/AiPill/AiPill.tsx
+++ b/packages/f36-ai-components/src/AiPill/AiPill.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { cx } from '@emotion/css';
 import type { CommonProps } from '@contentful/f36-core';
-import { IconButton } from '@contentful/f36-button';
-import { XIcon } from '@contentful/f36-icons';
-import { getAiPillStyles } from './AiPill.styles';
+import { PillNext } from '@contentful/f36-pill-next';
+import { aiPillOverrides } from './AiPill.styles';
 
 export interface AiPillProps extends CommonProps {
   label: string;
@@ -26,29 +25,17 @@ export const AiPill = React.forwardRef<HTMLDivElement, AiPillProps>(
       ...otherProps
     } = props;
 
-    const styles = getAiPillStyles(Boolean(onRemove));
-
     return (
-      <div
-        className={cx(styles.pill, className)}
-        data-test-id={testId}
+      <PillNext
         ref={ref}
+        label={label}
+        onRemove={onRemove}
+        removeButtonLabel={removeButtonLabel}
+        isDisabled={isDisabled}
+        testId={testId}
+        className={cx(aiPillOverrides, className)}
         {...otherProps}
-      >
-        <span className={styles.label}>{label}</span>
-
-        {onRemove && (
-          <IconButton
-            variant="transparent"
-            size="small"
-            icon={<XIcon size="small" />}
-            aria-label={removeButtonLabel}
-            onClick={onRemove}
-            isDisabled={isDisabled}
-            className={styles.removeButton}
-          />
-        )}
-      </div>
+      />
     );
   },
 );

--- a/packages/f36-ai-components/src/AiPill/AiPill.tsx
+++ b/packages/f36-ai-components/src/AiPill/AiPill.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { cx } from '@emotion/css';
 import type { CommonProps } from '@contentful/f36-core';
 import { PillNext } from '@contentful/f36-pill-next';
-import { aiPillOverrides } from './AiPill.styles';
+import { aiPillOverrides, aiPillRemoveButton } from './AiPill.styles';
+
+const PURPLE_600 = '#6c3ecf';
 
 export interface AiPillProps extends CommonProps {
   label: string;
@@ -34,6 +36,8 @@ export const AiPill = React.forwardRef<HTMLDivElement, AiPillProps>(
         isDisabled={isDisabled}
         testId={testId}
         className={cx(aiPillOverrides, className)}
+        removeButtonClassName={aiPillRemoveButton}
+        removeIconColor={isDisabled ? undefined : PURPLE_600}
         {...otherProps}
       />
     );

--- a/packages/f36-ai-components/src/AiPill/AiPill.tsx
+++ b/packages/f36-ai-components/src/AiPill/AiPill.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { cx } from '@emotion/css';
 import type { CommonProps } from '@contentful/f36-core';
+import tokens from '@contentful/f36-tokens';
 import { PillNext } from '@contentful/f36-pill-next';
 import { aiPillOverrides, aiPillRemoveButton } from './AiPill.styles';
-
-const PURPLE_600 = '#6c3ecf';
 
 export interface AiPillProps extends CommonProps {
   label: string;
@@ -37,7 +36,7 @@ export const AiPill = React.forwardRef<HTMLDivElement, AiPillProps>(
         testId={testId}
         className={cx(aiPillOverrides, className)}
         removeButtonClassName={aiPillRemoveButton}
-        removeIconColor={PURPLE_600}
+        removeIconColor={tokens.purple600}
         {...otherProps}
       />
     );

--- a/packages/f36-ai-components/src/AiPill/AiPill.tsx
+++ b/packages/f36-ai-components/src/AiPill/AiPill.tsx
@@ -37,7 +37,7 @@ export const AiPill = React.forwardRef<HTMLDivElement, AiPillProps>(
         testId={testId}
         className={cx(aiPillOverrides, className)}
         removeButtonClassName={aiPillRemoveButton}
-        removeIconColor={isDisabled ? undefined : PURPLE_600}
+        removeIconColor={PURPLE_600}
         {...otherProps}
       />
     );

--- a/packages/f36-ai-components/src/AiPill/index.ts
+++ b/packages/f36-ai-components/src/AiPill/index.ts
@@ -1,0 +1,1 @@
+export { AiPill, type AiPillProps } from './AiPill';

--- a/packages/f36-ai-components/src/index.ts
+++ b/packages/f36-ai-components/src/index.ts
@@ -30,3 +30,5 @@ export * from './AIChatSidePanel';
 export * from './AIChatSuggestionPill';
 
 export * from './Slider';
+
+export * from './AiPill';

--- a/packages/f36-ai-components/stories/AiPill.stories.tsx
+++ b/packages/f36-ai-components/stories/AiPill.stories.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import type { StoryObj, Meta } from '@storybook/react-vite';
+import { SectionHeading } from '@contentful/f36-typography';
+import { action } from 'storybook/actions';
+import { Flex } from '@contentful/f36-core';
+
+import { AiPill } from '../src/AiPill';
+import type { AiPillProps } from '../src/AiPill';
+
+export default {
+  title: 'AI/AiPill',
+  component: AiPill,
+  argTypes: {
+    label: { control: { type: 'text' } },
+    isDisabled: { control: { type: 'boolean' } },
+    className: { control: { disable: true } },
+    testId: { control: { disable: true } },
+  },
+} as Meta;
+
+export const Basic: StoryObj<AiPillProps> = {
+  render: (args) => <AiPill {...args} />,
+  args: {
+    label: 'AI suggested tag',
+  },
+};
+
+export const Removable: StoryObj<AiPillProps> = {
+  render: (args) => (
+    <Flex flexDirection="column" gap="spacingL">
+      <Flex flexDirection="column" gap="spacingS">
+        <SectionHeading as="h3">With remove button</SectionHeading>
+        <Flex flexDirection="row" gap="spacingXs">
+          <AiPill label="Machine learning" onRemove={args.onRemove} />
+          <AiPill label="Data science" onRemove={args.onRemove} />
+          <AiPill label="Neural networks" onRemove={args.onRemove} />
+        </Flex>
+      </Flex>
+      <Flex flexDirection="column" gap="spacingS">
+        <SectionHeading as="h3">Disabled remove button</SectionHeading>
+        <Flex flexDirection="row" gap="spacingXs">
+          <AiPill
+            label="Machine learning"
+            onRemove={args.onRemove}
+            isDisabled
+          />
+          <AiPill label="Data science" onRemove={args.onRemove} isDisabled />
+        </Flex>
+      </Flex>
+    </Flex>
+  ),
+  args: {
+    onRemove: action('remove'),
+  },
+};
+
+export const WithoutRemove: StoryObj<AiPillProps> = {
+  render: () => (
+    <Flex flexDirection="row" gap="spacingXs">
+      <AiPill label="Suggested category" />
+      <AiPill label="Auto-tagged" />
+    </Flex>
+  ),
+};


### PR DESCRIPTION
## Summary

- Adds `AiPill` component to `@contentful/f36-ai-components` for AI-suggested tags
- Gradient background (blue → purple → orange → yellow at 5% opacity), blue border, purple label
- Same circular X removal pattern as PillNext (hover purple background, disabled purple icon)
- No leading icon, no variants, no tooltip — single visual treatment per spec
- Includes Storybook stories and unit tests with axe a11y checks

## Screenshots
<img width="868" height="413" alt="Screenshot 2026-05-27 at 15 50 09" src="https://github.com/user-attachments/assets/d8a6a527-12ae-4f4b-bb1b-b03e48de495f" />

## Test plan

- [x] Stories render in Storybook (`AI/AiPill`)
- [x] Gradient background and AI Gradient/Default border visible
- [x] Label text is purple (#6c3ecf)
- [x] Remove button hover shows circular purple
- [x] Disabled remove button shows lighter purple, no hover effect, not focusable
- [x] `npx jest packages/f36-ai-components/src/AiPill` passes (13 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)