### PR TITLE
chore: use automatic jsx runtime

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,6 +6,7 @@ module.exports = (api) => {
         [
           '@babel/preset-react',
           {
+            runtime: 'automatic',
             targets: {
               node: 'current',
             },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,8 @@
       "dom.iterable",
       "esnext"
     ],
-    // allows react jsx in tsx files
-    "jsx": "react",
+    // uses React's automatic JSX runtime in tsx files
+    "jsx": "react-jsx",
     // Eventually turn off, one we have no more assumed default exports.
     // Allow default imports from modules with no default export.
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
# Purpose of PR

Switch component-library JSX emission to React's automatic runtime. Published tsup artifacts now import `react/jsx-runtime` rather than calling `React.createElement`; React peer ranges and public APIs are unchanged.

This should not affect consumers, as long as they are on one of our supported versions of React (18, 19)

Verified with:

- `pnpm --filter @contentful/f36-button build`
- `pnpm --filter @contentful/f36-components build`
- `pnpm test -- packages/components/button/src --runInBand`
- `pnpm tsc`
