### PR TITLE
feat: enable skip-to-main-content shortcut in navbar

### DIFF
--- a/.changeset/good-donuts-rescue.md
+++ b/.changeset/good-donuts-rescue.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-navbar': minor
+---
+
+Adds skipButton area to the Navbar to enable rendering a skip-to-main-content shortcut

--- a/.changeset/good-donuts-rescue.md
+++ b/.changeset/good-donuts-rescue.md
@@ -2,4 +2,4 @@
 '@contentful/f36-navbar': minor
 ---
 
-Adds skipButton area to the Navbar to enable rendering a skip-to-main-content shortcut
+Adds SkipButton to the Navbar to enable rendering a skip-to-main-content shortcut

--- a/packages/components/navbar/README.mdx
+++ b/packages/components/navbar/README.mdx
@@ -207,6 +207,15 @@ The Navbar component supports responsiveness. Different areas of the navbar will
   </Table.Head>
   <Table.Body>
     <Table.Row>
+      <Table.Cell>`skipButton`</Table.Cell>
+      <Table.Cell>
+        Accepts a Skip-to-Content shortcut link, which allows keyboard users to
+        skip main navigation items and directly jump to the main content area.
+      </Table.Cell>
+      <Table.Cell>Always visible</Table.Cell>
+      <Table.Cell>Custom element</Table.Cell>
+    </Table.Row>
+    <Table.Row>
       <Table.Cell>`logo`</Table.Cell>
       <Table.Cell>
         Allows to overwrite the Contentful logo with a custom logo and link.
@@ -289,6 +298,7 @@ The Navbar component supports responsiveness. Different areas of the navbar will
 
 Each `Menu.Item` offers and increased click-able area and the whole navigation is accessible via keyboard.  
 To further improve the accessibility, each Navbar area has a `aria-label`. These labels can be set via the `aria` prop oobject. Make sure to set a label for every `Menu.Item` in Icon-only modus, this is used to describe the Item for visually impaired users.
+Provide the `skipButton` for keyboard users to skip ahead to the main content.
 
 <Table>
   <Table.Head>

--- a/packages/components/navbar/src/Navbar.tsx
+++ b/packages/components/navbar/src/Navbar.tsx
@@ -6,14 +6,9 @@ import { cx } from '@emotion/css';
 import { Button } from '@contentful/f36-button';
 import { ListIcon } from '@contentful/f36-icons';
 import { NavbarMenu } from './NavbarMenu/NavbarMenu';
