### PR TITLE
fix(pill-next): support multiline label wrapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42622,7 +42622,7 @@
     },
     "packages/components/pill-next": {
       "name": "@contentful/f36-pill-next",
-      "version": "6.0.1-alpha.4",
+      "version": "6.0.1-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-button": "^6.8.0",

--- a/packages/components/pill-next/package.json
+++ b/packages/components/pill-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-pill-next",
-  "version": "6.0.1-alpha.4",
+  "version": "6.0.1-alpha.5",
   "description": "Forma 36: PillNext component (alpha)",
   "scripts": {
     "build": "tsup"

--- a/packages/components/pill-next/src/PillNext.styles.ts
+++ b/packages/components/pill-next/src/PillNext.styles.ts
@@ -36,7 +36,8 @@ export function getPillNextStyles(
       alignItems: 'center',
       // TODO: replace with border-radius token when new tokens ship in next major
       borderRadius: '16px',
-      height: '32px',
+      minHeight: '32px',
+      maxWidth: '100%',
       paddingTop: tokens.spacing2Xs,
       paddingBottom: tokens.spacing2Xs,
       paddingLeft: tokens.spacingS,
@@ -60,7 +61,7 @@ export function getPillNextStyles(
       fontSize: tokens.fontSizeM,
       fontWeight: tokens.fontWeightMedium,
       lineHeight: tokens.lineHeightM,
-      whiteSpace: 'nowrap',
+      wordBreak: 'break-word',
     }),
     removeButton: css({
       '&&': {

--- a/packages/components/pill-next/stories/PillNext.stories.tsx
+++ b/packages/components/pill-next/stories/PillNext.stories.tsx
@@ -186,7 +186,14 @@ export const LongLabels: StoryObj<PillNextInternalProps> = {
           />
           <PillNext
             label="fefhjejhfehufheuhfuehfuewdwhudhwuhduwhduehfuheufheufheuf euhfuehfuheufhuehfuheufheufhuehfuheufheufheuhf"
-            variant="primary"
+            variant="warning"
+            tooltipContent="This tag has restricted visibility"
+            onRemove={args.onRemove}
+          />
+          <PillNext
+            label="Negative variant with a long label that wraps to verify leading icon alignment with the remove button"
+            variant="negative"
+            tooltipContent="This tag was deleted"
             onRemove={args.onRemove}
           />
           <PillNext

--- a/packages/components/pill-next/stories/PillNext.stories.tsx
+++ b/packages/components/pill-next/stories/PillNext.stories.tsx
@@ -148,17 +148,50 @@ export const LongLabels: StoryObj<PillNextInternalProps> = {
     <Flex flexDirection="column" gap="spacingL">
       <Flex flexDirection="column" gap="spacingS">
         <SectionHeading as="h3">
-          Very long labels (pill expands, border-radius stays 16px)
+          Wide container — long pill fits on one line
         </SectionHeading>
-        <Flex flexDirection="column" alignItems="flex-start" gap="spacingXs">
+        <Flex
+          flexDirection="column"
+          alignItems="flex-start"
+          gap="spacingXs"
+          style={{ width: '800px', border: '1px dashed #ccc', padding: '16px' }}
+        >
           <PillNext
-            label="fefhjejhfehufheuhfuehfuewdwhudhwuhduwhduehfuheufheufheuf"
+            label="Vewkjsdhfkjsdhf kdsjhfdskjfhdskjfhdskjfhdskjfh sdkfjhsdkfh sdkfjhsdkfjh sdkfjhsdkfjh sdkfjhsdkfjh"
             variant="secondary"
             onRemove={args.onRemove}
           />
           <PillNext
-            label="This is an extremely long label that demonstrates the pill expanding to accommodate text without breaking the border radius"
+            label="Short label"
+            variant="secondary"
+            onRemove={args.onRemove}
+          />
+        </Flex>
+      </Flex>
+
+      <Flex flexDirection="column" gap="spacingS">
+        <SectionHeading as="h3">
+          Narrower container — long pill wraps to two lines
+        </SectionHeading>
+        <Flex
+          flexDirection="column"
+          alignItems="flex-start"
+          gap="spacingXs"
+          style={{ width: '550px', border: '1px dashed #ccc', padding: '16px' }}
+        >
+          <PillNext
+            label="Vewkjsdhfkjsdhf kdsjhfdskjfhdskjfhdskjfhdskjfh sdkfjhsdkfh sdkfjhsdkfjh sdkfjhsdkfjh sdkfjhsdkfjh"
+            variant="secondary"
+            onRemove={args.onRemove}
+          />
+          <PillNext
+            label="fefhjejhfehufheuhfuehfuewdwhudhwuhduwhduehfuheufheufheuf euhfuehfuheufhuehfuheufheufhuehfuheufheufheuhf"
             variant="primary"
+            onRemove={args.onRemove}
+          />
+          <PillNext
+            label="Short label"
+            variant="secondary"
             onRemove={args.onRemove}
           />
         </Flex>


### PR DESCRIPTION
## Summary
- Allow long labels in PillNext to wrap to multiple lines instead of extending indefinitely
- Pill respects container width via `max-width: 100%` and grows vertically (`minHeight` instead of fixed `height`)
- Remove icon stays vertically centered when label wraps

## Open question
Should there be a fixed max-width cap (e.g. 400px) so the pill wraps even in very wide containers? Waiting on design input from Anastasia.

## How to review
Check the **LongLabels** story in Storybook — it shows a wide container (pill on one line) vs a narrower container (pill wraps to two lines).

<img width="839" height="518" alt="Screenshot 2026-06-01 at 16 48 17" src="https://github.com/user-attachments/assets/5e70d42c-bd54-4a0a-aba7-e0b7609e2266" />

## Test plan
- [x] Verify short labels still render as single-line 32px pills
- [x] Verify long labels wrap correctly in narrow containers
- [x] Verify remove button stays vertically centered
- [x] Check warning/negative variants with leading icon still align correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)