### PR TITLE
chore(deps): declare remaining direct consumers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
       ],
       "devDependencies": {
         "@babel/core": "^7.29.6",
+        "@babel/preset-env": "^7.28.6",
+        "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.27.1",
         "@changesets/assemble-release-plan": "^6.0.9",
         "@changesets/changelog-github": "^0.7.0",
@@ -42550,6 +42552,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-core": "^6.16.2",
+        "@contentful/f36-icon": "^6.16.2",
         "@contentful/f36-icons": "^6.16.2",
         "@contentful/f36-tokens": "^6.1.3",
         "@emotion/css": "^11.13.5"
@@ -43848,6 +43851,7 @@
         "@emotion/babel-preset-css-prop": "^11.12.0",
         "@eslint/eslintrc": "^3",
         "@next/eslint-plugin-next": "^15.5.11",
+        "@types/unist": "^3.0.3",
         "broken-link-checker": "^0.7.8",
         "dotenv": "^16.0.3",
         "prettier": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
   "browserslist": "extends @contentful/browserslist-config",
   "devDependencies": {
     "@babel/core": "^7.29.6",
+    "@babel/preset-env": "^7.28.6",
+    "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.27.1",
     "@changesets/assemble-release-plan": "^6.0.9",
     "@changesets/changelog-github": "^0.7.0",

--- a/packages/components/text-link/package.json
+++ b/packages/components/text-link/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@contentful/f36-core": "^6.16.2",
+    "@contentful/f36-icon": "^6.16.2",
     "@contentful/f36-tokens": "^6.1.3",
     "@contentful/f36-icons": "^6.16.2",
     "@emotion/css": "^11.13.5"

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -61,6 +61,7 @@
     "@emotion/babel-preset-css-prop": "^11.12.0",
     "@eslint/eslintrc": "^3",
     "@next/eslint-plugin-next": "^15.5.11",
+    "@types/unist": "^3.0.3",
     "broken-link-checker": "^0.7.8",
     "dotenv": "^16.0.3",
     "prettier": "^3.8.1",

--- a/types/typings.d.ts
+++ b/types/typings.d.ts
@@ -1,6 +1,4 @@
 /* eslint-disable import/no-default-export */
-/// <reference types="@emotion/react/types/css-prop" />
-
 declare module '*.mdx' {
   let MDXComponent: (props: any) => JSX.Element;
   export default MDXComponent;


### PR DESCRIPTION
## Summary
- declare Babel presets and Emotion React used by root configuration and ambient typings
- declare `@contentful/f36-icon` in TextLink
- declare `@types/unist` in the website workspace
- reduce Knip unlisted findings from 401 to 397

Stacked on #3541. The remaining 397 findings are exclusively in examples, stories, tests, fixtures, and MDX files and need a separate dependency-ownership policy.

## Verification
- `npm exec knip -- --no-config-hints`
- `npm exec knip -- --include unlisted --no-config-hints --no-exit-code --reporter json` (no production/config findings)
- `npm run build --workspace @contentful/f36-text-link`
- `npm test -- --runInBand packages/components/text-link/src/TextLink.test.tsx` (17 tests)
- `npm run tsc`
- `npm run lint` (12 existing warnings)