### PR TITLE
chore: ignore missing Algolia peer warnings

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,14 @@ catalog:
 
 linkWorkspacePackages: true
 autoInstallPeers: false
+
+# DocSearch brings these Algolia peers transitively, but does not use them directly.
+peerDependencyRules:
+  ignoreMissing:
+    - search-insights
+    - '@algolia/client-search'
+    - algoliasearch
+
 # 15 days, matching the shared Renovate configuration.
 minimumReleaseAge: 21600
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## Purpose

Silence pnpm warnings for Algolia peer dependencies brought in transitively by `@docsearch/react`. These peers are not used directly by the website.

## Verification

- `pnpm install --lockfile-only --offline --ignore-scripts --frozen-lockfile`
- Pre-commit hook passed
