### PR TITLE
chore: migrate pill components to Vitest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -153,6 +153,8 @@ module.exports = {
     '/packages/components/note/',
     '/packages/components/navlist/',
     '/packages/components/pagination/',
+    '/packages/components/pill/',
+    '/packages/components/pill-next/',
     '/packages/components/progress-stepper/',
     '/packages/components/skeleton/',
     '/packages/components/spinner/',

--- a/packages/components/pill-next/package.json
+++ b/packages/components/pill-next/package.json
@@ -38,8 +38,6 @@
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.0",
-    "@types/jest-axe": "^3.5.9",
-    "jest-axe": "^10.0.0"
+    "@testing-library/react": "^16.3.0"
   }
 }

--- a/packages/components/pill-next/src/PillNext.test.tsx
+++ b/packages/components/pill-next/src/PillNext.test.tsx
@@ -1,7 +1,8 @@
+import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { axe } from 'jest-axe';
 import { XIcon } from '@contentful/f36-icons';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { PillNext } from './PillNext';
 
@@ -70,7 +71,7 @@ describe('PillNext', () => {
     });
 
     it('calls onAction when action button is clicked', () => {
-      const mockOnAction = jest.fn();
+      const mockOnAction = vi.fn();
       render(
         <PillNext
           label="test"
@@ -109,7 +110,7 @@ describe('PillNext', () => {
     });
 
     it('does not call onAction when disabled', () => {
-      const mockOnAction = jest.fn();
+      const mockOnAction = vi.fn();
       render(
         <PillNext
           label="test"
@@ -147,8 +148,7 @@ describe('PillNext', () => {
   describe('accessibility', () => {
     it('has no a11y violations with label only', async () => {
       const { container } = render(<PillNext label="test" />);
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
+      await expectNoA11yViolations(container);
     });
 
     it('has no a11y violations with action button', async () => {
@@ -160,8 +160,7 @@ describe('PillNext', () => {
           actionButtonLabel="Remove"
         />,
       );
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
+      await expectNoA11yViolations(container);
     });
 
     it('has no a11y violations with disabled action button', async () => {
@@ -174,8 +173,7 @@ describe('PillNext', () => {
           isDisabled
         />,
       );
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
+      await expectNoA11yViolations(container);
     });
 
     it('action button is not focusable when disabled', () => {

--- a/packages/components/pill-next/src/Tag/Tag.test.tsx
+++ b/packages/components/pill-next/src/Tag/Tag.test.tsx
@@ -1,7 +1,8 @@
+import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { axe } from 'jest-axe';
 import { XIcon } from '@contentful/f36-icons';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Tag } from './Tag';
 
@@ -101,7 +102,7 @@ describe('Tag', () => {
     });
 
     it('calls onAction when action button is clicked', () => {
-      const mockOnAction = jest.fn();
+      const mockOnAction = vi.fn();
       render(
         <Tag
           label="test"
@@ -143,7 +144,7 @@ describe('Tag', () => {
     });
 
     it('does not call onAction when disabled', () => {
-      const mockOnAction = jest.fn();
+      const mockOnAction = vi.fn();
       render(
         <Tag
           label="test"
@@ -179,8 +180,7 @@ describe('Tag', () => {
       const { container } = render(
         <Tag label="test" badge={<span>Draft</span>} />,
       );
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
+      await expectNoA11yViolations(container);
     });
 
     it('has no a11y violations with action button', async () => {
@@ -193,8 +193,7 @@ describe('Tag', () => {
           actionButtonLabel="Remove"
         />,
       );
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
+      await expectNoA11yViolations(container);
     });
 
     it('has no a11y violations with disabled action button', async () => {
@@ -208,8 +207,7 @@ describe('Tag', () => {
           isDisabled
         />,
       );
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
+      await expectNoA11yViolations(container);
     });
   });
 });

--- a/packages/components/pill/package.json
+++ b/packages/components/pill/package.json
@@ -38,8 +38,6 @@
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.0",
-    "@types/jest-axe": "^3.5.9",
-    "jest-axe": "^10.0.0"
+    "@testing-library/react": "^16.3.0"
   }
 }

--- a/packages/components/pill/src/Pill.test.tsx
+++ b/packages/components/pill/src/Pill.test.tsx
@@ -1,7 +1,8 @@
+import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { axe } from 'jest-axe';
 import tokens from '@contentful/f36-tokens';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Pill } from './Pill';
 
@@ -21,7 +22,7 @@ describe('Pill', () => {
   });
 
   it('renders the component with a dragging handle', () => {
-    const mockOnDrag = jest.fn();
+    const mockOnDrag = vi.fn();
     const { container } = render(<Pill label="test" onDrag={mockOnDrag} />);
 
     const dragHandler = screen.getByText('Reorder item');
@@ -31,7 +32,7 @@ describe('Pill', () => {
   });
 
   it('renders the component with a close button', () => {
-    const mockOnClose = jest.fn();
+    const mockOnClose = vi.fn();
     const { container } = render(<Pill label="test" onClose={mockOnClose} />);
 
     const button = screen.getByRole('button');
@@ -74,8 +75,6 @@ describe('Pill', () => {
 
   it('has no a11y issues', async () => {
     const { container } = render(<Pill label="test" />);
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1317,12 +1317,6 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@types/jest-axe':
-        specifier: ^3.5.9
-        version: 3.5.9
-      jest-axe:
-        specifier: ^10.0.0
-        version: 10.0.0
 
   packages/components/pill-next:
     dependencies:
@@ -1351,12 +1345,6 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@types/jest-axe':
-        specifier: ^3.5.9
-        version: 3.5.9
-      jest-axe:
-        specifier: ^10.0.0
-        version: 10.0.0
 
   packages/components/popover:
     dependencies:

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -61,6 +61,8 @@ const testFiles = [
   'packages/components/note/src/**/*.test.tsx',
   'packages/components/navlist/src/**/*.test.tsx',
   'packages/components/pagination/src/**/*.test.tsx',
+  'packages/components/pill/src/**/*.test.tsx',
+  'packages/components/pill-next/src/**/*.test.tsx',
   'packages/components/progress-stepper/src/**/*.test.tsx',
   'packages/components/skeleton/src/**/*.test.tsx',
   'packages/components/spinner/src/**/*.test.tsx',


### PR DESCRIPTION
# Purpose of PR

Migrates the pill and pill-next component packages from Jest to Vitest as the next PR in the migration stack. Tests now import Vitest APIs directly, use the shared axe-core helper, and the converted package tests are excluded from Jest.

This PR is based on `chore/vitest-foundation-components`.
