### PR TITLE
feat(ai-pill): support configurable action icon [GROOT-2867]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42846,7 +42846,7 @@
     },
     "packages/f36-ai-components": {
       "name": "@contentful/f36-ai-components",
-      "version": "0.0.2-alpha.1",
+      "version": "0.0.2-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-button": "^6.0.0",

--- a/packages/f36-ai-components/package.json
+++ b/packages/f36-ai-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-ai-components",
-  "version": "0.0.2-alpha.1",
+  "version": "0.0.2-alpha.2",
   "description": "A collection of components for use in AI applications, such as conversational interfaces.",
   "license": "MIT",
   "files": [

--- a/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
+++ b/packages/f36-ai-components/src/AiPill/AiPill.styles.ts
@@ -29,8 +29,28 @@ export const aiPillOverrides = css({
   },
 });
 
-export const aiPillRemoveButton = css({
-  '&&&:hover:not(:disabled)': {
+export const aiPillWithAction = css({
+  '&&': {
+    paddingRight: tokens.spacing2Xs,
+  },
+});
+
+export const aiPillActionButton = css({
+  all: 'unset',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '24px',
+  height: '24px',
+  borderRadius: '50%',
+  cursor: 'pointer',
+  flexShrink: 0,
+  marginLeft: tokens.spacingXs,
+  '&:hover:not(:disabled)': {
     backgroundColor: tokens.purple200,
+  },
+  '&:disabled': {
+    cursor: 'not-allowed',
+    opacity: 0.5,
   },
 });

--- a/packages/f36-ai-components/src/AiPill/AiPill.test.tsx
+++ b/packages/f36-ai-components/src/AiPill/AiPill.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
+import { PlusIcon, XIcon } from '@contentful/f36-icons';
 
 import { AiPill } from './AiPill';
 
@@ -20,53 +21,90 @@ describe('AiPill', () => {
     expect(container.firstChild).toHaveClass('my-class');
   });
 
-  it('renders gradient background', () => {
-    const { container } = render(<AiPill label="test" />);
-    const pill = container.firstChild as HTMLElement;
-    expect(pill.style || pill.className).toBeTruthy();
+  it('does not render action button when no actionIcon is provided', () => {
+    render(<AiPill label="test" />);
+    expect(screen.queryByRole('button')).toBeNull();
   });
 
-  describe('remove button', () => {
-    it('renders remove button when onRemove is provided', () => {
-      render(<AiPill label="test" onRemove={() => {}} />);
-      expect(screen.getByRole('button', { name: 'Remove' })).toBeTruthy();
-    });
-
-    it('does not render remove button when onRemove is not provided', () => {
-      render(<AiPill label="test" />);
-      expect(screen.queryByRole('button')).toBeNull();
-    });
-
-    it('calls onRemove when remove button is clicked', () => {
-      const mockOnRemove = jest.fn();
-      render(<AiPill label="test" onRemove={mockOnRemove} />);
-      fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
-      expect(mockOnRemove).toHaveBeenCalledTimes(1);
-    });
-
-    it('uses custom remove button label', () => {
+  describe('action button', () => {
+    it('renders action button when actionIcon is provided', () => {
       render(
         <AiPill
           label="test"
-          onRemove={() => {}}
-          removeButtonLabel="Delete suggestion"
+          actionIcon={<XIcon />}
+          onAction={() => {}}
+          actionButtonLabel="Remove"
+        />,
+      );
+      expect(screen.getByRole('button', { name: 'Remove' })).toBeTruthy();
+    });
+
+    it('calls onAction when action button is clicked', () => {
+      const mockOnAction = jest.fn();
+      render(
+        <AiPill
+          label="test"
+          actionIcon={<XIcon />}
+          onAction={mockOnAction}
+          actionButtonLabel="Remove"
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+      expect(mockOnAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses custom action button label', () => {
+      render(
+        <AiPill
+          label="test"
+          actionIcon={<PlusIcon />}
+          onAction={() => {}}
+          actionButtonLabel="Add suggestion"
         />,
       );
       expect(
-        screen.getByRole('button', { name: 'Delete suggestion' }),
+        screen.getByRole('button', { name: 'Add suggestion' }),
       ).toBeTruthy();
     });
 
-    it('disables remove button when isDisabled is true', () => {
-      render(<AiPill label="test" onRemove={() => {}} isDisabled />);
+    it('disables action button when isDisabled is true', () => {
+      render(
+        <AiPill
+          label="test"
+          actionIcon={<XIcon />}
+          onAction={() => {}}
+          actionButtonLabel="Remove"
+          isDisabled
+        />,
+      );
       expect(screen.getByRole('button', { name: 'Remove' })).toBeDisabled();
     });
 
-    it('does not call onRemove when disabled', () => {
-      const mockOnRemove = jest.fn();
-      render(<AiPill label="test" onRemove={mockOnRemove} isDisabled />);
+    it('does not call onAction when disabled', () => {
+      const mockOnAction = jest.fn();
+      render(
+        <AiPill
+          label="test"
+          actionIcon={<XIcon />}
+          onAction={mockOnAction}
+          actionButtonLabel="Remove"
+          isDisabled
+        />,
+      );
       fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
-      expect(mockOnRemove).not.toHaveBeenCalled();
+      expect(mockOnAction).not.toHaveBeenCalled();
+    });
+
+    it('works with any icon (PlusIcon)', () => {
+      render(
+        <AiPill
+          label="test"
+          actionIcon={<PlusIcon />}
+          onAction={() => {}}
+          actionButtonLabel="Add"
+        />,
+      );
+      expect(screen.getByRole('button', { name: 'Add' })).toBeTruthy();
     });
   });
 
@@ -77,15 +115,28 @@ describe('AiPill', () => {
       expect(results).toHaveNoViolations();
     });
 
-    it('has no a11y violations with remove button', async () => {
-      const { container } = render(<AiPill label="test" onRemove={() => {}} />);
+    it('has no a11y violations with action button', async () => {
+      const { container } = render(
+        <AiPill
+          label="test"
+          actionIcon={<XIcon />}
+          onAction={() => {}}
+          actionButtonLabel="Remove"
+        />,
+      );
       const results = await axe(container);
       expect(results).toHaveNoViolations();
     });
 
-    it('has no a11y violations with disabled remove button', async () => {
+    it('has no a11y violations with disabled action button', async () => {
       const { container } = render(
-        <AiPill label="test" onRemove={() => {}} isDisabled />,
+        <AiPill
+          label="test"
+          actionIcon={<XIcon />}
+          onAction={() => {}}
+          actionButtonLabel="Remove"
+          isDisabled
+        />,
       );
       const results = await axe(container);
       expect(results).toHaveNoViolations();

--- a/packages/f36-ai-components/src/AiPill/AiPill.tsx
+++ b/packages/f36-ai-components/src/AiPill/AiPill.tsx
@@ -3,13 +3,20 @@ import { cx } from '@emotion/css';
 import type { CommonProps } from '@contentful/f36-core';
 import tokens from '@contentful/f36-tokens';
 import { PillNext } from '@contentful/f36-pill-next';
-import { aiPillOverrides, aiPillRemoveButton } from './AiPill.styles';
+import {
+  aiPillOverrides,
+  aiPillWithAction,
+  aiPillActionButton,
+} from './AiPill.styles';
 
 export interface AiPillProps extends CommonProps {
   label: string;
-  onRemove?: () => void;
-  /** @default "Remove" */
-  removeButtonLabel?: string;
+  /** The icon element to render as the end action. */
+  actionIcon?: React.ReactElement;
+  /** Callback fired when the action button is clicked. Required when actionIcon is provided. */
+  onAction?: () => void;
+  /** Accessible label for the action button. Required when actionIcon is provided. */
+  actionButtonLabel?: string;
   isDisabled?: boolean;
   className?: string;
 }
@@ -18,8 +25,9 @@ export const AiPill = React.forwardRef<HTMLDivElement, AiPillProps>(
   (props, ref) => {
     const {
       label,
-      onRemove,
-      removeButtonLabel = 'Remove',
+      actionIcon,
+      onAction,
+      actionButtonLabel,
       isDisabled = false,
       testId = 'cf-ui-ai-pill',
       className,
@@ -30,15 +38,33 @@ export const AiPill = React.forwardRef<HTMLDivElement, AiPillProps>(
       <PillNext
         ref={ref}
         label={label}
-        onRemove={onRemove}
-        removeButtonLabel={removeButtonLabel}
         isDisabled={isDisabled}
         testId={testId}
-        className={cx(aiPillOverrides, className)}
-        removeButtonClassName={aiPillRemoveButton}
-        removeIconColor={tokens.purple600}
+        className={cx(
+          aiPillOverrides,
+          actionIcon && aiPillWithAction,
+          className,
+        )}
         {...otherProps}
-      />
+      >
+        {actionIcon && (
+          <button
+            type="button"
+            aria-label={actionButtonLabel}
+            disabled={isDisabled}
+            onClick={onAction}
+            className={aiPillActionButton}
+          >
+            {React.cloneElement(
+              actionIcon as React.ReactElement<{
+                size?: string;
+                color?: string;
+              }>,
+              { size: 'small', color: tokens.purple600 },
+            )}
+          </button>
+        )}
+      </PillNext>
     );
   },
 );

--- a/packages/f36-ai-components/stories/AiPill.stories.tsx
+++ b/packages/f36-ai-components/stories/AiPill.stories.tsx
@@ -3,6 +3,7 @@ import type { StoryObj, Meta } from '@storybook/react-vite';
 import { SectionHeading } from '@contentful/f36-typography';
 import { action } from 'storybook/actions';
 import { Flex } from '@contentful/f36-core';
+import { PlusIcon, XIcon } from '@contentful/f36-icons';
 
 import { AiPill } from '../src/AiPill';
 import type { AiPillProps } from '../src/AiPill';
@@ -25,36 +26,105 @@ export const Basic: StoryObj<AiPillProps> = {
   },
 };
 
-export const Removable: StoryObj<AiPillProps> = {
-  render: (args) => (
+export const WithRemoveIcon: StoryObj<AiPillProps> = {
+  render: () => (
     <Flex flexDirection="column" gap="spacingL">
       <Flex flexDirection="column" gap="spacingS">
-        <SectionHeading as="h3">With remove button</SectionHeading>
-        <Flex flexDirection="row" gap="spacingXs">
-          <AiPill label="Machine learning" onRemove={args.onRemove} />
-          <AiPill label="Data science" onRemove={args.onRemove} />
-          <AiPill label="Neural networks" onRemove={args.onRemove} />
-        </Flex>
-      </Flex>
-      <Flex flexDirection="column" gap="spacingS">
-        <SectionHeading as="h3">Disabled remove button</SectionHeading>
+        <SectionHeading as="h3">Dismiss action (XIcon)</SectionHeading>
         <Flex flexDirection="row" gap="spacingXs">
           <AiPill
             label="Machine learning"
-            onRemove={args.onRemove}
+            actionIcon={<XIcon />}
+            onAction={action('dismiss')}
+            actionButtonLabel="Dismiss Machine learning"
+          />
+          <AiPill
+            label="Data science"
+            actionIcon={<XIcon />}
+            onAction={action('dismiss')}
+            actionButtonLabel="Dismiss Data science"
+          />
+          <AiPill
+            label="Neural networks"
+            actionIcon={<XIcon />}
+            onAction={action('dismiss')}
+            actionButtonLabel="Dismiss Neural networks"
+          />
+        </Flex>
+      </Flex>
+      <Flex flexDirection="column" gap="spacingS">
+        <SectionHeading as="h3">Disabled</SectionHeading>
+        <Flex flexDirection="row" gap="spacingXs">
+          <AiPill
+            label="Machine learning"
+            actionIcon={<XIcon />}
+            onAction={action('dismiss')}
+            actionButtonLabel="Dismiss"
             isDisabled
           />
-          <AiPill label="Data science" onRemove={args.onRemove} isDisabled />
+          <AiPill
+            label="Data science"
+            actionIcon={<XIcon />}
+            onAction={action('dismiss')}
+            actionButtonLabel="Dismiss"
+            isDisabled
+          />
         </Flex>
       </Flex>
     </Flex>
   ),
-  args: {
-    onRemove: action('remove'),
-  },
 };
 
-export const WithoutRemove: StoryObj<AiPillProps> = {
+export const WithAddIcon: StoryObj<AiPillProps> = {
+  render: () => (
+    <Flex flexDirection="column" gap="spacingL">
+      <Flex flexDirection="column" gap="spacingS">
+        <SectionHeading as="h3">Add action (PlusIcon)</SectionHeading>
+        <Flex flexDirection="row" gap="spacingXs">
+          <AiPill
+            label="Machine learning"
+            actionIcon={<PlusIcon />}
+            onAction={action('add')}
+            actionButtonLabel="Add Machine learning suggestion"
+          />
+          <AiPill
+            label="Data science"
+            actionIcon={<PlusIcon />}
+            onAction={action('add')}
+            actionButtonLabel="Add Data science suggestion"
+          />
+          <AiPill
+            label="Neural networks"
+            actionIcon={<PlusIcon />}
+            onAction={action('add')}
+            actionButtonLabel="Add Neural networks suggestion"
+          />
+        </Flex>
+      </Flex>
+      <Flex flexDirection="column" gap="spacingS">
+        <SectionHeading as="h3">Disabled</SectionHeading>
+        <Flex flexDirection="row" gap="spacingXs">
+          <AiPill
+            label="Machine learning"
+            actionIcon={<PlusIcon />}
+            onAction={action('add')}
+            actionButtonLabel="Add suggestion"
+            isDisabled
+          />
+          <AiPill
+            label="Data science"
+            actionIcon={<PlusIcon />}
+            onAction={action('add')}
+            actionButtonLabel="Add suggestion"
+            isDisabled
+          />
+        </Flex>
+      </Flex>
+    </Flex>
+  ),
+};
+
+export const WithoutAction: StoryObj<AiPillProps> = {
   render: () => (
     <Flex flexDirection="row" gap="spacingXs">
       <AiPill label="Suggested category" />


### PR DESCRIPTION
## Summary

The initial AiPill implementation (PR #3414) hardcoded the end-icon as a remove/dismiss action (XIcon via PillNext's `onRemove`). This was shortsighted — the taxonomy assignment surfaces in `user_interface` (GROOT-2762) need an "apply suggestion" action (PlusCircleIcon), not a dismiss action.

Rather than bolting on a second action type alongside the existing remove, this PR replaces the `onRemove` API with a generic end-icon slot. The component no longer prescribes what the icon means — consumers pass any icon and handler they want:

- `actionIcon` — the icon element to render (XIcon, PlusIcon, any custom icon)
- `onAction` — callback when the button is clicked
- `actionButtonLabel` — accessible aria-label

This is a breaking change to the alpha API (`onRemove` and `removeButtonLabel` are removed), but there are no consumers yet so nothing breaks in practice.

## Changes

- Replace `onRemove` / `removeButtonLabel` with `actionIcon` / `onAction` / `actionButtonLabel`
- Remove PillNext's built-in remove button in favor of a custom `<button>` in the children slot
- Simplify styles (no more `aiPillRemoveButton` override needed)
- Update tests and stories to demonstrate both dismiss (XIcon) and apply (PlusIcon) use cases

<img width="1131" height="923" alt="Screenshot 2026-06-01 at 11 05 35" src="https://github.com/user-attachments/assets/2045ffcd-c8d6-4a4e-88bc-dd28fb9f29ca" />

## Test plan

- [x] 13 unit tests pass (action rendering, click handling, disabled state, accessibility)
- [x] No axe violations
- [x] TypeScript clean
- [x] Prettier formatted
- [x] Storybook: verify `WithRemoveIcon` and `WithAddIcon` stories render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)