### PR TITLE
chore: migrate core and utils tests to Vitest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -169,6 +169,8 @@ module.exports = {
     '/packages/components/typography/',
     '/packages/components/usage-card/',
     '/packages/components/usage-count/',
+    '/packages/components/utils/',
+    '/packages/core/',
     '/packages/forma-36-codemod/',
   ],
 

--- a/packages/components/utils/src/Portal/Portal.test.tsx
+++ b/packages/components/utils/src/Portal/Portal.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
 

--- a/packages/components/utils/src/getIconColorToken/getIconColorToken.test.ts
+++ b/packages/components/utils/src/getIconColorToken/getIconColorToken.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { getIconColorToken, iconColorByVariant } from './getIconColorToken';
 import type { Variant } from './getIconColorToken';
 import { ColorTokens } from '@contentful/f36-tokens';

--- a/packages/components/utils/src/getStringMatch/getStringMatch.test.ts
+++ b/packages/components/utils/src/getStringMatch/getStringMatch.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { getStringMatch } from './getStringMatch';
 
 describe('getStringMatch', () => {

--- a/packages/components/utils/src/getTextFromChildren/getTextFromChildren.test.tsx
+++ b/packages/components/utils/src/getTextFromChildren/getTextFromChildren.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { getTextFromChildren } from './getTextFromChildren';
 

--- a/packages/components/utils/src/hexToRGBA/hexToRGBA.test.ts
+++ b/packages/components/utils/src/hexToRGBA/hexToRGBA.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { hexToRGBA } from './hexToRGBA';
 import tokens from '@contentful/f36-tokens';
 

--- a/packages/components/utils/src/useDensity/useDensity.test.tsx
+++ b/packages/components/utils/src/useDensity/useDensity.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render, renderHook } from '@testing-library/react';
 

--- a/packages/components/utils/src/useKeyboard/useKeyboard.test.tsx
+++ b/packages/components/utils/src/useKeyboard/useKeyboard.test.tsx
@@ -1,10 +1,11 @@
+import { describe, expect, it, vi } from 'vitest';
 import React, { useRef } from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 
 import { useKeyboard } from './useKeyboard';
 
-const handleEnter = jest.fn();
-const handleArrowUp = jest.fn();
+const handleEnter = vi.fn();
+const handleArrowUp = vi.fn();
 
 const Component = () => {
   useKeyboard({
@@ -38,7 +39,7 @@ const ComponentWithRef = () => {
 describe('useKeyboard', () => {
   it('should attach handler to document by default', () => {
     const events = {};
-    document.addEventListener = jest.fn((event, callback) => {
+    document.addEventListener = vi.fn((event, callback) => {
       events[event] = callback;
     });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,8 +34,6 @@
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.0",
-    "@types/jest-axe": "^3.5.9",
-    "jest-axe": "^10.0.0"
+    "@testing-library/react": "^16.3.0"
   }
 }

--- a/packages/core/src/Box/Box.test.tsx
+++ b/packages/core/src/Box/Box.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 import tokens from '@contentful/f36-tokens';
 
 import { Box } from './Box';
@@ -20,9 +21,7 @@ describe('Box', () => {
 
   it('has no a11y issues', async () => {
     const { container } = render(<Box>Box</Box>);
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 
   describe('should have correct styles', () => {

--- a/packages/core/src/Flex/Flex.test.tsx
+++ b/packages/core/src/Flex/Flex.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 import tokens from '@contentful/f36-tokens';
 
 import { Flex } from './Flex';
@@ -25,9 +26,7 @@ describe('Flex', () => {
 
   it('has no a11y issues', async () => {
     const { container } = render(<Flex>Flex</Flex>);
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 
   describe('should have correct styles', () => {

--- a/packages/core/src/Grid/Grid.test.tsx
+++ b/packages/core/src/Grid/Grid.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { Grid } from './Grid';
 
@@ -19,9 +20,7 @@ describe('Grid', () => {
 
   it('has no a11y issues', async () => {
     const { container } = render(<Grid>Grid</Grid>);
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 
   describe('should have correct styles', () => {

--- a/packages/core/src/Grid/GridItem/GridItem.test.tsx
+++ b/packages/core/src/Grid/GridItem/GridItem.test.tsx
@@ -1,6 +1,7 @@
+import { describe, expect, it } from 'vitest';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { axe } from 'jest-axe';
+import { expectNoA11yViolations } from '@/scripts/test/expectNoA11yViolations';
 
 import { GridItem } from './GridItem';
 
@@ -23,9 +24,7 @@ describe('GridItem', () => {
 
   it('has no a11y issues', async () => {
     const { container } = render(<GridItem>Grid Item</GridItem>);
-    const results = await axe(container);
-
-    expect(results).toHaveNoViolations();
+    await expectNoA11yViolations(container);
   });
 
   describe('should have correct styles', () => {

--- a/packages/core/src/hooks/useImageLoaded.test.ts
+++ b/packages/core/src/hooks/useImageLoaded.test.ts
@@ -1,9 +1,10 @@
+import { describe, expect, it, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useImageLoaded } from './useImageLoaded';
 
 describe('useImageLoaded', () => {
   it('should call the onLoad function when the image loads', async () => {
-    const onLoad = jest.fn();
+    const onLoad = vi.fn();
     const mockImage = {
       complete: false,
       addEventListener: (event: string, callback: () => void) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1701,12 +1701,6 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@types/jest-axe':
-        specifier: ^3.5.9
-        version: 3.5.9
-      jest-axe:
-        specifier: ^10.0.0
-        version: 10.0.0
 
   packages/f36-ai-components:
     dependencies:

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -53,6 +53,7 @@ const testFiles = [
   'packages/components/card/src/**/*.test.tsx',
   'packages/components/collapse/src/**/*.test.tsx',
   'packages/components/copybutton/src/**/*.test.tsx',
+  'packages/components/utils/src/**/*.test.{ts,tsx}',
   'packages/components/datepicker/src/**/*.test.tsx',
   'packages/components/datetime/src/**/*.test.{ts,tsx}',
   'packages/components/drag-handle/src/**/*.test.tsx',
@@ -77,6 +78,7 @@ const testFiles = [
   'packages/components/typography/src/**/*.test.tsx',
   'packages/components/usage-card/src/**/*.test.tsx',
   'packages/components/usage-count/src/**/*.test.tsx',
+  'packages/core/src/**/*.test.{ts,tsx}',
 ];
 const ignoredPaths = [
   '**/node_modules/**',


### PR DESCRIPTION
# Purpose of PR

Migrate the core and utility package tests from Jest to Vitest as the next stack layer, preserving the existing assertions and test coverage.
