### PR TITLE
chore(deps): declare csstype consumers

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -4,6 +4,8 @@
     "files",
     "dependencies",
     "devDependencies",
+    "binaries",
+    "unresolved",
     "exports",
     "nsExports",
     "types",
@@ -42,7 +44,8 @@
         "scripts/plopfile.js",
         "scripts/plop-templates/**/*.js",
         "scripts/test/*.{js,ts}"
-      ]
+      ],
+      "ignoreUnresolved": ["^\\.\\./\\.\\./utils(?:/config)?$"]
     },
     "packages/components/*": {
       "entry": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -41950,7 +41950,8 @@
         "@contentful/f36-icons": "^6.16.2",
         "@contentful/f36-tokens": "^6.1.3",
         "@contentful/f36-utils": "^6.1.2",
-        "@emotion/css": "^11.13.5"
+        "@emotion/css": "^11.13.5",
+        "csstype": "^3.1.1"
       },
       "devDependencies": {
         "@contentful/f36-typography": "^6.16.2"
@@ -42520,7 +42521,8 @@
         "@contentful/f36-tokens": "^6.1.3",
         "@contentful/f36-typography": "^6.16.2",
         "@contentful/f36-utils": "^6.1.2",
-        "@emotion/css": "^11.13.5"
+        "@emotion/css": "^11.13.5",
+        "csstype": "^3.1.1"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42565,7 +42567,8 @@
         "@contentful/f36-core": "^6.16.2",
         "@contentful/f36-tokens": "^6.1.3",
         "@emotion/css": "^11.13.5",
-        "@floating-ui/react": "^0.27.16"
+        "@floating-ui/react": "^0.27.16",
+        "csstype": "^3.1.1"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42580,7 +42583,8 @@
         "@contentful/f36-core": "^6.16.2",
         "@contentful/f36-tokens": "^6.1.3",
         "@contentful/f36-utils": "^6.1.2",
-        "@emotion/css": "^11.13.5"
+        "@emotion/css": "^11.13.5",
+        "csstype": "^3.1.1"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
   "homepage": "https://github.com/contentful/forma-36#readme",
   "scripts": {
     "build": "turbo run build",
-    "commit": "git-cz",
-    "commitmsg": "validate-commit-msg",
     "generate": "plop --plopfile scripts/plopfile.js",
     "lint": "npm run-script lint:js && npm run-script lint:packages",
     "lint:js": "eslint packages --ext .js,.jsx,.ts,.tsx",

--- a/packages/components/badge/package.json
+++ b/packages/components/badge/package.json
@@ -24,7 +24,8 @@
     "@contentful/f36-icons": "^6.16.2",
     "@contentful/f36-tokens": "^6.1.3",
     "@contentful/f36-utils": "^6.1.2",
-    "@emotion/css": "^11.13.5"
+    "@emotion/css": "^11.13.5",
+    "csstype": "^3.1.1"
   },
   "devDependencies": {
     "@contentful/f36-typography": "^6.16.2"

--- a/packages/components/table/package.json
+++ b/packages/components/table/package.json
@@ -11,7 +11,8 @@
     "@contentful/f36-tokens": "^6.1.3",
     "@contentful/f36-typography": "^6.16.2",
     "@contentful/f36-utils": "^6.1.2",
-    "@emotion/css": "^11.13.5"
+    "@emotion/css": "^11.13.5",
+    "csstype": "^3.1.1"
   },
   "peerDependencies": {
     "react": "^18.3.0 || >=19.1.0",

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -9,7 +9,8 @@
     "@contentful/f36-core": "^6.16.2",
     "@contentful/f36-tokens": "^6.1.3",
     "@emotion/css": "^11.13.5",
-    "@floating-ui/react": "^0.27.16"
+    "@floating-ui/react": "^0.27.16",
+    "csstype": "^3.1.1"
   },
   "peerDependencies": {
     "react": "^18.3.0 || >=19.1.0",

--- a/packages/components/typography/package.json
+++ b/packages/components/typography/package.json
@@ -23,7 +23,8 @@
     "@contentful/f36-core": "^6.16.2",
     "@contentful/f36-tokens": "^6.1.3",
     "@contentful/f36-utils": "^6.1.2",
-    "@emotion/css": "^11.13.5"
+    "@emotion/css": "^11.13.5",
+    "csstype": "^3.1.1"
   },
   "peerDependencies": {
     "react": "^18.3.0 || >=19.1.0",


### PR DESCRIPTION
## Summary
- declare `csstype` in the four packages that import it from production source
- reuse the existing `^3.1.1` version and locked package resolution
- reduce Knip unlisted findings from 405 to 401

Stacked on #3540. Unlisted dependency enforcement remains disabled while the examples/tests workspace policy is resolved.

## Verification
- Knip reports zero remaining `csstype` findings
- builds for Badge, Table, Tooltip, and Typography
- `npm exec knip -- --no-config-hints`
- `npm run tsc`
- `npm run lint`