### PR TITLE
chore(deps): update react-day-picker to v8.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31658,6 +31658,20 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/react-day-picker": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.2.tgz",
+      "integrity": "sha512-LK68OTbHB3oJNhl9cA0qVizzp3o26w61YSjAFkYi67N86iro32wx86kSNeFU/hq+gI8m1yzWhnomMLfZ041RzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "date-fns": "^2.28.0 || ^3.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-devtools-inline": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/react-devtools-inline/-/react-devtools-inline-4.4.0.tgz",
@@ -40284,24 +40298,12 @@
         "@contentful/f36-tokens": "^6.1.3",
         "@emotion/css": "^11.13.5",
         "date-fns": "^2.28.0",
-        "react-day-picker": "^8.7.1",
+        "react-day-picker": "^8.10.2",
         "react-focus-lock": "^2.9.1"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
-      }
-    },
-    "packages/components/datepicker/node_modules/react-day-picker": {
-      "version": "8.10.1",
-      "license": "MIT",
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/gpbl"
-      },
-      "peerDependencies": {
-        "date-fns": "^2.28.0 || ^3.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "packages/components/datetime": {

--- a/package.json
+++ b/package.json
@@ -140,9 +140,6 @@
   "overrides": {
     "@emotion/eslint-plugin": {
       "eslint": ">=9.0.0"
-    },
-    "react-day-picker": {
-      "react": ">=19.1.0"
     }
   }
 }

--- a/packages/components/datepicker/package.json
+++ b/packages/components/datepicker/package.json
@@ -14,7 +14,7 @@
     "@contentful/f36-tokens": "^6.1.3",
     "@emotion/css": "^11.13.5",
     "date-fns": "^2.28.0",
-    "react-day-picker": "^8.7.1",
+    "react-day-picker": "^8.10.2",
     "react-focus-lock": "^2.9.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- update `react-day-picker` to 8.10.2
- remove the React peer dependency override now that upstream supports React 19
- unblock testing and adoption of React 19.2 without changing the Datepicker API

## Verification
- `npm run build`
- `npm run tsc`
- `npm run lint`
- `npm test -- --runInBand packages/components/datepicker/src/Datepicker.test.tsx`
- focused Datepicker tests with React 19.2.7 installed without saving