### PR TITLE
chore: remove obsolete react-day-picker override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,6 @@ overrides:
   eslint-plugin-import>eslint: '>=9.0.0'
   eslint-plugin-jsx-a11y>eslint: '>=9.0.0'
   eslint-plugin-react>eslint: '>=9.0.0'
-  react-day-picker>react: '>=19.1.0'
 
 importers:
 
@@ -10890,7 +10889,7 @@ packages:
     resolution: {integrity: sha512-LK68OTbHB3oJNhl9cA0qVizzp3o26w61YSjAFkYi67N86iro32wx86kSNeFU/hq+gI8m1yzWhnomMLfZ041RzQ==}
     peerDependencies:
       date-fns: ^2.28.0 || ^3.0.0
-      react: '>=19.1.0'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-devtools-inline@4.4.0:
     resolution: {integrity: sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,4 +48,3 @@ overrides:
   'eslint-plugin-import>eslint': '>=9.0.0'
   'eslint-plugin-jsx-a11y>eslint': '>=9.0.0'
   'eslint-plugin-react>eslint': '>=9.0.0'
-  'react-day-picker>react': '>=19.1.0'


### PR DESCRIPTION
# Purpose of PR

Remove the `react-day-picker>react` pnpm override. `react-day-picker@8.10.2` already supports React 19, and the override does not change the resolved dependency graph. The lockfile now records the package's published peer dependency range.
