### PR TITLE
chore: privatize forms implementation helpers

### DIFF
--- a/packages/components/datetime/src/utils/formatDateTimeUtils.ts
+++ b/packages/components/datetime/src/utils/formatDateTimeUtils.ts
@@ -81,30 +81,3 @@ export function formatMachineReadableDateTime(
 
   return dayjs(date).format(template);
 }
-
-/**
- * @example
- * > formatDate(date)
- * 13 Aug 2019
- */
-export const formatDate = (date: DateType): string => {
-  return formatDateAndTime(date, 'day');
-};
-
-/**
- * @example
- * > formatTime(date)
- * 8:00 AM
- */
-export const formatTime = (date: DateType): string => {
-  return formatDateAndTime(date, 'time');
-};
-
-/**
- * @example
- * > formatWeekdayDate(date)
- * Mon, 12 Aug
- */
-export const formatWeekdayDate = (date: DateType): string => {
-  return formatDateAndTime(date, 'weekday');
-};

--- a/packages/components/datetime/src/utils/index.ts
+++ b/packages/components/datetime/src/utils/index.ts
@@ -1,9 +1,6 @@
 export {
   formatDateAndTime,
   formatMachineReadableDateTime,
-  formatDate,
-  formatTime,
-  formatWeekdayDate,
 } from './formatDateTimeUtils';
 
 export {

--- a/packages/components/forms/src/BaseCheckbox/BaseCheckboxGroup.tsx
+++ b/packages/components/forms/src/BaseCheckbox/BaseCheckboxGroup.tsx
@@ -37,7 +37,7 @@ export interface BaseCheckboxGroupProps extends CommonProps {
   value?: Array<string> | string;
 }
 
-export const BaseCheckboxGroupBase = (
+const BaseCheckboxGroupBase = (
   props: ExpandProps<BaseCheckboxGroupProps>,
   ref: React.Ref<HTMLDivElement>,
 ) => {

--- a/packages/components/forms/src/BaseCheckbox/BaseCheckboxGroupContext.tsx
+++ b/packages/components/forms/src/BaseCheckbox/BaseCheckboxGroupContext.tsx
@@ -15,7 +15,7 @@ export const BaseCheckboxGroupContext = createContext<
   BaseCheckboxGroupContextProps | undefined
 >(undefined);
 
-export const useBaseCheckboxGroupContext = () => {
+const useBaseCheckboxGroupContext = () => {
   const context = useContext(BaseCheckboxGroupContext);
   return context;
 };

--- a/packages/components/forms/src/Checkbox/CheckboxGroup.tsx
+++ b/packages/components/forms/src/Checkbox/CheckboxGroup.tsx
@@ -19,7 +19,7 @@ export interface CheckboxGroupProps extends Omit<
   value?: Array<string>;
 }
 
-export const CheckboxGroupBase = (
+const CheckboxGroupBase = (
   props: ExpandProps<CheckboxGroupProps>,
   ref: React.Ref<HTMLDivElement>,
 ) => {

--- a/packages/components/forms/src/FormControl/FormControlContext.tsx
+++ b/packages/components/forms/src/FormControl/FormControlContext.tsx
@@ -9,7 +9,7 @@ export const FormControlContext = createContext<
   FormControlContextProps | undefined
 >(undefined);
 
-export const useFormControlContext = () => {
+const useFormControlContext = () => {
   const context = useContext(FormControlContext);
   return context;
 };

--- a/packages/components/forms/src/TextInput/TextInput.tsx
+++ b/packages/components/forms/src/TextInput/TextInput.tsx
@@ -4,7 +4,7 @@ import { TextInputProps } from './types';
 import { useFormControl } from '../FormControl/FormControlContext';
 import type { ExpandProps } from '@contentful/f36-core';
 
-export const TextInputBase = (
+const TextInputBase = (
   {
     className,
     testId = 'cf-ui-text-input',

--- a/packages/components/layout/src/Layout.styles.ts
+++ b/packages/components/layout/src/Layout.styles.ts
@@ -12,7 +12,7 @@ const SIDEBAR_WIDTHS: Record<LayoutSidebarVariant, `${number}px`> = {
 const getMainOffset = (withHeader: boolean, offsetTop: number) =>
   withHeader ? HEADER_HEIGHT + 1 + offsetTop + 'px' : offsetTop + 'px';
 
-export const getLayoutMaxWidthStyles = ({
+const getLayoutMaxWidthStyles = ({
   variant,
   withBoxShadow,
 }: {

--- a/packages/f36-ai-components/src/AIChatMessage/AIChatMessage.tsx
+++ b/packages/f36-ai-components/src/AIChatMessage/AIChatMessage.tsx
@@ -31,7 +31,7 @@ import {
 } from '@contentful/f36-components';
 import { cx } from '@emotion/css';
 
-export type AIChatMessageRole = 'user' | 'assistant';
+type AIChatMessageRole = 'user' | 'assistant';
 
 type ComponentPropOverrideHandler<T> = (
   defaultProps: React.PropsWithChildren<T>,
@@ -98,7 +98,7 @@ export interface AIChatMessageProps extends CommonProps {
  * @param props - The props react-markdown passes to the `code` renderer.
  * @returns `true` for block code, `false` for inline code.
  */
-export function isBlockCode(props: {
+function isBlockCode(props: {
   className?: string;
   children?: React.ReactNode;
 }): boolean {

--- a/packages/website/utils/colorTokens.ts
+++ b/packages/website/utils/colorTokens.ts
@@ -1,5 +1,4 @@
 import f36Tokens from '@contentful/f36-tokens';
-import { css } from '@emotion/css';
 
 export const tokens = {
   black: {
@@ -190,52 +189,4 @@ export const tokens = {
     'dataviz-semantic-negative': f36Tokens.datavizSemanticNegative,
     'dataviz-semantic-warning': f36Tokens.datavizSemanticWarning,
   },
-};
-
-const colorTokenToSvgFilter = {
-  white:
-    'brightness(0) saturate(100%) invert(100%) sepia(0%) saturate(0%) hue-rotate(345deg) brightness(102%) contrast(103%)',
-  blue600:
-    'brightness(0) saturate(100%) invert(30%) sepia(88%) saturate(7488%) hue-rotate(205deg) brightness(91%) contrast(101%)',
-  blue700:
-    'brightness(0) saturate(100%) invert(15%) sepia(98%) saturate(2531%) hue-rotate(211deg) brightness(96%) contrast(104%)',
-  gray600:
-    'brightness(0) saturate(100%) invert(37%) sepia(25%) saturate(427%) hue-rotate(182deg) brightness(96%) contrast(87%)',
-  gray700:
-    'brightness(0) saturate(100%) invert(25%) sepia(9%) saturate(1954%) hue-rotate(181deg) brightness(98%) contrast(80%)',
-  gray900:
-    'brightness(0) saturate(100%) invert(9%) sepia(5%) saturate(6679%) hue-rotate(180deg) brightness(90%) contrast(95%)',
-};
-
-export const svgStyles = {
-  white: css({
-    img: {
-      filter: colorTokenToSvgFilter.white,
-    },
-  }),
-  blue600: css({
-    img: {
-      filter: colorTokenToSvgFilter.blue600,
-    },
-    '&:hover': {
-      img: {
-        filter: colorTokenToSvgFilter.blue700,
-      },
-    },
-  }),
-  gray600: css({
-    img: {
-      filter: colorTokenToSvgFilter.gray600,
-    },
-    '&:hover': {
-      img: {
-        filter: colorTokenToSvgFilter.gray700,
-      },
-    },
-  }),
-  gray900: css({
-    img: {
-      filter: colorTokenToSvgFilter.gray900,
-    },
-  }),
 };


### PR DESCRIPTION
## Summary
- make five same-file Forms implementation helpers private
- preserve all public components, contexts, hooks, and prop types
- clear five Knip export findings without changing the package root barrel

Stacked on #3523. No component-specific CI step is added.

## Verification
- `npm exec knip -- --workspace packages/components/forms --include exports,types --no-config-hints --no-exit-code --reporter compact`
- `npm run build --workspace=@contentful/f36-forms`
- `npm run tsc`
- `npm run lint`
- `npm test -- --runInBand packages/components/forms`
- generated Forms declarations contain none of the privatized names