### PR TITLE
chore(deps): remove redundant wizer binary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2688,22 +2688,6 @@
         "wizer-linux-s390x": "wizer"
       }
     },
-    "node_modules/@bytecodealliance/wizer-linux-x64": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-x64/-/wizer-linux-x64-9.0.0.tgz",
-      "integrity": "sha512-ck6PujNYFOKMCm1qL21NwJ396JGMmRwsiV/JXMaUMxt8+jJtc1d/tsLZyxx3ltcurB+IHWD7+VhaPvI+tJvAUQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "wizer-linux-x64": "wizer"
-      }
-    },
     "node_modules/@bytecodealliance/wizer-win32-x64": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-win32-x64/-/wizer-win32-x64-7.0.5.tgz",
@@ -41863,7 +41847,6 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@bytecodealliance/wizer-linux-x64": "^9.0.0",
         "@napi-rs/lzma-linux-x64-gnu": "^1.4.5"
       }
     },

--- a/packages/cdn/package.json
+++ b/packages/cdn/package.json
@@ -21,7 +21,6 @@
     "serve": "fastly compute serve"
   },
   "optionalDependencies": {
-    "@bytecodealliance/wizer-linux-x64": "^9.0.0",
     "@napi-rs/lzma-linux-x64-gnu": "^1.4.5"
   }
 }


### PR DESCRIPTION
## Summary

- remove the direct `@bytecodealliance/wizer-linux-x64@^9` optional dependency from the CDN workspace
- keep the platform binary supplied by `@fastly/js-compute -> @bytecodealliance/wizer@7.0.5`
- remove the unused standalone Wizer 9 binary from the lockfile

This dependency was originally added as a workaround while regenerating platform-specific optional dependencies in the npm lockfile. It is no longer the source of the binary used by Fastly: `@bytecodealliance/wizer@7.0.5` declares and resolves its matching `@bytecodealliance/wizer-linux-x64@7.0.5` package.

The Linux CI build is the final safety check that the transitive optional dependency installs correctly.

## Verification

- `npx --yes npm@8.19.4 ci --ignore-scripts`
- `npm run build --workspace=@contentful/f36-cdn`
- `npm run tsc`
- `npm run lint`