### PR TITLE
docs: add agents-kits documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,98 @@
+# Forma 36 agent guidelines
+
+## Repository at a glance
+
+Forma 36 is Contentful's TypeScript/React design-system monorepo. It uses pnpm
+workspaces and Turborepo. The root workspace includes packages in
+`packages/*` and component packages in `packages/components/*`.
+
+- Use Node `24.x.x` (see `.nvmrc`) and pnpm `11` or newer.
+- Run commands from the repository root with `pnpm` unless a package-specific
+  command is required.
+- Treat generated output (`dist/`, `.next/`, `dist-storybook/`) as build
+  artifacts; do not edit it directly.
+- Never expose, commit, or print credentials. Local environment files are
+  intentionally ignored.
+
+## Find the right place before changing code
+
+- Reusable UI components live in `packages/components/<package>/src`.
+- Shared primitives and styling infrastructure live in `packages/core`.
+- Tokens are in `packages/forma-36-tokens`.
+- AI-focused components live in `packages/f36-ai-components`; this package is
+  currently private and prerelease.
+- The documentation site is `packages/website`.
+- Codemods are in `packages/forma-36-codemod`.
+- Shared test setup and helpers are in `scripts/test`.
+
+Read the nearest package `README`/`README.mdx` and its `package.json` before
+editing a package. Follow the component layout in
+[`docs/folder-structure.md`](docs/folder-structure.md): source, tests,
+examples, and stories are colocated with the package. Keep tests close to the
+code they exercise.
+
+## Implementing changes
+
+- Make the smallest change that satisfies the request; preserve public APIs
+  unless the task explicitly changes them.
+- Follow the existing local patterns before introducing a new abstraction,
+  dependency, or directory convention.
+- Use TypeScript and React idioms already used in the target package. Respect
+  the repository ESLint configuration rather than adding broad disables.
+- Follow [`docs/code-style-guide.md`](docs/code-style-guide.md) for component
+  API naming: callback props use `on…`, handlers use `handle…`, boolean state
+  uses `is…`, and visibility options use `with…` where applicable.
+- Preserve accessibility. For interactive or semantic UI changes, update or
+  add focused Testing Library/Vitest coverage and, when appropriate, a
+  Storybook story. The repository enables `jsx-a11y` and Storybook linting.
+- Update the package's MDX documentation/examples when a consumer-facing
+  component API or behavior changes. Component documentation is published by
+  the website, so retain the `README.mdx` naming convention.
+
+## Validate proportionately
+
+Run the narrowest relevant checks first, then expand for cross-package changes.
+The root commands are:
+
+```bash
+pnpm prettier:check
+pnpm lint
+pnpm tsc
+pnpm test
+pnpm exec knip
+pnpm build
+```
+
+`pnpm test` builds the token package first, then runs the configured Vitest
+suite in jsdom. Use a targeted Vitest invocation while iterating when possible;
+run the full suite for shared components, config, or workspace-wide changes.
+Do not use the root `pnpm prettier` command as a validation step: it writes to
+all matching source and Markdown files. Use `pnpm prettier:check`, or format
+only files you intentionally changed.
+
+For visual component changes, consider the existing Storybook workflow
+(`pnpm storybook` or `pnpm storybook:build`). Chromatic runs in CI. Website
+changes may need `pnpm docs:next:build`; link checking is a separate CI
+workflow and requires a production website build.
+
+## Releases, changesets, and pull requests
+
+- Read [`RELEASES.md`](RELEASES.md) before adding a release artifact.
+- Add a changeset for a publishable package change. Documentation-only changes
+  do not need one.
+- Do not add changesets for packages listed in `.changeset/config.json`'s
+  `ignore` array (including the private AI and website packages) unless the
+  release process is intentionally being changed.
+- Component packages are fixed-versioned as a group. Do not hand-edit package
+  versions, changelogs, or the lockfile to simulate a release.
+- Follow the PR checklist: tests/stories/documentation where needed, supported
+  browser behavior, and no sensitive information.
+
+## Agent operating rules
+
+- Inspect the working tree before editing and preserve unrelated user changes.
+- Do not run destructive Git commands, publish packages, deploy, or modify CI
+  credentials unless the user explicitly requests it.
+- State what you validated and what you did not validate in the handoff.
+- When repository documentation and these instructions disagree, follow the
+  more specific, nearer-to-code guidance and report the conflict.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,38 +55,50 @@ code they exercise.
 - Keep global browser-style behavior in `GlobalStyles` rather than introducing
   a competing global reset. It is the documented public mechanism for this
   concern and is built on Emotion's global styles support.
