### PR TITLE
test: migrate typography package to Vitest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -142,6 +142,7 @@ module.exports = {
     '/packages/components/image/',
     '/packages/components/note/',
     '/packages/components/spinner/',
+    '/packages/components/typography/',
     '/packages/components/usage-count/',
     '/packages/forma-36-codemod/',
   ],

--- a/packages/components/typography/package.json
+++ b/packages/components/typography/package.json
@@ -36,8 +36,6 @@
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.0",
-    "@types/jest-axe": "^3.5.9",
-    "jest-axe": "^10.0.0"
+    "@testing-library/react": "^16.3.0"
   }
 }

--- a/packages/components/typography/src/Caption/Caption.test.tsx
+++ b/packages/components/typography/src/Caption/Caption.test.tsx
@@ -1,12 +1,11 @@
+import { it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Caption } from './Caption';
 
 it('has no a11y issues', async () => {
   const { container } = render(<Caption>DisplayText</Caption>);
-  const results = await axe(container);
-
-  expect(results).toHaveNoViolations();
+  await expectNoA11yViolations(container);
 });

--- a/packages/components/typography/src/DisplayText/DisplayText.test.tsx
+++ b/packages/components/typography/src/DisplayText/DisplayText.test.tsx
@@ -1,12 +1,11 @@
+import { it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { DisplayText } from './DisplayText';
 
 it('has no a11y issues', async () => {
   const { container } = render(<DisplayText>DisplayText</DisplayText>);
-  const results = await axe(container);
-
-  expect(results).toHaveNoViolations();
+  await expectNoA11yViolations(container);
 });

--- a/packages/components/typography/src/Heading/Heading.test.tsx
+++ b/packages/components/typography/src/Heading/Heading.test.tsx
@@ -1,12 +1,11 @@
+import { it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Heading } from './Heading';
 
 it('has no a11y issues', async () => {
   const { container } = render(<Heading>Heading</Heading>);
-  const results = await axe(container);
-
-  expect(results).toHaveNoViolations();
+  await expectNoA11yViolations(container);
 });

--- a/packages/components/typography/src/Paragraph/Paragraph.test.tsx
+++ b/packages/components/typography/src/Paragraph/Paragraph.test.tsx
@@ -1,12 +1,11 @@
+import { it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Paragraph } from './Paragraph';
 
 it('has no a11y issues', async () => {
   const { container } = render(<Paragraph>Text</Paragraph>);
-  const results = await axe(container);
-
-  expect(results).toHaveNoViolations();
+  await expectNoA11yViolations(container);
 });

--- a/packages/components/typography/src/SectionHeading/SectionHeading.test.tsx
+++ b/packages/components/typography/src/SectionHeading/SectionHeading.test.tsx
@@ -1,12 +1,11 @@
+import { it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { SectionHeading } from './SectionHeading';
 
 it('has no a11y issues', async () => {
   const { container } = render(<SectionHeading>SectionHeading</SectionHeading>);
-  const results = await axe(container);
-
-  expect(results).toHaveNoViolations();
+  await expectNoA11yViolations(container);
 });

--- a/packages/components/typography/src/Subheading/Subheading.test.tsx
+++ b/packages/components/typography/src/Subheading/Subheading.test.tsx
@@ -1,15 +1,14 @@
+import { it, vi } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Subheading } from './Subheading';
 
 it('has no a11y issues', async () => {
   // Workaround for https://github.com/dequelabs/axe-core/issues/3055
-  jest.useRealTimers();
+  vi.useRealTimers();
 
   const { container } = render(<Subheading>Subheading</Subheading>);
-  const results = await axe(container);
-
-  expect(results).toHaveNoViolations();
+  await expectNoA11yViolations(container);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1739,12 +1739,6 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@types/jest-axe':
-        specifier: ^3.5.9
-        version: 3.5.9
-      jest-axe:
-        specifier: ^10.0.0
-        version: 10.0.0
 
   packages/components/usage-card:
     dependencies:

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -50,6 +50,7 @@ const testFiles = [
   'packages/components/image/src/**/*.test.tsx',
   'packages/components/note/src/**/*.test.tsx',
   'packages/components/spinner/src/**/*.test.tsx',
+  'packages/components/typography/src/**/*.test.tsx',
   'packages/components/usage-count/src/**/*.test.tsx',
 ];
 const ignoredPaths = [


### PR DESCRIPTION
## Summary

- #3590 is merged into `main`.
- Migrate all `@contentful/f36-typography` test files to Vitest with explicit imports.
- Replace `jest-axe` usage with the shared `expectNoA11yViolations` helper.
- Remove typography package Jest a11y dev dependencies now that tests use the shared root helper.
- Add typography tests to the opt-in Vitest config and exclude the package from Jest.

## Validation

- `pnpm test:vitest`: 14 files passed, 36 tests passed.
- `pnpm test`: 98 suites passed, 658 tests passed, 1 todo. Converted packages are covered by Vitest instead.
- `pnpm lint`: 0 errors; existing warnings remain.
- `pnpm exec knip`: no unused dependency failures; existing configuration hints remain.
- `pnpm exec prettier --check jest.config.js vitest.config.ts packages/components/typography/package.json packages/components/typography/src/{Caption,DisplayText,Heading,Paragraph,SectionHeading,Subheading}/*.test.tsx`: passed.
- `pnpm tsc`: fails only on known unresolved `@contentful/f36-table-next` imports in TableNext examples and LiveEditor.
