### PR TITLE
chore: remove circular dependencies

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -10,7 +10,8 @@
     "nsTypes",
     "enumMembers",
     "namespaceMembers",
-    "duplicates"
+    "duplicates",
+    "cycles"
   ],
   "entry": [
     "scripts/**/*.{js,ts,tsx,mjs}",

--- a/packages/components/avatar/src/Avatar/utils.ts
+++ b/packages/components/avatar/src/Avatar/utils.ts
@@ -1,6 +1,6 @@
 import tokens from '@contentful/f36-tokens';
 
-import { AvatarProps } from './Avatar';
+import type { AvatarProps } from './Avatar';
 import { type Variant } from './types';
 
 export type Size = 'tiny' | 'small' | 'medium' | 'large';

--- a/packages/components/card/src/Card/Card.styles.ts
+++ b/packages/components/card/src/Card/Card.styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
-import { CardProps } from '..';
+import type { CardProps } from './Card';
 
 const getCardPaddingValue = (padding: CardProps['padding']) => {
   switch (padding) {

--- a/packages/components/copybutton/src/CopyButton.styles.ts
+++ b/packages/components/copybutton/src/CopyButton.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { CopyButtonProps } from './CopyButton';
+import type { CopyButtonProps } from './CopyButton';
 
 export const getCopyButtonStyles = ({
   size,

--- a/packages/components/drag-handle/src/DragHandle.styles.ts
+++ b/packages/components/drag-handle/src/DragHandle.styles.ts
@@ -1,7 +1,7 @@
 import { cx, css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
 import { hexToRGBA } from '@contentful/f36-utils';
-import { DragHandleProps } from './DragHandle';
+import type { DragHandleProps } from './DragHandle';
 
 export const getStyles = () => ({
   label: css({

--- a/packages/components/entity-list/src/EntityListItem/EntityListItem.styles.ts
+++ b/packages/components/entity-list/src/EntityListItem/EntityListItem.styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
-import { EntityListItemProps } from './EntityListItem';
+import type { EntityListItemProps } from './EntityListItem';
 
 export const getEntityListItemStyles = () => ({
   root: (props: Pick<EntityListItemProps, 'isDragActive'>) =>

--- a/packages/components/forms/src/BaseCheckbox/BaseCheckboxGroupContext.tsx
+++ b/packages/components/forms/src/BaseCheckbox/BaseCheckboxGroupContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 import { BaseCheckboxProps } from './BaseCheckbox';
-import { BaseCheckboxGroupProps } from './BaseCheckboxGroup';
+import type { BaseCheckboxGroupProps } from './BaseCheckboxGroup';
 
 export type BaseCheckboxGroupContextProps = Omit<
   BaseCheckboxGroupProps,

--- a/packages/components/layout/src/LayoutContext.ts
+++ b/packages/components/layout/src/LayoutContext.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LayoutProps } from './Layout';
+import type { LayoutProps } from './Layout';
 
 export type LayoutContextType = {
   variant: NonNullable<LayoutProps['variant']>;

--- a/packages/components/layout/src/LayoutHeaderInner/HeaderTitle.tsx
+++ b/packages/components/layout/src/LayoutHeaderInner/HeaderTitle.tsx
@@ -5,7 +5,7 @@ import {
   type HeadingElement,
 } from '@contentful/f36-typography';
 import { getHeaderTitleStyles } from './HeaderTitle.styles';
-import { LayoutHeaderInnerProps } from './LayoutHeaderInner';
+import type { LayoutHeaderInnerProps } from './LayoutHeaderInner';
 
 type HeaderTitleProps = {
   title: LayoutHeaderInnerProps['title'];

--- a/packages/components/navbar/src/Navbar.styles.ts
+++ b/packages/components/navbar/src/Navbar.styles.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
 import { mqs } from './utils.styles';
-import { NavbarProps } from './Navbar';
+import type { NavbarProps } from './Navbar';
 import { NAVBAR_HEIGHT } from './constants';
 
 export const getNavbarStyles = ({

--- a/packages/components/navbar/src/NavbarAccount/NavbarAccount.styles.ts
+++ b/packages/components/navbar/src/NavbarAccount/NavbarAccount.styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
-import { NavbarAccountProps } from './NavbarAccount';
+import type { NavbarAccountProps } from './NavbarAccount';
 import { getGlowOnFocusStyles, increaseHitArea } from '../utils.styles';
 
 const notificationVarianColorMap: Record<

--- a/packages/components/navbar/src/NavbarSwitcher/NavbarEnvVariant.tsx
+++ b/packages/components/navbar/src/NavbarSwitcher/NavbarEnvVariant.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NavbarSwitcherProps } from '../NavbarSwitcher/NavbarSwitcher';
+import type { NavbarSwitcherProps } from '../NavbarSwitcher/NavbarSwitcher';
 import {
   EnvironmentAliasIcon,
   EnvironmentIcon,

--- a/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcher.styles.ts
+++ b/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcher.styles.ts
@@ -3,7 +3,7 @@ import tokens from '@contentful/f36-tokens';
 import { hexToRGBA } from '@contentful/f36-utils';
 
 import { getGlowOnFocusStyles, increaseHitArea, mqs } from '../utils.styles';
-import { EnvVariant } from './NavbarSwitcher';
+import type { EnvVariant } from './NavbarSwitcher';
 
 const BORDER_WIDTH = 1;
 

--- a/packages/components/skeleton/src/SkeletonBodyText/SkeletonBodyText.tsx
+++ b/packages/components/skeleton/src/SkeletonBodyText/SkeletonBodyText.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
-import { Skeleton } from '../index';
-import type { SkeletonTextProps } from '../SkeletonText/SkeletonText';
+import {
+  SkeletonText,
+  type SkeletonTextProps,
+} from '../SkeletonText/SkeletonText';
 
 export const SkeletonBodyText = ({
   lineHeight = 16,
@@ -12,7 +14,7 @@ export const SkeletonBodyText = ({
   ...otherProps
 }: SkeletonTextProps) => {
   return (
-    <Skeleton.Text
+    <SkeletonText
       lineHeight={lineHeight}
       marginBottom={marginBottom}
       numberOfLines={

--- a/packages/components/skeleton/src/SkeletonDisplayText/SkeletonDisplayText.tsx
+++ b/packages/components/skeleton/src/SkeletonDisplayText/SkeletonDisplayText.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
-import { Skeleton } from '../index';
-import type { SkeletonTextProps } from '../SkeletonText/SkeletonText';
+import {
+  SkeletonText,
+  type SkeletonTextProps,
+} from '../SkeletonText/SkeletonText';
 
 export const SkeletonDisplayText = ({
   lineHeight = 21,
@@ -13,7 +15,7 @@ export const SkeletonDisplayText = ({
   ...otherProps
 }: SkeletonTextProps): React.ReactElement => {
   return (
-    <Skeleton.Text
+    <SkeletonText
       lineHeight={lineHeight}
       marginBottom={marginBottom}
       numberOfLines={numberOfLines}

--- a/packages/components/skeleton/src/SkeletonRow/SkeletonTableCell/SkeletonTableCell.tsx
+++ b/packages/components/skeleton/src/SkeletonRow/SkeletonTableCell/SkeletonTableCell.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import { TableCell } from '@contentful/f36-table';
 
-import { Skeleton } from '../../index';
+import { SkeletonBodyText } from '../../SkeletonBodyText/SkeletonBodyText';
+import { SkeletonContainer } from '../../SkeletonContainer/SkeletonContainer';
 
 export const SkeletonTableCell = () => {
   return (
     <TableCell>
-      <Skeleton.Container
+      <SkeletonContainer
         svgHeight={16} // This is equal to the default height of a SkeletonText line, if no value is passed the svg will be bigger than the line
       >
-        <Skeleton.BodyText numberOfLines={1} />
-      </Skeleton.Container>
+        <SkeletonBodyText numberOfLines={1} />
+      </SkeletonContainer>
     </TableCell>
   );
 };

--- a/packages/components/table/src/tableContext.ts
+++ b/packages/components/table/src/tableContext.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from 'react';
-import { TableProps } from './Table';
+import type { TableProps } from './Table';
 
 type TableContext = {
   verticalAlign?: TableProps['verticalAlign'];

--- a/packages/components/text-link/src/TextLink.styles.ts
+++ b/packages/components/text-link/src/TextLink.styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
-import { TextLinkProps } from './TextLink';
+import type { TextLinkProps } from './TextLink';
 import { TextLinkVariant } from './types';
 
 const variantToStyles = (variant: TextLinkVariant) => {

--- a/packages/components/tooltip/src/TooltipTrigger.tsx
+++ b/packages/components/tooltip/src/TooltipTrigger.tsx
@@ -1,7 +1,7 @@
 import React, { HTMLAttributes, ReactNode } from 'react';
 import { useTooltipContext } from './TooltipContext';
 import { useMergeRefs } from '@floating-ui/react';
-import { TooltipInternalProps } from './Tooltip';
+import type { TooltipInternalProps } from './Tooltip';
 import { cx } from '@emotion/css';
 
 function getChildRef(

--- a/packages/components/usage-card/src/UsageCard.styles.ts
+++ b/packages/components/usage-card/src/UsageCard.styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
-import { UsageCardProps } from './UsageCard';
+import type { UsageCardProps } from './UsageCard';
 
 const variantToStyles = (variant: UsageCardProps['variant']) => {
   switch (variant) {

--- a/packages/components/usage-count/src/UsageCount.styles.ts
+++ b/packages/components/usage-count/src/UsageCount.styles.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
-import { Variant } from './UsageCount';
+import type { Variant } from './UsageCount';
 
 const variantToStyles = (variant: Variant) => {
   switch (variant) {

--- a/packages/f36-ai-components/src/AIChatHistory/AIChatHistoryTabs/AIChatHistoryTabs.tsx
+++ b/packages/f36-ai-components/src/AIChatHistory/AIChatHistoryTabs/AIChatHistoryTabs.tsx
@@ -2,7 +2,7 @@ import { Text } from '@contentful/f36-components';
 import { Box, type CommonProps } from '@contentful/f36-core';
 import { cx } from '@emotion/css';
 import React, { forwardRef, Ref } from 'react';
-import { MessageGroups } from '../AIChatHistory';
+import type { MessageGroups } from '../AIChatHistory';
 import { getStyles } from './AIChatHistoryTabs.styles';
 
 export interface AIChatHistoryTabsProps extends CommonProps {

--- a/packages/f36-ai-components/src/AIChatHistory/AIChatHistoryThread/AIChatHistoryThread.tsx
+++ b/packages/f36-ai-components/src/AIChatHistory/AIChatHistoryThread/AIChatHistoryThread.tsx
@@ -7,7 +7,7 @@ import {
 import { Box, type CommonProps } from '@contentful/f36-core';
 import { cx } from '@emotion/css';
 import React, { forwardRef, Ref } from 'react';
-import { MessageThread } from '../AIChatHistory';
+import type { MessageThread } from '../AIChatHistory';
 import { getStyles } from './AIChatHistoryThread.styles';
 
 export interface AIChatHistoryThreadProps extends CommonProps {

--- a/packages/f36-ai-components/src/AIChatInput/AIChatSubmitButton.tsx
+++ b/packages/f36-ai-components/src/AIChatInput/AIChatSubmitButton.tsx
@@ -1,7 +1,7 @@
 import { IconButton } from '@contentful/f36-button';
 import { Box } from '@contentful/f36-core';
 import { ArrowUpIcon } from '@contentful/f36-icons';
-import { AIChatInputProps } from './AIChatInput';
+import type { AIChatInputProps } from './AIChatInput';
 import { getStyles } from './AIChatInput.styles';
 import React from 'react';
 

--- a/packages/f36-ai-components/src/AIChatInput/AIChatTextArea.tsx
+++ b/packages/f36-ai-components/src/AIChatInput/AIChatTextArea.tsx
@@ -5,7 +5,7 @@ import Document from '@tiptap/extension-document';
 import Paragraph from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
 import { Placeholder, UndoRedo } from '@tiptap/extensions';
-import { AIChatInputProps } from './AIChatInput';
+import type { AIChatInputProps } from './AIChatInput';
 import { createAiChatMentionExtension } from './AIChatInputMentionExtention';
 
 type AIChatInputTextAreaProps = Pick<


### PR DESCRIPTION
## Summary
- convert reverse type dependencies to explicit type-only imports
- replace Skeleton compound self-imports with direct leaf component imports
- remove all 19 Knip circular dependency findings without changing public APIs
- enable global cycle enforcement in the existing Knip CI check

Stacked on #3534.

## Verification
- `npm exec knip -- --no-config-hints`
- builds for all 15 affected packages
- 26 targeted suites, 164 tests passed
- `npm run tsc`
- `npm run lint`