### PR TITLE
chore: release pill next v 6.0.1-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42575,7 +42575,7 @@
     },
     "packages/components/pill-next": {
       "name": "@contentful/f36-pill-next",
-      "version": "0.0.1-alpha.0",
+      "version": "6.0.1-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-button": "^6.8.0",

--- a/packages/components/pill-next/package.json
+++ b/packages/components/pill-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-pill-next",
-  "version": "6.0.1-alpha.1",
+  "version": "6.0.1-alpha.2",
   "description": "Forma 36: PillNext component (alpha)",
   "scripts": {
     "build": "tsup"


### PR DESCRIPTION
# Purpose of PR

This updates the package.json files of the PillNext component released under v 6.0.1-alpha.2