+- When a change would break a public component or prop API, follow the
+  [deprecation process](DEPRECATION.md) instead of removing it directly. A
+  deprecation needs a replacement and migration guidance; use
+  [MIGRATION.md](MIGRATION.md) and the affected component documentation for
+  before/after examples and any required codemod guidance.
 
-## Validate proportionately
+## Component quality and validation
 
-Run the narrowest relevant checks first, then expand for cross-package changes.
-The root commands are:
+For component work, make the implementation demonstrable and accessible:
+
+- Add or update Storybook stories that cover every relevant component variant
+  and interaction state.
+- Document recommended use and implementation patterns in the package's MDX
+  examples.
+- Add thorough Vitest/Testing Library coverage. Use the shared
+  `expectNoA11yViolations` helper for rendered component accessibility checks
+  where applicable.
+
+Before handing off, run the applicable root checks and ensure they succeed:
 
 ```bash
 pnpm prettier:check
 pnpm lint
-pnpm tsc
 pnpm test
-pnpm exec knip
 pnpm build
+pnpm storybook:build
 ```
 
-`pnpm test` builds the token package first, then runs the configured Vitest
-suite in jsdom. Use a targeted Vitest invocation while iterating when possible;
-run the full suite for shared components, config, or workspace-wide changes.
+Start Storybook with `pnpm storybook` for visual changes and confirm it serves
+the changed stories. `pnpm test` builds the token package before running the
+configured Vitest suite in jsdom. Use focused tests while iterating, but do not
+hand off a change with a failing lint, test, build, or Storybook build.
+
 Do not use the root `pnpm prettier` command as a validation step: it writes to
 all matching source and Markdown files. Use `pnpm prettier:check`, or format
 only files you intentionally changed.
-
-For visual component changes, consider the existing Storybook workflow
-(`pnpm storybook` or `pnpm storybook:build`). Chromatic runs in CI. Website
-changes may need `pnpm docs:next:build`; link checking is a separate CI
-workflow and requires a production website build.
 
 ## Releases, changesets, and pull requests
 
 - Read [`RELEASES.md`](RELEASES.md) before adding a release artifact.
 - Add a changeset for a publishable package change. Documentation-only changes
   do not need one.
+- Generate changesets only with `pnpm exec changeset` from the repository
+  root. Do not create or edit `.changeset` files by hand.
 - Do not add changesets for packages listed in `.changeset/config.json`'s
   `ignore` array (including the private AI and website packages) unless the
   release process is intentionally being changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,13 @@ code they exercise.
 - Update the package's MDX documentation/examples when a consumer-facing
   component API or behavior changes. Component documentation is published by
   the website, so retain the `README.mdx` naming convention.
+- Treat `@contentful/f36-components` as the primary consumer entry point; it
+  is tree-shakeable. Individual component packages and the separate
+  `@contentful/f36-icons` package are also supported public APIs, so preserve
+  their exports and package boundaries when making a change.
+- Keep global browser-style behavior in `GlobalStyles` rather than introducing
+  a competing global reset. It is the documented public mechanism for this
+  concern and is built on Emotion's global styles support.
 
 ## Validate proportionately
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,6 +39,14 @@ Reusable components are independently packaged beneath `packages/components`. Co
 
 `packages/core` contains shared primitives. `packages/forma-36-tokens` provides the token layer used by components. Prefer consuming these shared layers over duplicating tokens, layout primitives, or styling behavior in an individual component.
 
