### PR TITLE
fix(skeleton): correct SkeletonBodyText display name

### DIFF
--- a/.changeset/tidy-skeleton-name.md
+++ b/.changeset/tidy-skeleton-name.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-skeleton': patch
+---
+
+- Fix the `SkeletonBodyText` display name

--- a/packages/components/skeleton/src/SkeletonBodyText/SkeletonBodyText.tsx
+++ b/packages/components/skeleton/src/SkeletonBodyText/SkeletonBodyText.tsx
@@ -27,4 +27,4 @@ export const SkeletonBodyText = ({
   );
 };
 
-SkeletonBodyText.displayName = 'SkeletonBodyTeyt';
+SkeletonBodyText.displayName = 'SkeletonBodyText';


### PR DESCRIPTION
# Purpose of PR

Fix the `SkeletonBodyText` display name typo.

## PR Checklist

- [x] Relevant README reviewed
- [x] Commit follows the convention
- [x] Tests pass
- [x] Stories, usage notes, and browser testing are not required
- [x] No sensitive information
