### PR TITLE
chore: make pill-next package private as it is not stable

### DIFF
--- a/packages/components/pill-next/package.json
+++ b/packages/components/pill-next/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@contentful/f36-pill-next",
+  "private": true,
   "version": "6.0.1-alpha.6",
   "description": "Forma 36: PillNext component (alpha)",
   "scripts": {


### PR DESCRIPTION
# Purpose of PR

when creating this new alpha component, we forgot to set the package to private, so it currently causes a publihsing error, because it can not yet be publicly published. 
