### PR TITLE
feat: 🎸 add responsive header component

### DIFF
--- a/.changeset/lazy-moose-reply.md
+++ b/.changeset/lazy-moose-reply.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-layout": minor
+---
+
+feat: 🎸 add responsive header component Layout.HeaderInner

--- a/package-lock.json
+++ b/package-lock.json
@@ -41829,9 +41829,12 @@
       "version": "6.14.1",
       "license": "MIT",
       "dependencies": {
+        "@contentful/f36-button": "^6.14.1",
         "@contentful/f36-core": "^6.14.1",
         "@contentful/f36-header": "^6.14.1",
+        "@contentful/f36-icons": "^6.14.1",
         "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.14.1",
         "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {

--- a/packages/components/layout/README.mdx
+++ b/packages/components/layout/README.mdx
@@ -5,7 +5,7 @@ status: 'stable'
 slug: /components/layout/
 github: 'https://github.com/contentful/forma-36/tree/main/packages/components/layout'
 storybook: 'https://f36-storybook.contentful.com/?path=/story/components-layout--default'
-typescript: ./src/Layout.tsx, .src/LayoutBody.tsx, .src/LayoutHeader.tsx, .src/Layout.Sidebar.tsx
+typescript: ./src/Layout.tsx,./src/LayoutBody.tsx,./src/LayoutHeader.tsx,./src/LayoutHeaderInner/LayoutHeaderInner.tsx,./src/LayoutSidebar.tsx
 ---
 
 The Layout component is the basis of every single page view.
@@ -42,10 +42,20 @@ The `Layout` exports the following compound components
     <Table.Row>
       <Table.Cell>`Layout.Header`</Table.Cell>
       <Table.Cell>
-        Should contain a `Header` component. When passing at least one sidebar,
-        a divider is added underneath the header. Content inside will be
-        centered. It follows through in the `max-width` adjustment from `1550px`
-        to `1920px` on the `wide` variant.
+        Should contain a `Header` or `Layout.HeaderInner` component. When
+        passing at least one sidebar, a divider is added underneath the header.
+        Content inside will be centered. It follows through in the `max-width`
+        adjustment from `1550px` to `1920px` on the `wide` variant.
+      </Table.Cell>
+      <Table.Cell>`header`</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.Cell>`Layout.HeaderInner`</Table.Cell>
+      <Table.Cell>
+        The HeaderInner component exposes a way to build visually consistent
+        hierarchy into apps that look and feel like part of the Contentful UI.
+        It’s the responsive variant of the [Header](/components/header)
+        component.
       </Table.Cell>
       <Table.Cell>`header`</Table.Cell>
     </Table.Row>
@@ -79,6 +89,12 @@ The `Layout` exports the following compound components
 ### Layout with header
 
 ```jsx file=./examples/LayoutExampleWithHeader.tsx
+
+```
+
+### Layout with responsive header
+
+```jsx file=./examples/LayoutExampleWithResponsiveHeader.tsx
 
 ```
 
@@ -176,6 +192,10 @@ The `Layout` component offers 4 individual areas, which can be set via the props
 ### Layout.Header
 
 <PropsTable of="LayoutHeader" />
+
+### Layout.HeaderInner
+
+<PropsTable of="LayoutHeaderInner" />
 
 ### Layout.Sidebar
 

--- a/packages/components/layout/examples/LayoutExampleWithResponsiveHeader.tsx
+++ b/packages/components/layout/examples/LayoutExampleWithResponsiveHeader.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  Flex,
+  Form,
+  FormControl,
+  TextInput,
+  Textarea,
+  Layout,
+} from '@contentful/f36-components';
+
+export default function BasicLayoutExample() {
+  const [submitting, setSubmitting] = useState(false);
+  const submitForm = () => {
+    setSubmitting(true);
+    setTimeout(() => setSubmitting(false), 1000);
+  };
+
+  return (
+    <Layout
+      header={
+        <Layout.Header>
+          <Layout.HeaderInner
+            title="Your Details"
+            actions={
+              <Flex gap="spacingS">
+                <Button variant="primary" size="small">
+                  Autofill with Provider 1
+                </Button>
+                <Button variant="primary" size="small">
+                  Autofill with Provider 2
+                </Button>
+              </Flex>
+            }
+            withBackButton
+            breadcrumbs={[{ content: 'Account Settings', url: '#' }]}
+          />
+        </Layout.Header>
+      }
+    >
+      <Layout.Body>
+        <Box padding="none" marginBottom="spacingXl">
+          <Form onSubmit={submitForm}>
+            <FormControl>
+              <FormControl.Label isRequired>Name</FormControl.Label>
+              <TextInput />
+              <FormControl.HelpText>
+                Please enter your first name
+              </FormControl.HelpText>
+            </FormControl>
+
+            <FormControl>
+              <FormControl.Label>Description</FormControl.Label>
+              <Textarea />
+              <FormControl.HelpText>
+                Tell me about yourself
+              </FormControl.HelpText>
+            </FormControl>
+
+            <Button variant="primary" type="submit" isDisabled={submitting}>
+              {submitting ? 'Submitted' : 'Click me to submit'}
+            </Button>
+          </Form>
+        </Box>
+      </Layout.Body>
+    </Layout>
+  );
+}

