### PR TITLE
feat(popover): add closeOnScroll prop

### DIFF
--- a/.changeset/sharp-rules-appear.md
+++ b/.changeset/sharp-rules-appear.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-popover": minor
+---
+
+Add `closeOnScroll` to allow popovers to stay open when an ancestor scrolls.

--- a/packages/components/popover/src/Popover.test.tsx
+++ b/packages/components/popover/src/Popover.test.tsx
@@ -1,5 +1,11 @@
 import React, { useState } from 'react';
-import { render, act, waitFor, screen } from '@testing-library/react';
+import {
+  render,
+  act,
+  waitFor,
+  screen,
+  fireEvent,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
@@ -170,6 +176,37 @@ describe('Popover', function () {
     });
 
     await user.click(document.body);
+
+    await waitFor(() => {
+      expect(handleClose).not.toHaveBeenCalled();
+    });
+  });
+
+  it('call onClose when scrolling an ancestor', async () => {
+    const handleClose = jest.fn();
+
+    await renderWithAct({
+      isOpen: true,
+      onClose: handleClose,
+    });
+
+    fireEvent.scroll(window);
+
+    await waitFor(() => {
+      expect(handleClose).toHaveBeenCalled();
+    });
+  });
+
+  it('do NOT call onClose when scrolling an ancestor and closeOnScroll is false', async () => {
+    const handleClose = jest.fn();
+
+    await renderWithAct({
+      isOpen: true,
+      onClose: handleClose,
+      closeOnScroll: false,
+    });
+
+    fireEvent.scroll(window);
 
     await waitFor(() => {
       expect(handleClose).not.toHaveBeenCalled();

--- a/packages/components/popover/src/Popover.tsx
+++ b/packages/components/popover/src/Popover.tsx
@@ -74,6 +74,13 @@ export interface PopoverProps {
   closeOnEsc?: boolean;
 
   /**
+   * If true, the popover will close when an overflow ancestor is scrolled
+   *
+   * @default true
+   */
+  closeOnScroll?: boolean;
+
+  /**
    * If true, the popover will be focused after opening
    *
    * @default true

--- a/packages/components/popover/src/usePopover.ts
+++ b/packages/components/popover/src/usePopover.ts
@@ -21,6 +21,7 @@ export interface PopoverOptions {
   isOpen?: boolean;
   closeOnEsc?: boolean;
   closeOnBlur?: boolean;
+  closeOnScroll?: boolean;
   /**
    * If true the floating content will auto-focus on open. Defaults to true.
    */
@@ -42,6 +43,7 @@ export function usePopover({
   usePortal = true,
   closeOnEsc = true,
   closeOnBlur = true,
+  closeOnScroll = true,
   autoFocus = true,
 }: PopoverOptions = {}) {
   const [labelId, setLabelId] = React.useState<string | undefined>();
@@ -97,7 +99,7 @@ export function usePopover({
   const dismiss = useDismiss(context, {
     escapeKey: closeOnEsc,
     outsidePress: closeOnBlur,
-    ancestorScroll: true,
+    ancestorScroll: closeOnScroll,
   });
   const role = useRole(context);
 

--- a/packages/components/popover/stories/Popover.stories.tsx
+++ b/packages/components/popover/stories/Popover.stories.tsx
@@ -50,6 +50,7 @@ export const Basic = () => {
 export const InteractionOverview = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [is2Open, setIs2Open] = useState(false);
+  const [is3Open, setIs3Open] = useState(false);
   return (
     <section style={{ display: 'flex', gap: '15px', flexDirection: 'column' }}>
       <h3>Will not close when pressing escape</h3>
@@ -76,6 +77,22 @@ export const InteractionOverview = () => {
       >
         <Popover.Trigger>
           <Button onClick={() => setIs2Open(!is2Open)}>Toggle</Button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Box padding="spacingM">
+            <Paragraph>This is the content.</Paragraph>
+            <Button>Some action</Button>
+          </Box>
+        </Popover.Content>
+      </Popover>
+      <h3>Will not close on scroll</h3>
+      <Popover
+        closeOnScroll={false}
+        isOpen={is3Open}
+        onClose={() => setIs3Open(false)}
+      >
+        <Popover.Trigger>
+          <Button onClick={() => setIs3Open(!is3Open)}>Toggle</Button>
         </Popover.Trigger>
         <Popover.Content>
           <Box padding="spacingM">


### PR DESCRIPTION
Summary:
- Add Popover closeOnScroll, defaulting to true for existing behavior.
- Wire the prop to Floating UI useDismiss ancestorScroll.
- Add tests and a Storybook interaction example.