+import { SkipButton } from './SkipButton/SkipButton';
 
 type NavbarOwnProps = CommonProps & {
-  /**
-   * Skip link to allow screenreader users to jump to the main content
-   */
-
-  skipButton?: React.ReactNode;
-
   /**
    * Accepts a React Component that will be displayed
    * instead of the Contentful Logo
@@ -49,6 +44,12 @@ type NavbarOwnProps = CommonProps & {
     label?: string;
   };
 
+  skipButtonProps?: {
+    title: string;
+    href: string;
+    testId?: string;
+  };
+
   /**
    * Defines the max-width of the content inside the navbar.
    * @default '100%'
@@ -79,7 +80,7 @@ export type NavbarProps = NavbarHTMLElementProps & NavbarOwnProps;
 
 function _Navbar(props: ExpandProps<NavbarProps>, ref: React.Ref<HTMLElement>) {
   const {
-    skipButton,
+    skipButtonProps,
     logo,
     promotions,
     switcher,
@@ -113,7 +114,9 @@ function _Navbar(props: ExpandProps<NavbarProps>, ref: React.Ref<HTMLElement>) {
       className={cx(styles.container, className)}
       as="header"
     >
-      {skipButton}
+      {skipButtonProps?.title && skipButtonProps?.href && (
+        <SkipButton {...skipButtonProps} />
+      )}
       <Flex
         as="nav"
         className={styles.navigation}

--- a/packages/components/navbar/src/Navbar.tsx
+++ b/packages/components/navbar/src/Navbar.tsx
@@ -6,7 +6,7 @@ import { cx } from '@emotion/css';
 import { Button } from '@contentful/f36-button';
 import { ListIcon } from '@contentful/f36-icons';
 import { NavbarMenu } from './NavbarMenu/NavbarMenu';
-import { SkipButton } from './SkipButton/SkipButton';
+import { SkipButton, type SkipButtonProps } from './SkipButton/SkipButton';
 
 type NavbarOwnProps = CommonProps & {
   /**
@@ -44,11 +44,7 @@ type NavbarOwnProps = CommonProps & {
     label?: string;
   };
 
-  skipButtonProps?: {
-    title: string;
-    href: string;
-    testId?: string;
-  };
+  skipButtonProps?: SkipButtonProps;
 
   /**
    * Defines the max-width of the content inside the navbar.

--- a/packages/components/navbar/src/Navbar.tsx
+++ b/packages/components/navbar/src/Navbar.tsx
@@ -9,6 +9,12 @@ import { NavbarMenu } from './NavbarMenu/NavbarMenu';
 
 type NavbarOwnProps = CommonProps & {
   /**
+   * Skip link to allow screenreader users to jump to the main content
+   */
+
+  skipButton?: React.ReactNode;
+
+  /**
    * Accepts a React Component that will be displayed
    * instead of the Contentful Logo
    */
@@ -73,6 +79,7 @@ export type NavbarProps = NavbarHTMLElementProps & NavbarOwnProps;
 
 function _Navbar(props: ExpandProps<NavbarProps>, ref: React.Ref<HTMLElement>) {
   const {
+    skipButton,
     logo,
     promotions,
     switcher,
@@ -80,7 +87,10 @@ function _Navbar(props: ExpandProps<NavbarProps>, ref: React.Ref<HTMLElement>) {
     secondaryNavigation,
     account,
     mobileNavigation,
-    mobileNavigationProps = { breakpoint: 'small', label: 'Menu' },
+    mobileNavigationProps: {
+      breakpoint: mobileNavigationBreakpoint = 'small',
+      label: mobileNavigationLabel = 'Menu',
+    } = {},
     className,
     contentMaxWidth = '100%',
     testId = 'cf-ui-navbar',
@@ -103,6 +113,7 @@ function _Navbar(props: ExpandProps<NavbarProps>, ref: React.Ref<HTMLElement>) {
       className={cx(styles.container, className)}
       as="header"
     >
+      {skipButton}
       <Flex
         as="nav"
         className={styles.navigation}
@@ -116,11 +127,11 @@ function _Navbar(props: ExpandProps<NavbarProps>, ref: React.Ref<HTMLElement>) {
               trigger={
                 <Button
                   className={styles.mobileNavigationButton(
-                    mobileNavigationProps.breakpoint,
+                    mobileNavigationBreakpoint,
                   )}
                   startIcon={<ListIcon size="medium" />}
                 >
-                  {mobileNavigationProps.label}
+                  {mobileNavigationLabel}
                 </Button>
               }
             >
@@ -129,9 +140,7 @@ function _Navbar(props: ExpandProps<NavbarProps>, ref: React.Ref<HTMLElement>) {
           )}
           {mainNavigation && (
             <Flex
-              className={styles.mainNavigation(
-                mobileNavigationProps.breakpoint,
-              )}
+              className={styles.mainNavigation(mobileNavigationBreakpoint)}
               aria-label={aria.labelMainNavigation}
               gap="spacingXs"
             >

--- a/packages/components/navbar/src/SkipButton/SkipButton.test.tsx
+++ b/packages/components/navbar/src/SkipButton/SkipButton.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { SkipButton } from './SkipButton';
+
+describe('SkipButton', () => {
+  it('renders with title and href', () => {
+    render(<SkipButton title="Skip to main content" href="#main" />);
+
+    const button = screen.getByTestId('cf-ui-skipToMainButton');
+    expect(button).toBeTruthy();
+    expect(button).toHaveTextContent('Skip to main content');
+    expect(button).toHaveAttribute('href', '#main');
+  });
+
+  it('accepts a custom testId', () => {
+    render(
+      <SkipButton
+        title="Skip to main content"
+        href="#main"
+        testId="custom-skip"
+      />,
+    );
+
+    expect(screen.getByTestId('custom-skip')).toBeTruthy();
+  });
+
+  it('has no a11y violations', async () => {
+    const { container } = render(
+      <SkipButton title="Skip to main content" href="#main" />,
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/components/navbar/src/SkipButton/SkipButton.tsx
+++ b/packages/components/navbar/src/SkipButton/SkipButton.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import tokens from '@contentful/f36-tokens';
+import { Button, type ButtonProps } from '@contentful/f36-button';
+import { css, cx } from '@emotion/css';
+
+const styles = {
+  skipButton: css({
+    position: 'absolute',
+    top: tokens.spacingM,
+    opacity: 0,
+    width: '0px',
+    height: '0px',
+    minHeight: 0,
+    overflow: 'hidden',
+    padding: 0,
+    transition: `width ${tokens.transitionDurationDefault} ${tokens.transitionEasingDefault}`,
+    zIndex: tokens.zIndexWorkbenchHeader,
+    '&:focus': {
+      opacity: 1,
+      width: 'auto',
+      height: 'auto',
+      padding: `${tokens.spacingXs} ${tokens.spacingM}`,
+      minHeight: `40px`,
+    },
+  }),
+};
+
+interface SkipButtonProps extends ButtonProps<'a'> {
+  title: string;
+  href: string;
+}
+
+export const SkipButton = (props: SkipButtonProps) => {
+  const {
+    testId = 'cf-ui-skipToMainButton',
+    className,
+    href,
+    title,
+    ...otherProps
+  } = props;
+  const componentClassNames = cx(styles.skipButton, className);
+
+  return (
+    <Button
+      testId={testId}
+      className={componentClassNames}
+      variant="secondary"
+      href={href}
+      {...otherProps}
+    >
+      {title}
+    </Button>
+  );
+};

--- a/packages/components/navbar/src/SkipButton/SkipButton.tsx
+++ b/packages/components/navbar/src/SkipButton/SkipButton.tsx
@@ -25,7 +25,7 @@ const styles = {
   }),
 };
 
-interface SkipButtonProps extends ButtonProps<'a'> {
+export interface SkipButtonProps extends ButtonProps<'a'> {
   title: string;
   href: string;
 }

--- a/packages/components/navbar/stories/Navbar.stories.tsx
+++ b/packages/components/navbar/stories/Navbar.stories.tsx
@@ -16,7 +16,7 @@ import { SectionHeading } from '@contentful/f36-typography';
 import { Flex } from '@contentful/f36-core';
 import type { NavbarAccountProps } from '../src/NavbarAccount/NavbarAccount';
 import type { NavbarSwitcherProps } from '../src/NavbarSwitcher/NavbarSwitcher';
-import { Button, TextLink } from '@contentful/f36-components';
+import { TextLink } from '@contentful/f36-components';
 import { css } from '@emotion/css';
 
 export default {
@@ -24,32 +24,9 @@ export default {
   title: 'Components/Navbar',
 } as Meta;
 
-const storyStyles = {
-  skipButton: css({
-    position: 'absolute',
-    top: '12px',
-    left: '12px',
-    opacity: 0,
-    width: '0px',
-    height: '0px',
-    minHeight: 0,
-    overflow: 'hidden',
-    padding: 0,
-    '&:focus': {
-      opacity: 1,
-      width: 'auto',
-      height: 'auto',
-      minHeight: `40px`,
-    },
-  }),
-};
-
-const SkipButton = () => {
-  return (
-    <Button as="a" className={storyStyles.skipButton} href="#main-content">
-      Skip to main content
-    </Button>
-  );
+const skipButtonProps = {
+  title: 'Skip to main content',
+  href: '#main-content',
 };
 
 const Switcher = ({
@@ -166,7 +143,7 @@ export const Basic: StoryObj<{ initials?: string; avatar?: string }> = (
   return (
     <div style={{ minWidth: '900px' }}>
       <Navbar
-        skipButton={<SkipButton />}
+        skipButtonProps={skipButtonProps}
         mainNavigation={<MainItems />}
         switcher={<Switcher />}
         account={<Account {...args} />}
@@ -194,7 +171,7 @@ export const BasicNoEnvironment: StoryObj<{
   return (
     <div style={{ minWidth: '900px' }}>
       <Navbar
-        skipButton={<SkipButton />}
+        skipButtonProps={skipButtonProps}
         mainNavigation={<MainItems />}
         switcher={<Navbar.Switcher space="Our super long space name" />}
         account={<Account {...args} />}
@@ -214,7 +191,7 @@ export const SizeVariants = () => {
     <Flex gap="spacingL" style={{ width: '97vw' }} flexDirection="column">
       <SectionHeading marginBottom="none">Fullscreen</SectionHeading>
       <Navbar
-        skipButton={<SkipButton />}
+        skipButtonProps={skipButtonProps}
         switcher={<Switcher />}
         account={<Account />}
         variant="fullscreen"
@@ -238,7 +215,7 @@ export const WithDisabledItems: StoryObj<{
   return (
     <div style={{ minWidth: '900px' }}>
       <Navbar
-        skipButton={<SkipButton />}
+        skipButtonProps={skipButtonProps}
         mainNavigation={<MainItems withDisabled />}
         switcher={<Switcher />}
         account={<Account {...args} />}
@@ -260,7 +237,7 @@ export const WithInitialsAvatar: StoryObj<{
   return (
     <div style={{ minWidth: '900px' }}>
       <Navbar
-        skipButton={<SkipButton />}
+        skipButtonProps={skipButtonProps}
         switcher={<Switcher />}
         account={<Account {...args} />}
         mainNavigation={<MainItems />}
@@ -277,7 +254,7 @@ export const WithFallbackAvatar = (args) => {
   return (
     <div style={{ minWidth: '900px' }}>
       <Navbar
-        skipButton={<SkipButton />}
+        skipButtonProps={skipButtonProps}
         switcher={<Switcher />}
         account={<Account {...args} />}
         mainNavigation={<MainItems />}
@@ -291,7 +268,7 @@ WithFallbackAvatar.args = {};
 export const WithShortSpaceName = () => {
   return (
     <Navbar
-      skipButton={<SkipButton />}
+      skipButtonProps={skipButtonProps}
       mainNavigation={<MainItems />}
       switcher={<Switcher space="Space" />}
       account={<Account />}

--- a/packages/components/navbar/stories/Navbar.stories.tsx
+++ b/packages/components/navbar/stories/Navbar.stories.tsx
@@ -16,13 +16,41 @@ import { SectionHeading } from '@contentful/f36-typography';
 import { Flex } from '@contentful/f36-core';
 import type { NavbarAccountProps } from '../src/NavbarAccount/NavbarAccount';
 import type { NavbarSwitcherProps } from '../src/NavbarSwitcher/NavbarSwitcher';
-import { TextLink } from '@contentful/f36-components';
+import { Button, TextLink } from '@contentful/f36-components';
 import { css } from '@emotion/css';
 
 export default {
   component: Navbar,
   title: 'Components/Navbar',
 } as Meta;
+
+const storyStyles = {
+  skipButton: css({
+    position: 'absolute',
+    top: '12px',
+    left: '12px',
+    opacity: 0,
+    width: '0px',
+    height: '0px',
+    minHeight: 0,
+    overflow: 'hidden',
+    padding: 0,
+    '&:focus': {
+      opacity: 1,
+      width: 'auto',
+      height: 'auto',
+      minHeight: `40px`,
+    },
+  }),
+};
+
+const SkipButton = () => {
+  return (
+    <Button as="a" className={storyStyles.skipButton} href="#main-content">
+      Skip to main content
+    </Button>
+  );
+};
 
 const Switcher = ({
   space = "Kathrin's space",
@@ -138,6 +166,7 @@ export const Basic: StoryObj<{ initials?: string; avatar?: string }> = (
   return (
     <div style={{ minWidth: '900px' }}>
       <Navbar
+        skipButton={<SkipButton />}
         mainNavigation={<MainItems />}
         switcher={<Switcher />}
         account={<Account {...args} />}
@@ -165,6 +194,7 @@ export const BasicNoEnvironment: StoryObj<{
   return (
     <div style={{ minWidth: '900px' }}>
       <Navbar
+        skipButton={<SkipButton />}
         mainNavigation={<MainItems />}
         switcher={<Navbar.Switcher space="Our super long space name" />}
         account={<Account {...args} />}
@@ -184,6 +214,7 @@ export const SizeVariants = () => {
     <Flex gap="spacingL" style={{ width: '97vw' }} flexDirection="column">
       <SectionHeading marginBottom="none">Fullscreen</SectionHeading>
       <Navbar
+        skipButton={<SkipButton />}
         switcher={<Switcher />}
         account={<Account />}
         variant="fullscreen"
@@ -207,6 +238,7 @@ export const WithDisabledItems: StoryObj<{
   return (
     <div style={{ minWidth: '900px' }}>
       <Navbar
+        skipButton={<SkipButton />}
         mainNavigation={<MainItems withDisabled />}
         switcher={<Switcher />}
         account={<Account {...args} />}
@@ -228,6 +260,7 @@ export const WithInitialsAvatar: StoryObj<{
   return (
     <div style={{ minWidth: '900px' }}>
       <Navbar
+        skipButton={<SkipButton />}
         switcher={<Switcher />}
         account={<Account {...args} />}
         mainNavigation={<MainItems />}
@@ -244,6 +277,7 @@ export const WithFallbackAvatar = (args) => {
   return (
     <div style={{ minWidth: '900px' }}>
       <Navbar
+        skipButton={<SkipButton />}
         switcher={<Switcher />}
         account={<Account {...args} />}
         mainNavigation={<MainItems />}
@@ -257,6 +291,7 @@ WithFallbackAvatar.args = {};
 export const WithShortSpaceName = () => {
   return (
     <Navbar
+      skipButton={<SkipButton />}
       mainNavigation={<MainItems />}
       switcher={<Switcher space="Space" />}
       account={<Account />}


### PR DESCRIPTION
# Purpose of PR

Introduces a new property `skipButtonProps` which allows to render a skip-to-main-content shortcut in the Navbar which serves as the banner-landmark for a pages layout. A skip to main content shortcut helps keyboard only users to jump directly to the main content area instead of having to tab trough the entire navigation before reaching the content area.

`skipButtonProps` is an object expecting `title` and `href` to be set. `testId` can additionally be set, as any other default properties of a-tags. 

The skip Button is invisible unless it is receiving focus. 
