### PR TITLE
fix(popover): keep document tab order

### DIFF
--- a/.changeset/lazy-popover-focus.md
+++ b/.changeset/lazy-popover-focus.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-popover': patch
+---
+
+Fix portalled Popover tab order when using non-modal focus management.

--- a/packages/components/popover/src/Popover.test.tsx
+++ b/packages/components/popover/src/Popover.test.tsx
@@ -247,6 +247,16 @@ describe('Popover', function () {
     });
   });
 
+  it('does not render portal tab-order guards', async () => {
+    await renderWithAct({ isOpen: true });
+
+    expect(
+      document.querySelector(
+        '[data-floating-ui-focus-guard][data-type="outside"]',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it('popover should NOT receive focus when autoFocus=false', async () => {
     await renderWithAct({ isOpen: true, autoFocus: false });
     await waitFor(() => {

--- a/packages/components/popover/src/PopoverContent/PopoverContent.tsx
+++ b/packages/components/popover/src/PopoverContent/PopoverContent.tsx
@@ -83,7 +83,7 @@ const PopoverContentBase = (
     );
 
   return usePortal ? (
-    <FloatingPortal>
+    <FloatingPortal preserveTabOrder={false}>
       {maybeWrapWithFocusManager(content as React.ReactElement)}
     </FloatingPortal>
   ) : (


### PR DESCRIPTION
# Purpose of PR

Fix a bug where `Popover` rendered inside React portals resets the focus order once the `Popover` closes.

## Cause
The bug is caused by the new `FloatingPortal` from `floating-ui`. It defaults to `preserveTabOrder={true}`, which creates tab key handlers that try to be smart about restoring focus order after the popover closes. With the portal that causes issues, but it seems to work to just leave the order as-is by disabling the option.