### PR TITLE
chore(website): remove @emotion/babel-preset-css-prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4565,40 +4565,11 @@
         "stylis": "4.2.0"
       }
     },
-    "node_modules/@emotion/babel-plugin-jsx-pragmatic": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.3.0.tgz",
-      "integrity": "sha512-XkRI5RdNl+f7HqpJADfTWlzZkd4tNaz2Gjzt97ZqN72jFSOqpL0grGGLdzKJ9dMQHXJBT/KZV+kphTycOblIsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-syntax-jsx": "^7.17.12"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
     "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
-    },
-    "node_modules/@emotion/babel-preset-css-prop": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-11.12.0.tgz",
-      "integrity": "sha512-wJYhkqVvH4nbxqwmw6XEkF/IWFFRQhYXiv69p7gibbT/e4S/5bMatoukDxRVxZla7aNvpZbXnfPeeNDlFehkKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-react-jsx": "^7.17.12",
-        "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.12.0",
-        "@emotion/babel-plugin-jsx-pragmatic": "^0.3.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
     },
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
@@ -43793,7 +43764,6 @@
       "devDependencies": {
         "@contentful/rich-text-types": "^17.0.0",
         "@emotion/babel-plugin": "^11.13.5",
-        "@emotion/babel-preset-css-prop": "^11.12.0",
         "@eslint/eslintrc": "^3",
         "@next/eslint-plugin-next": "^15.5.11",
         "@types/unist": "^3.0.3",

--- a/packages/website/babel.config.js
+++ b/packages/website/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  presets: ['next/babel', '@emotion/babel-preset-css-prop'],
+  presets: ['next/babel'],
   plugins: ['@emotion'],
 };

--- a/packages/website/components/LiveEditor/ComponentSource.tsx
+++ b/packages/website/components/LiveEditor/ComponentSource.tsx
@@ -165,6 +165,7 @@ export function ComponentSource({
     <Flex flexDirection="column" className={styles.root}>
       <LiveProvider
         code={formatSourceCode(code)}
+        language="jsx"
         theme={theme}
         // The order is important here
         scope={liveProviderScope}

--- a/packages/website/components/LiveEditor/ComponentSource.tsx
+++ b/packages/website/components/LiveEditor/ComponentSource.tsx
@@ -170,7 +170,8 @@ export function ComponentSource({
         scope={liveProviderScope}
       >
         <Card className={styles.card}>
-          <LivePreview />
+          {/* @ts-expect-error react-live's types omit its runtime Component prop */}
+          <LivePreview Component="div" />
         </Card>
         <div style={{ position: 'relative' }}>
           <LiveError className={styles.error} />

--- a/packages/website/components/Playground/SandpackRenderer.tsx
+++ b/packages/website/components/Playground/SandpackRenderer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Interpolation, Theme } from '@emotion/react';
+import { css } from '@emotion/css';
 import {
   SandpackProvider,
   SandpackLayout,
@@ -11,11 +11,6 @@ import tokens from '@contentful/f36-tokens';
 import { PlaygroundTopBar } from './PlaygroundTopBar';
 import { palette } from '../LiveEditor/theme';
 
-declare module 'react' {
-  interface Attributes {
-    css?: Interpolation<Theme>;
-  }
-}
 const indexFile = `import React, { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { GlobalStyles } from "@contentful/f36-components";
@@ -48,7 +43,7 @@ export function SandpackRenderer({
   showOpenInCodeSandbox = false,
 }: Props) {
   // Styles that override Sandpack's default styling
-  const sandpackStyles: { [key: string]: Interpolation<Theme> } = {
+  const sandpackStyles = {
     wrapper: {
       overflow: 'hidden !important',
     },
@@ -91,7 +86,7 @@ export function SandpackRenderer({
 
   return (
     <SandpackProvider
-      css={sandpackStyles.wrapper}
+      className={css(sandpackStyles.wrapper)}
       customSetup={{
         dependencies: {
           '@dnd-kit/core': '^6.0.8',
@@ -163,7 +158,7 @@ export function SandpackRenderer({
     >
       <PlaygroundTopBar />
 
-      <SandpackLayout css={sandpackStyles.layout}>
+      <SandpackLayout className={css(sandpackStyles.layout)}>
         <SandpackCodeEditor
           showTabs={false}
           showLineNumbers

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -59,7 +59,6 @@
   "devDependencies": {
     "@contentful/rich-text-types": "^17.0.0",
     "@emotion/babel-plugin": "^11.13.5",
-    "@emotion/babel-preset-css-prop": "^11.12.0",
     "@eslint/eslintrc": "^3",
     "@next/eslint-plugin-next": "^15.5.11",
     "@types/unist": "^3.0.3",


### PR DESCRIPTION
## Summary

- Remove `@emotion/babel-preset-css-prop` from the website Babel configuration and dependencies.
- Replace the two Emotion React `css` props with `@emotion/css` class names.
- Explicitly set the `react-live` preview wrapper now that Emotion no longer supplies the JSX factory that masked its React 19 `defaultProps` dependency.
- Regenerate the lockfile.

## Validation

- `npm install`
- `npm run build`
- `npm run tsc`
- `npm run lint` (passes with existing warnings)
- `npm run docs:next:build`