### PR TITLE
chore: migrate forms tests to Vitest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -149,6 +149,7 @@ module.exports = {
     '/packages/components/datetime/',
     '/packages/components/drag-handle/',
     '/packages/components/entity-list/',
+    '/packages/components/forms/',
     '/packages/components/header/',
     '/packages/components/icon/',
     '/packages/components/image/',

--- a/packages/components/forms/package.json
+++ b/packages/components/forms/package.json
@@ -41,9 +41,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "@types/jest-axe": "^3.5.9",
     "formik": "^2.4.2",
-    "jest-axe": "^10.0.0",
     "react-hook-form": "^7.15.0"
   }
 }

--- a/packages/components/forms/src/BaseCheckbox/BaseCheckbox.test.tsx
+++ b/packages/components/forms/src/BaseCheckbox/BaseCheckbox.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { BaseCheckbox } from './BaseCheckbox';
 
@@ -60,7 +61,7 @@ describe('BaseCheckbox', function () {
   });
 
   it('can blur when clicking escape', () => {
-    const mockOnBlur = jest.fn();
+    const mockOnBlur = vi.fn();
     const { getByLabelText } = render(
       <BaseCheckbox {...commonProps} onBlur={mockOnBlur} willBlurOnEsc />,
     );
@@ -74,8 +75,6 @@ describe('BaseCheckbox', function () {
 
   it('has no a11y issues', async () => {
     const { container } = render(<BaseCheckbox {...commonProps} />);
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/BaseCheckbox/BaseCheckboxGroup.test.tsx
+++ b/packages/components/forms/src/BaseCheckbox/BaseCheckboxGroup.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 import { BaseCheckboxGroup } from './BaseCheckboxGroup';
 import { BaseCheckbox } from './BaseCheckbox';
 
@@ -40,7 +41,6 @@ describe('BaseCheckboxGroup', () => {
         ))}
       </BaseCheckboxGroup>,
     );
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/BaseInput/BaseInput.test.tsx
+++ b/packages/components/forms/src/BaseInput/BaseInput.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { BaseInput } from './BaseInput';
 
@@ -68,7 +69,7 @@ describe('InputBase', function () {
   });
 
   it('can blur when clicking escape', () => {
-    const onBlur = jest.fn();
+    const onBlur = vi.fn();
     const { getByLabelText } = render(
       <BaseInput
         id="InputBase"
@@ -89,8 +90,6 @@ describe('InputBase', function () {
     const { container } = render(
       <BaseInput id="InputBase" aria-label="InputBase" />,
     );
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/Checkbox/Checkbox.test.tsx
+++ b/packages/components/forms/src/Checkbox/Checkbox.test.tsx
@@ -1,7 +1,8 @@
+import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Checkbox } from './Checkbox';
 
@@ -17,7 +18,7 @@ describe('Checkbox', function () {
   });
 
   it('calls the onchange handler', async () => {
-    const handleChange = jest.fn();
+    const handleChange = vi.fn();
     const user = userEvent.setup();
 
     const { getByLabelText } = render(
@@ -33,8 +34,6 @@ describe('Checkbox', function () {
 
   it('has no a11y issues', async () => {
     const { container } = render(<Checkbox id="checkbox">label text</Checkbox>);
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/Checkbox/CheckboxGroup.test.tsx
+++ b/packages/components/forms/src/Checkbox/CheckboxGroup.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Checkbox } from './Checkbox';
 import { CheckboxGroup } from './CheckboxGroup';
@@ -23,8 +24,8 @@ describe('CheckboxGroup', function () {
   });
 
   it('should trigger the group and individual onChange when interacting with internal checkboxes', () => {
-    const mockOnChange = jest.fn();
-    const mockInternalOnChange = jest.fn();
+    const mockOnChange = vi.fn();
+    const mockInternalOnChange = vi.fn();
     const { getAllByRole } = render(
       <CheckboxGroup name="checkbox-options" onChange={mockOnChange}>
         <Checkbox
@@ -60,8 +61,6 @@ describe('CheckboxGroup', function () {
         </Checkbox>
       </CheckboxGroup>,
     );
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/FormLabel/FormLabel.test.tsx
+++ b/packages/components/forms/src/FormLabel/FormLabel.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { FormLabel } from './FormLabel';
 
@@ -54,8 +55,6 @@ describe('FormControl.Label', function () {
     const { container } = render(
       <FormLabel htmlFor="someInput">{labelText}</FormLabel>,
     );
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/HelpText/HelpText.test.tsx
+++ b/packages/components/forms/src/HelpText/HelpText.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 import { HelpText } from './HelpText';
 
 describe('HelpText', function () {
@@ -21,8 +22,6 @@ describe('HelpText', function () {
 
   it('has no a11y issues', async () => {
     const { container } = render(<HelpText>{helpText}</HelpText>);
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/Radio/Radio.test.tsx
+++ b/packages/components/forms/src/Radio/Radio.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Radio } from './Radio';
 
@@ -21,8 +22,6 @@ describe('Radio', function () {
 
   it('has no a11y issues', async () => {
     const { container } = render(<Radio>radio-button</Radio>);
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/Radio/RadioGroup.test.tsx
+++ b/packages/components/forms/src/Radio/RadioGroup.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Radio } from './Radio';
 import { RadioGroup } from './RadioGroup';
@@ -23,8 +24,8 @@ describe('RadioGroup', function () {
   });
 
   it('should trigger the group and individual onChange when interacting with internal radios', () => {
-    const mockOnChange = jest.fn();
-    const mockInternalOnChange = jest.fn();
+    const mockOnChange = vi.fn();
+    const mockInternalOnChange = vi.fn();
     const { getAllByRole } = render(
       <RadioGroup name="radio-options" onChange={mockOnChange}>
         <Radio onChange={mockInternalOnChange} value="option 1" id="option-1">
@@ -56,8 +57,6 @@ describe('RadioGroup', function () {
         </Radio>
       </RadioGroup>,
     );
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/Select/Select.test.tsx
+++ b/packages/components/forms/src/Select/Select.test.tsx
@@ -1,14 +1,15 @@
+import { describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Select } from './CompoundSelect';
 
 describe('Select', () => {
   it('should not dispatch onChange if disabled', async () => {
     const user = userEvent.setup();
-    const mockOnChange = jest.fn();
+    const mockOnChange = vi.fn();
     render(
       <Select
         name="optionSelect"
@@ -26,7 +27,7 @@ describe('Select', () => {
 
   it('should dispatch onChange', async () => {
     const user = userEvent.setup();
-    const mockOnChange = jest.fn();
+    const mockOnChange = vi.fn();
     render(
       <Select name="optionSelect" id="optionSelect" onChange={mockOnChange}>
         <Select.Option value="optionOne">Option One</Select.Option>
@@ -52,8 +53,6 @@ describe('Select', () => {
         <Select.Option value="optionThree">Selected option</Select.Option>
       </Select>,
     );
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/Switch/Switch.test.tsx
+++ b/packages/components/forms/src/Switch/Switch.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Switch } from './Switch';
 
@@ -21,8 +22,6 @@ describe('Switch', function () {
 
   it('has no a11y issues', async () => {
     const { container } = render(<Switch>Switch</Switch>);
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/TextInput/input-group/InputGroup.test.tsx
+++ b/packages/components/forms/src/TextInput/input-group/InputGroup.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { InputGroup } from './InputGroup';
 import { TextInput } from '@contentful/f36-forms';
@@ -62,8 +63,6 @@ describe('InputGroup', function () {
         />
       </InputGroup>,
     );
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/Textarea/Textarea.test.tsx
+++ b/packages/components/forms/src/Textarea/Textarea.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Textarea } from './Textarea';
 
@@ -32,8 +33,6 @@ describe('Textarea', function () {
     const { container } = render(
       <Textarea id="textarea" aria-label={labelText} />,
     );
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/ValidationMessage/ValidationMessage.test.tsx
+++ b/packages/components/forms/src/ValidationMessage/ValidationMessage.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { ValidationMessage } from './ValidationMessage';
 
@@ -30,8 +31,6 @@ describe('ValidationMessage', function () {
     const { container } = render(
       <ValidationMessage>This field is required</ValidationMessage>,
     );
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 });

--- a/packages/components/forms/src/test-integrations/Formik.test.tsx
+++ b/packages/components/forms/src/test-integrations/Formik.test.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { Formik, Field } from 'formik';
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
@@ -119,7 +120,7 @@ const MockForm = ({ handleData }) => {
   );
 };
 
-const mockHandleData = jest.fn((data) => {
+const mockHandleData = vi.fn((data) => {
   return Promise.resolve({ ...data });
 });
 

--- a/packages/components/forms/src/test-integrations/ReactHookForm.test.tsx
+++ b/packages/components/forms/src/test-integrations/ReactHookForm.test.tsx
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
@@ -91,7 +92,7 @@ const MockForm = ({ handleData }) => {
   );
 };
 
-const mockHandleData = jest.fn((data) => {
+const mockHandleData = vi.fn((data) => {
   return Promise.resolve({ ...data });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -814,15 +814,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
-      '@types/jest-axe':
-        specifier: ^3.5.9
-        version: 3.5.9
       formik:
         specifier: ^2.4.2
         version: 2.4.9(@types/react@19.2.10)(react@19.2.8)
-      jest-axe:
-        specifier: ^10.0.0
-        version: 10.0.0
       react-hook-form:
         specifier: ^7.15.0
         version: 7.71.1(react@19.2.8)

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -57,6 +57,7 @@ const testFiles = [
   'packages/components/datetime/src/**/*.test.{ts,tsx}',
   'packages/components/drag-handle/src/**/*.test.tsx',
   'packages/components/entity-list/src/**/*.test.tsx',
+  'packages/components/forms/src/**/*.test.tsx',
   'packages/components/header/src/**/*.test.tsx',
   'packages/components/icon/src/**/*.test.tsx',
   'packages/components/image/src/**/*.test.tsx',


### PR DESCRIPTION
# Purpose of PR

Migrate the forms package tests from Jest to Vitest, keeping the existing test coverage and behavior while aligning the package with the repository's Vitest migration.
