### PR TITLE
chore(deps): declare user-event test consumers

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -53,7 +53,10 @@
         "src/**/*.{test,figma}.{js,jsx,ts,tsx}",
         "stories/**/*.{js,jsx,ts,tsx}",
         "**/examples/**/*.{js,jsx,ts,tsx}"
-      ]
+      ],
+      "ignoreIssues": {
+        "**/examples/**/*.{js,jsx,ts,tsx}": ["unlisted"]
+      }
     },
     "packages/cdn": {
       "entry": ["src/index.js", "static-publish.rc.js"]
@@ -64,7 +67,10 @@
         "src/**/*.test.{js,jsx,ts,tsx}",
         "src/**/examples/**/*.{js,jsx,ts,tsx}",
         "stories/**/*.{js,jsx,ts,tsx}"
-      ]
+      ],
+      "ignoreIssues": {
+        "src/**/examples/**/*.{js,jsx,ts,tsx}": ["unlisted"]
+      }
     },
     "packages/f36-ai-components": {
       "entry": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -38902,7 +38902,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38920,7 +38919,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38938,7 +38936,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38956,7 +38953,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38974,7 +38970,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -38992,7 +38987,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39010,7 +39004,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39028,7 +39021,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39046,7 +39038,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39064,7 +39055,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39082,7 +39072,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39100,7 +39089,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39118,7 +39106,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39136,7 +39123,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39154,7 +39140,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39172,7 +39157,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39190,7 +39174,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39208,7 +39191,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39226,7 +39208,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39244,7 +39225,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39262,7 +39242,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39280,7 +39259,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39298,7 +39276,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39316,7 +39293,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39334,7 +39310,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -39352,7 +39327,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -41861,7 +41835,11 @@
         "@emotion/css": "^11.13.5"
       },
       "devDependencies": {
-        "@testing-library/user-event": "^14.6.1"
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -41879,6 +41857,12 @@
         "@contentful/f36-tokens": "^6.1.3",
         "@contentful/f36-typography": "^6.16.2",
         "@emotion/css": "^11.13.5"
+      },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -41903,6 +41887,8 @@
         "downshift": "^9.0.10"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1"
       },
       "peerDependencies": {
@@ -41945,7 +41931,12 @@
         "@emotion/css": "^11.13.5"
       },
       "devDependencies": {
-        "@testing-library/user-event": "^14.6.1"
+        "@contentful/f36-icons": "^6.16.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -41965,7 +41956,11 @@
         "csstype": "^3.1.1"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^6.16.2"
+        "@contentful/f36-typography": "^6.16.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -41987,7 +41982,11 @@
       "devDependencies": {
         "@contentful/f36-icon": "^6.16.2",
         "@contentful/f36-icons": "^6.16.2",
-        "@testing-library/user-event": "^14.6.1"
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42015,7 +42014,11 @@
         "truncate": "^3.0.0"
       },
       "devDependencies": {
-        "@testing-library/user-event": "^14.6.1"
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42032,7 +42035,11 @@
         "@emotion/css": "^11.13.5"
       },
       "devDependencies": {
-        "@testing-library/user-event": "^14.6.1"
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42051,7 +42058,11 @@
         "@emotion/css": "^11.13.5"
       },
       "devDependencies": {
-        "@testing-library/user-event": "^14.6.1"
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42075,7 +42086,11 @@
         "react-focus-lock": "^2.9.1"
       },
       "devDependencies": {
-        "@testing-library/user-event": "^14.6.1"
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42089,6 +42104,10 @@
       "dependencies": {
         "@contentful/f36-core": "^6.16.2",
         "dayjs": "^1.11.5"
+      },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42107,7 +42126,10 @@
         "@emotion/css": "^11.13.5"
       },
       "devDependencies": {
-        "@testing-library/user-event": "^14.6.1"
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42145,6 +42167,13 @@
         "@contentful/f36-typography": "^6.16.2",
         "@emotion/css": "^11.13.5"
       },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42164,8 +42193,13 @@
         "@emotion/css": "^11.13.5"
       },
       "devDependencies": {
+        "@contentful/f36-button": "^6.16.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
         "formik": "^2.4.2",
+        "jest-axe": "^10.0.0",
         "react-hook-form": "^7.15.0"
       },
       "peerDependencies": {
@@ -42185,6 +42219,13 @@
         "@contentful/f36-typography": "^6.16.2",
         "@emotion/css": "^11.13.5"
       },
