### PR TITLE
chore: cleanup releases

### DIFF
--- a/.changeset/add-ai-pill.md
+++ b/.changeset/add-ai-pill.md
@@ -1,5 +1,0 @@
----
-"@contentful/f36-ai-components": minor
----
-
-feat: add AiPill component for AI-suggested tags with gradient treatment

--- a/.changeset/add-tag-component.md
+++ b/.changeset/add-tag-component.md
@@ -1,5 +1,0 @@
----
-"@contentful/f36-pill-next": minor
----
-
-feat: add Tag component with badge slot for metadata-oriented pills

--- a/.changeset/align-tiptap-deps.md
+++ b/.changeset/align-tiptap-deps.md
@@ -1,5 +1,0 @@
----
-"@contentful/f36-ai-components": patch
----
-
-chore: align tiptap dependencies to version 3.24.0

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,6 @@
     "@contentful/f36-pill-next",
     "@contentful/f36-cdn",
     "@contentful/f36-i18n-utils",
-    "@contentful/f36-codemod",
     "@contentful/f36-website",
     "@contentful/f36-ai-components"
   ],

--- a/.changeset/pill-next-action-icon.md
+++ b/.changeset/pill-next-action-icon.md
@@ -1,5 +1,0 @@
----
-'@contentful/f36-pill-next': minor
----
-
-Replace `onRemove`/`removeButtonLabel`/`removeButtonClassName`/`removeIconColor` with a generic action icon slot. The new `actionIcon`, `onAction`, and `actionButtonLabel` props allow consumers to render any icon as the end action button (e.g., X for remove, + for add, ... for menu) with the correct pill styling (24px circular IconButton, gray/300 hover, luminosity blend). Breaking change to the alpha API — no stable consumers exist.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -87,11 +87,15 @@ Since we want to show the documentation of the components that are still on prer
 
 For that we need to take some precautions:
 
-- The package.json of the pre-released package must be have `private: true`, to avoid changesets of trying to publish the package.
-- The package that is in prerelease (alpha, beta) needs to be added to the ignore field on the [.changeset/config.json](https://github.com/contentful/forma-36/blob/main/.changeset/config.json), so if a changeset is created for that package it will be ignored and not change the version or publish that specific package.
-- The package that is in prerelease (alpha, beta) needs to be added to the `ignorePkgs` array in [scripts/changesets/changelog-generate.js](https://github.com/contentful/forma-36/blob/main/scripts/changesets/changelog-generate.js), so if a changeset is created for that package it will be ignored and not change the version or publish that specific package.
-- And we don't have prerelease packages being part of the umbrela package (`f36-components`), which means that when it becomes stable we add it there and replace where it was being used before, e.g. on the website and/or playground.
+- The `package.json` of the prerelease package must have `private: true` committed, to avoid changesets trying to publish the package.
+- The package that is in prerelease (alpha, beta) needs to be added to the ignore field on the [.changeset/config.json](https://github.com/contentful/forma-36/blob/main/.changeset/config.json), so it is excluded from the automated changeset release process.
+- The package that is in prerelease (alpha, beta) needs to be added to the `ignorePkgs` array in [scripts/changesets/changelog-generate.js](https://github.com/contentful/forma-36/blob/main/scripts/changesets/changelog-generate.js), so it is excluded from the automated What's new changelog generation.
+- Do not add a manual changeset file for prerelease packages. These files will not be processed correctly while the package is excluded through changeset config and the changelog generation script.
+- If you want to track a changelog entry for a prerelease package, add it manually to the package changelog.
+- And we don't have prerelease packages being part of the umbrella package (`f36-components`), which means that when it becomes stable we add it there and replace where it was being used before, e.g. on the website and/or playground.
 
-Trying to make prereleases easier to handle we created a script that you can use on your branch before merging into master, that will bump the package you select, and you can choose if you it's an alpha or beta release, before publishing it to NPM.
+Trying to make prereleases easier to handle we created a script that you can use on your branch before merging into `main`, that will bump the package you select, and you can choose if it's an alpha or beta release, before publishing it to NPM.
+
+Before running the local manual prerelease publish command, temporarily remove the `private: true` setting from the prerelease package's local `package.json`. This local edit is only needed so the npm publish command can run. Do not commit the removal; keep `private: true` in the package on `main` so the package stays out of the automated release process.
 
 You can check the script [here](https://github.com/contentful/forma-36/blob/c6b10071959a085b21e49f5411a5ebff2f8a70d6/scripts/prerelease.mjs)

--- a/packages/f36-ai-components/package.json
+++ b/packages/f36-ai-components/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@contentful/f36-ai-components",
   "version": "0.0.2-alpha.3",
+  "private": "true",
   "description": "A collection of components for use in AI applications, such as conversational interfaces.",
   "license": "MIT",
   "files": [

--- a/scripts/changesets/changelog-generate.js
+++ b/scripts/changesets/changelog-generate.js
@@ -17,6 +17,8 @@ const ignorePkgs = [
   '@contentful/f36-i18n-utils',
   '@contentful/f36-website',
   '@contentful/f36-docs-utils',
+  '@contentful/f36-pill-next',
+  '@contentful/ai-components',
 ];
 
 // Format package names as Start Case

--- a/scripts/changesets/changelog-generate.js
+++ b/scripts/changesets/changelog-generate.js
@@ -18,7 +18,7 @@ const ignorePkgs = [
   '@contentful/f36-website',
   '@contentful/f36-docs-utils',
   '@contentful/f36-pill-next',
-  '@contentful/ai-components',
+  '@contentful/f36-ai-components',
 ];
 
 // Format package names as Start Case


### PR DESCRIPTION
## Purpose

Remove `@contentful/f36-codemod` from the Changesets ignore list so its pending patch changeset can be released through the normal Forma 36 release flow.

The codemod package was previously ignored together with manually released alpha packages, but it should be handled by Changesets. Because of that ignore entry, the existing codemod changeset was never consumed and the fix was not published.

This also cleans up stale changesets for alpha packages that were already released manually and should not be picked up by the standard release automation.

## Approach

- Remove `@contentful/f36-codemod` from `.changeset/config.json` `ignore`
- Keep the existing codemod changeset so the next release job can version and publish it
- Remove stale changesets for manually released alpha packages
- Leave manually released alpha packages ignored

## Expected Release Impact

On the next `main` release, Changesets should publish:

- `@contentful/f36-codemod`: `6.0.0` -> `6.0.1`

The existing `.changeset/shy-eggs-add.md` should be consumed by the release job.

The removed alpha-package changesets should have no release impact because those packages were released manually and remain ignored by Changesets.

## Testing

- Verified the remaining changeset targets `@contentful/f36-codemod` as a patch release
- Verified the removed changesets only targeted manually released alpha packages
- No runtime code changes