--- a/packages/components/layout/package.json
+++ b/packages/components/layout/package.json
@@ -6,9 +6,12 @@
     "build": "tsup"
   },
   "dependencies": {
+    "@contentful/f36-button": "^6.14.1",
     "@contentful/f36-core": "^6.14.1",
     "@contentful/f36-header": "^6.14.1",
+    "@contentful/f36-icons": "^6.14.1",
     "@contentful/f36-tokens": "^6.1.3",
+    "@contentful/f36-typography": "^6.14.1",
     "@emotion/css": "^11.13.5"
   },
   "peerDependencies": {

--- a/packages/components/layout/src/CompoundLayout.ts
+++ b/packages/components/layout/src/CompoundLayout.ts
@@ -3,14 +3,17 @@ import { Layout as OriginalLayout } from './Layout';
 import { LayoutHeader } from './LayoutHeader';
 import { LayoutBody } from './LayoutBody';
 import { LayoutSidebar } from './LayoutSidebar';
+import { LayoutHeaderInner } from './LayoutHeaderInner/LayoutHeaderInner';
 
 type CompoundLayout = typeof OriginalLayout & {
   Header: typeof LayoutHeader;
+  HeaderInner: typeof LayoutHeaderInner;
   Body: typeof LayoutBody;
   Sidebar: typeof LayoutSidebar;
 };
 
 export const Layout = OriginalLayout as CompoundLayout;
 Layout.Header = LayoutHeader;
+Layout.HeaderInner = LayoutHeaderInner;
 Layout.Body = LayoutBody;
 Layout.Sidebar = LayoutSidebar;

--- a/packages/components/layout/src/Layout.styles.ts
+++ b/packages/components/layout/src/Layout.styles.ts
@@ -76,6 +76,7 @@ export const getLayoutStyles = ({
   leftSidebarVariant,
   withRightSidebar,
   rightSidebarVariant,
+  withResponsiveHeader,
   offsetTop,
 }: {
   variant: LayoutProps['variant'];
@@ -84,6 +85,7 @@ export const getLayoutStyles = ({
   leftSidebarVariant?: LayoutSidebarVariant;
   withRightSidebar?: boolean;
   rightSidebarVariant?: LayoutSidebarVariant;
+  withResponsiveHeader: boolean;
   offsetTop: number;
 }) => ({
   layoutMainContainer: css(
@@ -92,32 +94,61 @@ export const getLayoutStyles = ({
       backgroundColor: tokens.colorWhite,
       minHeight: `calc(100vh - ${offsetTop}px)`,
     },
+    !withResponsiveHeader && {
+      display: 'flex',
+      flexDirection: 'column',
+    },
+    withResponsiveHeader && {
+      display: 'grid',
+      gridTemplateRows: 'max-content auto',
+    },
+    withResponsiveHeader &&
+      getContentContainerGridTemplateColumns({
+        variant,
+        withLeftSidebar,
+        leftSidebarVariant,
+        withRightSidebar,
+        rightSidebarVariant,
+      }),
   ),
   layoutContentContainer: css(
-    getContentContainerGridTemplateColumns({
-      variant,
-      withLeftSidebar,
-      leftSidebarVariant,
-      withRightSidebar,
-      rightSidebarVariant,
-    }),
+    !withResponsiveHeader &&
+      getContentContainerGridTemplateColumns({
+        variant,
+        withLeftSidebar,
+        leftSidebarVariant,
+        withRightSidebar,
+        rightSidebarVariant,
+      }),
     {
       width: '100%',
       display: 'grid',
+    },
+    withResponsiveHeader && {
+      gridTemplateColumns: 'subgrid',
+      gridTemplateRows: 'subgrid',
+      gridColumn: '1 / -1',
+      minHeight: 0,
     },
   ),
 });
 
 export const getLayoutBodyStyles = (
   withHeader: boolean,
+  withResponsiveHeader: boolean,
   offsetTop: number,
 ) => ({
-  layoutBodyContainer: css({
-    width: '100%',
-    padding: `${tokens.spacingL} ${tokens.spacingL} 0`,
-    overflowY: 'auto',
-    height: `calc(100vh - ${getMainOffset(withHeader, offsetTop)})`,
-  }),
+  layoutBodyContainer: css(
+    {
+      width: '100%',
+      padding: `${tokens.spacingL} ${tokens.spacingL} 0`,
+      overflowY: 'auto',
+    },
+    !withResponsiveHeader &&
+      css({
+        height: `calc(100vh - ${getMainOffset(withHeader, offsetTop)})`,
+      }),
+  ),
   layoutBodyInner: css({
     maxWidth: '900px',
     margin: '0 auto',
@@ -145,19 +176,24 @@ export const getLayoutHeaderStyles = ({
   variant,
   withLeftSidebar,
   withRightSidebar,
+  withResponsiveHeader,
 }: {
   variant: LayoutProps['variant'];
-  withLeftSidebar?: boolean;
-  withRightSidebar?: boolean;
+  withLeftSidebar: boolean;
+  withRightSidebar: boolean;
+  withResponsiveHeader: boolean;
 }) => ({
-  layoutHeader: css({
-    padding: `${tokens.spacing2Xs}  ${tokens.spacingL} 0 ${tokens.spacingL} `,
-    width: '100%',
-    maxWidth: variant === 'fullscreen' ? '100%' : '1920px',
-    borderBottom:
-      withLeftSidebar || withRightSidebar
-        ? `1px solid ${tokens.gray200}`
-        : `none`,
-  }),
+  layoutHeader: css(
+    {
+      padding: `${tokens.spacing2Xs}  ${tokens.spacingL} 0 ${tokens.spacingL} `,
+      width: '100%',
+      maxWidth: variant === 'fullscreen' ? '100%' : '1920px',
+      borderBottom:
+        withLeftSidebar || withRightSidebar
+          ? `1px solid ${tokens.gray200}`
+          : `none`,
+    },
+    withResponsiveHeader && css({ gridColumn: '1 / -1' }),
+  ),
   layoutHeaderInner: css({ width: '100%' }),
 });

--- a/packages/components/layout/src/Layout.styles.ts
+++ b/packages/components/layout/src/Layout.styles.ts
@@ -185,7 +185,7 @@ export const getLayoutHeaderStyles = ({
 }) => ({
   layoutHeader: css(
     {
-      padding: `${tokens.spacing2Xs}  ${tokens.spacingL} 0 ${tokens.spacingL} `,
+      padding: `${tokens.spacing2Xs} ${tokens.spacingL} 0 ${tokens.spacingL}`,
       width: '100%',
       maxWidth: variant === 'fullscreen' ? '100%' : '1920px',
       borderBottom:

--- a/packages/components/layout/src/Layout.test.tsx
+++ b/packages/components/layout/src/Layout.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { Layout } from './Layout';
+import { LayoutHeaderInner } from './LayoutHeaderInner/LayoutHeaderInner';
 
 describe('Layout', () => {
   it('renders children inside content container', () => {
@@ -121,5 +122,78 @@ describe('Layout', () => {
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  describe('with LayoutHeaderInner', () => {
+    it('renders header', () => {
+      render(
+        <Layout header={<LayoutHeaderInner title="Header"></LayoutHeaderInner>}>
+          <p>Body</p>
+        </Layout>,
+      );
+      expect(screen.getByText('Header')).toBeInTheDocument();
+      expect(screen.getByText('Body')).toBeInTheDocument();
+    });
+
+    it('has no a11y issues', async () => {
+      const { container } = render(
+        <Layout
+          header={<LayoutHeaderInner title="Header" />}
+          leftSidebar={<nav data-test-id="left">Left sidebar</nav>}
+          rightSidebar={<aside data-test-id="right">Right sidebar</aside>}
+        >
+          <main>
+            <h1>Title</h1>
+            <p>Body</p>
+          </main>
+        </Layout>,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('has no a11y issues with back button and breadcrumbs', async () => {
+      const { container } = render(
+        <Layout
+          header={
+            <LayoutHeaderInner
+              title="Header"
+              withBackButton
+              backButtonProps={{ onClick: jest.fn() }}
+              breadcrumbs={[{ content: 'Breadcrumb', url: '#' }]}
+            />
+          }
+        >
+          <main>
+            <h1>Title</h1>
+            <p>Body</p>
+          </main>
+        </Layout>,
+      );
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it('renders header with custom className', async () => {
+      const additionalClassName = 'my-extra-class';
+      render(
+        <Layout
+          header={
+            <LayoutHeaderInner title="Header" className={additionalClassName} />
+          }
+        >
+          <main>
+            <h1>Title</h1>
+            <p>Body</p>
+          </main>
+        </Layout>,
+      );
+
+      expect(
+        screen
+          .getByTestId('cf-ui-header')
+          .classList.contains(additionalClassName),
+      ).toBeTruthy();
+    });
   });
 });

--- a/packages/components/layout/src/Layout.test.tsx
+++ b/packages/components/layout/src/Layout.test.tsx
@@ -191,7 +191,7 @@ describe('Layout', () => {
 
       expect(
         screen
-          .getByTestId('cf-ui-header')
+          .getByTestId('cf-layout-header-inner')
           .classList.contains(additionalClassName),
       ).toBeTruthy();
     });

--- a/packages/components/layout/src/Layout.tsx
+++ b/packages/components/layout/src/Layout.tsx
@@ -3,9 +3,10 @@ import React, {
   useMemo,
   type Ref,
   type HTMLAttributes,
+  useState,
 } from 'react';
 import { cx } from '@emotion/css';
-import { type CommonProps, Box, Flex } from '@contentful/f36-core';
+import { type CommonProps, Box } from '@contentful/f36-core';
 import { LayoutContextProvider, LayoutContextType } from './LayoutContext';
 import { getLayoutStyles } from './Layout.styles';
 
@@ -68,6 +69,7 @@ const LayoutBase = (props: LayoutProps, ref: Ref<HTMLDivElement>) => {
     ...otherProps
   } = props;
 
+  const [withResponsiveHeader, setWithResponsiveHeader] = useState(false);
   const withLeftSidebar = Boolean(leftSidebar);
   const withRightSidebar = Boolean(rightSidebar);
   const styles = getLayoutStyles({
@@ -78,6 +80,7 @@ const LayoutBase = (props: LayoutProps, ref: Ref<HTMLDivElement>) => {
     leftSidebarVariant,
     withRightSidebar,
     rightSidebarVariant,
+    withResponsiveHeader,
   });
 
   const contextValue: LayoutContextType = useMemo(
@@ -86,20 +89,29 @@ const LayoutBase = (props: LayoutProps, ref: Ref<HTMLDivElement>) => {
       withHeader: Boolean(header),
       withLeftSidebar: withLeftSidebar,
       withRightSidebar: withRightSidebar,
+      withResponsiveHeader,
+      setWithResponsiveHeader,
       offsetTop,
     }),
-    [variant, header, withLeftSidebar, withRightSidebar, offsetTop],
+    [
+      variant,
+      header,
+      withLeftSidebar,
+      withRightSidebar,
+      withResponsiveHeader,
+      setWithResponsiveHeader,
+      offsetTop,
+    ],
   );
 
   return (
     <LayoutContextProvider value={contextValue}>
-      <Flex
+      <Box
         ref={ref}
         testId={testId}
         as="section"
         {...otherProps}
         className={cx(styles.layoutMainContainer, className)}
-        flexDirection="column"
       >
         {header}
 
@@ -111,7 +123,7 @@ const LayoutBase = (props: LayoutProps, ref: Ref<HTMLDivElement>) => {
           {children}
           {rightSidebar}
         </Box>
-      </Flex>
+      </Box>
     </LayoutContextProvider>
   );
 };

--- a/packages/components/layout/src/LayoutBody.tsx
+++ b/packages/components/layout/src/LayoutBody.tsx
@@ -16,8 +16,13 @@ const LayoutBodyBase = (props: LayoutBodyProps, ref: Ref<HTMLDivElement>) => {
     testId = 'cf-layout-body',
     ...otherProps
   } = props;
-  const { variant, withHeader, offsetTop } = useLayoutContext();
-  const styles = getLayoutBodyStyles(withHeader, offsetTop);
+  const { variant, withHeader, offsetTop, withResponsiveHeader } =
+    useLayoutContext();
+  const styles = getLayoutBodyStyles(
+    withHeader,
+    withResponsiveHeader,
+    offsetTop,
+  );
 
   return (
     <Box

--- a/packages/components/layout/src/LayoutContext.ts
+++ b/packages/components/layout/src/LayoutContext.ts
@@ -6,6 +6,8 @@ export type LayoutContextType = {
   withHeader: boolean;
   withLeftSidebar: boolean;
   withRightSidebar: boolean;
+  withResponsiveHeader: boolean;
+  setWithResponsiveHeader: (value: boolean) => void;
   offsetTop: number;
 };
 

--- a/packages/components/layout/src/LayoutHeader.tsx
+++ b/packages/components/layout/src/LayoutHeader.tsx
@@ -19,11 +19,13 @@ const LayoutHeaderBase = (
     testId = 'cf-layout-header',
     ...otherProps
   } = props;
-  const { variant, withLeftSidebar, withRightSidebar } = useLayoutContext();
+  const { variant, withLeftSidebar, withRightSidebar, withResponsiveHeader } =
+    useLayoutContext();
   const styles = getLayoutHeaderStyles({
     variant,
     withLeftSidebar,
     withRightSidebar,
+    withResponsiveHeader,
   });
 
   return (

--- a/packages/components/layout/src/LayoutHeaderInner/BackButton.styles.ts
+++ b/packages/components/layout/src/LayoutHeaderInner/BackButton.styles.ts
@@ -1,0 +1,5 @@
+import { css } from '@emotion/css';
+
+export const getBackButtonStyles = () => ({
+  button: css({ alignSelf: 'flex-start' }),
+});

--- a/packages/components/layout/src/LayoutHeaderInner/BackButton.tsx
+++ b/packages/components/layout/src/LayoutHeaderInner/BackButton.tsx
@@ -1,0 +1,43 @@
+import React, { forwardRef, type Ref } from 'react';
+import tokens from '@contentful/f36-tokens';
+import { IconButton, type IconButtonProps } from '@contentful/f36-button';
+import { ArrowLeftIcon } from '@contentful/f36-icons';
+import { cx } from '@emotion/css';
+import { getBackButtonStyles } from './BackButton.styles';
+
+export type BackButtonProps = Omit<
+  Partial<IconButtonProps>,
+  'children' | 'icon' | 'variant' | 'size'
+> & {
+  'aria-label'?: string;
+};
+
+function BackButtonBase(
+  {
+    onClick,
+    'aria-label': ariaLabel = 'Go back',
+    className,
+    ...otherProps
+  }: BackButtonProps,
+  ref: Ref<HTMLButtonElement>,
+) {
+  const styles = getBackButtonStyles();
+
+  return (
+    <IconButton
+      {...otherProps}
+      className={cx(styles.button, className)}
+      aria-label={ariaLabel}
+      icon={<ArrowLeftIcon color={tokens.gray600} />}
+      onClick={onClick}
+      size="small"
+      ref={ref}
+      variant="transparent"
+    />
+  );
+}
+
+BackButtonBase.displayName = 'BackButton';
+export const BackButton = forwardRef<HTMLButtonElement, BackButtonProps>(
+  BackButtonBase,
+);

--- a/packages/components/layout/src/LayoutHeaderInner/Breadcrumb.styles.ts
+++ b/packages/components/layout/src/LayoutHeaderInner/Breadcrumb.styles.ts
@@ -1,0 +1,13 @@
+import { css } from '@emotion/css';
+import tokens from '@contentful/f36-tokens';
+
+export const getBreadcrumbStyles = () => ({
+  button: css({
+    color: tokens.gray500,
+    fontSize: tokens.fontSizeL,
+    fontWeight: tokens.fontWeightNormal,
+    maxWidth: 'none',
+    paddingLeft: tokens.spacingXs,
+    paddingRight: tokens.spacingXs,
+  }),
+});

--- a/packages/components/layout/src/LayoutHeaderInner/Breadcrumb.tsx
+++ b/packages/components/layout/src/LayoutHeaderInner/Breadcrumb.tsx
@@ -1,0 +1,37 @@
+import React, { MouseEventHandler } from 'react';
+import { Button } from '@contentful/f36-button';
+import { Segmentation } from './Segmentation';
+import { getBreadcrumbStyles } from './Breadcrumb.styles';
+
+type Breadcrumb = {
+  content: string;
+  url: string;
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
+};
+
+export type BreadcrumbProps = {
+  breadcrumbs: Breadcrumb[];
+};
+
+export const Breadcrumb = ({ breadcrumbs, ...otherProps }: BreadcrumbProps) => {
+  const styles = getBreadcrumbStyles();
+  const segments = breadcrumbs.map((breadcrumb) => {
+    const handleBreadcrumbClick = breadcrumb.onClick;
+    return (
+      <Button
+        as="a"
+        className={styles.button}
+        href={breadcrumb.url}
+        key={breadcrumb.url}
+        size="small"
+        variant="transparent"
+        onClick={handleBreadcrumbClick}
+      >
+        {breadcrumb.content}
+      </Button>
+    );
+  });
+  return <Segmentation segments={segments} {...otherProps} />;
+};
+
+Breadcrumb.displayName = 'Breadcrumb';

--- a/packages/components/layout/src/LayoutHeaderInner/HeaderTitle.styles.ts
+++ b/packages/components/layout/src/LayoutHeaderInner/HeaderTitle.styles.ts
@@ -1,0 +1,15 @@
+import { css } from '@emotion/css';
+import tokens from '@contentful/f36-tokens';
+
+export const getHeaderTitleStyles = ({ variant, withBackButton }) => ({
+  title: css({
+    margin: 0,
+    padding:
+      variant === 'breadcrumb' || withBackButton
+        ? `${tokens.spacing2Xs}  ${tokens.spacingXs}`
+        : 0,
+  }),
+  noWrap: css({
+    textWrap: 'nowrap',
+  }),
+});

--- a/packages/components/layout/src/LayoutHeaderInner/HeaderTitle.tsx
+++ b/packages/components/layout/src/LayoutHeaderInner/HeaderTitle.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {
+  DisplayText,
+  Subheading,
+  type HeadingElement,
+} from '@contentful/f36-typography';
+import { getHeaderTitleStyles } from './HeaderTitle.styles';
+import { LayoutHeaderInnerProps } from './LayoutHeaderInner';
+
+type HeaderTitleProps = {
+  title: LayoutHeaderInnerProps['title'];
+  variant: string;
+  withBackButton?: boolean;
+  as?: HeadingElement;
+  size?: 'medium' | 'large';
+};
+
+export function HeaderTitle({
+  title,
+  variant,
+  withBackButton = false,
+  as = 'h1',
+  size = 'large',
+}: HeaderTitleProps) {
+  const styles = getHeaderTitleStyles({ variant, withBackButton });
+  const Element =
+    variant === 'breadcrumb' || size === 'medium' ? Subheading : DisplayText;
+
+  return (
+    <Element as={as} className={styles.title}>
+      {title}
+    </Element>
+  );
+}
+
+HeaderTitle.displayName = 'HeaderTitle';

--- a/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.styles.ts
+++ b/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.styles.ts
@@ -1,0 +1,30 @@
+import { css } from '@emotion/css';
+import tokens from '@contentful/f36-tokens';
+
+export const getLayoutHeaderInnerStyles = () => ({
+  actions: css({
+    flexGrow: 0,
+    flexShrink: 1,
+    flexBasis: 'max-content',
+    justifyContent: 'flex-end',
+    gap: tokens.spacingS,
+  }),
+  wrapper: css({
+    flexGrow: 0,
+    flexShrink: 1,
+    flexBasis: 'max-content',
+  }),
+  filters: css({
+    display: 'flex',
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: '50%',
+  }),
+  root: css({
+    background: tokens.colorWhite,
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    paddingBottom: tokens.spacingS,
+    paddingTop: tokens.spacingS,
+  }),
+});

--- a/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.tsx
+++ b/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.tsx
@@ -1,5 +1,4 @@
 import React, {
-  type ElementType,
   forwardRef,
   type Ref,
   type ReactElement,
@@ -7,21 +6,13 @@ import React, {
   useEffect,
 } from 'react';
 import { cx } from '@emotion/css';
-import {
-  Flex,
-  type ExpandProps,
-  type PolymorphicComponent,
-  type PolymorphicProps,
-  type CommonProps,
-} from '@contentful/f36-core';
+import { Flex, type CommonProps } from '@contentful/f36-core';
 import { BackButton, type BackButtonProps } from './BackButton';
 import { Breadcrumb, type BreadcrumbProps } from './Breadcrumb';
 import { HeaderTitle } from './HeaderTitle';
 import { getLayoutHeaderInnerStyles } from './LayoutHeaderInner.styles';
 import type { HeadingElement } from '@contentful/f36-typography';
 import { useLayoutContext } from '../LayoutContext';
-
-const LAYOUT_HEADER_INNER_DEFAULT_TAG = 'header';
 
 type Variant =
   | {
@@ -52,7 +43,7 @@ type Variant =
       withBackButton: true;
     };
 
-type LayoutHeaderInnerInternalProps = CommonProps &
+export type LayoutHeaderInnerProps = CommonProps &
   Variant & {
     /**
      * Optional JSX children to display as complementary actions (e.g. buttons) related to the current page/route.
@@ -69,28 +60,20 @@ type LayoutHeaderInnerInternalProps = CommonProps &
     metadata?: ReactNode;
   };
 
-export type LayoutHeaderInnerProps<
-  E extends ElementType = typeof LAYOUT_HEADER_INNER_DEFAULT_TAG,
-> = PolymorphicProps<LayoutHeaderInnerInternalProps, E>;
-
-function LayoutHeaderInnerBase<
-  E extends ElementType = typeof LAYOUT_HEADER_INNER_DEFAULT_TAG,
->(
+function LayoutHeaderInnerBase(
   {
     actions,
-    as,
     backButtonProps,
     breadcrumbs,
     className,
-    filters,
     metadata,
     title,
     titleProps,
     withBackButton,
     testId = 'cf-ui-header',
     ...otherProps
-  }: LayoutHeaderInnerProps<E>,
-  forwardedRef: Ref<HTMLElement>,
+  }: LayoutHeaderInnerProps,
+  forwardedRef: Ref<HTMLDivElement>,
 ) {
   const variant = breadcrumbs ? 'breadcrumb' : 'title';
   const styles = getLayoutHeaderInnerStyles();
@@ -103,7 +86,6 @@ function LayoutHeaderInnerBase<
   return (
     <Flex
       alignItems="center"
-      as={LAYOUT_HEADER_INNER_DEFAULT_TAG}
       gap="spacingM"
       className={cx(styles.root, className)}
       ref={forwardedRef}
@@ -142,9 +124,4 @@ function LayoutHeaderInnerBase<
 
 LayoutHeaderInnerBase.displayName = 'LayoutHeaderInner';
 
-export const LayoutHeaderInner = forwardRef(
-  LayoutHeaderInnerBase,
-) as PolymorphicComponent<
-  ExpandProps<LayoutHeaderInnerInternalProps>,
-  typeof LAYOUT_HEADER_INNER_DEFAULT_TAG
->;
+export const LayoutHeaderInner = forwardRef(LayoutHeaderInnerBase);

--- a/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.tsx
+++ b/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.tsx
@@ -1,0 +1,150 @@
+import React, {
+  type ElementType,
+  forwardRef,
+  type Ref,
+  type ReactElement,
+  type ReactNode,
+  useEffect,
+} from 'react';
+import { cx } from '@emotion/css';
+import {
+  Flex,
+  type ExpandProps,
+  type PolymorphicComponent,
+  type PolymorphicProps,
+  type CommonProps,
+} from '@contentful/f36-core';
+import { BackButton, type BackButtonProps } from './BackButton';
+import { Breadcrumb, type BreadcrumbProps } from './Breadcrumb';
+import { HeaderTitle } from './HeaderTitle';
+import { getLayoutHeaderInnerStyles } from './LayoutHeaderInner.styles';
+import type { HeadingElement } from '@contentful/f36-typography';
+import { useLayoutContext } from '../LayoutContext';
+
+const LAYOUT_HEADER_INNER_DEFAULT_TAG = 'header';
+
+type Variant =
+  | {
+      /**
+       * An (optional) list of navigable links to prepend to the current title.
+       */
+      breadcrumbs?: BreadcrumbProps['breadcrumbs'];
+      /**
+       * Ensure that backbutton props can not be passed when `withBackButton` is false.
+       * This is to prevent confusion, as the back button will not be rendered.
+       */
+      backButtonProps?: never;
+      withBackButton?: false | never;
+    }
+  | {
+      /**
+       * An (optional) list of navigable links to prepend to the current title.
+       */
+      breadcrumbs?: BreadcrumbProps['breadcrumbs'];
+      /**
+       * Props to spread on the back button. You almost certainly want to pass
+       * an `onClick` handler.
+       */
+      backButtonProps?: BackButtonProps;
+      /**
+       * If `true`, renders a leading back button within the header.
+       */
+      withBackButton: true;
+    };
+
+type LayoutHeaderInnerInternalProps = CommonProps &
+  Variant & {
+    /**
+     * Optional JSX children to display as complementary actions (e.g. buttons) related to the current page/route.
+     */
+    actions?: ReactElement | ReactElement[];
+    /**
+     * The title of the element this header pertains to.
+     */
+    title: string;
+    titleProps?: {
+      as?: HeadingElement;
+      size?: 'medium' | 'large';
+    };
+    metadata?: ReactNode;
+  };
+
+export type LayoutHeaderInnerProps<
+  E extends ElementType = typeof LAYOUT_HEADER_INNER_DEFAULT_TAG,
+> = PolymorphicProps<LayoutHeaderInnerInternalProps, E>;
+
+function LayoutHeaderInnerBase<
+  E extends ElementType = typeof LAYOUT_HEADER_INNER_DEFAULT_TAG,
+>(
+  {
+    actions,
+    as,
+    backButtonProps,
+    breadcrumbs,
+    className,
+    filters,
+    metadata,
+    title,
+    titleProps,
+    withBackButton,
+    testId = 'cf-ui-header',
+    ...otherProps
+  }: LayoutHeaderInnerProps<E>,
+  forwardedRef: Ref<HTMLElement>,
+) {
+  const variant = breadcrumbs ? 'breadcrumb' : 'title';
+  const styles = getLayoutHeaderInnerStyles();
+
+  const { setWithResponsiveHeader } = useLayoutContext();
+  useEffect(() => {
+    setWithResponsiveHeader(true);
+  }, [setWithResponsiveHeader]);
+
+  return (
+    <Flex
+      alignItems="center"
+      as={LAYOUT_HEADER_INNER_DEFAULT_TAG}
+      gap="spacingM"
+      className={cx(styles.root, className)}
+      ref={forwardedRef}
+      testId={testId}
+      {...otherProps}
+    >
+      <Flex className={styles.wrapper}>
+        <Flex alignItems="center">
+          {withBackButton && <BackButton {...backButtonProps} />}
+          <Flex flexWrap="wrap">
+            {breadcrumbs && <Breadcrumb breadcrumbs={breadcrumbs} />}
+            <HeaderTitle
+              withBackButton={withBackButton}
+              title={title}
+              variant={variant}
+              {...titleProps}
+            />
+          </Flex>
+          {metadata && (
+            <Flex
+              flexShrink="0"
+              alignItems="center"
+              gap="spacing2Xs"
+              marginLeft="spacing2Xs"
+              alignSelf="flex-start"
+            >
+              {metadata}
+            </Flex>
+          )}
+        </Flex>
+      </Flex>
+      <Flex className={styles.actions}>{actions}</Flex>
+    </Flex>
+  );
+}
+
+LayoutHeaderInnerBase.displayName = 'LayoutHeaderInner';
+
+export const LayoutHeaderInner = forwardRef(
+  LayoutHeaderInnerBase,
+) as PolymorphicComponent<
+  ExpandProps<LayoutHeaderInnerInternalProps>,
+  typeof LAYOUT_HEADER_INNER_DEFAULT_TAG
+>;

--- a/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.tsx
+++ b/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.tsx
@@ -70,7 +70,7 @@ function LayoutHeaderInnerBase(
     title,
     titleProps,
     withBackButton,
-    testId = 'cf-ui-header',
+    testId = 'cf-layout-header-inner',
     ...otherProps
   }: LayoutHeaderInnerProps,
   forwardedRef: Ref<HTMLDivElement>,

--- a/packages/components/layout/src/LayoutHeaderInner/Segmentation.styles.ts
+++ b/packages/components/layout/src/LayoutHeaderInner/Segmentation.styles.ts
@@ -1,0 +1,29 @@
+import tokens from '@contentful/f36-tokens';
+import { css } from '@emotion/css';
+
+export const getSegmentationStyles = () => {
+  return {
+    root: css({
+      alignItems: 'center',
+      display: 'flex',
+      flexWrap: 'wrap',
+    }),
+    separator: css({
+      height: tokens.spacingXl,
+      position: 'relative',
+      width: tokens.spacingXs,
+
+      '&::after': {
+        backgroundColor: tokens.gray200,
+        content: '""',
+        display: 'block',
+        height: '16px',
+        position: 'absolute',
+        left: '50%',
+        top: '50%',
+        width: '1px',
+        transform: 'translate3d(-50%, -50%, 0) rotate3d(0, 0, 1, 18deg)',
+      },
+    }),
+  };
+};

--- a/packages/components/layout/src/LayoutHeaderInner/Segmentation.test.tsx
+++ b/packages/components/layout/src/LayoutHeaderInner/Segmentation.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Segmentation } from './Segmentation';
+import { Button } from '@contentful/f36-button';
+import { axe } from 'jest-axe';
+
+describe('Segmentation', function () {
+  it('renders text', () => {
+    render(<Segmentation segments={['1', '2', '3']} />);
+
+    expect(screen.getByTestId('cf-ui-segmentation')).toHaveTextContent('123');
+  });
+
+  it('renders components', () => {
+    render(
+      <Segmentation
+        segments={[
+          <span key={1}>1</span>,
+          <Button key={2}>2</Button>,
+          <div key={3}>3</div>,
+        ]}
+      />,
+    );
+    expect(screen.getByTestId('cf-ui-segmentation')).toHaveTextContent('123');
+  });
+
+  it('renders children', () => {
+    render(
+      <Segmentation>
+        <span>1</span>
+        <Button>2</Button>
+        <div>3</div>
+      </Segmentation>,
+    );
+    expect(screen.getByTestId('cf-ui-segmentation')).toHaveTextContent('123');
+  });
+
+  it('has no a11y issues', async () => {
+    const { container } = render(
+      <Segmentation
+        segments={[
+          <span key={1}>1</span>,
+          <Button key={2}>2</Button>,
+          <div key={3}>3</div>,
+        ]}
+      />,
+    );
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/components/layout/src/LayoutHeaderInner/Segmentation.tsx
+++ b/packages/components/layout/src/LayoutHeaderInner/Segmentation.tsx
@@ -1,0 +1,83 @@
+import {
+  Box,
+  type CommonProps,
+  type ExpandProps,
+  Flex,
+  type PolymorphicComponent,
+  type PolymorphicProps,
+} from '@contentful/f36-core';
+import { cx } from '@emotion/css';
+import React, {
+  forwardRef,
+  type ElementType,
+  type Ref,
+  type ReactNode,
+  type ReactElement,
+} from 'react';
+import { getSegmentationStyles } from './Segmentation.styles';
+
+const SEGMENTATION_DEFAULT_TAG = 'div';
+
+type ChildrenOrSegments =
+  | {
+      children: ReactNode[];
+      segments?: never;
+    }
+  | {
+      children?: never;
+      segments: ReactNode[];
+    };
+
+type SegmentationInternalProps = CommonProps &
+  ChildrenOrSegments & {
+    separator?: ReactElement;
+  };
+
+export type SegmentationProps<
+  E extends ElementType = typeof SEGMENTATION_DEFAULT_TAG,
+> = PolymorphicProps<SegmentationInternalProps, E>;
+
+function SegmentationBase<
+  E extends ElementType = typeof SEGMENTATION_DEFAULT_TAG,
+>(
+  {
+    children,
+    className,
+    segments,
+    separator: SeparatorComponent,
+    testId = 'cf-ui-segmentation',
+  }: SegmentationProps<E>,
+  forwardedRef: Ref<HTMLDivElement>,
+) {
+  const styles = getSegmentationStyles();
+  const separator = SeparatorComponent ?? <div className={styles.separator} />;
+
+  const mapSegments = (segment: ReactNode, index: number) => (
+    <Flex key={index} flexWrap="nowrap">
+      {segment}
+      {separator}
+    </Flex>
+  );
+
+  return (
+    <Box
+      as={SEGMENTATION_DEFAULT_TAG}
+      className={cx(styles.root, className)}
+      ref={forwardedRef}
+      testId={testId}
+    >
+      {children
+        ? React.Children.toArray(children).map(mapSegments)
+        : segments.map(mapSegments)}
+    </Box>
+  );
+}
+
+SegmentationBase.displayName = 'Segmentation';
+
+export const Segmentation = forwardRef(
+  SegmentationBase,
+) as PolymorphicComponent<
+  ExpandProps<SegmentationInternalProps>,
+  typeof SEGMENTATION_DEFAULT_TAG
+>;

--- a/packages/components/layout/stories/Layout.stories.tsx
+++ b/packages/components/layout/stories/Layout.stories.tsx
@@ -7,6 +7,7 @@ import { action } from 'storybook/actions';
 import type { LayoutProps } from '../src';
 import { Header } from '../../header/src/Header';
 import { Layout } from '../src/CompoundLayout';
+import { CopySimpleIcon } from '@contentful/f36-icons';
 
 const NAVBAR_HEIGHT = 60;
 
@@ -39,6 +40,7 @@ const ExampleWrapper = ({ withNavbar = true, children }) => (
           width: '100vw',
           height: `${NAVBAR_HEIGHT}px`,
           backgroundColor: 'lavender',
+          flexShrink: 0,
         })}
       >
         Navbar
@@ -53,6 +55,20 @@ const LayoutHeaderComp = () => (
     <Header
       className={css({ padding: '0', backgroundColor: 'white' })}
       title="Headline"
+      actions={
+        <Button variant="primary" size="small">
+          Button
+        </Button>
+      }
+    />
+  </Layout.Header>
+);
+
+const LayoutHeaderResponsiveComp = () => (
+  <Layout.Header>
+    <Layout.HeaderInner
+      className={css({ backgroundColor: 'white' })}
+      title="Long Headline to Showcase Responsive Header"
       actions={
         <Button variant="primary" size="small">
           Button
@@ -559,6 +575,262 @@ export const VariantNarrowWithRightSidebar: StoryFn<LayoutProps> = () => {
               width: '100%',
               height: '900px',
               backgroundColor: 'lavenderblush',
+            })}
+          >
+            Content
+          </Box>
+        </Layout.Body>
+      </Layout>
+    </ExampleWrapper>
+  );
+};
+
+export const WithResponsiveHeader: StoryFn<LayoutProps> = () => {
+  return (
+    <ExampleWrapper>
+      <Layout header={<LayoutHeaderResponsiveComp />} offsetTop={NAVBAR_HEIGHT}>
+        <Layout.Body>
+          <Box
+            className={css({
+              width: '100%',
+              height: '400px',
+              backgroundColor: 'lavenderblush',
+              marginBottom: '1rem',
+            })}
+          >
+            Content
+          </Box>
+          <Box
+            className={css({
+              width: '100%',
+              height: '240px',
+              backgroundColor: 'blanchedalmond',
+              marginBottom: '1rem',
+            })}
+          >
+            Content
+          </Box>
+          <Box
+            className={css({
+              width: '100%',
+              height: '1000px',
+              backgroundColor: 'aliceblue',
+              marginBottom: '1rem',
+            })}
+          >
+            Content
+          </Box>
+        </Layout.Body>
+      </Layout>
+    </ExampleWrapper>
+  );
+};
+
+export const WithResponsiveHeaderAndBreadcrumbs: StoryFn<LayoutProps> = () => {
+  return (
+    <ExampleWrapper>
+      <Layout
+        header={
+          <Layout.Header>
+            <Layout.HeaderInner
+              className={css({ backgroundColor: 'white' })}
+              title="Long Headline to Showcase Responsive Header"
+              breadcrumbs={[{ content: 'Content Types', url: '#' }]}
+              backButtonProps={{ onClick: action('navigate back') }}
+              withBackButton
+              actions={
+                <Button variant="primary" size="small">
+                  Button
+                </Button>
+              }
+            />
+          </Layout.Header>
+        }
+        offsetTop={NAVBAR_HEIGHT}
+      >
+        <Layout.Body>
+          <Box
+            className={css({
+              width: '100%',
+              height: '400px',
+              backgroundColor: 'lavenderblush',
+              marginBottom: '1rem',
+            })}
+          >
+            Content
+          </Box>
+          <Box
+            className={css({
+              width: '100%',
+              height: '240px',
+              backgroundColor: 'blanchedalmond',
+              marginBottom: '1rem',
+            })}
+          >
+            Content
+          </Box>
+          <Box
+            className={css({
+              width: '100%',
+              height: '1000px',
+              backgroundColor: 'aliceblue',
+              marginBottom: '1rem',
+            })}
+          >
+            Content
+          </Box>
+        </Layout.Body>
+      </Layout>
+    </ExampleWrapper>
+  );
+};
+
+export const WithFullResponsiveHeader: StoryFn<LayoutProps> = () => {
+  return (
+    <ExampleWrapper>
+      <Layout
+        header={
+          <Layout.Header>
+            <Layout.HeaderInner
+              className={css({ backgroundColor: 'white' })}
+              title="Long Headline to Showcase Responsive Header"
+              metadata={
+                <Button
+                  variant="transparent"
+                  startIcon={<CopySimpleIcon />}
+                  size="small"
+                >
+                  Copy ID
+                </Button>
+              }
+              breadcrumbs={[{ content: 'Content Types', url: '#' }]}
+              backButtonProps={{ onClick: action('navigate back') }}
+              withBackButton
+              actions={
+                <Button variant="primary" size="small">
+                  Button
+                </Button>
+              }
+            />
+          </Layout.Header>
+        }
+        offsetTop={NAVBAR_HEIGHT}
+      >
+        <Layout.Body>
+          <Box
+            className={css({
+              width: '100%',
+              height: '400px',
+              backgroundColor: 'lavenderblush',
+              marginBottom: '1rem',
+            })}
+          >
+            Content
+          </Box>
+          <Box
+            className={css({
+              width: '100%',
+              height: '240px',
+              backgroundColor: 'blanchedalmond',
+              marginBottom: '1rem',
+            })}
+          >
+            Content
+          </Box>
+          <Box
+            className={css({
+              width: '100%',
+              height: '1000px',
+              backgroundColor: 'aliceblue',
+              marginBottom: '1rem',
+            })}
+          >
+            Content
+          </Box>
+        </Layout.Body>
+      </Layout>
+    </ExampleWrapper>
+  );
+};
+
+export const WithResponsiveHeaderAndSidebar: StoryFn<LayoutProps> = () => {
+  return (
+    <ExampleWrapper>
+      <Layout
+        header={<LayoutHeaderResponsiveComp />}
+        offsetTop={NAVBAR_HEIGHT}
+        leftSidebar={
+          <Layout.Sidebar>
+            <Box
+              className={css({
+                backgroundColor: 'violet',
+                width: '100%',
+                height: '200px',
+                marginBottom: '1rem',
+              })}
+            >
+              Sidebar Content
+            </Box>
+            <Box
+              className={css({
+                backgroundColor: 'springgreen',
+                width: '100%',
+                height: '400px',
+                marginBottom: '1rem',
+              })}
+            >
+              Sidebar Content
+            </Box>
+            <Box
+              className={css({
+                backgroundColor: 'lightcoral',
+                width: '100%',
+                height: '200px',
+                marginBottom: '1rem',
+              })}
+            >
+              Sidebar Content
+            </Box>
+            <Box
+              className={css({
+                backgroundColor: 'indianred',
+                width: '100%',
+                height: '400px',
+                marginBottom: '1rem',
+              })}
+            >
+              Sidebar Content
+            </Box>
+          </Layout.Sidebar>
+        }
+      >
+        <Layout.Body>
+          <Box
+            className={css({
+              width: '100%',
+              height: '400px',
+              backgroundColor: 'lavenderblush',
+              marginBottom: '1rem',
+            })}
+          >
+            Content
+          </Box>
+          <Box
+            className={css({
+              width: '100%',
+              height: '240px',
+              backgroundColor: 'blanchedalmond',
+              marginBottom: '1rem',
+            })}
+          >
+            Content
+          </Box>
+          <Box
+            className={css({
+              width: '100%',
+              height: '1000px',
+              backgroundColor: 'aliceblue',
+              marginBottom: '1rem',
             })}
           >
             Content


### PR DESCRIPTION
# Purpose of PR

This PR adds the `Layout.HeaderInner` component, a responsive replacement for the existing `Header`.

When using the new component it
* changes the Header’s styling to support breaking into multiple rows,
* makes the `title` required and support only `string` as argument,
* removes the fixed height from the Layout to support the responsive header,
* changes the breadcrumbs such that each segment and its following separator stay on one line, and
* removes the `filters` prop because the placement of the filters would create confusion when the header is broken into multiple lines.

<img width="1226" height="80" alt="image" src="https://github.com/user-attachments/assets/e2bcd60a-14c0-4dbe-94cb-7dbde3ec59d8" />
<img width="528" height="176" alt="image" src="https://github.com/user-attachments/assets/67106944-da30-42f4-8fc5-dfc61adc03ee" />


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
