### PR TITLE
feat(icons): add SidebarSimple icon

### DIFF
--- a/.changeset/wise-eagles-hang.md
+++ b/.changeset/wise-eagles-hang.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-icons": patch
+---
+
+feat(icons): add SidebarSimple icon

--- a/.changeset/wise-eagles-hang.md
+++ b/.changeset/wise-eagles-hang.md
@@ -1,5 +1,5 @@
 ---
-"@contentful/f36-icons": patch
+"@contentful/f36-icons": minor
 ---
 
 feat(icons): add SidebarSimple icon

--- a/packages/components/icons/src/index.ts
+++ b/packages/components/icons/src/index.ts
@@ -212,6 +212,7 @@ export * from './vendor/phosphor/RowsPlusBottomIcon.js';
 export * from './vendor/phosphor/SealIcon.js';
 export * from './vendor/phosphor/SelectionIcon.js';
 export * from './vendor/phosphor/ShoppingCartSimpleIcon.js';
+export * from './vendor/phosphor/SidebarSimpleIcon.js';
 export * from './vendor/phosphor/SignInIcon.js';
 export * from './vendor/phosphor/SignOutIcon.js';
 export * from './vendor/phosphor/SketchLogoIcon.js';

--- a/packages/components/icons/src/vendor/phosphor/SidebarSimpleIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/SidebarSimpleIcon.tsx
@@ -1,0 +1,4 @@
+import { generateForma36Icon } from '@contentful/f36-icon';
+import { SidebarSimpleIcon as SidebarSimple } from '@phosphor-icons/react';
+
+export const SidebarSimpleIcon = generateForma36Icon(SidebarSimple);


### PR DESCRIPTION
# Purpose of PR

Adds the Phosphor `sidebar-simple` icon.

<img width="242" height="63" alt="image" src="https://github.com/user-attachments/assets/e30813e3-db9b-4893-847b-e6e9af589846" />

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
