### PR TITLE
ci: check unresolved imports and binaries

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -4,6 +4,8 @@
     "files",
     "dependencies",
     "devDependencies",
+    "binaries",
+    "unresolved",
     "exports",
     "nsExports",
     "types",
@@ -42,7 +44,8 @@
         "scripts/plopfile.js",
         "scripts/plop-templates/**/*.js",
         "scripts/test/*.{js,ts}"
-      ]
+      ],
+      "ignoreUnresolved": ["^\\.\\./\\.\\./utils(?:/config)?$"]
     },
     "packages/components/*": {
       "entry": [

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
   "homepage": "https://github.com/contentful/forma-36#readme",
   "scripts": {
     "build": "turbo run build",
-    "commit": "git-cz",
-    "commitmsg": "validate-commit-msg",
     "generate": "plop --plopfile scripts/plopfile.js",
     "lint": "npm run-script lint:js && npm run-script lint:packages",
     "lint:js": "eslint packages --ext .js,.jsx,.ts,.tsx",


### PR DESCRIPTION
## Summary
- remove two stale npm scripts whose binaries are not installed
- enable Knip checks for unresolved imports and unlisted binaries
- ignore the generated codemod template destination-relative utility imports with a narrow regex
- leave the configured Knip run with zero findings

## Verification
- `npm exec knip -- --no-config-hints`
- `npm run tsc`
- `npm run lint` (12 existing warnings)