### PR TITLE
chore(deps): remove emnapi workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,10 +83,6 @@
         "node": ">=22.12.0",
         "npm": ">=8.11.0",
         "yarn": "Please use npm"
-      },
-      "optionalDependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -133,10 +133,6 @@
     "npm": ">=8.11.0",
     "yarn": "Please use npm"
   },
-  "optionalDependencies": {
-    "@emnapi/core": "1.11.1",
-    "@emnapi/runtime": "1.11.1"
-  },
   "overrides": {
     "@emotion/eslint-plugin": {
       "eslint": ">=9.0.0"


### PR DESCRIPTION
## Summary

- remove the direct `@emnapi/core` and `@emnapi/runtime` optional dependencies
- leave their transitive, platform-specific dependency entries managed by Storybook/OXC and Sharp
- supersede Renovate PRs #3499 and #3500

These dependencies were added in #3431 to work around an npm/CircleCI lockfile issue after the Storybook 10 upgrade. Current consumers now declare their own emnapi dependencies, so the root pins should no longer be necessary. This draft lets CI verify the original Linux install failure does not return.

## Verification

- `npm ci`
- `npm run tsc`
- `npm run lint` (passes with 12 existing warnings)