### PR TITLE
feat: deprecate Navbar Component

### DIFF
--- a/.changeset/metal-boxes-repair.md
+++ b/.changeset/metal-boxes-repair.md
@@ -1,0 +1,5 @@
+---
+'@contentful/f36-navbar': minor
+---
+
+This deprecates the Navbar component, because horizontal main navigation is discontinued. The component will be removed without a replacement in the next Major version.

--- a/DEPRECATIONLOG.md
+++ b/DEPRECATIONLOG.md
@@ -15,6 +15,13 @@ This log tracks all deprecated features and components in Forma 36. For details 
 - **Migration**: Use `PillNext` from `@contentful/f36-pill-next` instead
 - **Guide**: [Migration documentation](./packages/components/pill/MIGRATION.md)
 
+### Navbar (`@contentful/f36-navbar`)
+
+- **Deprecated**: 2026-08-11
+- **Deprecated In**: v6.x.x
+- **Removed In**: next Major (v7)
+- **Reason**: We moved away from a horizontal main navigation to a vertical sidebar Navigation.
+
 ---
 
 ## Removed Deprecations

--- a/packages/components/navbar/src/Navbar.tsx
+++ b/packages/components/navbar/src/Navbar.tsx
@@ -71,6 +71,13 @@ type NavbarOwnProps = CommonProps & {
   as?: 'header' | 'div';
 };
 
+if (process.env.NODE_ENV === 'development') {
+  // eslint-disable-next-line no-console
+  console.warn(
+    'Warning: `Navbar` is deprecated and will be removed in next major version.',
+  );
+}
+
 // expose only the HTML props that are needed to not pollute the API
 type NavbarHTMLElementProps = Pick<React.ComponentPropsWithoutRef<'div'>, 'id'>;
 
@@ -186,4 +193,7 @@ const NavbarBase = (
   );
 };
 
+/**
+ * @deprecated Navbar component is deprecated and will be removed in the next major version. Horizontal navigation is discontinued and there is no replacement component.
+ */
 export const Navbar = React.forwardRef(NavbarBase);


### PR DESCRIPTION
# Purpose of PR

Deprecates the `Navbar` component because horizontal main navigation is discontinued in favor of vertical sidebar navigation.

This PR:
- adds a development-only deprecation warning for `Navbar`
- marks the exported `Navbar` component with a TSDoc `@deprecated` annotation
- documents the deprecation in `DEPRECATIONLOG.md`
- adds a minor changeset for `@contentful/f36-navbar`

The component is planned for removal in the next major version and does not have a direct replacement.