### PR TITLE
feat(icons): add ArrowsClockwiseIcon [TOL-4331]

### DIFF
--- a/.changeset/swift-arrows-spin.md
+++ b/.changeset/swift-arrows-spin.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-icons': minor
+---
+
+Adds `ArrowsClockwiseIcon` from Phosphor.

--- a/packages/components/icons/src/index.ts
+++ b/packages/components/icons/src/index.ts
@@ -68,6 +68,7 @@ export * from './vendor/phosphor/ArrowUDownRightIcon.js';
 export * from './vendor/phosphor/ArrowUUpLeftIcon.js';
 export * from './vendor/phosphor/ArrowUUpRightIcon.js';
 export * from './vendor/phosphor/ArrowUpIcon.js';
+export * from './vendor/phosphor/ArrowsClockwiseIcon.js';
 export * from './vendor/phosphor/ArrowsLeftRightIcon.js';
 export * from './vendor/phosphor/ArrowsOutCardinalIcon.js';
 export * from './vendor/phosphor/ArrowsOutIcon.js';

--- a/packages/components/icons/src/vendor/phosphor/ArrowsClockwiseIcon.tsx
+++ b/packages/components/icons/src/vendor/phosphor/ArrowsClockwiseIcon.tsx
@@ -1,0 +1,4 @@
+import { generateForma36Icon } from '@contentful/f36-icon';
+import { ArrowsClockwiseIcon as ArrowsClockwise } from '@phosphor-icons/react';
+
+export const ArrowsClockwiseIcon = generateForma36Icon(ArrowsClockwise);


### PR DESCRIPTION
## What changed

- adds the Phosphor ArrowsClockwiseIcon through generateForma36Icon
- exports it from @contentful/f36-icons
- adds a minor changeset

## Verification

- icons workspace build
- ESLint
- changeset status