### PR TITLE
[AHOY-5112] Update TextInput value text color token from gray700 to gray900

### DIFF
--- a/.changeset/ahoy-5112-text-input-color-token.md
+++ b/.changeset/ahoy-5112-text-input-color-token.md
@@ -1,0 +1,6 @@
+---
+'@contentful/f36-tokens': minor
+'@contentful/f36-forms': patch
+---
+
+Add semantic input color tokens `color-text-input-value` (gray900) and `color-text-input-placeholder` (gray500). Update TextInput, Textarea, Select, Autocomplete, and MultiSelect to use them, replacing direct gray700/gray500 references.

--- a/packages/components/forms/src/BaseInput/BaseInput.styles.ts
+++ b/packages/components/forms/src/BaseInput/BaseInput.styles.ts
@@ -109,7 +109,7 @@ const getStyles = ({
       ...(as === 'textarea' ? { resize } : getSizeStyles({ size, density })),
 
       '&::placeholder': {
-        color: tokens.colorTextInputDefaultvalue,
+        color: tokens.colorTextInputPlaceholder,
       },
 
       '&:active, &:active:hover, &:focus': {

--- a/packages/components/forms/src/BaseInput/BaseInput.styles.ts
+++ b/packages/components/forms/src/BaseInput/BaseInput.styles.ts
@@ -97,7 +97,7 @@ const getStyles = ({
       boxSizing: 'border-box',
       backgroundColor: isDisabled ? tokens.gray100 : tokens.colorWhite,
       border: `1px solid ${isInvalid ? tokens.red600 : tokens.gray300}`,
-      color: tokens.gray700,
+      color: tokens.colorTextInputValue,
       fontFamily: tokens.fontStackPrimary,
       margin: 0,
       cursor: isDisabled ? 'not-allowed' : 'auto',
@@ -109,7 +109,7 @@ const getStyles = ({
       ...(as === 'textarea' ? { resize } : getSizeStyles({ size, density })),
 
       '&::placeholder': {
-        color: tokens.gray500,
+        color: tokens.colorTextInputDefaultvalue,
       },
 
       '&:active, &:active:hover, &:focus': {

--- a/packages/components/forms/src/Select/Select.styles.ts
+++ b/packages/components/forms/src/Select/Select.styles.ts
@@ -33,7 +33,7 @@ export function getSelectStyles({ isInvalid, isDisabled, size, density }) {
     display: 'block',
     appearance: 'none',
     backgroundColor: tokens.colorWhite,
-    color: tokens.gray700,
+    color: tokens.colorTextInputValue,
 
     fontSize: tokens.fontSizeM,
     lineHeight: tokens.lineHeightM,
@@ -47,7 +47,7 @@ export function getSelectStyles({ isInvalid, isDisabled, size, density }) {
     textOverflow: 'ellipsis',
 
     '&::placeholder': {
-      color: tokens.gray500,
+      color: tokens.colorTextInputDefaultvalue,
     },
     '&:focus': {
       outline: 'none',

--- a/packages/components/forms/src/Select/Select.styles.ts
+++ b/packages/components/forms/src/Select/Select.styles.ts
@@ -47,7 +47,7 @@ export function getSelectStyles({ isInvalid, isDisabled, size, density }) {
     textOverflow: 'ellipsis',
 
     '&::placeholder': {
-      color: tokens.colorTextInputDefaultvalue,
+      color: tokens.colorTextInputPlaceholder,
     },
     '&:focus': {
       outline: 'none',

--- a/packages/forma-36-tokens/src/tokens/colors/colors-input.js
+++ b/packages/forma-36-tokens/src/tokens/colors/colors-input.js
@@ -1,0 +1,8 @@
+const colorsGray = require('./colors-gray');
+
+const colorsInput = {
+  'color-text-input-value': colorsGray['gray-900'],
+  'color-text-input-defaultvalue': colorsGray['gray-500'],
+};
+
+module.exports = colorsInput;

--- a/packages/forma-36-tokens/src/tokens/colors/colors-input.js
+++ b/packages/forma-36-tokens/src/tokens/colors/colors-input.js
@@ -2,7 +2,7 @@ const colorsGray = require('./colors-gray');
 
 const colorsInput = {
   'color-text-input-value': colorsGray['gray-900'],
-  'color-text-input-defaultvalue': colorsGray['gray-500'],
+  'color-text-input-placeholder': colorsGray['gray-500'],
 };
 
 module.exports = colorsInput;


### PR DESCRIPTION
# Purpose of PR

The `TextInput`, `Textarea`, `Select`, `Autocomplete`, and `MultiSelect` components used `gray700` (#414D63) as the input value text color, which is insufficiently dark for readability. Design (Hande) and Daniel aligned that the typed value should use `gray900` (#111B2B) for sufficient contrast. This also introduces two semantic tokens (`color-text-input-value` and `color-text-input-defaultvalue`) as requested in [AHOY-5112](https://contentful.atlassian.net/browse/AHOY-5112) comments, making the intent explicit and reusable.

The approach adds `colors-input.js` to `forma-36-tokens` with the two new aliases (gray900 for value, gray500 for placeholder), then updates `BaseInput.styles.ts` and `Select.styles.ts` to use them. `Textarea`, `Autocomplete`, and `MultiSelect` all inherit through `BaseInput`/`TextInput` and pick up the change automatically.

## PR Checklist

- [ ] I have read the relevant `readme.md` file(s)
- [ ] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [ ] Tests are added/updated/not required
- [ ] Tests are passing
- [ ] Storybook stories are added/updated/not required
- [ ] Usage notes are added/updated/not required
- [ ] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [ ] Doesn't contain any sensitive information

[AHOY-5112]: https://contentful.atlassian.net/browse/AHOY-5112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