### PR TITLE
refactor(navbar): remove environment icon resizing

### DIFF
--- a/.changeset/spotty-deserts-lick.md
+++ b/.changeset/spotty-deserts-lick.md
@@ -1,0 +1,5 @@
+---
+"@contentful/f36-navbar": patch
+---
+
+refactor(navbar): remove environment icon resizing

--- a/packages/components/navbar/src/NavbarSwitcher/NavbarEnvVariant.tsx
+++ b/packages/components/navbar/src/NavbarSwitcher/NavbarEnvVariant.tsx
@@ -22,7 +22,7 @@ export function NavbarEnvVariant({
 }: NavbarEnvVariantProps) {
   if (envVariant === 'trial') {
     return (
-      <FlaskIcon color={tokens.purple700} className={className} size="medium" />
+      <FlaskIcon color={tokens.purple700} className={className} size="small" />
     );
   }
 
@@ -31,13 +31,13 @@ export function NavbarEnvVariant({
 
   if (isMaster) {
     return (
-      <RocketLaunchIcon color={color} className={className} size="medium" />
+      <RocketLaunchIcon color={color} className={className} size="small" />
     );
   } else if (isAlias) {
     return (
-      <EnvironmentAliasIcon color={color} className={className} size="medium" />
+      <EnvironmentAliasIcon color={color} className={className} size="small" />
     );
   }
 
-  return <EnvironmentIcon color={color} className={className} size="medium" />;
+  return <EnvironmentIcon color={color} className={className} size="small" />;
 }

--- a/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcher.styles.ts
+++ b/packages/components/navbar/src/NavbarSwitcher/NavbarSwitcher.styles.ts
@@ -87,10 +87,6 @@ export const getNavbarSwitcherStyles = (variant: EnvVariant) => ({
 
   switcherEnvIcon: css({
     minWidth: '0',
-    [mqs.small]: {
-      width: '16px',
-      height: '16px',
-    },
   }),
 });
 


### PR DESCRIPTION
# Purpose of PR

This aligns the navbar environment icon to a fixed `small` size.

## QA

→ https://forma-36-storybook-git-hk-000-space-switcher-env-icon-resize.colorfuldemo.com/?path=/story/components-navbar--with-responsiveness

**Before**

The environment icon increases in size on smaller screens (< 867px).

https://github.com/user-attachments/assets/c749be23-62d5-46f6-8956-24144f8bb585

**After**

The environment icon stays consistent across all screen sizes.

https://github.com/user-attachments/assets/95305a96-8c12-457c-873e-f41362728f2e

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
