### PR TITLE
feat(collapse): introduce the transition duration property

### DIFF
--- a/.changeset/tired-cats-move.md
+++ b/.changeset/tired-cats-move.md
@@ -1,0 +1,6 @@
+---
+"@contentful/f36-tokens": patch
+"@contentful/f36-collapse": patch
+---
+
+feat(collapse): introduce the transition duration property

--- a/packages/components/collapse/README.mdx
+++ b/packages/components/collapse/README.mdx
@@ -31,6 +31,14 @@ The collapse component is a basic component to show and hide content programmati
 
 ```
 
+### Custom transition duration
+
+Use `transitionDuration` to control how long the expand and collapse animation takes.
+
+```jsx file=./examples/CollapseTransitionDurationExample.tsx
+
+```
+
 ## Props (API reference)
 
 <PropsTable of="Collapse" />

--- a/packages/components/collapse/examples/CollapseTransitionDurationExample.tsx
+++ b/packages/components/collapse/examples/CollapseTransitionDurationExample.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Button, Collapse, Text, Stack } from '@contentful/f36-components';
+
+export default function CollapseTransitionDurationExample() {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+
+  return (
+    <Stack flexDirection="column">
+      <Button onClick={() => setIsExpanded(!isExpanded)}>Toggle</Button>
+      <Collapse
+        isExpanded={isExpanded}
+        transitionDuration="transitionDurationDefault"
+      >
+        <Text>
+          Customers on the Team tier can pay with a credit card (American
+          Express, MasterCard or Visa). Enterprise customers have the choice of
+          paying with a credit card or wire transfer.
+        </Text>
+      </Collapse>
+    </Stack>
+  );
+}

--- a/packages/components/collapse/src/Collapse.test.tsx
+++ b/packages/components/collapse/src/Collapse.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
+import tokens from '@contentful/f36-tokens';
 
 import { Collapse } from './Collapse';
-import userEvent from '@testing-library/user-event';
 
 it('has no a11y issues', async () => {
   const { container } = render(<Collapse isExpanded>Collapse me </Collapse>);
@@ -67,6 +68,22 @@ describe('Collapse behavior', () => {
     // After transition ends height should be auto per handleTransitionEnd
     expect(panel.style.height).toBe('auto');
     expect(panel.style.display).toBe('block');
+  });
+
+  it('applies transition duration from token', () => {
+    const { getByTestId, rerender } = render(
+      <Collapse isExpanded={false} transitionDuration="transitionDurationLong">
+        Content
+      </Collapse>,
+    );
+    const panel = getByTestId('cf-collapse');
+    setMockScrollHeight(panel, 128);
+    rerender(
+      <Collapse isExpanded transitionDuration="transitionDurationLong">
+        Content
+      </Collapse>,
+    );
+    expect(panel.style.transition).toContain(tokens.transitionDurationLong);
   });
 
   it('collapses from expanded: sets pointer-events none and display none after transition', () => {

--- a/packages/components/collapse/src/Collapse.tsx
+++ b/packages/components/collapse/src/Collapse.tsx
@@ -24,7 +24,9 @@ interface CollapseInternalProps extends CommonProps {
   className?: string;
   /**
    * Control the expansion/collapsing transition duration.
+   * Pass one of the transition duration token values.
    * @default 'transitionDurationDefault'
+   * @example <Collapse transitionDuration="transitionDurationLong" ... />
    */
   transitionDuration?: TransitionDurationTokens;
 }

--- a/packages/components/collapse/src/Collapse.tsx
+++ b/packages/components/collapse/src/Collapse.tsx
@@ -24,7 +24,6 @@ interface CollapseInternalProps extends CommonProps {
   className?: string;
   /**
    * Control the expansion/collapsing transition duration.
-   * Accepts Forma 36 transition duration token values or any valid CSS time value.
    * @default 'transitionDurationDefault'
    */
   transitionDuration?: TransitionDurationTokens;

--- a/packages/components/collapse/src/Collapse.tsx
+++ b/packages/components/collapse/src/Collapse.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import type { TransitionDurationTokens } from '@contentful/f36-tokens';
 import {
   Box,
   type CommonProps,
@@ -14,12 +15,19 @@ interface CollapseInternalProps extends CommonProps {
   children?: React.ReactNode;
   /**
    * A boolean that tells if the accordion should be expanded or collapsed
+   * @default false
    */
   isExpanded: boolean;
   /**
    * string for additional classNames
    */
   className?: string;
+  /**
+   * Control the expansion/collapsing transition duration.
+   * Accepts Forma 36 transition duration token values or any valid CSS time value.
+   * @default 'transitionDurationDefault'
+   */
+  transitionDuration?: TransitionDurationTokens;
 }
 
 export type CollapseProps = PropsWithHTMLElement<CollapseInternalProps, 'div'>;
@@ -28,12 +36,14 @@ export const Collapse = ({
   children,
   className,
   isExpanded = false,
+  transitionDuration = 'transitionDurationDefault',
   testId = 'cf-collapse',
   ...otherProps
 }: CollapseProps) => {
   const panelEl = useRef<HTMLDivElement>(null);
   const styles = getCollapseStyles({ className });
   const isMounted = useRef(false);
+  const duration = tokens[transitionDuration];
 
   const getPanelContentHeight = () => {
     const { current } = panelEl;
@@ -65,7 +75,7 @@ export const Collapse = ({
       // to avoid animating the initial render
       current?.style.setProperty(
         'transition',
-        `height ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}, padding ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}`,
+        `height ${duration} ${tokens.transitionEasingDefault}, padding ${duration} ${tokens.transitionEasingDefault}`,
       );
 
       requestAnimationFrame(function () {
@@ -91,7 +101,7 @@ export const Collapse = ({
       handleTransitionEnd();
       isMounted.current = true;
     }
-  }, [handleTransitionEnd, isExpanded]);
+  }, [handleTransitionEnd, isExpanded, duration]);
 
   useEffect(() => {
     const { current } = panelEl;

--- a/packages/components/collapse/stories/Collapse.stories.tsx
+++ b/packages/components/collapse/stories/Collapse.stories.tsx
@@ -3,7 +3,13 @@ import type { StoryObj } from '@storybook/react-vite';
 import { Stack } from '@contentful/f36-core';
 import { SectionHeading, Text } from '@contentful/f36-typography';
 import { Button } from '@contentful/f36-button';
+import tokens, { type TransitionDurationTokens } from '@contentful/f36-tokens';
+
 import { Collapse, CollapseProps } from '../src';
+
+const transitionDurationOptions = Object.keys(tokens).filter((key) =>
+  key.startsWith('transitionDuration'),
+) as TransitionDurationTokens[];
 
 export default {
   title: 'Animation/Collapse',
@@ -15,6 +21,10 @@ export default {
     children: { control: { disable: true } },
     className: { control: { disable: true } },
     isExpanded: { control: 'boolean' },
+    transitionDuration: {
+      control: 'select',
+      options: transitionDurationOptions,
+    },
   },
 };
 
@@ -39,7 +49,11 @@ export const Basic: StoryObj<CollapseProps> = (args) => {
       >
         Toggle content
       </Button>
-      <Collapse id="collapsible-foo" isExpanded={isExpanded}>
+      <Collapse
+        id="collapsible-foo"
+        isExpanded={isExpanded}
+        transitionDuration={args.transitionDuration}
+      >
         <SectionHeading>Collapsable Element</SectionHeading>
         <Text>{defaultText}</Text>
       </Collapse>
@@ -49,6 +63,7 @@ export const Basic: StoryObj<CollapseProps> = (args) => {
 
 Basic.args = {
   isExpanded: false,
+  transitionDuration: 'transitionDurationDefault',
 };
 
 export const Expanded: StoryObj<CollapseProps> = (args) => {
@@ -109,4 +124,34 @@ export const Nested: StoryObj<CollapseProps> = (args) => {
 };
 Nested.args = {
   isExpanded: false,
+};
+
+export const TransitionDuration: StoryObj<CollapseProps> = () => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const durations = transitionDurationOptions.map((value) => ({
+    label: value.replace('transitionDuration', ''),
+    value,
+  }));
+
+  return (
+    <Stack flexDirection="column" spacing="spacingL">
+      <Button onClick={() => setIsExpanded(!isExpanded)}>Toggle all</Button>
+      {durations.map(({ label, value }) => (
+        <Stack key={label} flexDirection="column" spacing="spacingXs">
+          <Text fontWeight="fontWeightMedium">
+            {label} ({tokens[value]})
+          </Text>
+          <Collapse isExpanded={isExpanded} transitionDuration={value}>
+            <Text>{defaultText}</Text>
+          </Collapse>
+        </Stack>
+      ))}
+    </Stack>
+  );
+};
+
+TransitionDuration.args = {
+  isExpanded: false,
+  transitionDuration: 'transitionDurationDefault',
 };

--- a/packages/forma-36-tokens/tools/build.js
+++ b/packages/forma-36-tokens/tools/build.js
@@ -200,6 +200,8 @@ const buildIndexDTS = async (srcPath, tokens) => {
       ${createUnionThatStarts('borderRadius', 'BorderRadiusTokens')}
       ${createUnionThatStarts('zIndex', 'ZIndexTokens')}
       ${createUnionThatStarts('glow', 'GlowTokens')}
+      ${createUnionThatStarts('transitionDuration', 'TransitionDurationTokens')}
+      ${createUnionThatStarts('transitionEasing', 'TransitionEasingTokens')}
       const tokens: F36Tokens;
       export { tokens as default };
     }`,


### PR DESCRIPTION
# Purpose of PR

- Exposes the transition duration and easing types from the tokens packages - 048f62ef1ddbe691b55820b05e9a0a9b403d9146
- Introduces a new transition duration property to the Collapse component - 252963e9a3704303764fafe24f7a2d86de022eec

Docs: https://forma-36-git-ufo-2415.colorfuldemo.com/components/collapse#custom-transition-duration
Storybook: https://forma-36-storybook-git-ufo-2415.colorfuldemo.com/?path=/story/animation-collapse--transition-duration 

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
