### PR TITLE
fix: add PillNext package to docs website

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38420,7 +38420,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38438,7 +38437,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38456,7 +38454,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38474,7 +38471,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38492,7 +38488,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38510,7 +38505,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38528,7 +38522,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38546,7 +38539,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38564,7 +38556,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38582,7 +38573,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38600,7 +38590,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38618,7 +38607,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38636,7 +38624,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38654,7 +38641,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38672,7 +38658,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38690,7 +38675,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38708,7 +38692,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38726,7 +38709,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38744,7 +38726,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38762,7 +38743,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38780,7 +38760,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38798,7 +38777,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38816,7 +38794,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38834,7 +38811,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38852,7 +38828,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38870,7 +38845,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -43566,6 +43540,7 @@
         "@contentful/f36-navbar": "^6.14.0",
         "@contentful/f36-navlist": "^6.14.0",
         "@contentful/f36-progress-stepper": "^6.14.0",
+        "@contentful/f36-pill-next": "^6.0.1-alpha.7",
         "@contentful/f36-tokens": "^6.2.1",
         "@contentful/f36-utils": "^6.1.2",
         "@contentful/rich-text-react-renderer": "^16.0.0",

--- a/packages/website/components/LiveEditor/ComponentSource.tsx
+++ b/packages/website/components/LiveEditor/ComponentSource.tsx
@@ -26,6 +26,7 @@ import tokens from '@contentful/f36-tokens';
 import * as f36utils from '@contentful/f36-utils';
 import * as f36Components from '@contentful/f36-components';
 import * as f36Navbar from '@contentful/f36-navbar';
+import * as f36PillNext from '@contentful/f36-pill-next';
 import { Card, Button, CopyButton, Flex } from '@contentful/f36-components';
 
 import { theme } from './theme';
@@ -41,6 +42,7 @@ const liveProviderScope = {
   // Make all icons available as namespace import (e.g., import * as icons)
   f36icons,
   ...f36Navbar,
+  ...f36PillNext,
   css,
   tokens,
   // most used react hooks

--- a/packages/website/components/Playground/SandpackRenderer.tsx
+++ b/packages/website/components/Playground/SandpackRenderer.tsx
@@ -101,6 +101,7 @@ export function SandpackRenderer({
           'react-scripts': '^4.0.0',
           '@contentful/f36-components': '^6.0.0',
           '@contentful/f36-navbar': '^6.0.0',
+          '@contentful/f36-pill-next': '^6.0.1-alpha.7',
           '@contentful/f36-tokens': '^6.0.0',
           '@contentful/f36-icons': '^6.0.0',
           '@contentful/f36-utils': '^6.0.0',

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -22,6 +22,7 @@
     "@contentful/f36-navbar": "^6.14.0",
     "@contentful/f36-navlist": "^6.14.0",
     "@contentful/f36-progress-stepper": "^6.14.0",
+    "@contentful/f36-pill-next": "6.0.1-alpha.7",
     "@contentful/f36-tokens": "^6.2.1",
     "@contentful/f36-utils": "^6.1.2",
     "@contentful/rich-text-react-renderer": "^16.0.0",


### PR DESCRIPTION
# Purpose of PR

fixes the `PillNext` and `Tag` component website examples. The components are still in alpha-state and therefore not exported via the regular components package. This is why it needs to be added separately for the website package. 