### PR TITLE
fix: scrollable table border [UFO-2462]

### DIFF
--- a/.changeset/swift-tigers-eat.md
+++ b/.changeset/swift-tigers-eat.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-table': patch
+---
+
+Fixes the missing border for scrollable Tables

--- a/packages/components/table/src/Table.tsx
+++ b/packages/components/table/src/Table.tsx
@@ -85,8 +85,11 @@ export const Table = forwardRef<HTMLTableElement, ExpandProps<TableProps>>(
 
     if (isScrollable) {
       return (
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- scrollable region requires tabIndex for keyboard access (WCAG 2.1 SC 2.1.1)
-        <section tabIndex={0} className={styles.scrollableWrapper}>
+        <section
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- scrollable region requires tabIndex for keyboard access (WCAG 2.1 SC 2.1.1)
+          tabIndex={0}
+          className={cx(styles.scrollableWrapper, styles.inline)}
+        >
           {tableElement}
         </section>
       );


### PR DESCRIPTION
# Purpose of PR

the scrollable variation of the Table was missing the outer border from the default inline styling. 

Before:
<img width="1178" height="746" alt="image" src="https://github.com/user-attachments/assets/ca44dce5-6a4e-498f-a2fd-6a734180780c" />


After:

<img width="1768" height="610" alt="image" src="https://github.com/user-attachments/assets/2ca3d83e-4fc2-4f21-8820-a790a63e73d6" />
