### PR TITLE
fix: 🐛 correct responsive header top spacing

### DIFF
--- a/.changeset/dull-pigs-wash.md
+++ b/.changeset/dull-pigs-wash.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-layout": patch
+---
+
+fix: 🐛 correct responsive header top spacing

--- a/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.styles.ts
+++ b/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.styles.ts
@@ -25,6 +25,6 @@ export const getLayoutHeaderInnerStyles = () => ({
     flexWrap: 'wrap',
     justifyContent: 'space-between',
     paddingBottom: tokens.spacingS,
-    paddingTop: tokens.spacingS,
+    paddingTop: tokens.spacingM,
   }),
 });


### PR DESCRIPTION
# Purpose of PR

Give the new responsive header a bit more space.

## Before
<img width="687" height="116" alt="image" src="https://github.com/user-attachments/assets/b0dfb245-ec2b-4e71-aecf-d909f7334c06" />

## After
<img width="687" height="122" alt="image" src="https://github.com/user-attachments/assets/fa2a9029-38fb-42a3-85d5-b7e2c64efefd" />


## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