+## Consumer package boundaries
+
+Consumers ordinarily install `@contentful/f36-components`, the umbrella package for the component library. It is designed to be tree-shakeable, so its use does not require every component to be included in an application bundle.
+
+Individual component packages are also supported for consumers that need them. Icons are deliberately delivered through the separate `@contentful/f36-icons` package to keep the main component bundle smaller. Maintain these package exports and package boundaries as public API.
+
+`GlobalStyles` is the documented component for managing default browser styles. It uses Emotion's global styling support, so global browser-style changes belong there rather than in individual components.
+
 ## Build and dependency graph
 
 Package builds are commonly implemented with `tsup` and output to each package's `dist/` directory. The root `pnpm build` command runs the Turborepo build graph, so dependencies build before their consumers. Generated build output must not be edited manually.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,62 @@
+# Architecture
+
+Forma 36 is Contentful's TypeScript and React design-system monorepo. It uses pnpm workspaces for dependency management and Turborepo to coordinate builds across packages.
+
+## Workspace layout
+
+```text
+packages/
+  components/                  Publishable UI component packages
+  core/                        Shared React primitives and styling utilities
+  forma-36-tokens/             Design tokens
+  forma-36-react-components/   Umbrella package for the component library
+  f36-ai-components/           Private, prerelease AI-focused components
+  f36-docs-utils/              Documentation helpers
+  f36-i18n-utils/              Internationalisation utilities
+  forma-36-codemod/            Migration codemods
+  website/                     The Forma 36 documentation site
+  cdn/                         CDN assets
+scripts/                       Shared build, test, Storybook, and release tooling
+docs/                          Contributor and implementation documentation
+```
+
+The workspace roots are `packages/*` and `packages/components/*`. Every publishable package owns its `package.json`; package source generally begins at `src/index.ts`.
+
+## Components and documentation
+
+Reusable components are independently packaged beneath `packages/components`. Component code, unit tests, examples, and Storybook stories are deliberately colocated. A typical component package contains:
+
+```text
+<component>/
+  src/          Implementation, exports, and colocated tests
+  examples/     Documentation examples
+  stories/      Storybook stories
+  README.mdx    Published component documentation
+  package.json
+```
+
+`README.mdx` files are consumed by the documentation website as well as shown on GitHub. See [docs/folder-structure.md](docs/folder-structure.md) for the supported layouts, including multi-component packages.
+
+`packages/core` contains shared primitives. `packages/forma-36-tokens` provides the token layer used by components. Prefer consuming these shared layers over duplicating tokens, layout primitives, or styling behavior in an individual component.
+
+## Build and dependency graph
+
+Package builds are commonly implemented with `tsup` and output to each package's `dist/` directory. The root `pnpm build` command runs the Turborepo build graph, so dependencies build before their consumers. Generated build output must not be edited manually.
+
+The repository uses a pnpm catalog for React and React DOM versions and links workspace packages locally. Package dependencies and exports are the source of truth for public package boundaries.
+
+## Quality boundaries
+
+Vitest runs unit tests in jsdom, using aliases generated from workspace package metadata. Tests are restricted to the package paths listed in `vitest.config.mts`; add new test locations there only when introducing a new tested package area. Testing Library and the shared setup in `scripts/test` support component tests.
+
+ESLint covers TypeScript, React, accessibility, imports, and Storybook files. Prettier formats source and Markdown. CircleCI runs build, formatting, lint, type checking, Knip, tests, Storybook/Chromatic, and website link checks in separate workflows.
+
+## Documentation site
+
+`packages/website` is a private Next.js application. It renders component MDX and repository-driven documentation. Its production build is exposed through the root `pnpm docs:next:build` command; link checking starts the production site after a successful build.
+
+## Publishing
+
+Changesets drive releases for publishable packages. Most component packages and the umbrella package are fixed-versioned together. Packages listed in `.changeset/config.json`'s `ignore` array are excluded from the automated changeset flow; this includes private/prerelease packages such as `@contentful/f36-ai-components` and the website.
+
+Read [RELEASES.md](RELEASES.md) and [DEPRECATION.md](DEPRECATION.md) before changing the release or deprecation behavior.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,6 +47,12 @@ Individual component packages are also supported for consumers that need them. I
 
 `GlobalStyles` is the documented component for managing default browser styles. It uses Emotion's global styling support, so global browser-style changes belong there rather than in individual components.
 
