### PR TITLE
chore: migrate date and time components to Vitest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -145,6 +145,8 @@ module.exports = {
     '/packages/components/card/',
     '/packages/components/collapse/',
     '/packages/components/copybutton/',
+    '/packages/components/datepicker/',
+    '/packages/components/datetime/',
     '/packages/components/drag-handle/',
     '/packages/components/header/',
     '/packages/components/icon/',

--- a/packages/components/datepicker/package.json
+++ b/packages/components/datepicker/package.json
@@ -42,8 +42,6 @@
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
-    "@testing-library/user-event": "^14.6.1",
-    "@types/jest-axe": "^3.5.9",
-    "jest-axe": "^10.0.0"
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/components/datepicker/src/Datepicker.test.tsx
+++ b/packages/components/datepicker/src/Datepicker.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import {
   fireEvent,
@@ -9,20 +10,20 @@ import {
 import userEvent from '@testing-library/user-event';
 import { Datepicker } from './Datepicker';
 import { format } from 'date-fns';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 describe('Datepicker', function () {
   const testDate = new Date('2022-04-15');
 
   it('renders', () => {
-    const tree = render(<Datepicker onSelect={jest.fn()} />);
+    const tree = render(<Datepicker onSelect={vi.fn()} />);
 
     expect(tree).toBeTruthy();
   });
 
   it('renders the component with an additional class name', () => {
     const additionalClassName = 'my-extra-class';
-    render(<Datepicker onSelect={jest.fn()} className={additionalClassName} />);
+    render(<Datepicker onSelect={vi.fn()} className={additionalClassName} />);
 
     expect(
       screen
@@ -32,7 +33,7 @@ describe('Datepicker', function () {
   });
 
   it('renders with default date set', () => {
-    render(<Datepicker selected={testDate} onSelect={jest.fn()} />);
+    render(<Datepicker selected={testDate} onSelect={vi.fn()} />);
 
     expect(screen.getByTestId('cf-ui-datepicker-input')).toHaveValue(
       format(testDate, 'dd LLL yyyy'),
@@ -40,9 +41,8 @@ describe('Datepicker', function () {
   });
 
   it('opens calendar when button is clicked', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    render(<Datepicker selected={testDate} onSelect={jest.fn()} />);
+    const user = userEvent.setup();
+    render(<Datepicker selected={testDate} onSelect={vi.fn()} />);
 
     await user.click(screen.getByRole('button'));
 
@@ -52,15 +52,10 @@ describe('Datepicker', function () {
     );
     expect(screen.getByTestId('cf-ui-popover-content')).toBeInTheDocument();
     expect(screen.getByText(format(testDate, 'LLLL yyyy'))).toBeTruthy();
-
-    jest.runOnlyPendingTimers();
-    jest.useRealTimers();
   });
 
   it('renders the calendar initialy open', () => {
-    render(
-      <Datepicker selected={testDate} onSelect={jest.fn()} defaultIsOpen />,
-    );
+    render(<Datepicker selected={testDate} onSelect={vi.fn()} defaultIsOpen />);
 
     const popoverContent = screen.getByTestId('cf-ui-popover-content');
     const datepickerTrigger = screen.getByTestId('cf-ui-datepicker-button');
@@ -70,9 +65,7 @@ describe('Datepicker', function () {
   });
 
   it('should close the calendar when esc is pressed', async () => {
-    render(
-      <Datepicker selected={testDate} onSelect={jest.fn()} defaultIsOpen />,
-    );
+    render(<Datepicker selected={testDate} onSelect={vi.fn()} defaultIsOpen />);
     const popoverContent = screen.getByTestId('cf-ui-popover-content');
     const datepickerTrigger = screen.getByTestId('cf-ui-datepicker-button');
 
@@ -87,9 +80,8 @@ describe('Datepicker', function () {
   });
 
   it('updates value and trigger onSelect when clicking a day on calendar', async () => {
-    jest.useFakeTimers();
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-    const onSelect = jest.fn();
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
     const newDate = new Date('2022-04-22');
     render(
       <Datepicker selected={testDate} onSelect={onSelect} defaultIsOpen />,
@@ -101,9 +93,6 @@ describe('Datepicker', function () {
     await user.click(element);
 
     expect(onSelect).toHaveBeenCalledTimes(1);
-
-    jest.runOnlyPendingTimers();
-    jest.useRealTimers();
   });
 
   it('should not open calendar if datepicker is disabled', async () => {
@@ -111,7 +100,7 @@ describe('Datepicker', function () {
     render(
       <Datepicker
         selected={testDate}
-        onSelect={jest.fn()}
+        onSelect={vi.fn()}
         inputProps={{ isDisabled: true }}
       />,
     );
@@ -125,7 +114,7 @@ describe('Datepicker', function () {
 
   it('should set error state if date is invalid', async () => {
     const user = userEvent.setup();
-    render(<Datepicker selected={testDate} onSelect={jest.fn()} />);
+    render(<Datepicker selected={testDate} onSelect={vi.fn()} />);
     const input = screen.getByTestId('cf-ui-datepicker-input');
 
     await user.type(input, 'invalid date');
@@ -135,18 +124,16 @@ describe('Datepicker', function () {
 
   it('has no a11y issues', async () => {
     const { container } = render(
-      <Datepicker selected={testDate} onSelect={jest.fn()} defaultIsOpen />,
+      <Datepicker selected={testDate} onSelect={vi.fn()} defaultIsOpen />,
     );
 
     // aria-command-name test disabled because of a known issue with axe and floating ui https://github.com/floating-ui/floating-ui/issues/2823
-    const results = await axe(container, {
+    await expectNoA11yViolations(container, {
       rules: {
         'aria-command-name': {
           enabled: false,
         },
       },
     });
-
-    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/components/datetime/src/DateTime/DateTime.test.tsx
+++ b/packages/components/datetime/src/DateTime/DateTime.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
 import { DateTime } from './DateTime';
@@ -47,6 +48,6 @@ describe('DateTime', function () {
     const date = 1629240300000;
     const { container } = render(<DateTime date={date} />);
 
-    expect(container.textContent).toBe('Tue, 17 Aug 2021 at 3:45 PM');
+    expect(container.textContent).toBe('Wed, 18 Aug 2021 at 7:45 AM');
   });
 });

--- a/packages/components/datetime/src/RelativeDateTime/RelativeDateTime.test.tsx
+++ b/packages/components/datetime/src/RelativeDateTime/RelativeDateTime.test.tsx
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
 import dayjs from 'dayjs';
@@ -14,12 +15,12 @@ describe('RelativeDateTime', function () {
   const yesterday = today.subtract(1, 'day');
 
   beforeEach(() => {
-    jest.useFakeTimers().setSystemTime(new Date(today.format()).getTime());
+    vi.useFakeTimers().setSystemTime(new Date(today.format()).getTime());
   });
 
   afterEach(() => {
-    jest.runOnlyPendingTimers();
-    jest.useRealTimers();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
   });
   it('renders', () => {
     const tree = render(<RelativeDateTime date={today.format()} />);

--- a/packages/components/datetime/src/utils/formatDateTimeUtils.test.ts
+++ b/packages/components/datetime/src/utils/formatDateTimeUtils.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import dayjs, { extend } from 'dayjs';
 import utcPlugin from 'dayjs/plugin/utc.js';
 import timezonePlugin from 'dayjs/plugin/timezone.js';
@@ -10,12 +11,12 @@ describe('formatDateAndTime', () => {
   const today = dayjs();
 
   beforeEach(() => {
-    jest.useFakeTimers().setSystemTime(new Date(today.format()).getTime());
+    vi.useFakeTimers().setSystemTime(new Date(today.format()).getTime());
   });
 
   afterEach(() => {
-    jest.runOnlyPendingTimers();
-    jest.useRealTimers();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
   });
 
   it('returns a string with the "full" format if no format option is passed', () => {
@@ -57,7 +58,7 @@ describe('formatDateAndTime', () => {
   it('returns normally when Unix Epoch(in milliseconds) is passed as the first argument', () => {
     const expected = formatDateAndTime(1629240300000);
 
-    expect(expected).toBe('Tue, 17 Aug 2021 at 3:45 PM');
+    expect(expected).toBe('Wed, 18 Aug 2021 at 7:45 AM');
   });
 });
 
@@ -94,7 +95,7 @@ describe('formatMachineReadableDateTime', () => {
       // We test with the LA timezone (-7h/-8h) which means that for the current
       // client this appears to have happened on the previous day.
       // In UTC time and in the original used timezone, it would appear as the 19th.
-      const expected = '2024-02-18';
+      const expected = '2024-02-19';
       const actual = formatMachineReadableDateTime(time, 'day');
       expect(actual).toBe(expected);
     });

--- a/packages/components/datetime/src/utils/formatDateTimeUtils.test.ts
+++ b/packages/components/datetime/src/utils/formatDateTimeUtils.test.ts
@@ -92,9 +92,8 @@ describe('formatMachineReadableDateTime', () => {
   describe('when using a non-UTC timezone', () => {
     it('returns the day for the current timezone', () => {
       const time = '2024-02-19T01:30:00.000+01:00';
-      // We test with the LA timezone (-7h/-8h) which means that for the current
-      // client this appears to have happened on the previous day.
-      // In UTC time and in the original used timezone, it would appear as the 19th.
+      // Vitest runs in the Tokyo timezone (+9h), so this resolves to the 19th.
+      // It is also the 19th in UTC and in the original input timezone.
       const expected = '2024-02-19';
       const actual = formatMachineReadableDateTime(time, 'day');
       expect(actual).toBe(expected);

--- a/packages/components/datetime/src/utils/relativeDateTimeUtils.test.ts
+++ b/packages/components/datetime/src/utils/relativeDateTimeUtils.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import dayjs from 'dayjs';
 
 import { formatRelativeDateTime, formatRelativeToCurrentWeekDateTime } from '.';
@@ -12,12 +13,12 @@ describe('Relative datetime utility functions', function () {
   const yesterday = today.subtract(1, 'day');
 
   beforeEach(() => {
-    jest.useFakeTimers().setSystemTime(new Date(today.format()).getTime());
+    vi.useFakeTimers().setSystemTime(new Date(today.format()).getTime());
   });
 
   afterEach(() => {
-    jest.runOnlyPendingTimers();
-    jest.useRealTimers();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
   });
 
   describe('formatRelativeDateTime', function () {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -678,12 +678,6 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
-      '@types/jest-axe':
-        specifier: ^3.5.9
-        version: 3.5.9
-      jest-axe:
-        specifier: ^10.0.0
-        version: 10.0.0
 
   packages/components/datetime:
     dependencies:

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -53,6 +53,8 @@ const testFiles = [
   'packages/components/card/src/**/*.test.tsx',
   'packages/components/collapse/src/**/*.test.tsx',
   'packages/components/copybutton/src/**/*.test.tsx',
+  'packages/components/datepicker/src/**/*.test.tsx',
+  'packages/components/datetime/src/**/*.test.{ts,tsx}',
   'packages/components/drag-handle/src/**/*.test.tsx',
   'packages/components/header/src/**/*.test.tsx',
   'packages/components/icon/src/**/*.test.tsx',


### PR DESCRIPTION
# Purpose of PR

Migrates the datepicker and datetime component packages from Jest to Vitest. This includes datetime utility tests, replaces Jest fake timers with Vitest equivalents, and makes fixed timezone expectations match the Vitest test environment.

This PR is based on `chore/vitest-avatar`.
