### PR TITLE
fix(ci): sync pnpm lockfile after changeset version in release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,9 @@ jobs:
           name: Generate packages changelogs
           command: pnpm exec changeset version
       - run:
+          name: Sync lockfile with version bumps
+          command: pnpm install --no-frozen-lockfile
+      - run:
           name: Publish packages and create releases
           command: |
             pnpm changeset:publish


### PR DESCRIPTION
## Summary
- The release job's `pnpm changeset:publish` step was failing with `ERR_PNPM_OUTDATED_LOCKFILE`. `pnpm exec changeset version` bumps versions across the fixed release group in each package's `package.json` (e.g. `@contentful/f36-core` `^6.17.0` → `^6.18.0`) but never touches `pnpm-lock.yaml`.
- The next step, `pnpm changeset:publish`, shells out to `pnpm exec changeset publish`. pnpm 11's `verify-deps-before-run` check fires on that `pnpm exec` call, detects the lockfile is now out of sync, and tries to auto-heal via `pnpm install`. But that is forced to `--frozen-lockfile` in CI, so it fails instead of fixing itself.

The fix: add an explicit `pnpm install --no-frozen-lockfile` step between the version-bump and publish steps to resync the lockfile. The existing `git add . && ... && git push` in `scripts/changesets/generate-releases.js` carries the updated lockfile into the same release commit, so there's no permanent drift.