### PR TITLE
chore: migrate avatar to Vitest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -139,6 +139,7 @@ module.exports = {
     '/dist/',
     '/packages/components/accordion/',
     '/packages/components/asset/',
+    '/packages/components/avatar/',
     '/packages/components/badge/',
     '/packages/components/button/',
     '/packages/components/card/',

--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -39,8 +39,6 @@
     "@contentful/f36-icons": "^6.19.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
-    "@testing-library/user-event": "^14.6.1",
-    "@types/jest-axe": "^3.5.9",
-    "jest-axe": "^10.0.0"
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/avatar/src/Avatar/Avatar.test.tsx
+++ b/packages/components/avatar/src/Avatar/Avatar.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -5,9 +6,9 @@ import tokens from '@contentful/f36-tokens';
 import { CheckCircleIcon } from '@contentful/f36-icons';
 import { Avatar } from './Avatar';
 
-jest.mock('@contentful/f36-image', () => ({
+vi.mock('@contentful/f36-image', () => ({
   // eslint-disable-next-line jsx-a11y/alt-text
-  Image: jest.fn((props) => <img {...props} />),
+  Image: vi.fn((props) => <img {...props} />),
 }));
 
 describe('Avatar', () => {

--- a/packages/components/avatar/src/AvatarGroup/AvatarGroup.test.tsx
+++ b/packages/components/avatar/src/AvatarGroup/AvatarGroup.test.tsx
@@ -1,12 +1,13 @@
+import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Avatar } from '../Avatar';
 import { AvatarGroup } from './AvatarGroup';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
-jest.mock('@contentful/f36-image', () => ({
-  Image: jest.fn((props) => <img alt="fallback avatar" {...props} />),
+vi.mock('@contentful/f36-image', () => ({
+  Image: vi.fn((props) => <img alt="fallback avatar" {...props} />),
 }));
 
 const imgUrl = 'https://example.com/image.jpg';
@@ -126,8 +127,6 @@ describe('AvatarGroup', () => {
         <Avatar alt="Bart Simpson" src={imgUrl} />
       </AvatarGroup>,
     );
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,12 +462,6 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
-      '@types/jest-axe':
-        specifier: ^3.5.9
-        version: 3.5.9
-      jest-axe:
-        specifier: ^10.0.0
-        version: 10.0.0
 
   packages/components/badge:
     dependencies:

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -47,6 +47,7 @@ const aliases = [
 const testFiles = [
   'packages/components/accordion/src/**/*.test.tsx',
   'packages/components/asset/src/**/*.test.tsx',
+  'packages/components/avatar/src/**/*.test.tsx',
   'packages/components/badge/src/**/*.test.tsx',
   'packages/components/button/src/**/*.test.tsx',
   'packages/components/card/src/**/*.test.tsx',


### PR DESCRIPTION
# Purpose of PR

Migrates the avatar component package from Jest to Vitest as the next PR in the migration stack. Tests now import Vitest APIs directly, use the shared axe-core helper, and the converted package tests are excluded from Jest.

This PR is based on `chore/vitest-pill-components`.
