### PR TITLE
feat: expose AiPill subpath and defer tiptap to peer deps [PIC-1170]

### DIFF
--- a/.changeset/aipill-subpath-tiptap-peer.md
+++ b/.changeset/aipill-subpath-tiptap-peer.md
@@ -1,8 +1,0 @@
----
-"@contentful/f36-ai-components": minor
----
-
-feat: expose AiPill via `/aipill` subpath and move tiptap to peer dependencies
-
-- Adds `import { AiPill } from '@contentful/f36-ai-components/aipill'` so consumers can use AiPill without pulling in the AIChatInput tiptap stack.
-- Moves all `@tiptap/*` packages from `dependencies` to `peerDependencies` (`^3.15.0`). Consumers using AIChatInput must install `@tiptap/core`, `@tiptap/react`, `@tiptap/pm`, `@tiptap/extension-document`, `@tiptap/extension-paragraph`, `@tiptap/extension-text`, `@tiptap/extension-mention`, `@tiptap/extensions`, and `@tiptap/suggestion` themselves. Fixes duplicate-instance issues like `export 'isNodeViewSelected' was not found in '@tiptap/core'`.

--- a/.changeset/aipill-subpath-tiptap-peer.md
+++ b/.changeset/aipill-subpath-tiptap-peer.md
@@ -1,0 +1,8 @@
+---
+"@contentful/f36-ai-components": minor
+---
+
+feat: expose AiPill via `/aipill` subpath and move tiptap to peer dependencies
+
+- Adds `import { AiPill } from '@contentful/f36-ai-components/aipill'` so consumers can use AiPill without pulling in the AIChatInput tiptap stack.
+- Moves all `@tiptap/*` packages from `dependencies` to `peerDependencies` (`^3.15.0`). Consumers using AIChatInput must install `@tiptap/core`, `@tiptap/react`, `@tiptap/pm`, `@tiptap/extension-document`, `@tiptap/extension-paragraph`, `@tiptap/extension-text`, `@tiptap/extension-mention`, `@tiptap/extensions`, and `@tiptap/suggestion` themselves. Fixes duplicate-instance issues like `export 'isNodeViewSelected' was not found in '@tiptap/core'`.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,7 +24,7 @@ export default [
       '*.css.d.ts',
       'public/**',
       '.cache/**',
-      'tsup.config.ts',
+      '**/tsup.config.ts',
       '**/__testfixtures__',
       '**/.next/**',
       '**/.turbo/**',

--- a/package-lock.json
+++ b/package-lock.json
@@ -250,6 +250,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1990,6 +1991,7 @@
       "integrity": "sha512-GaTI4nXDrs7l0qaJ6Rg06dtOXTBCG6TMDB44zbqofCIC4PqC7SEvmFFtpxzCDw9W5aJ7RKVshgXTLvLdBFV/qw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
         "@babel/helper-compilation-targets": "^7.28.6",
@@ -4198,6 +4200,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4221,6 +4224,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4242,6 +4246,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -5363,6 +5368,7 @@
       "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-3.32.2.tgz",
       "integrity": "sha512-WgLTC6F7OE+siZDjunP+hshoMu7jM0UAL2hV8anWLXpxhl+cFUBxQ147Wv5I6Bj7dqOn7wemly2yxfz2ooqDag==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@bytecodealliance/jco": "^1.7.0",
         "@bytecodealliance/weval": "^0.3.2",
@@ -5392,6 +5398,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
       "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.4",
         "@floating-ui/utils": "^0.2.10"
@@ -7561,6 +7568,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -8220,6 +8228,7 @@
       "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -8828,6 +8837,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -11266,6 +11276,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -11355,6 +11366,7 @@
       "integrity": "sha512-GTAsXAI32p4hEZgPzvUv2RPrObxamy9AFhmhG10fXSvN/cDUs8naEYVIqDV3Sh99jMwQEbTFKW1E1mcspsY6ow==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -11478,6 +11490,7 @@
       "integrity": "sha512-QQP/78ryOZDN99gNBV7dgh69/8AYaOYQYFklq/iR+ZRFaaL3+qqHFvPVJapGkzPdymBgNJ34xjFM8n5pJ4QmMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-commands": "^1.6.2",
@@ -11532,6 +11545,7 @@
       "integrity": "sha512-UlLIij1fxFy7tbCmqUoInWRijzsi8hsbaXKCx6L3KvLXtxHb4hMnDhd6W++rOk9Q1hDpmNf8qNIX498q/ZNstw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -11962,6 +11976,7 @@
       "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -11989,6 +12004,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -11999,6 +12015,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -13053,6 +13070,7 @@
       "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -13190,6 +13208,7 @@
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -13429,6 +13448,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -13516,6 +13536,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14839,6 +14860,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -16107,6 +16129,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -17591,6 +17614,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -18072,7 +18096,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
       "integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "5.2.2",
@@ -18971,6 +18996,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -19172,6 +19198,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -23455,6 +23482,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -25088,6 +25116,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -25850,6 +25879,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -26530,6 +26560,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -30008,6 +30039,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -30337,6 +30369,7 @@
       "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -31592,6 +31625,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -32213,6 +32247,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
       "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -32251,6 +32286,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -32803,6 +32839,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -32890,6 +32927,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -34870,6 +34908,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -35487,6 +35526,7 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -36320,6 +36360,7 @@
       "integrity": "sha512-JBG8dioIs0m2kHOhs9jD6E/tZKD08vmbf2bfqj/rJyNWqJxk/ZcakixjhYtsqdbi+AKVbfPkt3g2RRZiKaizYA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "lilconfig": "^3.1.3",
@@ -36644,6 +36685,7 @@
       "integrity": "sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -38974,7 +39016,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38992,7 +39033,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39010,7 +39050,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39028,7 +39067,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39046,7 +39084,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39064,7 +39101,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39082,7 +39118,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39100,7 +39135,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39118,7 +39152,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39136,7 +39169,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39154,7 +39186,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39172,7 +39203,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39190,7 +39220,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39208,7 +39237,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39226,7 +39254,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39244,7 +39271,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39262,7 +39288,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39280,7 +39305,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39298,7 +39322,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39316,7 +39339,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39334,7 +39356,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39352,7 +39373,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39370,7 +39390,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39388,7 +39407,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39406,7 +39424,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39424,7 +39441,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39720,6 +39736,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -40612,6 +40629,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -41194,6 +41212,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -41369,6 +41388,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -42013,6 +42033,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -42894,7 +42915,7 @@
     },
     "packages/f36-ai-components": {
       "name": "@contentful/f36-ai-components",
-      "version": "0.0.2-alpha.3",
+      "version": "0.0.2-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-button": "^6.9.1",
@@ -43415,7 +43436,7 @@
     },
     "packages/forma-36-codemod": {
       "name": "@contentful/f36-codemod",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
         "camelcase-keys": "^6.2.2",
@@ -45479,6 +45500,7 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11353,6 +11353,7 @@
       "version": "3.24.0",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.24.0.tgz",
       "integrity": "sha512-GTAsXAI32p4hEZgPzvUv2RPrObxamy9AFhmhG10fXSvN/cDUs8naEYVIqDV3Sh99jMwQEbTFKW1E1mcspsY6ow==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -11385,6 +11386,7 @@
       "version": "3.24.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.24.0.tgz",
       "integrity": "sha512-yxgM3+yXy2XZzEwH43y2Kp8D1BkblxEWLXqo0YCoAKtxyKCcEaT8kdlf70kS7D0+VSzYU4D0iN7VdQIYHcL2mA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -11415,6 +11417,7 @@
       "version": "3.24.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.24.0.tgz",
       "integrity": "sha512-c68AYrEoHJ4vlBvt5stBUTveKXiNwt5BxaQxgq2R4OXjc3VMoh+XJqo1bBbMNHEJfuGMNpcdfZ2zf09jnBf8/A==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -11430,6 +11433,7 @@
       "version": "3.24.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.24.0.tgz",
       "integrity": "sha512-wD06aB6hO7LgcrlhGiw7I64k2tus9kNoICX5R+UecBSB1DVJdzKvXoXL2kPNv4DqYvljHdkIeK/OpuOTQd6MJA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -11443,6 +11447,7 @@
       "version": "3.24.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.24.0.tgz",
       "integrity": "sha512-Im7keLPEihxm3+LyF+drYCoaOY5hlq35lvHAp/el6M8pJ/scts88HrYpdR1Yc4BtpZBIhfHSyWgPaupI4qwdeg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -11456,6 +11461,7 @@
       "version": "3.24.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.24.0.tgz",
       "integrity": "sha512-z6gRYzy2ucJp07OQ0F2W07NxyhMTxPYH1ia2eGiQkWax1i56oExpjMsDHP8THWlg8Tb7NnbfKpkfh881EsmofA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -11470,6 +11476,7 @@
       "version": "3.24.0",
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.24.0.tgz",
       "integrity": "sha512-QQP/78ryOZDN99gNBV7dgh69/8AYaOYQYFklq/iR+ZRFaaL3+qqHFvPVJapGkzPdymBgNJ34xjFM8n5pJ4QmMg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
@@ -11523,6 +11530,7 @@
       "version": "3.24.0",
       "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.24.0.tgz",
       "integrity": "sha512-UlLIij1fxFy7tbCmqUoInWRijzsi8hsbaXKCx6L3KvLXtxHb4hMnDhd6W++rOk9Q1hDpmNf8qNIX498q/ZNstw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -30649,6 +30657,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/os-name": {
@@ -32420,6 +32429,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.0.tgz",
       "integrity": "sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-transform": "^1.0.0"
@@ -32429,6 +32439,7 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
       "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "^1.0.0",
@@ -32440,6 +32451,7 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
       "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "^1.0.0",
@@ -32451,6 +32463,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
       "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-keymap": "^1.0.0",
@@ -32463,6 +32476,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
       "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "^1.2.2",
@@ -32475,6 +32489,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
       "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "^1.0.0",
@@ -32485,6 +32500,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
       "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-state": "^1.0.0",
@@ -32495,6 +32511,7 @@
       "version": "1.25.7",
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.7.tgz",
       "integrity": "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "orderedmap": "^2.0.0"
@@ -32504,6 +32521,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
       "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "^1.0.0",
@@ -32515,6 +32533,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "^1.0.0",
@@ -32526,6 +32545,7 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
       "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-keymap": "^1.2.3",
@@ -32539,6 +32559,7 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
       "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "^1.21.0"
@@ -32548,6 +32569,7 @@
       "version": "1.41.8",
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
       "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "^1.20.0",
@@ -35241,6 +35263,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rrweb-cssom": {
@@ -42871,7 +42894,7 @@
     },
     "packages/f36-ai-components": {
       "name": "@contentful/f36-ai-components",
-      "version": "0.0.2-alpha.2",
+      "version": "0.0.2-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-button": "^6.9.1",
@@ -42885,25 +42908,31 @@
         "@contentful/f36-typography": "^6.9.1",
         "@contentful/f36-utils": "^6.0.0",
         "@emotion/css": "^11.13.5",
-        "@tiptap/extension-document": "3.24.0",
-        "@tiptap/extension-mention": "3.24.0",
-        "@tiptap/extension-paragraph": "3.24.0",
-        "@tiptap/extension-text": "3.24.0",
-        "@tiptap/extensions": "3.24.0",
-        "@tiptap/suggestion": "3.24.0",
         "react-markdown": "^9.0.3",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
         "@tiptap/core": "3.24.0",
-        "@tiptap/pm": "3.24.0",
-        "@tiptap/react": "3.24.0"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.24.0",
+        "@tiptap/extension-document": "3.24.0",
+        "@tiptap/extension-mention": "3.24.0",
+        "@tiptap/extension-paragraph": "3.24.0",
+        "@tiptap/extension-text": "3.24.0",
+        "@tiptap/extensions": "3.24.0",
         "@tiptap/pm": "3.24.0",
         "@tiptap/react": "3.24.0",
+        "@tiptap/suggestion": "3.24.0"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.15.0",
+        "@tiptap/extension-document": "^3.15.0",
+        "@tiptap/extension-mention": "^3.15.0",
+        "@tiptap/extension-paragraph": "^3.15.0",
+        "@tiptap/extension-text": "^3.15.0",
+        "@tiptap/extensions": "^3.15.0",
+        "@tiptap/pm": "^3.15.0",
+        "@tiptap/react": "^3.15.0",
+        "@tiptap/suggestion": "^3.15.0",
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
       }

--- a/packages/f36-ai-components/package.json
+++ b/packages/f36-ai-components/package.json
@@ -11,6 +11,19 @@
   "types": "dist/index.d.ts",
   "source": "src/index.ts",
   "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/index.js"
+    },
+    "./aipill": {
+      "types": "./dist/aipill.d.ts",
+      "import": "./dist/esm/aipill.js",
+      "require": "./dist/aipill.js"
+    },
+    "./package.json": "./package.json"
+  },
   "browserslist": "extends @contentful/browserslist-config",
   "scripts": {
     "build": "tsup"
@@ -27,25 +40,31 @@
     "@contentful/f36-typography": "^6.9.1",
     "@contentful/f36-utils": "^6.0.0",
     "@emotion/css": "^11.13.5",
-    "@tiptap/extension-document": "3.24.0",
-    "@tiptap/extension-mention": "3.24.0",
-    "@tiptap/extension-paragraph": "3.24.0",
-    "@tiptap/extension-text": "3.24.0",
-    "@tiptap/extensions": "3.24.0",
-    "@tiptap/suggestion": "3.24.0",
     "react-markdown": "^9.0.3",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
     "@tiptap/core": "3.24.0",
-    "@tiptap/pm": "3.24.0",
-    "@tiptap/react": "3.24.0"
-  },
-  "peerDependencies": {
-    "@tiptap/core": "3.24.0",
+    "@tiptap/extension-document": "3.24.0",
+    "@tiptap/extension-mention": "3.24.0",
+    "@tiptap/extension-paragraph": "3.24.0",
+    "@tiptap/extension-text": "3.24.0",
+    "@tiptap/extensions": "3.24.0",
     "@tiptap/pm": "3.24.0",
     "@tiptap/react": "3.24.0",
+    "@tiptap/suggestion": "3.24.0"
+  },
+  "peerDependencies": {
+    "@tiptap/core": "^3.15.0",
+    "@tiptap/extension-document": "^3.15.0",
+    "@tiptap/extension-mention": "^3.15.0",
+    "@tiptap/extension-paragraph": "^3.15.0",
+    "@tiptap/extension-text": "^3.15.0",
+    "@tiptap/extensions": "^3.15.0",
+    "@tiptap/pm": "^3.15.0",
+    "@tiptap/react": "^3.15.0",
+    "@tiptap/suggestion": "^3.15.0",
     "react": "^18.3.0 || >=19.1.0",
     "react-dom": "^18.3.0 || >=19.1.0"
   },

