### PR TITLE
ci: check unlisted dependencies

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -4,6 +4,7 @@
     "files",
     "dependencies",
     "devDependencies",
+    "unlisted",
     "binaries",
     "unresolved",
     "exports",


### PR DESCRIPTION
## Summary
- add `unlisted` to the default Knip issue set
- enforce the direct-dependency cleanup completed in the preceding stack

Stacked on #3553.

## Verification
- `npm exec knip -- --no-config-hints`
- `npm run tsc`
- `npm run lint` (12 existing warnings)