### PR TITLE
fix: 🐛 restore CSS and JSON exports in f36-tokens package

### DIFF
--- a/.changeset/strict-singers-enter.md
+++ b/.changeset/strict-singers-enter.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-tokens": patch
+---
+
+fix: 🐛 restore CSS and JSON exports in f36-tokens package

--- a/packages/forma-36-tokens/README.md
+++ b/packages/forma-36-tokens/README.md
@@ -35,7 +35,7 @@ import F36Tokens from '@contentful/f36-tokens';
 #### JSON
 
 ```js
-import tokens from '@contentful/f36-tokens/dist/json/transitions/transition-easings';
+import tokens from '@contentful/f36-tokens/dist/json/transitions/transition-easings.json';
 ```
 
 ## Development

--- a/packages/forma-36-tokens/package.json
+++ b/packages/forma-36-tokens/package.json
@@ -11,7 +11,9 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.mjs"
-    }
+    },
+    "./dist/css/index.css": "./dist/css/index.css",
+    "./dist/json/*.json": "./dist/json/*.json"
   },
   "license": "MIT",
   "files": [


### PR DESCRIPTION
✅ Closes: #3569

# Purpose of PR

Add back JSON and CSS exports in the f36-tokens package, which got lost in the v6 update.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