+      "devDependencies": {
+        "@contentful/f36-forms": "^6.16.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42201,6 +42242,8 @@
         "@phosphor-icons/react": "2.1.8"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
         "react-icons": "^4.4.0",
         "tsconfig-to-dual-package": "^1.2.0"
       },
@@ -42243,6 +42286,12 @@
         "@contentful/f36-skeleton": "^6.16.2",
         "@emotion/css": "^11.13.5"
       },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42261,6 +42310,12 @@
         "@contentful/f36-typography": "^6.16.2",
         "@emotion/css": "^11.13.5"
       },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42274,6 +42329,12 @@
         "@contentful/f36-core": "^6.16.2",
         "@contentful/f36-tokens": "^6.1.3",
         "@emotion/css": "^11.13.5"
+      },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42293,6 +42354,9 @@
         "@floating-ui/react": "^0.27.16"
       },
       "devDependencies": {
+        "@contentful/f36-button": "^6.16.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.9.2",
         "react-router-dom": "^7.17.0"
@@ -42326,6 +42390,12 @@
         "@types/react-modal": "^3.16.3",
         "react-modal": "^3.16.3"
       },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42348,7 +42418,11 @@
         "@emotion/css": "^11.13.5"
       },
       "devDependencies": {
-        "@testing-library/user-event": "^14.6.1"
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42387,6 +42461,12 @@
         "@contentful/f36-tokens": "^6.1.3",
         "@emotion/css": "^11.13.5"
       },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42405,6 +42485,12 @@
         "@contentful/f36-typography": "^6.16.2",
         "@contentful/f36-utils": "^6.1.2",
         "@emotion/css": "^11.13.5"
+      },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42425,6 +42511,12 @@
         "@emotion/css": "^11.13.5",
         "react-animate-height": "^3.0.4"
       },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42442,7 +42534,11 @@
         "@contentful/f36-typography": "^6.16.2"
       },
       "devDependencies": {
-        "@testing-library/user-event": "^14.6.1"
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42462,6 +42558,12 @@
         "@contentful/f36-tooltip": "^6.16.2",
         "@emotion/css": "^11.13.5"
       },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42479,6 +42581,12 @@
         "@contentful/f36-tooltip": "^6.16.2",
         "@emotion/css": "^11.13.5"
       },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42495,7 +42603,12 @@
         "@floating-ui/react": "^0.27.16"
       },
       "devDependencies": {
-        "@testing-library/user-event": "^14.6.1"
+        "@contentful/f36-button": "^6.16.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42513,6 +42626,12 @@
         "@contentful/f36-tokens": "^6.1.3",
         "@emotion/css": "^11.13.5"
       },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42526,6 +42645,12 @@
         "@contentful/f36-core": "^6.16.2",
         "@contentful/f36-table": "^6.16.2",
         "@contentful/f36-tokens": "^6.1.3"
+      },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42542,7 +42667,11 @@
         "@emotion/css": "^11.13.5"
       },
       "devDependencies": {
-        "@contentful/f36-typography": "^6.16.2"
+        "@contentful/f36-typography": "^6.16.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42563,7 +42692,11 @@
         "csstype": "^3.1.1"
       },
       "devDependencies": {
-        "@testing-library/user-event": "^14.6.1"
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42579,6 +42712,12 @@
         "@contentful/f36-tokens": "^6.1.3",
         "@emotion/css": "^11.13.5",
         "@radix-ui/react-tabs": "^1.1.12"
+      },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42597,7 +42736,11 @@
         "@emotion/css": "^11.13.5"
       },
       "devDependencies": {
-        "@testing-library/user-event": "^14.6.1"
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42616,7 +42759,13 @@
         "csstype": "^3.1.1"
       },
       "devDependencies": {
-        "@testing-library/user-event": "^14.6.1"
+        "@contentful/f36-icons": "^6.16.2",
+        "@contentful/f36-typography": "^6.16.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42633,6 +42782,12 @@
         "@contentful/f36-utils": "^6.1.2",
         "@emotion/css": "^11.13.5",
         "csstype": "^3.1.1"
+      },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42653,6 +42808,13 @@
         "@contentful/f36-typography": "^6.16.2",
         "@emotion/css": "^11.13.5"
       },
