### PR TITLE
fix: 🐛 adjust responsiv header spacing

### DIFF
--- a/.changeset/tidy-spiders-melt.md
+++ b/.changeset/tidy-spiders-melt.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-layout": patch
+---
+
+fix: 🐛 adjust responsiv header spacing

--- a/packages/components/layout/src/Layout.styles.ts
+++ b/packages/components/layout/src/Layout.styles.ts
@@ -136,12 +136,13 @@ export const getLayoutStyles = ({
 export const getLayoutBodyStyles = (
   withHeader: boolean,
   withResponsiveHeader: boolean,
+  withSidebar: boolean,
   offsetTop: number,
 ) => ({
   layoutBodyContainer: css(
     {
       width: '100%',
-      padding: `${tokens.spacingL} ${tokens.spacingL} 0`,
+      padding: `${withResponsiveHeader && !withSidebar ? 0 : tokens.spacingL} ${tokens.spacingL} 0`,
       overflowY: 'auto',
     },
     !withResponsiveHeader &&
@@ -185,7 +186,7 @@ export const getLayoutHeaderStyles = ({
 }) => ({
   layoutHeader: css(
     {
-      padding: `${tokens.spacing2Xs} ${tokens.spacingL} 0 ${tokens.spacingL}`,
+      padding: `${withResponsiveHeader ? 0 : tokens.spacing2Xs} ${tokens.spacingL} 0 ${tokens.spacingL}`,
       width: '100%',
       maxWidth: variant === 'fullscreen' ? '100%' : '1920px',
       borderBottom:

--- a/packages/components/layout/src/LayoutBody.tsx
+++ b/packages/components/layout/src/LayoutBody.tsx
@@ -16,11 +16,18 @@ const LayoutBodyBase = (props: LayoutBodyProps, ref: Ref<HTMLDivElement>) => {
     testId = 'cf-layout-body',
     ...otherProps
   } = props;
-  const { variant, withHeader, offsetTop, withResponsiveHeader } =
-    useLayoutContext();
+  const {
+    variant,
+    withHeader,
+    offsetTop,
+    withResponsiveHeader,
+    withLeftSidebar,
+    withRightSidebar,
+  } = useLayoutContext();
   const styles = getLayoutBodyStyles(
     withHeader,
     withResponsiveHeader,
+    withLeftSidebar || withRightSidebar,
     offsetTop,
   );
 

--- a/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.styles.ts
+++ b/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.styles.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
 
-export const getLayoutHeaderInnerStyles = () => ({
+export const getLayoutHeaderInnerStyles = (withBreadcrumbs: boolean) => ({
   actions: css({
     flexGrow: 0,
     flexShrink: 1,
@@ -24,7 +24,7 @@ export const getLayoutHeaderInnerStyles = () => ({
     background: tokens.colorWhite,
     flexWrap: 'wrap',
     justifyContent: 'space-between',
-    paddingBottom: tokens.spacingS,
-    paddingTop: tokens.spacingM,
+    paddingBottom: withBreadcrumbs ? tokens.spacingS : tokens.spacingL,
+    paddingTop: withBreadcrumbs ? tokens.spacingS : tokens.spacingL,
   }),
 });

--- a/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.tsx
+++ b/packages/components/layout/src/LayoutHeaderInner/LayoutHeaderInner.tsx
@@ -76,7 +76,7 @@ function LayoutHeaderInnerBase(
   forwardedRef: Ref<HTMLDivElement>,
 ) {
   const variant = breadcrumbs ? 'breadcrumb' : 'title';
-  const styles = getLayoutHeaderInnerStyles();
+  const styles = getLayoutHeaderInnerStyles(!!breadcrumbs);
 
   const { setWithResponsiveHeader } = useLayoutContext();
   useEffect(() => {

--- a/packages/components/layout/stories/Layout.stories.tsx
+++ b/packages/components/layout/stories/Layout.stories.tsx
@@ -64,20 +64,6 @@ const LayoutHeaderComp = () => (
   </Layout.Header>
 );
 
-const LayoutHeaderResponsiveComp = () => (
-  <Layout.Header>
-    <Layout.HeaderInner
-      className={css({ backgroundColor: 'white' })}
-      title="Long Headline to Showcase Responsive Header"
-      actions={
-        <Button variant="primary" size="small">
-          Button
-        </Button>
-      }
-    />
-  </Layout.Header>
-);
-
 const LayoutSidebarComp = ({ content }) => (
   <Layout.Sidebar>
     <Box
@@ -588,7 +574,22 @@ export const VariantNarrowWithRightSidebar: StoryFn<LayoutProps> = () => {
 export const WithResponsiveHeader: StoryFn<LayoutProps> = () => {
   return (
     <ExampleWrapper>
-      <Layout header={<LayoutHeaderResponsiveComp />} offsetTop={NAVBAR_HEIGHT}>
+      <Layout
+        header={
+          <Layout.Header>
+            <Layout.HeaderInner
+              className={css({ backgroundColor: 'white' })}
+              title="Long Headline to Showcase Responsive Header"
+              actions={
+                <Button variant="primary" size="small">
+                  Button
+                </Button>
+              }
+            />
+          </Layout.Header>
+        }
+        offsetTop={NAVBAR_HEIGHT}
+      >
         <Layout.Body>
           <Box
             className={css({
@@ -757,7 +758,22 @@ export const WithResponsiveHeaderAndSidebar: StoryFn<LayoutProps> = () => {
   return (
     <ExampleWrapper>
       <Layout
-        header={<LayoutHeaderResponsiveComp />}
+        header={
+          <Layout.Header>
+            <Layout.HeaderInner
+              className={css({ backgroundColor: 'white' })}
+              title="Long Headline to Showcase Responsive Header"
+              breadcrumbs={[{ content: 'Content Types', url: '#' }]}
+              backButtonProps={{ onClick: action('navigate back') }}
+              withBackButton
+              actions={
+                <Button variant="primary" size="small">
+                  Button
+                </Button>
+              }
+            />
+          </Layout.Header>
+        }
         offsetTop={NAVBAR_HEIGHT}
         leftSidebar={
           <Layout.Sidebar>


### PR DESCRIPTION
# Purpose of PR

Adjust the responsive header spacing once more. 😇 

* LayoutHeader loses the 4px top padding for consistency.
* LayoutHeaderInner _without_ breadcrumbs gets 24px top/bottom padding.
* LayoutHeaderInner _with_ breadcrumbs gets 12px top/bottom padding.
* LayoutBody loses the top padding unless there’s a border above it (because of sidebars).

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
