### PR TITLE
ci: ignore unlisted doc and fixture imports

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -55,6 +55,7 @@
         "**/examples/**/*.{js,jsx,ts,tsx}"
       ],
       "ignoreIssues": {
+        "**/*.mdx": ["unlisted"],
         "stories/**/*.{js,jsx,ts,tsx}": ["unlisted"],
         "**/examples/**/*.{js,jsx,ts,tsx}": ["unlisted"]
       }
@@ -70,6 +71,7 @@
         "stories/**/*.{js,jsx,ts,tsx}"
       ],
       "ignoreIssues": {
+        "src/**/*.mdx": ["unlisted"],
         "stories/**/*.{js,jsx,ts,tsx}": ["unlisted"],
         "src/**/examples/**/*.{js,jsx,ts,tsx}": ["unlisted"]
       }
@@ -91,7 +93,10 @@
         "bin/*.mjs",
         "transforms/**/*.{js,ts,tsx}",
         "utils/**/*.js"
-      ]
+      ],
+      "ignoreIssues": {
+        "transforms/__testfixtures__/**/*.{js,jsx,ts,tsx}": ["unlisted"]
+      }
     },
     "packages/forma-36-react-components": {
       "ignoreDependencies": ["@contentful/browserslist-config"]


### PR DESCRIPTION
## Summary
- ignore `unlisted` findings for package MDX docs
- ignore `unlisted` findings for codemod test fixtures
- reduce remaining unlisted files from 22 to 11

Stacked on #3550.

## Verification
- `npm exec knip -- --include unlisted --no-config-hints --no-exit-code --reporter json` (11 remaining files)
- `npm exec knip -- --no-config-hints`
- `npm run tsc`
- `npm run lint` (12 existing warnings)