### PR TITLE
test: migrate spinner package to Vitest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -139,6 +139,7 @@ module.exports = {
     '/dist/',
     '/packages/components/asset/',
     '/packages/components/image/',
+    '/packages/components/spinner/',
     '/packages/forma-36-codemod/',
   ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43257,9 +43257,7 @@
       "devDependencies": {
         "@contentful/f36-typography": "^6.16.2",
         "@testing-library/dom": "^10.4.1",
-        "@testing-library/react": "^16.3.0",
-        "@types/jest-axe": "^3.5.9",
-        "jest-axe": "^10.0.0"
+        "@testing-library/react": "^16.3.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -13,9 +13,7 @@
   "devDependencies": {
     "@contentful/f36-typography": "^6.16.2",
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.0",
-    "@types/jest-axe": "^3.5.9",
-    "jest-axe": "^10.0.0"
+    "@testing-library/react": "^16.3.0"
   },
   "peerDependencies": {
     "react": "^18.3.0 || >=19.1.0",

--- a/packages/components/spinner/src/Spinner.test.tsx
+++ b/packages/components/spinner/src/Spinner.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Spinner } from '.';
 
@@ -48,8 +49,6 @@ describe('Spinner', function () {
 
   it('has no a11y issues', async () => {
     const { container } = render(<Spinner />);
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ const aliases = [
 const testFiles = [
   'packages/components/asset/src/**/*.test.tsx',
   'packages/components/image/src/**/*.test.tsx',
+  'packages/components/spinner/src/**/*.test.tsx',
 ];
 const ignoredPaths = [
   '**/node_modules/**',


### PR DESCRIPTION
## Summary
- Stack on #3590.
- Fully migrate `@contentful/f36-spinner` tests to Vitest with explicit imports.
- Replace `jest-axe` usage with the shared `expectNoA11yViolations` helper.
- Remove spinner package Jest a11y dev dependencies now that the test uses the shared root helper.
- Add spinner tests to the opt-in Vitest config and exclude the package from Jest.

## Validation
- `npm run test:vitest:converted`: 4 files passed, 14 tests passed.
- `npm run test`: 108 suites passed, 680 tests passed, 1 todo. Converted image + asset + spinner packages are covered by Vitest instead.
- `npm run lint`: 0 errors; existing warnings remain.
- `npm run lint:packages`: passed.
- `npm exec knip`: no unused dependency failures; existing configuration hints remain.
- `npx prettier --check jest.config.js vitest.config.ts packages/components/spinner/package.json packages/components/spinner/src/Spinner.test.tsx`: passed.
- `npm run tsc`: fails only on known unresolved `@contentful/f36-table-next` imports in TableNext examples and LiveEditor.