+      "devDependencies": {
+        "@contentful/f36-usage-count": "^6.16.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42668,6 +42830,12 @@
         "@contentful/f36-typography": "^6.16.2",
         "@emotion/css": "^11.13.5"
       },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42679,6 +42847,10 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^6.1.2"
+      },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42694,6 +42866,12 @@
         "@emotion/css": "^11.13.5",
         "@emotion/react": "^11.14.0",
         "csstype": "^3.1.1"
+      },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42719,6 +42897,8 @@
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "@tiptap/core": "3.27.3",
         "@tiptap/extension-document": "3.27.3",
@@ -42728,7 +42908,9 @@
         "@tiptap/extensions": "3.27.3",
         "@tiptap/pm": "3.27.3",
         "@tiptap/react": "3.27.3",
-        "@tiptap/suggestion": "3.27.3"
+        "@tiptap/suggestion": "3.27.3",
+        "@types/jest-axe": "^3.5.9",
+        "jest-axe": "^10.0.0"
       },
       "peerDependencies": {
         "@tiptap/core": "^3.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41860,6 +41860,9 @@
         "@contentful/f36-typography": "^6.16.2",
         "@emotion/css": "^11.13.5"
       },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -41898,6 +41901,9 @@
         "@contentful/f36-utils": "^6.1.2",
         "@emotion/css": "^11.13.5",
         "downshift": "^9.0.10"
+      },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -41938,6 +41944,9 @@
         "@contentful/f36-tooltip": "^6.16.2",
         "@emotion/css": "^11.13.5"
       },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -41977,7 +41986,8 @@
       },
       "devDependencies": {
         "@contentful/f36-icon": "^6.16.2",
-        "@contentful/f36-icons": "^6.16.2"
+        "@contentful/f36-icons": "^6.16.2",
+        "@testing-library/user-event": "^14.6.1"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42004,6 +42014,9 @@
         "@emotion/css": "^11.13.5",
         "truncate": "^3.0.0"
       },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42017,6 +42030,9 @@
         "@contentful/f36-core": "^6.16.2",
         "@contentful/f36-tokens": "^6.1.3",
         "@emotion/css": "^11.13.5"
+      },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42033,6 +42049,9 @@
         "@contentful/f36-icons": "^6.16.2",
         "@contentful/f36-tooltip": "^6.16.2",
         "@emotion/css": "^11.13.5"
+      },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42054,6 +42073,9 @@
         "date-fns": "^2.28.0",
         "react-day-picker": "^8.10.2",
         "react-focus-lock": "^2.9.1"
+      },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42083,6 +42105,9 @@
         "@contentful/f36-tokens": "^6.1.3",
         "@contentful/f36-utils": "^6.1.2",
         "@emotion/css": "^11.13.5"
+      },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42139,6 +42164,7 @@
         "@emotion/css": "^11.13.5"
       },
       "devDependencies": {
+        "@testing-library/user-event": "^14.6.1",
         "formik": "^2.4.2",
         "react-hook-form": "^7.15.0"
       },
@@ -42267,6 +42293,7 @@
         "@floating-ui/react": "^0.27.16"
       },
       "devDependencies": {
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.9.2",
         "react-router-dom": "^7.17.0"
       },
@@ -42319,6 +42346,9 @@
         "@contentful/f36-typography": "^6.16.2",
         "@contentful/f36-utils": "^6.1.2",
         "@emotion/css": "^11.13.5"