--- a/packages/f36-ai-components/package.json
+++ b/packages/f36-ai-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-ai-components",
-  "version": "0.0.2-alpha.3",
+  "version": "0.0.2-alpha.4",
   "private": "true",
   "description": "A collection of components for use in AI applications, such as conversational interfaces.",
   "license": "MIT",

--- a/packages/f36-ai-components/tsup.config.ts
+++ b/packages/f36-ai-components/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  clean: true,
+  dts: true,
+  entry: {
+    index: 'src/index.ts',
+    aipill: 'src/AiPill/index.ts',
+  },
+  external: ['react', 'react-dom', '@contentful/f36-*', '@tiptap/*'],
+  format: ['cjs', 'esm'],
+  legacyOutput: true,
+  minify: true,
+  platform: 'browser',
+  sourcemap: true,
+  target: 'es6',
+  treeshake: true,
+});

--- a/packages/f36-ai-components/tsup.config.ts
+++ b/packages/f36-ai-components/tsup.config.ts
@@ -1,16 +1,13 @@
-import { defineConfig } from 'tsup';
+import { defineConfig, type Options } from 'tsup';
 import sharedConfig from '../../tsup.config';
 
-export default defineConfig((options) => {
-  const base =
-    typeof sharedConfig === 'function' ? sharedConfig(options) : sharedConfig;
+const base = sharedConfig as Options;
 
-  return {
-    ...base,
-    entry: {
-      index: 'src/index.ts',
-      aipill: 'src/AiPill/index.ts',
-    },
-    external: [...(base.external ?? []), '@tiptap/*'],
-  };
+export default defineConfig({
+  ...base,
+  entry: {
+    index: 'src/index.ts',
+    aipill: 'src/AiPill/index.ts',
+  },
+  external: [...(base.external ?? []), '@tiptap/*'],
 });

--- a/packages/f36-ai-components/tsup.config.ts
+++ b/packages/f36-ai-components/tsup.config.ts
@@ -1,18 +1,16 @@
 import { defineConfig } from 'tsup';
+import sharedConfig from '../../tsup.config';
 
-export default defineConfig({
-  clean: true,
-  dts: true,
-  entry: {
-    index: 'src/index.ts',
-    aipill: 'src/AiPill/index.ts',
-  },
-  external: ['react', 'react-dom', '@contentful/f36-*', '@tiptap/*'],
-  format: ['cjs', 'esm'],
-  legacyOutput: true,
-  minify: true,
-  platform: 'browser',
-  sourcemap: true,
-  target: 'es6',
-  treeshake: true,
+export default defineConfig((options) => {
+  const base =
+    typeof sharedConfig === 'function' ? sharedConfig(options) : sharedConfig;
+
+  return {
+    ...base,
+    entry: {
+      index: 'src/index.ts',
+      aipill: 'src/AiPill/index.ts',
+    },
+    external: [...(base.external ?? []), '@tiptap/*'],
+  };
 });


### PR DESCRIPTION
## Summary
- Add `@contentful/f36-ai-components/aipill` subpath export so consumers can import `AiPill` without pulling in the AIChatInput tiptap stack (~2.5KB bundle, no tiptap deps).
- Move all `@tiptap/*` packages from `dependencies` to `peerDependencies` with `^3.15.0` ranges. This fixes the `export 'isNodeViewSelected' was not found in '@tiptap/core'` webpack error in user_interface caused by `@tiptap/react@3.24` colliding with their `@tiptap/core@3.15.3`.
- Add a per-package `tsup.config.ts` with multi-entry build (`src/index.ts` + `src/AiPill/index.ts`) and `exports` map covering `.` and `./aipill`.


## Ticket
[PIC-1170](https://contentful.atlassian.net/browse/PIC-1170)


[PIC-1170]: https://contentful.atlassian.net/browse/PIC-1170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