### PR TITLE
chore(website): ignore Contentful linkchecker 429s

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           command: pnpm exec wait-on http://localhost:3000
       - run:
           name: Run links checker
-          command: pnpm --filter @contentful/f36-website exec blc http://localhost:3000 -ro --exclude "https://medium.com/contentful-design" --exclude "https://github.com/contentful/forma-36" --exclude "https://www.figma.com/@contentful" --exclude "https://react-hook-form.com" --exclude "https://emotion.sh"
+          command: pnpm --filter @contentful/f36-website check-links
 
   deploy_chromatic:
     docker:

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.1",
   "private": true,
   "scripts": {
+    "check-links": "node ./scripts/check-links.mjs",
+    "test:check-links": "node --test ./scripts/check-links.test.mjs",
     "generate-public-files": "ts-node ./scripts/generate-public-files.ts",
     "build:prod": "pnpm generate-public-files && next build",
     "start": "next dev",

--- a/packages/website/scripts/check-links.mjs
+++ b/packages/website/scripts/check-links.mjs
@@ -5,12 +5,25 @@ import brokenLinkChecker from 'broken-link-checker';
 const { SiteChecker } = brokenLinkChecker;
 
 const DEFAULT_URL = 'http://localhost:3000';
-const EXCLUDED_KEYWORDS = [
+const DEFAULT_EXCLUDED_KEYWORDS = [
   'https://medium.com/contentful-design',
   'https://github.com/contentful/forma-36',
   'https://www.figma.com/@contentful',
   'https://react-hook-form.com',
 ];
+
+function getExcludedKeywords(
+  value = process.env.LINKCHECKER_EXCLUDED_KEYWORDS,
+) {
+  if (value === undefined) {
+    return DEFAULT_EXCLUDED_KEYWORDS;
+  }
+
+  return value
+    .split(',')
+    .map((keyword) => keyword.trim())
+    .filter(Boolean);
+}
 
 function isContentfulHost(hostname) {
   return hostname === 'contentful.com' || hostname.endsWith('.contentful.com');
@@ -50,7 +63,7 @@ export function run(url = DEFAULT_URL) {
 
   const checker = new SiteChecker(
     {
-      excludedKeywords: EXCLUDED_KEYWORDS,
+      excludedKeywords: getExcludedKeywords(),
     },
     {
       link(result) {
@@ -86,4 +99,4 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   run(process.argv[2]);
 }
 
-export { isContentfulHost, shouldIgnoreRateLimit };
+export { getExcludedKeywords, isContentfulHost, shouldIgnoreRateLimit };

--- a/packages/website/scripts/check-links.mjs
+++ b/packages/website/scripts/check-links.mjs
@@ -1,0 +1,90 @@
+import { fileURLToPath } from 'node:url';
+
+import brokenLinkChecker from 'broken-link-checker';
+
+const { SiteChecker } = brokenLinkChecker;
+
+const DEFAULT_URL = 'http://localhost:3000';
+const EXCLUDED_KEYWORDS = [
+  'https://medium.com/contentful-design',
+  'https://github.com/contentful/forma-36',
+  'https://www.figma.com/@contentful',
+  'https://react-hook-form.com',
+  'https://emotion.sh',
+];
+
+function isContentfulHost(hostname) {
+  return hostname === 'contentful.com' || hostname.endsWith('.contentful.com');
+}
+
+function getResponseUrl(result) {
+  return (
+    result.http?.response?.url ||
+    result.url?.redirected ||
+    result.url?.resolved ||
+    result.url?.original
+  );
+}
+
+function shouldIgnoreRateLimit(result) {
+  if (result.broken !== true || result.http?.response?.statusCode !== 429) {
+    return false;
+  }
+
+  try {
+    return isContentfulHost(new URL(getResponseUrl(result)).hostname);
+  } catch {
+    return false;
+  }
+}
+
+function formatResult(result) {
+  return `${getResponseUrl(result)} (${result.brokenReason})`;
+}
+
+function writeOutput(stream, message) {
+  process[stream].write(`${message}\n`);
+}
+
+export function run(url = DEFAULT_URL) {
+  let brokenLinks = 0;
+
+  const checker = new SiteChecker(
+    {
+      excludedKeywords: EXCLUDED_KEYWORDS,
+    },
+    {
+      link(result) {
+        if (shouldIgnoreRateLimit(result)) {
+          writeOutput(
+            'stdout',
+            `Ignoring rate-limited Contentful link: ${formatResult(result)}`,
+          );
+          return;
+        }
+
+        if (result.broken === true) {
+          brokenLinks += 1;
+          writeOutput('stderr', `Broken link: ${formatResult(result)}`);
+        }
+      },
+      page(error, pageUrl) {
+        if (error != null) {
+          brokenLinks += 1;
+          writeOutput('stderr', `Unable to scan ${pageUrl}: ${error.message}`);
+        }
+      },
+      end() {
+        process.exitCode = brokenLinks === 0 ? 0 : 1;
+      },
+    },
+  );
+
+  checker.enqueue(url);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  run(process.argv[2]);
+}
+
+export { isContentfulHost, shouldIgnoreRateLimit };

--- a/packages/website/scripts/check-links.mjs
+++ b/packages/website/scripts/check-links.mjs
@@ -10,7 +10,6 @@ const EXCLUDED_KEYWORDS = [
   'https://github.com/contentful/forma-36',
   'https://www.figma.com/@contentful',
   'https://react-hook-form.com',
-  'https://emotion.sh',
 ];
 
 function isContentfulHost(hostname) {

--- a/packages/website/scripts/check-links.test.mjs
+++ b/packages/website/scripts/check-links.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { shouldIgnoreRateLimit } from './check-links.mjs';
+
+function resultFor(url, statusCode, broken = true) {
+  return {
+    broken,
+    brokenReason: `HTTP_${statusCode}`,
+    http: {
+      response: {
+        statusCode,
+        url,
+      },
+    },
+    url: {
+      original: url,
+      resolved: url,
+    },
+  };
+}
+
+test('ignores a 429 from contentful.com', () => {
+  assert.equal(
+    shouldIgnoreRateLimit(resultFor('https://contentful.com/docs', 429)),
+    true,
+  );
+});
+
+test('ignores a 429 from a contentful.com subdomain', () => {
+  assert.equal(
+    shouldIgnoreRateLimit(resultFor('https://www.contentful.com/docs', 429)),
+    true,
+  );
+});
+
+test('does not ignore other status codes from contentful.com', () => {
+  assert.equal(
+    shouldIgnoreRateLimit(resultFor('https://contentful.com/docs', 404)),
+    false,
+  );
+});
+
+test('does not ignore 429 responses from other domains', () => {
+  assert.equal(
+    shouldIgnoreRateLimit(resultFor('https://example.com/docs', 429)),
+    false,
+  );
+});

--- a/packages/website/scripts/check-links.test.mjs
+++ b/packages/website/scripts/check-links.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { shouldIgnoreRateLimit } from './check-links.mjs';
+import { getExcludedKeywords, shouldIgnoreRateLimit } from './check-links.mjs';
 
 function resultFor(url, statusCode, broken = true) {
   return {
@@ -45,5 +45,21 @@ test('does not ignore 429 responses from other domains', () => {
   assert.equal(
     shouldIgnoreRateLimit(resultFor('https://example.com/docs', 429)),
     false,
+  );
+});
+
+test('uses the default exclusions when the environment variable is unset', () => {
+  assert.deepEqual(getExcludedKeywords(undefined), [
+    'https://medium.com/contentful-design',
+    'https://github.com/contentful/forma-36',
+    'https://www.figma.com/@contentful',
+    'https://react-hook-form.com',
+  ]);
+});
+
+test('reads comma-separated exclusions from the environment variable', () => {
+  assert.deepEqual(
+    getExcludedKeywords('https://example.com, https://another.example.com'),
+    ['https://example.com', 'https://another.example.com'],
   );
 });


### PR DESCRIPTION
# Purpose of PR

Prevent the Forma 36 website linkchecker job from failing when `contentful.com` or one of its subdomains returns HTTP 429 due to rate limiting. Other HTTP errors and 429 responses from unrelated domains remain blocking.