+## API evolution and migrations
+
+Public component and prop APIs evolve through the repository's deprecation process. Do not remove or rename a public API directly when doing so would break consumers. Instead, follow [DEPRECATION.md](DEPRECATION.md): provide a replacement, document the deprecation, create migration guidance with before/after examples, and add a codemod when it is appropriate.
+
+Deprecations are introduced in a minor release and remain available for at least one major-version cycle or six months, whichever is longer. Removal happens in a later major release. Use [MIGRATION.md](MIGRATION.md), component migration documentation, and [DEPRECATIONLOG.md](DEPRECATIONLOG.md) to keep the migration path discoverable.
+
 ## Build and dependency graph
 
 Package builds are commonly implemented with `tsup` and output to each package's `dist/` directory. The root `pnpm build` command runs the Turborepo build graph, so dependencies build before their consumers. Generated build output must not be edited manually.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to Forma 36
+
+Forma 36 is an open-source design system by Contentful and we welcome contributions from our community. If you have an idea that could help other users, a new solution, a fix to an existing component, or a new component, this guide explains how to transform those ideas into contributions.
+
+## Before contributing
+
+### Check if your idea is already present
+
+Before writing a proposal or code, explore this website and the [GitHub repository](https://github.com/contentful/forma-36) to check whether the idea is already implemented. Review the current [open proposals](https://github.com/contentful/forma-36/issues?q=is%3Aopen+is%3Aissue+label%3Aproposal), too: you may find a similar idea and be able to collaborate with its proposer.
+
+### Could an existing component be extended to realize your idea?
+
+If an existing component almost meets the need, propose an update or refactor instead. This may mean a new variation or a new component property.
+
+## Contribution process
+
+Once you have checked the library and decided to create a component or extend an existing one, follow this process.
+
+### Step 1: Open a GitHub issue
+
+[Open a new GitHub issue](https://github.com/contentful/forma-36/issues/new/choose) using the appropriate template. Describe the idea in detail and include images when they help explain it.
+
+### Step 2: Proposal review
+
+The Forma 36 team reviews repository issues regularly and provides feedback on proposals. After discussion and approval, you can begin work; the team can help as needed.
+
+Review similar components and follow the [code style guide](docs/code-style-guide.md) so that your contribution uses the established conventions.
+
+### Step 3: Open a pull request
+
+When the code is ready, open a pull request. The pull request template explains what to include.
+
+Include a changeset if the change should result in a new version. From the repository root, run:
+
+```bash
+pnpm exec changeset
+```
+
+Read [RELEASES.md](RELEASES.md) for details about changesets and publishing.
+
+### Step 4: Code and design review
+
+The team reviews the code and any design changes to ensure that the solution is maintainable and scalable.
+
+### Step 5: Merge the changes to the main branch
+
+After approval, merge the pull request into `main`. If it includes a changeset, the automated release process publishes a new Forma 36 version containing the change.
+
+## Bugs and light contributions
+
+For bugs, it is possible to skip the proposal steps and open a pull request directly with the fix. The same applies to light contributions: visual defects, small visual changes, and documentation updates.


### PR DESCRIPTION
# Purpose of PR

Support agentic development with relevant documents/guidance.

## PR Checklist

- [x] I have read the relevant `readme.md` file(s)
- [x] All commits follow our [Git commit message convention](https://github.com/contentful/forma-36/tree/main/packages/forma-36-react-components#commits)
- [x] Tests are added/updated/not required
- [x] Tests are passing
- [x] Storybook stories are added/updated/not required
- [x] Usage notes are added/updated/not required
- [x] Has been tested based on [Contentful's browser support](https://www.contentful.com/faq/about-contentful/#which-browsers-does-contentful-support)
- [x] Doesn't contain any sensitive information