+      },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42411,6 +42441,9 @@
         "@contentful/f36-icons": "^6.16.2",
         "@contentful/f36-typography": "^6.16.2"
       },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42460,6 +42493,9 @@
         "@contentful/f36-tokens": "^6.1.3",
         "@emotion/css": "^11.13.5",
         "@floating-ui/react": "^0.27.16"
+      },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42526,6 +42562,9 @@
         "@emotion/css": "^11.13.5",
         "csstype": "^3.1.1"
       },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42557,6 +42596,9 @@
         "@contentful/f36-tokens": "^6.1.3",
         "@emotion/css": "^11.13.5"
       },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
+      },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
         "react-dom": "^18.3.0 || >=19.1.0"
@@ -42572,6 +42614,9 @@
         "@emotion/css": "^11.13.5",
         "@floating-ui/react": "^0.27.16",
         "csstype": "^3.1.1"
+      },
+      "devDependencies": {
+        "@testing-library/user-event": "^14.6.1"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",
@@ -42674,6 +42719,7 @@
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
+        "@testing-library/user-event": "^14.6.1",
         "@tiptap/core": "3.27.3",
         "@tiptap/extension-document": "3.27.3",
         "@tiptap/extension-mention": "3.27.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
       ],
       "devDependencies": {
         "@babel/core": "^7.29.6",
+        "@babel/preset-env": "^7.28.6",
+        "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.27.1",
         "@changesets/assemble-release-plan": "^6.0.9",
         "@changesets/changelog-github": "^0.7.0",
@@ -42550,6 +42552,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/f36-core": "^6.16.2",
+        "@contentful/f36-icon": "^6.16.2",
         "@contentful/f36-icons": "^6.16.2",
         "@contentful/f36-tokens": "^6.1.3",
         "@emotion/css": "^11.13.5"
@@ -43848,6 +43851,7 @@
         "@emotion/babel-preset-css-prop": "^11.12.0",
         "@eslint/eslintrc": "^3",
         "@next/eslint-plugin-next": "^15.5.11",
+        "@types/unist": "^3.0.3",
         "broken-link-checker": "^0.7.8",
         "dotenv": "^16.0.3",
         "prettier": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
   "browserslist": "extends @contentful/browserslist-config",
   "devDependencies": {
     "@babel/core": "^7.29.6",
+    "@babel/preset-env": "^7.28.6",
+    "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.27.1",
     "@changesets/assemble-release-plan": "^6.0.9",
     "@changesets/changelog-github": "^0.7.0",

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -36,6 +36,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^14.6.1"
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -34,5 +34,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/asset/package.json
+++ b/packages/components/asset/package.json
@@ -34,5 +34,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/autocomplete/package.json
+++ b/packages/components/autocomplete/package.json
@@ -9,14 +9,14 @@
     "@contentful/f36-button": "^6.16.2",
     "@contentful/f36-core": "^6.16.2",
     "@contentful/f36-forms": "^6.16.2",
+    "@contentful/f36-icons": "^6.16.2",
     "@contentful/f36-popover": "^6.16.2",
     "@contentful/f36-skeleton": "^6.16.2",
-    "@contentful/f36-icons": "^6.16.2",
     "@contentful/f36-tokens": "^6.1.3",
     "@contentful/f36-typography": "^6.16.2",
     "@contentful/f36-utils": "^6.1.2",
-    "downshift": "^9.0.10",
-    "@emotion/css": "^11.13.5"
+    "@emotion/css": "^11.13.5",
+    "downshift": "^9.0.10"
   },
   "peerDependencies": {
     "react": "^18.3.0 || >=19.1.0",
@@ -39,5 +39,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/autocomplete/package.json
+++ b/packages/components/autocomplete/package.json
@@ -41,6 +41,8 @@
     "access": "public"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -36,6 +36,11 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^14.6.1"
+    "@contentful/f36-icons": "^6.16.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -34,5 +34,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/badge/package.json
+++ b/packages/components/badge/package.json
@@ -28,7 +28,11 @@
     "csstype": "^3.1.1"
   },
   "devDependencies": {
-    "@contentful/f36-typography": "^6.16.2"
+    "@contentful/f36-typography": "^6.16.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   },
   "peerDependencies": {
     "react": "^18.3.0 || >=19.1.0",

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -15,7 +15,8 @@
   },
   "devDependencies": {
     "@contentful/f36-icon": "^6.16.2",
-    "@contentful/f36-icons": "^6.16.2"
+    "@contentful/f36-icons": "^6.16.2",
+    "@testing-library/user-event": "^14.6.1"
   },
   "peerDependencies": {
     "react": "^18.3.0 || >=19.1.0",

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -16,7 +16,11 @@
   "devDependencies": {
     "@contentful/f36-icon": "^6.16.2",
     "@contentful/f36-icons": "^6.16.2",
-    "@testing-library/user-event": "^14.6.1"
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   },
   "peerDependencies": {
     "react": "^18.3.0 || >=19.1.0",

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -44,6 +44,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^14.6.1"
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -42,5 +42,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/collapse/package.json
+++ b/packages/components/collapse/package.json
@@ -33,6 +33,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^14.6.1"
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/collapse/package.json
+++ b/packages/components/collapse/package.json
@@ -31,5 +31,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/copybutton/package.json
+++ b/packages/components/copybutton/package.json
@@ -35,6 +35,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^14.6.1"
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/copybutton/package.json
+++ b/packages/components/copybutton/package.json
@@ -33,5 +33,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/datepicker/package.json
+++ b/packages/components/datepicker/package.json
@@ -40,6 +40,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^14.6.1"
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/datepicker/package.json
+++ b/packages/components/datepicker/package.json
@@ -6,11 +6,11 @@
     "build": "tsup"
   },
   "dependencies": {
+    "@contentful/f36-button": "^6.16.2",
     "@contentful/f36-core": "^6.16.2",
     "@contentful/f36-forms": "^6.16.2",
-    "@contentful/f36-popover": "^6.16.2",
     "@contentful/f36-icons": "^6.16.2",
-    "@contentful/f36-button": "^6.16.2",
+    "@contentful/f36-popover": "^6.16.2",
     "@contentful/f36-tokens": "^6.1.3",
     "@emotion/css": "^11.13.5",
     "date-fns": "^2.28.0",
@@ -38,5 +38,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/datetime/package.json
+++ b/packages/components/datetime/package.json
@@ -30,5 +30,9 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0"
   }
 }

--- a/packages/components/drag-handle/package.json
+++ b/packages/components/drag-handle/package.json
@@ -8,8 +8,8 @@
   "dependencies": {
     "@contentful/f36-core": "^6.16.2",
     "@contentful/f36-icons": "^6.16.2",
-    "@contentful/f36-utils": "^6.1.2",
     "@contentful/f36-tokens": "^6.1.3",
+    "@contentful/f36-utils": "^6.1.2",
     "@emotion/css": "^11.13.5"
   },
   "peerDependencies": {
@@ -33,5 +33,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/entity-list/package.json
+++ b/packages/components/entity-list/package.json
@@ -41,6 +41,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^14.6.1"
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/entity-list/package.json
+++ b/packages/components/entity-list/package.json
@@ -39,5 +39,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/forms/package.json
+++ b/packages/components/forms/package.json
@@ -37,8 +37,13 @@
     "access": "public"
   },
   "devDependencies": {
+    "@contentful/f36-button": "^6.16.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
     "formik": "^2.4.2",
+    "jest-axe": "^10.0.0",
     "react-hook-form": "^7.15.0"
   }
 }

--- a/packages/components/forms/package.json
+++ b/packages/components/forms/package.json
@@ -37,6 +37,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@testing-library/user-event": "^14.6.1",
     "formik": "^2.4.2",
     "react-hook-form": "^7.15.0"
   }

