### PR TITLE
fix(card): restore actions button aria-label override

### DIFF
--- a/.changeset/cold-points-greet.md
+++ b/.changeset/cold-points-greet.md
@@ -1,0 +1,6 @@
+---
+'@contentful/f36-card': patch
+---
+
+- Restore `actionsButtonProps['aria-label']` override behavior for card action buttons.
+- Pass `actionsButtonProps` through the `Card` header action path.

--- a/packages/components/card/src/BaseCard/CardActions.tsx
+++ b/packages/components/card/src/BaseCard/CardActions.tsx
@@ -24,8 +24,8 @@ export const CardActions = ({
     <Menu>
       <Menu.Trigger>
         <IconButton
-          {...buttonProps}
           aria-label="Actions"
+          {...buttonProps}
           icon={<DotsThreeIcon />}
           className={cx(styles.root, buttonProps?.className)}
           size="small"

--- a/packages/components/card/src/Card/Card.test.tsx
+++ b/packages/components/card/src/Card/Card.test.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
+import { MenuItem } from '@contentful/f36-menu';
 
 import { Card } from './Card';
 
@@ -71,6 +72,22 @@ describe('Card', () => {
     await user.click(screen.getByText('Card as link'));
 
     expect(onClick).toHaveBeenCalled();
+  });
+
+  it('uses the provided aria-label for the actions button', () => {
+    render(
+      <Card
+        title="Card title"
+        actionsButtonProps={{ 'aria-label': 'Toggle card actions' }}
+        actions={[<MenuItem key="copy">Copy</MenuItem>]}
+      >
+        Card
+      </Card>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Toggle card actions' }),
+    ).toBeInTheDocument();
   });
 
   it('has no a11y issues', async () => {

--- a/packages/components/card/src/Card/Card.tsx
+++ b/packages/components/card/src/Card/Card.tsx
@@ -37,6 +37,7 @@ export type CardProps<
 function CardBase<E extends React.ElementType = typeof BASE_CARD_DEFAULT_TAG>(
   {
     actions,
+    actionsButtonProps,
     badge,
     icon,
     padding = 'default',
@@ -74,7 +75,11 @@ function CardBase<E extends React.ElementType = typeof BASE_CARD_DEFAULT_TAG>(
                 {badge}
               </Flex>
             )}
-            {actions && <CardActions>{actions}</CardActions>}
+            {actions && (
+              <CardActions buttonProps={actionsButtonProps}>
+                {actions}
+              </CardActions>
+            )}
           </Flex>
         )
       }


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

The migration to v6 forced the `CardAction` component to keep its hard-coded `aria-label` without the ability to override it using `buttonProps`.

This PR restores the possibility to override, and also gives that option to the `CardBase` component which previously didn't pass `actionsButtonProps` to its `CardAction` child.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
