### PR TITLE
chore(website): remove private playground dependencies

### DIFF
--- a/packages/website/components/LiveEditor/ComponentSource.tsx
+++ b/packages/website/components/LiveEditor/ComponentSource.tsx
@@ -34,6 +34,7 @@ import { Card, Button, CopyButton, Flex } from '@contentful/f36-components';
 import { theme } from './theme';
 import { formatSourceCode } from './utils';
 import * as coder from '../../utils/coder';
+import { useFrontMatterContext } from '../../utils/frontMatterContext';
 import * as f36icons from '@contentful/f36-icons';
 
 const liveProviderScope = {
@@ -154,12 +155,13 @@ export function ComponentSource({
   const [showSource, setShowSource] = useState(true);
   const tooltipId = useId();
   const copyTooltipId = `component-source-copy-${tooltipId}`;
+  const { status } = useFrontMatterContext() ?? {};
 
   const handleToggle = () => {
     setShowSource((prevState) => !prevState);
   };
 
-  const isExampleFromFile = Boolean(file);
+  const canOpenInPlayground = Boolean(file) && status !== 'alpha';
 
   return (
     <Flex flexDirection="column" className={styles.root}>
@@ -212,7 +214,7 @@ export function ComponentSource({
                     value={code}
                     size="small"
                   />
-                  {isExampleFromFile && (
+                  {canOpenInPlayground && (
                     <Button
                       as="a"
                       className={cx(styles.playgroundButton)}

--- a/packages/website/components/Playground/SandpackRenderer.tsx
+++ b/packages/website/components/Playground/SandpackRenderer.tsx
@@ -96,8 +96,6 @@ export function SandpackRenderer({
           'react-scripts': '^4.0.0',
           '@contentful/f36-components': '^6.0.0',
           '@contentful/f36-navbar': '^6.0.0',
-          '@contentful/f36-pill-next': '^6.0.1-alpha.7',
-          '@contentful/f36-table-next': '^6.0.1-alpha.1',
           '@contentful/f36-tokens': '^6.0.0',
           '@contentful/f36-icons': '^6.0.0',
           '@contentful/f36-utils': '^6.0.0',


### PR DESCRIPTION
# Purpose of PR

The public playground was requesting metadata for private alpha packages through the public npm registry. This caused Sandpack previews to fail before rendering, including the default Button example.

This removes the private `pill-next` and `table-next` packages from the public playground dependency list. Alpha component pages also hide the “Open in Playground” action because those packages are not available to Sandpack. Their inline examples and local documentation rendering remain available.
