### PR TITLE
fix(AIChatMessage): re-add inline code formatting

### DIFF
--- a/packages/f36-ai-components/package.json
+++ b/packages/f36-ai-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/f36-ai-components",
-  "version": "0.0.2-alpha.4",
+  "version": "0.0.2-alpha.5",
   "private": "true",
   "description": "A collection of components for use in AI applications, such as conversational interfaces.",
   "license": "MIT",

--- a/packages/f36-ai-components/src/AIChatMessage/AIChatMessage.test.tsx
+++ b/packages/f36-ai-components/src/AIChatMessage/AIChatMessage.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { AIChatMessage } from './AIChatMessage';
+import { AIChatMessage, getMarkdownComponents } from './AIChatMessage';
+import { getStyles } from './AIChatMessage.styles';
 import { Box } from '@contentful/f36-core';
 
 // Mocking react-markdown and its plugins as current jest version does not support ESM
@@ -75,5 +76,36 @@ describe('AIChatMessage', () => {
 
     const actionButtons = screen.getByTestId('cf-ui-ai-chat-message-actions');
     expect(actionButtons.textContent).toContain('Action Buttons');
+  });
+});
+
+describe('AIChatMessage code rendering', () => {
+  const styles = getStyles({ isUserMessage: false });
+  const components = getMarkdownComponents(styles);
+
+  // react-markdown is mocked above (it is ESM-only), so the `code` renderer is
+  // exercised directly rather than through a full markdown render.
+  it('renders inline code with the inline style, not the block style', () => {
+    const element = components.code({ children: 'spaceId' });
+
+    expect(element.props.className).toContain(styles.inlineCode);
+    expect(element.props.className).not.toContain(styles.codeBlock);
+  });
+
+  it('renders a fenced code block with the block style', () => {
+    const element = components.code({
+      className: 'language-ts',
+      children: 'const id = "x"\n',
+    });
+
+    expect(element.props.className).toContain(styles.codeBlock);
+    expect(element.props.className).not.toContain(styles.inlineCode);
+  });
+
+  it('renders an unlabelled multi-line code block with the block style', () => {
+    const element = components.code({ children: 'first line\nsecond line\n' });
+
+    expect(element.props.className).toContain(styles.codeBlock);
+    expect(element.props.className).not.toContain(styles.inlineCode);
   });
 });

--- a/packages/f36-ai-components/src/AIChatMessage/AIChatMessage.tsx
+++ b/packages/f36-ai-components/src/AIChatMessage/AIChatMessage.tsx
@@ -85,7 +85,45 @@ export interface AIChatMessageProps extends CommonProps {
   contentComponentsOverrides?: ComponentsPropOverrides;
 }
 
-function getMarkdownComponents(
+/**
+ * Determines whether a react-markdown `code` node is a fenced or indented code
+ * block rather than inline code.
+ *
+ * @remarks
+ * react-markdown v9 removed the `inline` prop that previously distinguished the
+ * two, so block code is inferred from the `language-*` class it adds to fenced
+ * blocks or from a newline in the code contents (block code always carries a
+ * trailing newline, while inline code never spans multiple lines).
+ *
+ * @param props - The props react-markdown passes to the `code` renderer.
+ * @returns `true` for block code, `false` for inline code.
+ */
+export function isBlockCode(props: {
+  className?: string;
+  children?: React.ReactNode;
+}): boolean {
+  if (/(?:^|\s)language-/.test(props.className ?? '')) {
+    return true;
+  }
+
+  return React.Children.toArray(props.children).some(
+    (child) => typeof child === 'string' && child.includes('\n'),
+  );
+}
+
+/**
+ * Builds the markdown element renderers used by {@link AIChatMessage}.
+ *
+ * @remarks
+ * Exported for unit testing the individual element renderers (most notably
+ * `code`), since react-markdown is ESM-only and cannot be rendered under the
+ * package's jest setup. Not part of the package's public API.
+ *
+ * @param styles - The resolved style classes for the message.
+ * @param contentComponentsOverrides - Optional per-element prop overrides.
+ * @returns A map of markdown tag names to React element renderers.
+ */
+export function getMarkdownComponents(
   styles: ReturnType<typeof getStyles>,
   contentComponentsOverrides: ComponentsPropOverrides = {},
 ) {
@@ -349,9 +387,12 @@ function getMarkdownComponents(
     code: (props) => (
       <code
         {...{
-          className: props.inline ? styles.inlineCode : styles.codeBlock,
           children: props.children,
           ...props,
+          // Set the style class after `...props`: react-markdown v9 dropped the
+          // `inline` prop, and the className it provides (e.g. "language-ts" for
+          // fenced blocks, or none for inline code) would otherwise clobber it.
+          className: isBlockCode(props) ? styles.codeBlock : styles.inlineCode,
           ...(contentComponentsOverrides?.code
             ? contentComponentsOverrides.code(props)
             : {}),


### PR DESCRIPTION
<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

This PR fixes a bug in which inline code formatting for AI Chat messages defaulted to multi-line code blocks. This meant that where users expected to see inline code, they instead saw surrounding text broken up by a block on new lines.

| Before | After |
| --- | --- |
| <img width="1840" height="1106" alt="Screenshot 2026-06-23 at 10 37 47" src="https://github.com/user-attachments/assets/236ec0d6-77c8-4baf-bfb2-424aee451d5c" /> | <img width="1840" height="1106" alt="Screenshot 2026-06-23 at 10 37 55" src="https://github.com/user-attachments/assets/933d8b9f-b10c-4631-97c5-791911d78d3d" /> |


<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information