### PR TITLE
test: migrate usage-count package to Vitest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -140,6 +140,7 @@ module.exports = {
     '/packages/components/asset/',
     '/packages/components/image/',
     '/packages/components/spinner/',
+    '/packages/components/usage-count/',
     '/packages/forma-36-codemod/',
   ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43439,9 +43439,7 @@
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
-        "@testing-library/react": "^16.3.0",
-        "@types/jest-axe": "^3.5.9",
-        "jest-axe": "^10.0.0"
+        "@testing-library/react": "^16.3.0"
       },
       "peerDependencies": {
         "react": "^18.3.0 || >=19.1.0",

--- a/packages/components/usage-count/package.json
+++ b/packages/components/usage-count/package.json
@@ -35,8 +35,6 @@
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.0",
-    "@types/jest-axe": "^3.5.9",
-    "jest-axe": "^10.0.0"
+    "@testing-library/react": "^16.3.0"
   }
 }

--- a/packages/components/usage-count/src/UsageCount.test.tsx
+++ b/packages/components/usage-count/src/UsageCount.test.tsx
@@ -1,7 +1,8 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { UsageCount } from './UsageCount';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 describe('UsageCount', function () {
   it('renders consumption component', () => {
@@ -50,8 +51,7 @@ describe('UsageCount', function () {
       />,
     );
 
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 
   it('has no a11y issues with periodic variant', async () => {
@@ -64,7 +64,6 @@ describe('UsageCount', function () {
       />,
     );
 
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ const testFiles = [
   'packages/components/asset/src/**/*.test.tsx',
   'packages/components/image/src/**/*.test.tsx',
   'packages/components/spinner/src/**/*.test.tsx',
+  'packages/components/usage-count/src/**/*.test.tsx',
 ];
 const ignoredPaths = [
   '**/node_modules/**',


### PR DESCRIPTION
## Summary
- Stack on #3591.
- Fully migrate `@contentful/f36-usage-count` tests to Vitest with explicit imports.
- Replace `jest-axe` usage with the shared `expectNoA11yViolations` helper.
- Remove usage-count package Jest a11y dev dependencies now that the test uses the shared root helper.
- Add usage-count tests to the opt-in Vitest config and exclude the package from Jest.

## Validation
- `npm run test:vitest:converted`: 5 files passed, 19 tests passed.
- `npm run test`: 107 suites passed, 675 tests passed, 1 todo. Converted image + asset + spinner + usage-count packages are covered by Vitest instead.
- `npm run lint`: 0 errors; existing warnings remain.
- `npm exec knip`: no unused dependency failures; existing configuration hints remain.
- `npx prettier --check jest.config.js vitest.config.ts packages/components/usage-count/package.json packages/components/usage-count/src/UsageCount.test.tsx`: passed.
- `npm run tsc`: fails only on known unresolved `@contentful/f36-table-next` imports in TableNext examples and LiveEditor.