### PR TITLE
chore: align Renovate minimum release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>contentful/renovate-config"],
+  "minimumReleaseAge": "15 days",
   "rangeStrategy": "update-lockfile",
   "labels": ["dependencies"]
 }


### PR DESCRIPTION
# Purpose of PR

Align Renovate's minimum release age with pnpm's project policy. The repository's `pnpm-workspace.yaml` requires packages to be 15 days old before installation, so Renovate should use the same minimum age.
