### PR TITLE
feat(button): add tiny size variant

### DIFF
--- a/.changeset/tiny-buttons-appear.md
+++ b/.changeset/tiny-buttons-appear.md
@@ -2,4 +2,4 @@
 "@contentful/f36-button": minor
 ---
 
-feat(button): add `tiny` size variant to Button
+feat(button): add `tiny` size variant

--- a/.changeset/tiny-buttons-appear.md
+++ b/.changeset/tiny-buttons-appear.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-button": minor
+---
+
+feat(button): add `tiny` size variant to Button

--- a/packages/components/button/examples/ButtonSizesExample.tsx
+++ b/packages/components/button/examples/ButtonSizesExample.tsx
@@ -7,6 +7,7 @@ export default function ButtonSizesExample() {
       <Button size="large">Large</Button>
       <Button size="medium">Medium</Button>
       <Button size="small">Small</Button>
+      <Button size="tiny">Tiny</Button>
     </Stack>
   );
 }

--- a/packages/components/button/src/Button/Button.figma.tsx
+++ b/packages/components/button/src/Button/Button.figma.tsx
@@ -16,6 +16,7 @@ figma.connect(Button, FIGMA_URL, {
       Transparent: 'transparent',
     }),
     size: figma.enum('Size', {
+      Tiny: 'tiny',
       'Small (default)': 'small',
       Medium: 'medium',
     }),
@@ -54,6 +55,7 @@ figma.connect(Button, FIGMA_URL, {
       Transparent: 'transparent',
     }),
     size: figma.enum('Size', {
+      Tiny: 'tiny',
       'Small (default)': 'small',
       Medium: 'medium',
     }),

--- a/packages/components/button/src/Button/Button.styles.ts
+++ b/packages/components/button/src/Button/Button.styles.ts
@@ -113,6 +113,13 @@ const sizeToStyles = (size: ButtonSize, density: Density) => {
   const isHighDensity = density === 'high';
 
   switch (size) {
+    case 'tiny':
+      return {
+        fontSize: tokens.fontSizeS,
+        lineHeight: tokens.lineHeightCondensed,
+        padding: `${tokens.spacing2Xs} ${tokens.spacingS}`,
+        minHeight: tokens.spacingL,
+      };
     case 'small':
       return {
         fontSize: isHighDensity ? tokens.fontSizeS : tokens.fontSizeM,

--- a/packages/components/button/src/Button/Button.test.tsx
+++ b/packages/components/button/src/Button/Button.test.tsx
@@ -29,6 +29,13 @@ describe('Button', function () {
     expect(button.getElementsByTagName('svg')).toHaveLength(1);
   });
 
+  it('renders the tiny size', () => {
+    render(<Button size="tiny">Button</Button>);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveStyle({ minHeight: '1.5rem' });
+  });
+
   it('should not dispatch onClick if disabled', async () => {
     const user = userEvent.setup();
     const mockOnClick = jest.fn();

--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -85,7 +85,9 @@ function ButtonBase<E extends React.ElementType = typeof BUTTON_DEFAULT_TAG>(
         })}
       >
         {React.cloneElement(icon, {
-          size: icon.props.size ?? `${size === 'large' ? 'medium' : 'small'}`,
+          size:
+            icon.props.size ??
+            (size === 'large' ? 'medium' : size === 'tiny' ? 'tiny' : 'small'),
           color: iconColor,
         })}
       </Flex>

--- a/packages/components/button/src/Button/README.mdx
+++ b/packages/components/button/src/Button/README.mdx
@@ -39,7 +39,7 @@ Button has 5 different variants:
 
 ### Sizes
 
-Button has 3 different sizes:
+Button has 4 different sizes:
 
 ```jsx file=../../examples/ButtonSizesExample.tsx
 

--- a/packages/components/button/src/types.ts
+++ b/packages/components/button/src/types.ts
@@ -1,7 +1,7 @@
 import type { CommonProps } from '@contentful/f36-core';
 import type { IconProps } from '@contentful/f36-icon';
 
-export type ButtonSize = 'small' | 'medium' | 'large';
+export type ButtonSize = 'tiny' | 'small' | 'medium' | 'large';
 
 export type ButtonVariant =
   | 'negative'

--- a/packages/components/button/stories/ButtonComponent.stories.tsx
+++ b/packages/components/button/stories/ButtonComponent.stories.tsx
@@ -25,7 +25,7 @@ export default {
       control: 'select',
       options: ['', ...Object.keys(icons)],
     },
-    size: { control: 'select', options: ['small', 'medium', 'large'] },
+    size: { control: 'select', options: ['tiny', 'small', 'medium', 'large'] },
     variant: {
       control: 'select',
       options: ['negative', 'positive', 'primary', 'secondary', 'transparent'],
@@ -116,6 +116,10 @@ export const Overview = {
             marginBottom="spacingM"
             spacing="spacingXs"
           >
+            <Button variant="primary" size="tiny">
+              Tiny
+            </Button>
+
             <Button variant="primary" size="small">
               Small
             </Button>


### PR DESCRIPTION
Adds a `tiny` (24px) size to Button following the Figma spec, using existing spacing/typography tokens. Includes Code Connect mapping, story, docs example, and test coverage.

<!--
🎉❤️ Thank you for taking time to contribute to Forma 36! ❤️🎉
For ease of review, please follow this template for your contribution.
If you have any questions feel free to get in touch on the #forma36 channel on our Contentful Community Discord (sign up here: https://www.contentful.com/discord/.
-->

# Purpose of PR

<!--
Please describe the purpose of your pull request here. What do you want to add? Why do you want to add it? What are the use cases?
-->

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