--- a/packages/components/header/package.json
+++ b/packages/components/header/package.json
@@ -34,5 +34,12 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@contentful/f36-forms": "^6.16.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -33,10 +33,12 @@
   "dependencies": {
     "@contentful/f36-core": "^6.16.2",
     "@contentful/f36-tokens": "^6.1.3",
-    "@phosphor-icons/react": "2.1.8",
-    "@emotion/css": "^11.13.5"
+    "@emotion/css": "^11.13.5",
+    "@phosphor-icons/react": "2.1.8"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
     "react-icons": "^4.4.0",
     "tsconfig-to-dual-package": "^1.2.0"
   },

--- a/packages/components/image/package.json
+++ b/packages/components/image/package.json
@@ -31,5 +31,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/layout/package.json
+++ b/packages/components/layout/package.json
@@ -35,5 +35,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/list/package.json
+++ b/packages/components/list/package.json
@@ -31,5 +31,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -14,6 +14,7 @@
     "@floating-ui/react": "^0.27.16"
   },
   "devDependencies": {
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.9.2",
     "react-router-dom": "^7.17.0"
   },

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -14,6 +14,9 @@
     "@floating-ui/react": "^0.27.16"
   },
   "devDependencies": {
+    "@contentful/f36-button": "^6.16.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.9.2",
     "react-router-dom": "^7.17.0"

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -11,8 +11,8 @@
     "@contentful/f36-icons": "^6.16.2",
     "@contentful/f36-tokens": "^6.1.3",
     "@contentful/f36-typography": "^6.16.2",
-    "@types/react-modal": "^3.16.3",
     "@emotion/css": "^11.13.5",
+    "@types/react-modal": "^3.16.3",
     "react-modal": "^3.16.3"
   },
   "peerDependencies": {
@@ -36,5 +36,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/multiselect/package.json
+++ b/packages/components/multiselect/package.json
@@ -40,6 +40,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^14.6.1"
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/multiselect/package.json
+++ b/packages/components/multiselect/package.json
@@ -38,5 +38,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/navlist/package.json
+++ b/packages/components/navlist/package.json
@@ -31,5 +31,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/note/package.json
+++ b/packages/components/note/package.json
@@ -11,8 +11,8 @@
     "@contentful/f36-icon": "^6.16.2",
     "@contentful/f36-icons": "^6.16.2",
     "@contentful/f36-tokens": "^6.1.3",
-    "@contentful/f36-utils": "^6.1.2",
     "@contentful/f36-typography": "^6.16.2",
+    "@contentful/f36-utils": "^6.1.2",
     "@emotion/css": "^11.13.5"
   },
   "peerDependencies": {
@@ -36,5 +36,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/notification/package.json
+++ b/packages/components/notification/package.json
@@ -36,5 +36,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -35,6 +35,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^14.6.1"
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -33,5 +33,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/pill-next/package.json
+++ b/packages/components/pill-next/package.json
@@ -35,5 +35,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/pill/package.json
+++ b/packages/components/pill/package.json
@@ -35,5 +35,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -34,6 +34,11 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^14.6.1"
+    "@contentful/f36-button": "^6.16.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -32,5 +32,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/progress-stepper/package.json
+++ b/packages/components/progress-stepper/package.json
@@ -33,5 +33,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/skeleton/package.json
+++ b/packages/components/skeleton/package.json
@@ -31,5 +31,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -11,7 +11,11 @@
     "@emotion/css": "^11.13.5"
   },
   "devDependencies": {
-    "@contentful/f36-typography": "^6.16.2"
+    "@contentful/f36-typography": "^6.16.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   },
   "peerDependencies": {
     "react": "^18.3.0 || >=19.1.0",

--- a/packages/components/table/package.json
+++ b/packages/components/table/package.json
@@ -37,6 +37,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^14.6.1"
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/table/package.json
+++ b/packages/components/table/package.json
@@ -35,5 +35,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -32,5 +32,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/text-link/package.json
+++ b/packages/components/text-link/package.json
@@ -35,6 +35,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^14.6.1"
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/text-link/package.json
+++ b/packages/components/text-link/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@contentful/f36-core": "^6.16.2",
+    "@contentful/f36-icon": "^6.16.2",
     "@contentful/f36-tokens": "^6.1.3",
     "@contentful/f36-icons": "^6.16.2",
     "@emotion/css": "^11.13.5"

--- a/packages/components/text-link/package.json
+++ b/packages/components/text-link/package.json
@@ -8,8 +8,8 @@
   "dependencies": {
     "@contentful/f36-core": "^6.16.2",
     "@contentful/f36-icon": "^6.16.2",
-    "@contentful/f36-tokens": "^6.1.3",
     "@contentful/f36-icons": "^6.16.2",
+    "@contentful/f36-tokens": "^6.1.3",
     "@emotion/css": "^11.13.5"
   },
   "peerDependencies": {
@@ -33,5 +33,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -35,6 +35,12 @@
     "access": "public"
   },
   "devDependencies": {
-    "@testing-library/user-event": "^14.6.1"
+    "@contentful/f36-icons": "^6.16.2",
+    "@contentful/f36-typography": "^6.16.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -33,5 +33,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/tooltip/src/Tooltip.figma.tsx
+++ b/packages/components/tooltip/src/Tooltip.figma.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import figma from '@figma/code-connect';
 import { Tooltip } from './Tooltip';
-import { Button } from '@contentful/f36-button';
 
 figma.connect(
   Tooltip,
@@ -18,7 +17,7 @@ figma.connect(
     },
     example: ({ content, placement }) => (
       <Tooltip content={content} placement={placement}>
-        <Button>Trigger</Button>
+        <button type="button">Trigger</button>
       </Tooltip>
     ),
   },

--- a/packages/components/tooltip/src/Tooltip.test.tsx
+++ b/packages/components/tooltip/src/Tooltip.test.tsx
@@ -7,7 +7,6 @@ import { Tooltip } from './Tooltip';
 import { Paragraph } from '@contentful/f36-typography';
 import { StarIcon } from '@contentful/f36-icons';
 import { Icon } from '../../icon/src';
-import { Button } from '@contentful/f36-button';
 
 jest.mock('@contentful/f36-core', () => {
   const actual = jest.requireActual('@contentful/f36-core');
@@ -60,10 +59,12 @@ describe('Tooltip', () => {
     );
   });
 
-  it('renders around an Button', async () => {
+  it('renders around a button', async () => {
     render(
       <Tooltip content="Tooltip content">
-        <Button testId="hover-me">Hover me</Button>
+        <button type="button" data-test-id="hover-me">
+          Hover me
+        </button>
       </Tooltip>,
     );
     await userEvent.hover(screen.getByTestId('hover-me'));
@@ -107,10 +108,12 @@ describe('Tooltip', () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it('renders around a disabled Button', async () => {
+  it('renders around a disabled button', async () => {
     render(
       <Tooltip content="Tooltip content" data-test-id="hover-me">
-        <Button isDisabled>Hover me</Button>
+        <button type="button" disabled>
+          Hover me
+        </button>
       </Tooltip>,
     );
     await userEvent.hover(screen.getByTestId('hover-me'));

--- a/packages/components/typography/package.json
+++ b/packages/components/typography/package.json
@@ -33,5 +33,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/usage-card/package.json
+++ b/packages/components/usage-card/package.json
@@ -36,5 +36,12 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@contentful/f36-usage-count": "^6.16.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/usage-count/package.json
+++ b/packages/components/usage-count/package.json
@@ -32,5 +32,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/components/utils/package.json
+++ b/packages/components/utils/package.json
@@ -29,5 +29,9 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,5 +31,11 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "public"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   }
 }

--- a/packages/f36-ai-components/package.json
+++ b/packages/f36-ai-components/package.json
@@ -31,10 +31,10 @@
   },
   "dependencies": {
     "@contentful/f36-button": "^6.16.2",
-    "@contentful/f36-pill-next": "6.0.1-alpha.7",
     "@contentful/f36-components": "^6.16.2",
     "@contentful/f36-core": "^6.16.2",
     "@contentful/f36-icons": "^6.16.2",
+    "@contentful/f36-pill-next": "6.0.1-alpha.7",
     "@contentful/f36-tokens": "^6.2.1",
     "@contentful/f36-typography": "^6.16.2",
     "@contentful/f36-utils": "^6.1.2",
@@ -44,6 +44,7 @@
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
+    "@testing-library/user-event": "^14.6.1",
     "@tiptap/core": "3.27.3",
     "@tiptap/extension-document": "3.27.3",
     "@tiptap/extension-mention": "3.27.3",

--- a/packages/f36-ai-components/package.json
+++ b/packages/f36-ai-components/package.json
@@ -44,6 +44,8 @@
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@tiptap/core": "3.27.3",
     "@tiptap/extension-document": "3.27.3",
@@ -53,7 +55,9 @@
     "@tiptap/extensions": "3.27.3",
     "@tiptap/pm": "3.27.3",
     "@tiptap/react": "3.27.3",
-    "@tiptap/suggestion": "3.27.3"
+    "@tiptap/suggestion": "3.27.3",
+    "@types/jest-axe": "^3.5.9",
+    "jest-axe": "^10.0.0"
   },
   "peerDependencies": {
     "@tiptap/core": "^3.15.0",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -61,6 +61,7 @@
     "@emotion/babel-preset-css-prop": "^11.12.0",
     "@eslint/eslintrc": "^3",
     "@next/eslint-plugin-next": "^15.5.11",
+    "@types/unist": "^3.0.3",
     "broken-link-checker": "^0.7.8",
     "dotenv": "^16.0.3",
     "prettier": "^3.8.1",

--- a/types/typings.d.ts
+++ b/types/typings.d.ts
@@ -1,6 +1,4 @@
 /* eslint-disable import/no-default-export */
-/// <reference types="@emotion/react/types/css-prop" />
-
 declare module '*.mdx' {
   let MDXComponent: (props: any) => JSX.Element;
   export default MDXComponent;


### PR DESCRIPTION
## Summary
- declare `@testing-library/user-event` in each workspace that imports it from tests
- remove the root `@testing-library/user-event` shortcut and Knip ignore
- reduce remaining unlisted files from 92 to 72 without relying on root test tooling ownership

Stacked on #3547.

## Verification
- `npm exec knip -- --include unlisted --no-config-hints --no-exit-code --reporter json` (72 remaining files; no `@testing-library/user-event` findings)
- `npm exec knip -- --no-config-hints`
- `npm test -- --runInBand packages/f36-ai-components/src/AIChatReasoning/AIChatReasoning.test.tsx packages/f36-ai-components/src/AIChatLayout/AIChatLayout.test.tsx packages/f36-ai-components/src/AIChatSuggestionPill/AIChatSuggestionPill.test.tsx packages/components/pagination/src/Pagination.test.tsx packages/components/entity-list/src/EntityListItem/EntityListItem.test.tsx packages/components/autocomplete/src/Autocomplete.test.tsx packages/components/datepicker/src/Datepicker.test.tsx packages/components/text-link/src/TextLink.test.tsx packages/components/accordion/src/Accordion.test.tsx packages/components/copybutton/src/CopyButton.test.tsx packages/components/forms/src/Select/Select.test.tsx packages/components/multiselect/src/Multiselect.test.tsx packages/components/forms/src/Checkbox/Checkbox.test.tsx packages/components/menu/src/Menu.test.tsx packages/components/tooltip/src/Tooltip.test.tsx packages/components/table/src/Table.test.tsx packages/components/button/src/IconButton/IconButton.test.tsx packages/components/card/src/Card/Card.test.tsx packages/components/button/src/Button/Button.test.tsx packages/components/button/src/ToggleButton/ToggleButton.test.tsx packages/components/avatar/src/Avatar/Avatar.test.tsx packages/components/avatar/src/AvatarGroup/AvatarGroup.test.tsx packages/components/collapse/src/Collapse.test.tsx packages/components/popover/src/Popover.test.tsx` (24 suites, 263 passed, 1 todo)
- `npm run tsc`
- `npm run lint` (12 existing warnings)