### PR TITLE
feat: introduce eslint ratchet setup

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,0 +1,7 @@
+{
+  "types/typings.d.ts": {
+    "@typescript-eslint/no-explicit-any": {
+      "count": 2
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "jest-environment-jsdom": "^30.4.0",
         "jest-resolve": "^30.1.3",
         "jest-watch-typeahead": "^3.0.1",
+        "lint-staged": "^16.4.0",
         "octokit": "^2.0.14",
         "playwright": "^1.55.0",
         "plop": "^4.0.5",
@@ -16440,6 +16441,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -16613,6 +16648,13 @@
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -21117,9 +21159,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -25266,6 +25308,121 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -25543,6 +25700,131 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/longest-streak": {
@@ -34608,6 +34890,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -36065,6 +36354,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -36832,6 +37167,16 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-hash": {
@@ -42097,14 +42442,14 @@
     },
     "packages/components/accordion": {
       "name": "@contentful/f36-accordion",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-collapse": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-collapse": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
@@ -42114,14 +42459,14 @@
     },
     "packages/components/asset": {
       "name": "@contentful/f36-asset",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icon": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icon": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
@@ -42131,17 +42476,17 @@
     },
     "packages/components/autocomplete": {
       "name": "@contentful/f36-autocomplete",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-forms": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
-        "@contentful/f36-popover": "^6.9.1",
-        "@contentful/f36-skeleton": "^6.9.1",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-forms": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
+        "@contentful/f36-popover": "^6.10.0",
+        "@contentful/f36-skeleton": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@contentful/f36-utils": "^6.1.0",
         "@emotion/css": "^11.13.5",
         "downshift": "^9.0.10"
@@ -42175,14 +42520,14 @@
     },
     "packages/components/avatar": {
       "name": "@contentful/f36-avatar",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-image": "^6.9.1",
-        "@contentful/f36-menu": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-image": "^6.10.0",
+        "@contentful/f36-menu": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-tooltip": "^6.9.1",
+        "@contentful/f36-tooltip": "^6.10.0",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
@@ -42192,17 +42537,17 @@
     },
     "packages/components/badge": {
       "name": "@contentful/f36-badge",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@contentful/f36-utils": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^6.9.1"
+        "@contentful/f36-typography": "^6.10.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42211,19 +42556,19 @@
     },
     "packages/components/button": {
       "name": "@contentful/f36-button",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-spinner": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-spinner": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-tooltip": "^6.9.1",
+        "@contentful/f36-tooltip": "^6.10.0",
         "@contentful/f36-utils": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
       "devDependencies": {
-        "@contentful/f36-icon": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1"
+        "@contentful/f36-icon": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42232,21 +42577,21 @@
     },
     "packages/components/card": {
       "name": "@contentful/f36-card",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-asset": "^6.9.1",
-        "@contentful/f36-badge": "^6.9.1",
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-drag-handle": "^6.9.1",
-        "@contentful/f36-icon": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
-        "@contentful/f36-menu": "^6.9.1",
-        "@contentful/f36-skeleton": "^6.9.1",
+        "@contentful/f36-asset": "^6.10.0",
+        "@contentful/f36-badge": "^6.10.0",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-drag-handle": "^6.10.0",
+        "@contentful/f36-icon": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
+        "@contentful/f36-menu": "^6.10.0",
+        "@contentful/f36-skeleton": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-tooltip": "^6.9.1",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-tooltip": "^6.10.0",
+        "@contentful/f36-typography": "^6.10.0",
         "@emotion/css": "^11.13.5",
         "truncate": "^3.0.0"
       },
@@ -42257,10 +42602,10 @@
     },
     "packages/components/collapse": {
       "name": "@contentful/f36-collapse",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
@@ -42271,14 +42616,14 @@
     },
     "packages/components/copybutton": {
       "name": "@contentful/f36-copybutton",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-tooltip": "^6.9.1",
+        "@contentful/f36-tooltip": "^6.10.0",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
@@ -42288,16 +42633,16 @@
     },
     "packages/components/datepicker": {
       "name": "@contentful/f36-datepicker",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-forms": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
-        "@contentful/f36-popover": "^6.9.1",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-forms": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
+        "@contentful/f36-popover": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@emotion/css": "^11.13.5",
         "date-fns": "^2.28.0",
         "react-day-picker": "^8.7.1",
@@ -42322,10 +42667,10 @@
     },
     "packages/components/datetime": {
       "name": "@contentful/f36-datetime",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@emotion/css": "^11.13.5",
         "dayjs": "^1.11.5"
@@ -42337,11 +42682,11 @@
     },
     "packages/components/drag-handle": {
       "name": "@contentful/f36-drag-handle",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@contentful/f36-utils": "^6.1.0",
         "@emotion/css": "^11.13.5"
@@ -42353,11 +42698,11 @@
     },
     "packages/components/empty-state": {
       "name": "@contentful/f36-empty-state",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
@@ -42367,19 +42712,19 @@
     },
     "packages/components/entity-list": {
       "name": "@contentful/f36-entity-list",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-badge": "^6.9.1",
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-drag-handle": "^6.9.1",
-        "@contentful/f36-icon": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
-        "@contentful/f36-menu": "^6.9.1",
-        "@contentful/f36-skeleton": "^6.9.1",
+        "@contentful/f36-badge": "^6.10.0",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-drag-handle": "^6.10.0",
+        "@contentful/f36-icon": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
+        "@contentful/f36-menu": "^6.10.0",
+        "@contentful/f36-skeleton": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
@@ -42389,14 +42734,14 @@
     },
     "packages/components/forms": {
       "name": "@contentful/f36-forms",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icon": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icon": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@contentful/f36-utils": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
@@ -42411,14 +42756,14 @@
     },
     "packages/components/header": {
       "name": "@contentful/f36-header",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
@@ -42428,10 +42773,10 @@
     },
     "packages/components/icon": {
       "name": "@contentful/f36-icon",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@emotion/css": "^11.13.5",
         "@phosphor-icons/react": "2.1.8"
@@ -42450,11 +42795,11 @@
     },
     "packages/components/icons": {
       "name": "@contentful/f36-icons",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icon": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icon": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@emotion/css": "^11.13.5",
         "@phosphor-icons/react": "2.1.8"
@@ -42473,11 +42818,11 @@
     },
     "packages/components/image": {
       "name": "@contentful/f36-image",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-skeleton": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-skeleton": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
@@ -42488,11 +42833,11 @@
     },
     "packages/components/layout": {
       "name": "@contentful/f36-layout",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-header": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-header": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
@@ -42503,10 +42848,10 @@
     },
     "packages/components/list": {
       "name": "@contentful/f36-list",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
@@ -42517,14 +42862,14 @@
     },
     "packages/components/menu": {
       "name": "@contentful/f36-menu",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
-        "@contentful/f36-popover": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
+        "@contentful/f36-popover": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@contentful/f36-utils": "^6.1.0",
         "@emotion/css": "^11.13.5",
         "@floating-ui/dom": "^1.7.4",
@@ -42551,14 +42896,14 @@
     },
     "packages/components/modal": {
       "name": "@contentful/f36-modal",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@emotion/css": "^11.13.5",
         "@types/react-modal": "^3.16.3",
         "react-modal": "^3.16.3"
@@ -42570,19 +42915,19 @@
     },
     "packages/components/multiselect": {
       "name": "@contentful/f36-multiselect",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.1",
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-forms": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
-        "@contentful/f36-popover": "^6.9.1",
-        "@contentful/f36-skeleton": "^6.9.1",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-forms": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
+        "@contentful/f36-popover": "^6.10.0",
+        "@contentful/f36-skeleton": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-tooltip": "^6.9.1",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-tooltip": "^6.10.0",
+        "@contentful/f36-typography": "^6.10.0",
         "@contentful/f36-utils": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
@@ -42597,19 +42942,19 @@
     },
     "packages/components/navbar": {
       "name": "@contentful/f36-navbar",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-avatar": "^6.9.1",
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icon": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
-        "@contentful/f36-menu": "^6.9.1",
-        "@contentful/f36-skeleton": "^6.9.1",
+        "@contentful/f36-avatar": "^6.10.0",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icon": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
+        "@contentful/f36-menu": "^6.10.0",
+        "@contentful/f36-skeleton": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-tooltip": "^6.9.1",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-tooltip": "^6.10.0",
+        "@contentful/f36-typography": "^6.10.0",
         "@contentful/f36-utils": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
@@ -42620,10 +42965,10 @@
     },
     "packages/components/navlist": {
       "name": "@contentful/f36-navlist",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
@@ -42634,15 +42979,15 @@
     },
     "packages/components/note": {
       "name": "@contentful/f36-note",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icon": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icon": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@contentful/f36-utils": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
@@ -42653,15 +42998,15 @@
     },
     "packages/components/notification": {
       "name": "@contentful/f36-notification",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
-        "@contentful/f36-text-link": "^6.9.1",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
+        "@contentful/f36-text-link": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@emotion/css": "^11.13.5",
         "react-animate-height": "^3.0.4"
       },
@@ -42672,15 +43017,15 @@
     },
     "packages/components/pagination": {
       "name": "@contentful/f36-pagination",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-forms": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-forms": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
@@ -42690,15 +43035,15 @@
     },
     "packages/components/pill": {
       "name": "@contentful/f36-pill",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-drag-handle": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-drag-handle": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-tooltip": "^6.9.1",
+        "@contentful/f36-tooltip": "^6.10.0",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
@@ -42711,11 +43056,11 @@
       "version": "6.0.1-alpha.7",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-tooltip": "^6.9.1",
+        "@contentful/f36-tooltip": "^6.10.0",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
@@ -42725,10 +43070,10 @@
     },
     "packages/components/popover": {
       "name": "@contentful/f36-popover",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@contentful/f36-utils": "^6.1.0",
         "@emotion/css": "^11.13.5",
@@ -42742,14 +43087,14 @@
     },
     "packages/components/progress-stepper": {
       "name": "@contentful/f36-progress-stepper",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
@@ -42759,11 +43104,11 @@
     },
     "packages/components/skeleton": {
       "name": "@contentful/f36-skeleton",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-table": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-table": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
@@ -42774,15 +43119,15 @@
     },
     "packages/components/spinner": {
       "name": "@contentful/f36-spinner",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^6.9.1"
+        "@contentful/f36-typography": "^6.10.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42791,13 +43136,13 @@
     },
     "packages/components/table": {
       "name": "@contentful/f36-table",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@contentful/f36-utils": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
@@ -42808,10 +43153,10 @@
     },
     "packages/components/tabs": {
       "name": "@contentful/f36-tabs",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@emotion/css": "^11.13.5",
         "@radix-ui/react-tabs": "^1.1.12"
@@ -42823,11 +43168,11 @@
     },
     "packages/components/text-link": {
       "name": "@contentful/f36-text-link",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@emotion/css": "^11.13.5"
       },
@@ -42838,10 +43183,10 @@
     },
     "packages/components/tooltip": {
       "name": "@contentful/f36-tooltip",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@contentful/f36-utils": "^6.1.0",
         "@emotion/css": "^11.13.5",
@@ -42855,10 +43200,10 @@
     },
     "packages/components/typography": {
       "name": "@contentful/f36-typography",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
         "@contentful/f36-utils": "^6.1.0",
         "@emotion/css": "^11.13.5"
@@ -42870,16 +43215,16 @@
     },
     "packages/components/usage-card": {
       "name": "@contentful/f36-usage-card",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-card": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
-        "@contentful/f36-text-link": "^6.9.1",
+        "@contentful/f36-card": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
+        "@contentful/f36-text-link": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-tooltip": "^6.9.1",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-tooltip": "^6.10.0",
+        "@contentful/f36-typography": "^6.10.0",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
@@ -42889,12 +43234,12 @@
     },
     "packages/components/usage-count": {
       "name": "@contentful/f36-usage-count",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^6.9.1",
+        "@contentful/f36-core": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
@@ -42917,7 +43262,7 @@
     },
     "packages/core": {
       "name": "@contentful/f36-core",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^6.1.0",
@@ -42935,15 +43280,15 @@
       "version": "0.0.2-alpha.4",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-components": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-header": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
-        "@contentful/f36-layout": "^6.9.1",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-components": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-header": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
+        "@contentful/f36-layout": "^6.10.0",
         "@contentful/f36-pill-next": "6.0.1-alpha.7",
         "@contentful/f36-tokens": "^6.0.0",
-        "@contentful/f36-typography": "^6.9.1",
+        "@contentful/f36-typography": "^6.10.0",
         "@contentful/f36-utils": "^6.0.0",
         "@emotion/css": "^11.13.5",
         "react-markdown": "^9.0.3",
@@ -43914,51 +44259,51 @@
     },
     "packages/forma-36-react-components": {
       "name": "@contentful/f36-components",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-accordion": "^6.9.1",
-        "@contentful/f36-asset": "^6.9.1",
-        "@contentful/f36-autocomplete": "^6.9.1",
-        "@contentful/f36-avatar": "^6.9.1",
-        "@contentful/f36-badge": "^6.9.1",
-        "@contentful/f36-button": "^6.9.1",
-        "@contentful/f36-card": "^6.9.1",
-        "@contentful/f36-collapse": "^6.9.1",
-        "@contentful/f36-copybutton": "^6.9.1",
-        "@contentful/f36-core": "^6.9.1",
-        "@contentful/f36-datepicker": "^6.9.1",
-        "@contentful/f36-datetime": "^6.9.1",
-        "@contentful/f36-drag-handle": "^6.9.1",
-        "@contentful/f36-empty-state": "^6.9.1",
-        "@contentful/f36-entity-list": "^6.9.1",
-        "@contentful/f36-forms": "^6.9.1",
-        "@contentful/f36-header": "^6.9.1",
-        "@contentful/f36-icon": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
-        "@contentful/f36-image": "^6.9.1",
-        "@contentful/f36-layout": "^6.9.1",
-        "@contentful/f36-list": "^6.9.1",
-        "@contentful/f36-menu": "^6.9.1",
-        "@contentful/f36-modal": "^6.9.1",
-        "@contentful/f36-multiselect": "^6.9.1",
-        "@contentful/f36-navlist": "^6.9.1",
-        "@contentful/f36-note": "^6.9.1",
-        "@contentful/f36-notification": "^6.9.1",
-        "@contentful/f36-pagination": "^6.9.1",
-        "@contentful/f36-pill": "^6.9.1",
-        "@contentful/f36-popover": "^6.9.1",
-        "@contentful/f36-progress-stepper": "^6.9.1",
-        "@contentful/f36-skeleton": "^6.9.1",
-        "@contentful/f36-spinner": "^6.9.1",
-        "@contentful/f36-table": "^6.9.1",
-        "@contentful/f36-tabs": "^6.9.1",
-        "@contentful/f36-text-link": "^6.9.1",
+        "@contentful/f36-accordion": "^6.10.0",
+        "@contentful/f36-asset": "^6.10.0",
+        "@contentful/f36-autocomplete": "^6.10.0",
+        "@contentful/f36-avatar": "^6.10.0",
+        "@contentful/f36-badge": "^6.10.0",
+        "@contentful/f36-button": "^6.10.0",
+        "@contentful/f36-card": "^6.10.0",
+        "@contentful/f36-collapse": "^6.10.0",
+        "@contentful/f36-copybutton": "^6.10.0",
+        "@contentful/f36-core": "^6.10.0",
+        "@contentful/f36-datepicker": "^6.10.0",
+        "@contentful/f36-datetime": "^6.10.0",
+        "@contentful/f36-drag-handle": "^6.10.0",
+        "@contentful/f36-empty-state": "^6.10.0",
+        "@contentful/f36-entity-list": "^6.10.0",
+        "@contentful/f36-forms": "^6.10.0",
+        "@contentful/f36-header": "^6.10.0",
+        "@contentful/f36-icon": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
+        "@contentful/f36-image": "^6.10.0",
+        "@contentful/f36-layout": "^6.10.0",
+        "@contentful/f36-list": "^6.10.0",
+        "@contentful/f36-menu": "^6.10.0",
+        "@contentful/f36-modal": "^6.10.0",
+        "@contentful/f36-multiselect": "^6.10.0",
+        "@contentful/f36-navlist": "^6.10.0",
+        "@contentful/f36-note": "^6.10.0",
+        "@contentful/f36-notification": "^6.10.0",
+        "@contentful/f36-pagination": "^6.10.0",
+        "@contentful/f36-pill": "^6.10.0",
+        "@contentful/f36-popover": "^6.10.0",
+        "@contentful/f36-progress-stepper": "^6.10.0",
+        "@contentful/f36-skeleton": "^6.10.0",
+        "@contentful/f36-spinner": "^6.10.0",
+        "@contentful/f36-table": "^6.10.0",
+        "@contentful/f36-tabs": "^6.10.0",
+        "@contentful/f36-text-link": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.0",
-        "@contentful/f36-tooltip": "^6.9.1",
-        "@contentful/f36-typography": "^6.9.1",
-        "@contentful/f36-usage-card": "^6.9.1",
-        "@contentful/f36-usage-count": "^6.9.1",
+        "@contentful/f36-tooltip": "^6.10.0",
+        "@contentful/f36-typography": "^6.10.0",
+        "@contentful/f36-usage-card": "^6.10.0",
+        "@contentful/f36-usage-count": "^6.10.0",
         "@contentful/f36-utils": "^6.1.0"
       },
       "devDependencies": {
@@ -44082,18 +44427,18 @@
       "version": "1.0.1",
       "dependencies": {
         "@codesandbox/sandpack-react": "^2.20.0",
-        "@contentful/f36-components": "^6.9.1",
+        "@contentful/f36-components": "^6.10.0",
         "@contentful/f36-docs-utils": "^5.1.0",
-        "@contentful/f36-empty-state": "^6.9.1",
-        "@contentful/f36-header": "^6.9.1",
-        "@contentful/f36-icon": "^6.9.1",
-        "@contentful/f36-icons": "^6.9.1",
-        "@contentful/f36-image": "^6.9.1",
-        "@contentful/f36-layout": "^6.9.1",
-        "@contentful/f36-multiselect": "^6.9.1",
-        "@contentful/f36-navbar": "^6.9.1",
-        "@contentful/f36-navlist": "^6.9.1",
-        "@contentful/f36-progress-stepper": "^6.9.1",
+        "@contentful/f36-empty-state": "^6.10.0",
+        "@contentful/f36-header": "^6.10.0",
+        "@contentful/f36-icon": "^6.10.0",
+        "@contentful/f36-icons": "^6.10.0",
+        "@contentful/f36-image": "^6.10.0",
+        "@contentful/f36-layout": "^6.10.0",
+        "@contentful/f36-multiselect": "^6.10.0",
+        "@contentful/f36-navbar": "^6.10.0",
+        "@contentful/f36-navlist": "^6.10.0",
+        "@contentful/f36-progress-stepper": "^6.10.0",
         "@contentful/f36-tokens": "^6.1.2",
         "@contentful/f36-utils": "^6.1.1",
         "@contentful/rich-text-react-renderer": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "jest-environment-jsdom": "^30.4.0",
     "jest-resolve": "^30.1.3",
     "jest-watch-typeahead": "^3.0.1",
+    "lint-staged": "^16.4.0",
     "octokit": "^2.0.14",
     "playwright": "^1.55.0",
     "plop": "^4.0.5",
@@ -124,8 +125,11 @@
     "vite": "^7.3.2",
     "vitest": "^4.1.8"
   },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": "eslint --fix --prune-suppressions"
+  },
   "simple-git-hooks": {
-    "pre-commit": "npm run-script pretty:quick",
+    "pre-commit": "npm run-script pretty:quick && npx lint-staged",
     "commit-msg": "npx commitlint -e \"$@\""
   },
   "engines": {


### PR DESCRIPTION
# Purpose of PR
Introduces linting at the pre-commit stage and creates a base-line supression file. 

This enables us to introduce stricter, custom linting rules without the need to fix every issue immediately. 
In order to introduce new linter rules and update the suppression file, you have to run `npx eslint --fix --suppress-all` 

Fixes in files will automatically update the suppression file as the prune command is also run on the staged command. 

The main goals for this is
* do not introduce new errors, by running lint before committing
* ratchet down the suppression file when new issues have been suppressed
* disrupt implementation as little as possible